### PR TITLE
Reduce manual traversal by using visitor pattern

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,6 +17,9 @@ fi
 echo "pre-commit: checking staged Rust file line counts (SPEC_0021)..."
 cargo run --quiet --bin rum -- check-rust-file-lines
 
+echo "pre-commit: enforcing traversal policy..."
+cargo run --quiet --bin rumoca-traversal-policy-check
+
 echo "pre-commit: running cargo fmt --check..."
 cargo fmt --all -- --check
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -17,6 +17,9 @@ fi
 echo "pre-push: checking Rust file line counts across workspace..."
 cargo run --quiet --bin rum -- check-rust-file-lines --all-files
 
+echo "pre-push: enforcing traversal policy..."
+cargo run --quiet --bin rumoca-traversal-policy-check
+
 echo "pre-push: running ci-parity command..."
 cargo run --bin rum -- ci-parity
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Check Rust file line count (SPEC_0021)
         run: cargo run --quiet --bin rum -- check-rust-file-lines --all-files
 
+      - name: Enforce traversal policy
+        run: cargo run --quiet --bin rumoca-traversal-policy-check
+
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,6 +3103,7 @@ dependencies = [
  "rumoca-session",
  "serde",
  "serde_json",
+ "syn 2.0.114",
  "tar",
  "tempfile",
  "toml",

--- a/crates/rumoca-ir-ast/src/lib.rs
+++ b/crates/rumoca-ir-ast/src/lib.rs
@@ -64,7 +64,8 @@ pub type Token = rumoca_ir_core::Token;
 pub type Variability = rumoca_ir_core::Variability;
 
 pub use visitor::{
-    ExpressionTransformer, Visitor, collect_component_refs, contains_component_ref,
+    ComponentReferenceContext, ExpressionContext, ExpressionTransformer, FunctionCallContext,
+    SubscriptContext, TypeNameContext, Visitor, collect_component_refs, contains_component_ref,
     contains_function_call,
 };
 

--- a/crates/rumoca-ir-ast/src/visitor.rs
+++ b/crates/rumoca-ir-ast/src/visitor.rs
@@ -49,10 +49,66 @@
 
 use crate::{
     ClassDef, Component, ComponentReference, Equation, EquationBlock, Expression, Extend, ForIndex,
-    Statement, StatementBlock, StoredDefinition, Subscript,
+    Name, Statement, StatementBlock, StoredDefinition, Subscript,
 };
 use std::ops::ControlFlow::{self, Break, Continue};
 use std::sync::Arc;
+
+/// Context for traversed function call targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FunctionCallContext {
+    Expression,
+    Equation,
+    Statement,
+}
+
+/// Context for traversed component references.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComponentReferenceContext {
+    Expression,
+    EquationConnectLhs,
+    EquationConnectRhs,
+    EquationFunctionCallTarget,
+    StatementFunctionCallTarget,
+    AssignmentTarget,
+    ReinitTarget,
+    ClassModificationTarget,
+    ModificationTarget,
+}
+
+/// Context for traversed type names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeNameContext {
+    ExtendsBase,
+    ComponentType,
+    ClassConstrainedBy,
+    ComponentConstrainedBy,
+}
+
+/// Context for traversed subscript expressions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscriptContext {
+    ComponentReferencePart,
+    ArrayIndex,
+}
+
+/// Context for traversed expressions from declaration/equation/statement fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpressionContext {
+    Generic,
+    ComponentStart,
+    ComponentModification,
+    ComponentCondition,
+    ComponentAnnotation,
+    EquationAssertCondition,
+    EquationAssertMessage,
+    EquationAssertLevel,
+    StatementAssertCondition,
+    StatementAssertMessage,
+    StatementAssertLevel,
+    StatementFunctionOutput,
+    ExtendModification,
+}
 
 /// Trait for visiting AST nodes without modification.
 ///
@@ -77,6 +133,54 @@ pub trait Visitor {
         Continue(())
     }
 
+    /// Visit an expression with contextual metadata.
+    ///
+    /// Default behavior defers to [`Visitor::visit_expression`].
+    fn visit_expression_ctx(
+        &mut self,
+        expr: &Expression,
+        _ctx: ExpressionContext,
+    ) -> ControlFlow<()> {
+        self.visit_expression(expr)
+    }
+
+    /// Visit a component reference with contextual metadata.
+    ///
+    /// Default behavior defers to [`Visitor::visit_component_reference`].
+    fn visit_component_reference_ctx(
+        &mut self,
+        cr: &ComponentReference,
+        _ctx: ComponentReferenceContext,
+    ) -> ControlFlow<()> {
+        self.visit_component_reference(cr)
+    }
+
+    /// Visit a function-call target with contextual metadata.
+    ///
+    /// Default behavior defers to [`Visitor::visit_expr_function_call`].
+    fn visit_expr_function_call_ctx(
+        &mut self,
+        comp: &ComponentReference,
+        args: &[Expression],
+        _ctx: FunctionCallContext,
+    ) -> ControlFlow<()> {
+        self.visit_expr_function_call(comp, args)
+    }
+
+    /// Visit a type name in declaration context.
+    ///
+    /// Default behavior is no-op to preserve existing traversal behavior.
+    fn visit_type_name(&mut self, _name: &Name, _ctx: TypeNameContext) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    /// Visit a subscript with contextual metadata.
+    ///
+    /// Default behavior defers to [`Visitor::visit_subscript`].
+    fn visit_subscript_ctx(&mut self, sub: &Subscript, _ctx: SubscriptContext) -> ControlFlow<()> {
+        self.visit_subscript(sub)
+    }
+
     // =========================================================================
     // Expression methods
     // =========================================================================
@@ -97,18 +201,28 @@ pub trait Visitor {
                 self.visit_expression(lhs)?;
                 self.visit_expression(rhs)
             }
-            Expression::ComponentReference(cr) => self.visit_component_reference(cr),
-            Expression::FunctionCall { comp, args } => self.visit_expr_function_call(comp, args),
+            Expression::ComponentReference(cr) => {
+                self.visit_component_reference_ctx(cr, ComponentReferenceContext::Expression)
+            }
+            Expression::FunctionCall { comp, args } => {
+                self.visit_expr_function_call_ctx(comp, args, FunctionCallContext::Expression)
+            }
             Expression::ClassModification {
                 target,
                 modifications,
             } => {
-                self.visit_component_reference(target)?;
+                self.visit_component_reference_ctx(
+                    target,
+                    ComponentReferenceContext::ClassModificationTarget,
+                )?;
                 self.visit_each(modifications, Self::visit_expression)
             }
             Expression::NamedArgument { value, .. } => self.visit_expression(value),
             Expression::Modification { target, value } => {
-                self.visit_component_reference(target)?;
+                self.visit_component_reference_ctx(
+                    target,
+                    ComponentReferenceContext::ModificationTarget,
+                )?;
                 self.visit_expression(value)
             }
             Expression::Array { elements, .. } | Expression::Tuple { elements } => {
@@ -139,7 +253,10 @@ pub trait Visitor {
             }
             Expression::ArrayIndex { base, subscripts } => {
                 self.visit_expression(base)?;
-                self.visit_each(subscripts, Self::visit_subscript)
+                for subscript in subscripts {
+                    self.visit_subscript_ctx(subscript, SubscriptContext::ArrayIndex)?;
+                }
+                Continue(())
             }
             Expression::FieldAccess { base, .. } => self.visit_expression(base),
         }
@@ -148,8 +265,11 @@ pub trait Visitor {
     /// Visit a component reference.
     fn visit_component_reference(&mut self, cr: &ComponentReference) -> ControlFlow<()> {
         for part in &cr.parts {
-            if let Some(subs) = &part.subs {
-                self.visit_each(subs, Self::visit_subscript)?;
+            let Some(subs) = &part.subs else {
+                continue;
+            };
+            for subscript in subs {
+                self.visit_subscript_ctx(subscript, SubscriptContext::ComponentReferencePart)?;
             }
         }
         Continue(())
@@ -214,8 +334,8 @@ pub trait Visitor {
         lhs: &ComponentReference,
         rhs: &ComponentReference,
     ) -> ControlFlow<()> {
-        self.visit_component_reference(lhs)?;
-        self.visit_component_reference(rhs)
+        self.visit_component_reference_ctx(lhs, ComponentReferenceContext::EquationConnectLhs)?;
+        self.visit_component_reference_ctx(rhs, ComponentReferenceContext::EquationConnectRhs)
     }
 
     /// Visit a for-equation.
@@ -252,8 +372,11 @@ pub trait Visitor {
         comp: &ComponentReference,
         args: &[Expression],
     ) -> ControlFlow<()> {
-        self.visit_component_reference(comp)?;
-        self.visit_each(args, Self::visit_expression)
+        self.visit_component_reference_ctx(
+            comp,
+            ComponentReferenceContext::EquationFunctionCallTarget,
+        )?;
+        self.visit_expr_function_call_ctx(comp, args, FunctionCallContext::Equation)
     }
 
     /// Visit an assert equation.
@@ -263,10 +386,10 @@ pub trait Visitor {
         message: &Expression,
         level: Option<&Expression>,
     ) -> ControlFlow<()> {
-        self.visit_expression(condition)?;
-        self.visit_expression(message)?;
+        self.visit_expression_ctx(condition, ExpressionContext::EquationAssertCondition)?;
+        self.visit_expression_ctx(message, ExpressionContext::EquationAssertMessage)?;
         if let Some(lvl) = level {
-            self.visit_expression(lvl)?;
+            self.visit_expression_ctx(lvl, ExpressionContext::EquationAssertLevel)?;
         }
         Continue(())
     }
@@ -313,7 +436,7 @@ pub trait Visitor {
         comp: &ComponentReference,
         value: &Expression,
     ) -> ControlFlow<()> {
-        self.visit_component_reference(comp)?;
+        self.visit_component_reference_ctx(comp, ComponentReferenceContext::AssignmentTarget)?;
         self.visit_expression(value)
     }
 
@@ -352,9 +475,15 @@ pub trait Visitor {
         args: &[Expression],
         outputs: &[Expression],
     ) -> ControlFlow<()> {
-        self.visit_component_reference(comp)?;
-        self.visit_each(args, Self::visit_expression)?;
-        self.visit_each(outputs, Self::visit_expression)
+        self.visit_component_reference_ctx(
+            comp,
+            ComponentReferenceContext::StatementFunctionCallTarget,
+        )?;
+        self.visit_expr_function_call_ctx(comp, args, FunctionCallContext::Statement)?;
+        for output in outputs {
+            self.visit_expression_ctx(output, ExpressionContext::StatementFunctionOutput)?;
+        }
+        Continue(())
     }
 
     /// Visit a reinit statement.
@@ -363,7 +492,7 @@ pub trait Visitor {
         variable: &ComponentReference,
         value: &Expression,
     ) -> ControlFlow<()> {
-        self.visit_component_reference(variable)?;
+        self.visit_component_reference_ctx(variable, ComponentReferenceContext::ReinitTarget)?;
         self.visit_expression(value)
     }
 
@@ -374,10 +503,10 @@ pub trait Visitor {
         message: &Expression,
         level: Option<&Expression>,
     ) -> ControlFlow<()> {
-        self.visit_expression(condition)?;
-        self.visit_expression(message)?;
+        self.visit_expression_ctx(condition, ExpressionContext::StatementAssertCondition)?;
+        self.visit_expression_ctx(message, ExpressionContext::StatementAssertMessage)?;
         if let Some(lvl) = level {
-            self.visit_expression(lvl)?;
+            self.visit_expression_ctx(lvl, ExpressionContext::StatementAssertLevel)?;
         }
         Continue(())
     }
@@ -402,6 +531,9 @@ pub trait Visitor {
 
     /// Visit a class definition.
     fn visit_class_def(&mut self, class: &ClassDef) -> ControlFlow<()> {
+        if let Some(constrainedby) = &class.constrainedby {
+            self.visit_type_name(constrainedby, TypeNameContext::ClassConstrainedBy)?;
+        }
         for ext in &class.extends {
             self.visit_extend(ext)?;
         }
@@ -424,24 +556,32 @@ pub trait Visitor {
 
     /// Visit an extends clause.
     fn visit_extend(&mut self, ext: &Extend) -> ControlFlow<()> {
+        self.visit_type_name(&ext.base_name, TypeNameContext::ExtendsBase)?;
         for modification in &ext.modifications {
-            self.visit_expression(&modification.expr)?;
+            self.visit_expression_ctx(&modification.expr, ExpressionContext::ExtendModification)?;
         }
         Continue(())
     }
 
     /// Visit a component declaration.
     fn visit_component(&mut self, comp: &Component) -> ControlFlow<()> {
+        self.visit_type_name(&comp.type_name, TypeNameContext::ComponentType)?;
+        if let Some(constrainedby) = &comp.constrainedby {
+            self.visit_type_name(constrainedby, TypeNameContext::ComponentConstrainedBy)?;
+        }
         if !matches!(comp.start, Expression::Empty) {
-            self.visit_expression(&comp.start)?;
+            self.visit_expression_ctx(&comp.start, ExpressionContext::ComponentStart)?;
         }
         for (_, mod_expr) in &comp.modifications {
-            self.visit_expression(mod_expr)?;
+            self.visit_expression_ctx(mod_expr, ExpressionContext::ComponentModification)?;
         }
         if let Some(cond) = &comp.condition {
-            self.visit_expression(cond)?;
+            self.visit_expression_ctx(cond, ExpressionContext::ComponentCondition)?;
         }
-        self.visit_each(&comp.annotation, Self::visit_expression)
+        for annotation in &comp.annotation {
+            self.visit_expression_ctx(annotation, ExpressionContext::ComponentAnnotation)?;
+        }
+        Continue(())
     }
 }
 
@@ -727,6 +867,20 @@ mod tests {
         }
     }
 
+    fn make_comp_ref_with_subscript(name: &str, sub: Expression) -> ComponentReference {
+        ComponentReference {
+            local: false,
+            parts: vec![ComponentRefPart {
+                ident: Token {
+                    text: std::sync::Arc::from(name),
+                    ..Default::default()
+                },
+                subs: Some(vec![Subscript::Expression(sub)]),
+            }],
+            def_id: None,
+        }
+    }
+
     #[test]
     fn test_collect_component_refs() {
         let expr = Expression::Binary {
@@ -849,6 +1003,263 @@ mod tests {
         let mut finder = FirstConnect(None);
         let _ = finder.visit_equation(&eq);
         assert_eq!(finder.0, Some("first".into()));
+    }
+
+    #[test]
+    fn test_function_call_context_dispatch() {
+        #[derive(Default)]
+        struct ContextRecorder {
+            function_contexts: Vec<FunctionCallContext>,
+            component_contexts: Vec<ComponentReferenceContext>,
+            statement_output_expression_contexts: usize,
+        }
+
+        impl Visitor for ContextRecorder {
+            fn visit_expr_function_call_ctx(
+                &mut self,
+                comp: &ComponentReference,
+                args: &[Expression],
+                ctx: FunctionCallContext,
+            ) -> ControlFlow<()> {
+                self.function_contexts.push(ctx);
+                self.visit_expr_function_call(comp, args)
+            }
+
+            fn visit_component_reference_ctx(
+                &mut self,
+                cr: &ComponentReference,
+                ctx: ComponentReferenceContext,
+            ) -> ControlFlow<()> {
+                self.component_contexts.push(ctx);
+                self.visit_component_reference(cr)
+            }
+
+            fn visit_expression_ctx(
+                &mut self,
+                expr: &Expression,
+                ctx: ExpressionContext,
+            ) -> ControlFlow<()> {
+                self.statement_output_expression_contexts +=
+                    usize::from(ctx == ExpressionContext::StatementFunctionOutput);
+                self.visit_expression(expr)
+            }
+        }
+
+        let expr_call = Expression::FunctionCall {
+            comp: make_comp_ref("f_expr"),
+            args: vec![make_int(1)],
+        };
+        let equation_call = Equation::FunctionCall {
+            comp: make_comp_ref("f_eq"),
+            args: vec![make_int(2)],
+        };
+        let statement_call = Statement::FunctionCall {
+            comp: make_comp_ref("f_stmt"),
+            args: vec![make_int(3)],
+            outputs: vec![make_var("out")],
+        };
+
+        let mut recorder = ContextRecorder::default();
+        let _ = recorder.visit_expression(&expr_call);
+        let _ = recorder.visit_equation(&equation_call);
+        let _ = recorder.visit_statement(&statement_call);
+
+        assert_eq!(
+            recorder.function_contexts,
+            vec![
+                FunctionCallContext::Expression,
+                FunctionCallContext::Equation,
+                FunctionCallContext::Statement,
+            ]
+        );
+        assert!(
+            recorder
+                .component_contexts
+                .contains(&ComponentReferenceContext::EquationFunctionCallTarget)
+        );
+        assert!(
+            recorder
+                .component_contexts
+                .contains(&ComponentReferenceContext::StatementFunctionCallTarget)
+        );
+        assert_eq!(recorder.statement_output_expression_contexts, 1);
+    }
+
+    #[test]
+    fn test_type_name_context_dispatch() {
+        #[derive(Default)]
+        struct TypeNameRecorder {
+            seen: Vec<(String, TypeNameContext)>,
+        }
+
+        impl Visitor for TypeNameRecorder {
+            fn visit_type_name(&mut self, name: &Name, ctx: TypeNameContext) -> ControlFlow<()> {
+                self.seen.push((name.to_string(), ctx));
+                Continue(())
+            }
+        }
+
+        let mut components = IndexMap::new();
+        components.insert(
+            "comp".to_string(),
+            Component {
+                type_name: Name::from_string("MyComponentType"),
+                constrainedby: Some(Name::from_string("MyComponentConstraint")),
+                ..Default::default()
+            },
+        );
+
+        let class = ClassDef {
+            constrainedby: Some(Name::from_string("MyClassConstraint")),
+            extends: vec![Extend {
+                base_name: Name::from_string("MyBaseClass"),
+                ..Default::default()
+            }],
+            components,
+            ..Default::default()
+        };
+
+        let mut recorder = TypeNameRecorder::default();
+        let _ = recorder.visit_class_def(&class);
+
+        assert!(recorder.seen.contains(&(
+            "MyClassConstraint".to_string(),
+            TypeNameContext::ClassConstrainedBy
+        )));
+        assert!(
+            recorder
+                .seen
+                .contains(&("MyBaseClass".to_string(), TypeNameContext::ExtendsBase))
+        );
+        assert!(recorder.seen.contains(&(
+            "MyComponentType".to_string(),
+            TypeNameContext::ComponentType
+        )));
+        assert!(recorder.seen.contains(&(
+            "MyComponentConstraint".to_string(),
+            TypeNameContext::ComponentConstrainedBy
+        )));
+    }
+
+    #[test]
+    fn test_subscript_context_dispatch() {
+        #[derive(Default)]
+        struct SubscriptRecorder {
+            seen: Vec<SubscriptContext>,
+        }
+
+        impl Visitor for SubscriptRecorder {
+            fn visit_subscript_ctx(
+                &mut self,
+                sub: &Subscript,
+                ctx: SubscriptContext,
+            ) -> ControlFlow<()> {
+                self.seen.push(ctx);
+                self.visit_subscript(sub)
+            }
+        }
+
+        let expr = Expression::ArrayIndex {
+            base: Arc::new(Expression::ComponentReference(
+                make_comp_ref_with_subscript("a", make_int(1)),
+            )),
+            subscripts: vec![Subscript::Expression(make_int(2))],
+        };
+
+        let mut recorder = SubscriptRecorder::default();
+        let _ = recorder.visit_expression(&expr);
+
+        assert!(
+            recorder
+                .seen
+                .contains(&SubscriptContext::ComponentReferencePart)
+        );
+        assert!(recorder.seen.contains(&SubscriptContext::ArrayIndex));
+    }
+
+    fn make_expression_context_dispatch_class() -> ClassDef {
+        let mut component = Component {
+            type_name: Name::from_string("Real"),
+            start: make_int(1),
+            condition: Some(make_var("cond")),
+            ..Default::default()
+        };
+        component.modifications.insert("k".to_string(), make_int(2));
+        component.annotation.push(make_int(3));
+
+        ClassDef {
+            extends: vec![Extend {
+                base_name: Name::from_string("Base"),
+                modifications: vec![crate::ExtendModification {
+                    expr: make_int(4),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            components: {
+                let mut comps = IndexMap::new();
+                comps.insert("x".to_string(), component);
+                comps
+            },
+            equations: vec![Equation::Assert {
+                condition: make_var("eq_cond"),
+                message: make_int(5),
+                level: Some(make_int(6)),
+            }],
+            algorithms: vec![vec![
+                Statement::Assert {
+                    condition: make_var("stmt_cond"),
+                    message: make_int(7),
+                    level: Some(make_int(8)),
+                },
+                Statement::FunctionCall {
+                    comp: make_comp_ref("f"),
+                    args: vec![make_int(9)],
+                    outputs: vec![make_var("y")],
+                },
+            ]],
+            ..Default::default()
+        }
+    }
+
+    fn assert_expression_contexts_seen(seen: &[ExpressionContext]) {
+        assert!(seen.contains(&ExpressionContext::ComponentStart));
+        assert!(seen.contains(&ExpressionContext::ComponentModification));
+        assert!(seen.contains(&ExpressionContext::ComponentCondition));
+        assert!(seen.contains(&ExpressionContext::ComponentAnnotation));
+        assert!(seen.contains(&ExpressionContext::ExtendModification));
+        assert!(seen.contains(&ExpressionContext::EquationAssertCondition));
+        assert!(seen.contains(&ExpressionContext::EquationAssertMessage));
+        assert!(seen.contains(&ExpressionContext::EquationAssertLevel));
+        assert!(seen.contains(&ExpressionContext::StatementAssertCondition));
+        assert!(seen.contains(&ExpressionContext::StatementAssertMessage));
+        assert!(seen.contains(&ExpressionContext::StatementAssertLevel));
+        assert!(seen.contains(&ExpressionContext::StatementFunctionOutput));
+    }
+
+    #[test]
+    fn test_expression_context_dispatch() {
+        #[derive(Default)]
+        struct ExpressionContextRecorder {
+            seen: Vec<ExpressionContext>,
+        }
+
+        impl Visitor for ExpressionContextRecorder {
+            fn visit_expression_ctx(
+                &mut self,
+                expr: &Expression,
+                ctx: ExpressionContext,
+            ) -> ControlFlow<()> {
+                self.seen.push(ctx);
+                self.visit_expression(expr)
+            }
+        }
+
+        let class = make_expression_context_dispatch_class();
+
+        let mut recorder = ExpressionContextRecorder::default();
+        let _ = recorder.visit_class_def(&class);
+        assert_expression_contexts_seen(&recorder.seen);
     }
 
     struct ClassNames(Vec<String>);

--- a/crates/rumoca-ir-dae/src/lib.rs
+++ b/crates/rumoca-ir-dae/src/lib.rs
@@ -24,10 +24,16 @@ use rumoca_core::Span;
 use serde::{Deserialize, Serialize};
 
 mod types;
+pub mod visitor;
 pub use types::{
     BuiltinFunction, ComponentRefPart, ComponentReference, ComprehensionIndex,
     DerivativeAnnotation, Expression, ExternalFunction, ForIndex, Function, FunctionParam, Literal,
     Statement, StatementBlock, Subscript, VarName, component_base_name, extract_algorithm_outputs,
+};
+pub use visitor::{
+    AlgorithmOutputCollector, ContainsDerChecker, ContainsDerOfStateChecker, ExpressionVisitor,
+    ImplicitSampleChecker, StateVariableCollector, StatementVisitor, VarRefCollector,
+    VarRefWithSubscriptsCollector,
 };
 
 /// Detailed breakdown of balance calculation components.

--- a/crates/rumoca-ir-dae/src/types.rs
+++ b/crates/rumoca-ir-dae/src/types.rs
@@ -1,4 +1,3 @@
-use indexmap::IndexSet;
 use rumoca_core::{DefId, Span};
 use rumoca_ir_core::{OpBinary, OpUnary};
 use serde::{Deserialize, Serialize};
@@ -439,67 +438,18 @@ pub enum Statement {
 }
 
 pub fn extract_algorithm_outputs(statements: &[Statement]) -> Vec<VarName> {
-    let mut outputs = IndexSet::new();
-    for stmt in statements {
-        collect_algorithm_outputs_from_statement(stmt, &mut outputs);
+    use crate::visitor::{AlgorithmOutputCollector, StatementVisitor};
+
+    let mut collector = AlgorithmOutputCollector::new();
+    for statement in statements {
+        collector.visit_statement(statement);
     }
-    outputs.into_iter().collect()
+    collector.into_outputs()
 }
 
 pub(crate) fn component_ref_to_base_var_name(comp: &ComponentReference) -> VarName {
     let parts: Vec<String> = comp.parts.iter().map(|p| p.ident.to_string()).collect();
     VarName::new(parts.join("."))
-}
-
-fn collect_algorithm_outputs_from_statement(stmt: &Statement, outputs: &mut IndexSet<VarName>) {
-    match stmt {
-        Statement::Assignment { comp, .. } => {
-            outputs.insert(component_ref_to_base_var_name(comp));
-        }
-        Statement::For { equations, .. } => {
-            for s in equations {
-                collect_algorithm_outputs_from_statement(s, outputs);
-            }
-        }
-        Statement::While(block) => {
-            for s in &block.stmts {
-                collect_algorithm_outputs_from_statement(s, outputs);
-            }
-        }
-        Statement::If {
-            cond_blocks,
-            else_block,
-        } => {
-            for block in cond_blocks {
-                for s in &block.stmts {
-                    collect_algorithm_outputs_from_statement(s, outputs);
-                }
-            }
-            if let Some(stmts) = else_block {
-                for s in stmts {
-                    collect_algorithm_outputs_from_statement(s, outputs);
-                }
-            }
-        }
-        Statement::When(blocks) => {
-            for block in blocks {
-                for s in &block.stmts {
-                    collect_algorithm_outputs_from_statement(s, outputs);
-                }
-            }
-        }
-        Statement::FunctionCall { outputs: outs, .. } => {
-            for out in outs {
-                if let Expression::VarRef { name, .. } = out {
-                    outputs.insert(name.clone());
-                }
-            }
-        }
-        Statement::Reinit { variable, .. } => {
-            outputs.insert(component_ref_to_base_var_name(variable));
-        }
-        Statement::Empty | Statement::Return | Statement::Break | Statement::Assert { .. } => {}
-    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -592,28 +542,11 @@ impl FunctionParam {
 
 impl Expression {
     pub fn contains_der(&self) -> bool {
-        match self {
-            Expression::BuiltinCall { function, .. } if *function == BuiltinFunction::Der => true,
-            _ => self.walk().any(|expr| {
-                matches!(
-                    expr,
-                    Expression::BuiltinCall { function, .. } if *function == BuiltinFunction::Der
-                )
-            }),
-        }
+        crate::visitor::ContainsDerChecker::check(self)
     }
 
     pub fn contains_der_of_state(&self, state_vars: &std::collections::HashSet<VarName>) -> bool {
-        self.walk().any(|expr| {
-            if let Expression::BuiltinCall { function, args } = expr
-                && *function == BuiltinFunction::Der
-                && let Some(Expression::VarRef { name, .. }) = args.first()
-            {
-                state_vars.contains(name)
-            } else {
-                false
-            }
-        })
+        crate::visitor::ContainsDerOfStateChecker::check(self, state_vars)
     }
 
     pub fn get_der_variable(&self) -> Option<&VarName> {
@@ -629,100 +562,18 @@ impl Expression {
     }
 
     pub fn collect_state_variables(&self, states: &mut std::collections::HashSet<VarName>) {
-        for expr in self.walk() {
-            if let Expression::BuiltinCall { function, args } = expr
-                && *function == BuiltinFunction::Der
-                && let Some(Expression::VarRef { name, .. }) = args.first()
-            {
-                states.insert(name.clone());
-            }
-        }
+        use crate::visitor::{ExpressionVisitor, StateVariableCollector};
+
+        let mut collector = StateVariableCollector::new();
+        collector.visit_expression(self);
+        states.extend(collector.into_states());
     }
 
     pub fn collect_var_refs(&self, vars: &mut std::collections::HashSet<VarName>) {
-        for expr in self.walk() {
-            if let Expression::VarRef { name, .. } = expr {
-                vars.insert(name.clone());
-            }
-        }
-    }
+        use crate::visitor::{ExpressionVisitor, VarRefCollector};
 
-    fn walk(&self) -> ExpressionWalker<'_> {
-        ExpressionWalker { stack: vec![self] }
-    }
-}
-
-struct ExpressionWalker<'a> {
-    stack: Vec<&'a Expression>,
-}
-
-impl<'a> Iterator for ExpressionWalker<'a> {
-    type Item = &'a Expression;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let expr = self.stack.pop()?;
-        match expr {
-            Expression::Binary { lhs, rhs, .. } => {
-                self.stack.push(rhs);
-                self.stack.push(lhs);
-            }
-            Expression::Unary { rhs, .. } => {
-                self.stack.push(rhs);
-            }
-            Expression::BuiltinCall { args, .. } | Expression::FunctionCall { args, .. } => {
-                for arg in args.iter().rev() {
-                    self.stack.push(arg);
-                }
-            }
-            Expression::If {
-                branches,
-                else_branch,
-            } => {
-                self.stack.push(else_branch);
-                for (cond, value) in branches.iter().rev() {
-                    self.stack.push(value);
-                    self.stack.push(cond);
-                }
-            }
-            Expression::Array { elements, .. } | Expression::Tuple { elements } => {
-                for element in elements.iter().rev() {
-                    self.stack.push(element);
-                }
-            }
-            Expression::Range { start, step, end } => {
-                self.stack.push(end);
-                if let Some(step) = step {
-                    self.stack.push(step);
-                }
-                self.stack.push(start);
-            }
-            Expression::ArrayComprehension {
-                expr,
-                indices,
-                filter,
-            } => {
-                if let Some(filter) = filter {
-                    self.stack.push(filter);
-                }
-                for index in indices.iter().rev() {
-                    self.stack.push(&index.range);
-                }
-                self.stack.push(expr);
-            }
-            Expression::Index { base, subscripts } => {
-                for expr in subscripts.iter().rev().filter_map(|sub| match sub {
-                    Subscript::Expr(expr) => Some(expr.as_ref()),
-                    Subscript::Index(_) | Subscript::Colon => None,
-                }) {
-                    self.stack.push(expr);
-                }
-                self.stack.push(base);
-            }
-            Expression::FieldAccess { base, .. } => {
-                self.stack.push(base);
-            }
-            Expression::VarRef { .. } | Expression::Literal(_) | Expression::Empty => {}
-        }
-        Some(expr)
+        let mut collector = VarRefCollector::new();
+        collector.visit_expression(self);
+        vars.extend(collector.into_vars());
     }
 }

--- a/crates/rumoca-ir-dae/src/visitor.rs
+++ b/crates/rumoca-ir-dae/src/visitor.rs
@@ -1,0 +1,603 @@
+//! Visitor traits for traversing DAE expression and statement trees.
+//!
+//! These visitors centralize traversal logic so analysis passes can focus on
+//! semantics instead of hand-written recursion.
+
+use crate::{
+    BuiltinFunction, ComponentReference, ComprehensionIndex, Expression, ForIndex, Statement,
+    StatementBlock, Subscript, VarName,
+};
+use indexmap::IndexSet;
+
+/// Visitor for DAE expressions.
+pub trait ExpressionVisitor {
+    fn visit_expression(&mut self, expr: &Expression) {
+        self.walk_expression(expr);
+    }
+
+    fn walk_expression(&mut self, expr: &Expression) {
+        match expr {
+            Expression::Binary { op, lhs, rhs } => self.visit_binary(op, lhs, rhs),
+            Expression::Unary { rhs, .. } => self.visit_expression(rhs),
+            Expression::VarRef { name, subscripts } => self.visit_var_ref(name, subscripts),
+            Expression::BuiltinCall { function, args } => self.visit_builtin_call(function, args),
+            Expression::FunctionCall {
+                name,
+                args,
+                is_constructor,
+            } => self.visit_function_call(name, args, *is_constructor),
+            Expression::Literal(lit) => self.visit_literal(lit),
+            Expression::If {
+                branches,
+                else_branch,
+            } => self.visit_if(branches, else_branch),
+            Expression::Array {
+                elements,
+                is_matrix,
+            } => self.visit_array(elements, *is_matrix),
+            Expression::Tuple { elements } => self.visit_tuple(elements),
+            Expression::Range { start, step, end } => self.visit_range(start, step.as_deref(), end),
+            Expression::ArrayComprehension {
+                expr,
+                indices,
+                filter,
+            } => self.visit_array_comprehension(expr, indices, filter.as_deref()),
+            Expression::Index { base, subscripts } => self.visit_index(base, subscripts),
+            Expression::FieldAccess { base, field } => self.visit_field_access(base, field),
+            Expression::Empty => {}
+        }
+    }
+
+    fn visit_binary(&mut self, _op: &rumoca_ir_core::OpBinary, lhs: &Expression, rhs: &Expression) {
+        self.visit_expression(lhs);
+        self.visit_expression(rhs);
+    }
+
+    fn visit_var_ref(&mut self, _name: &VarName, subscripts: &[Subscript]) {
+        for subscript in subscripts {
+            self.visit_subscript(subscript);
+        }
+    }
+
+    fn visit_subscript(&mut self, subscript: &Subscript) {
+        if let Subscript::Expr(expr) = subscript {
+            self.visit_expression(expr);
+        }
+    }
+
+    fn visit_builtin_call(&mut self, _function: &BuiltinFunction, args: &[Expression]) {
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+
+    fn visit_function_call(&mut self, _name: &VarName, args: &[Expression], _is_constructor: bool) {
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+
+    fn visit_literal(&mut self, _lit: &crate::Literal) {}
+
+    fn visit_if(&mut self, branches: &[(Expression, Expression)], else_branch: &Expression) {
+        for (cond, then_expr) in branches {
+            self.visit_expression(cond);
+            self.visit_expression(then_expr);
+        }
+        self.visit_expression(else_branch);
+    }
+
+    fn visit_array(&mut self, elements: &[Expression], _is_matrix: bool) {
+        for elem in elements {
+            self.visit_expression(elem);
+        }
+    }
+
+    fn visit_tuple(&mut self, elements: &[Expression]) {
+        for elem in elements {
+            self.visit_expression(elem);
+        }
+    }
+
+    fn visit_range(&mut self, start: &Expression, step: Option<&Expression>, end: &Expression) {
+        self.visit_expression(start);
+        if let Some(step_expr) = step {
+            self.visit_expression(step_expr);
+        }
+        self.visit_expression(end);
+    }
+
+    fn visit_array_comprehension(
+        &mut self,
+        expr: &Expression,
+        indices: &[ComprehensionIndex],
+        filter: Option<&Expression>,
+    ) {
+        self.visit_expression(expr);
+        for index in indices {
+            self.visit_expression(&index.range);
+        }
+        if let Some(filter_expr) = filter {
+            self.visit_expression(filter_expr);
+        }
+    }
+
+    fn visit_index(&mut self, base: &Expression, subscripts: &[Subscript]) {
+        self.visit_expression(base);
+        for subscript in subscripts {
+            self.visit_subscript(subscript);
+        }
+    }
+
+    fn visit_field_access(&mut self, base: &Expression, _field: &str) {
+        self.visit_expression(base);
+    }
+}
+
+/// Visitor for DAE statements.
+pub trait StatementVisitor: ExpressionVisitor {
+    fn visit_statement(&mut self, stmt: &Statement) {
+        self.walk_statement(stmt);
+    }
+
+    fn walk_statement(&mut self, stmt: &Statement) {
+        match stmt {
+            Statement::Empty | Statement::Return | Statement::Break => {}
+            Statement::Assignment { comp, value } => self.visit_assignment(comp, value),
+            Statement::For { indices, equations } => self.visit_for_statement(indices, equations),
+            Statement::While(block) => self.visit_statement_block(block),
+            Statement::If {
+                cond_blocks,
+                else_block,
+            } => self.visit_if_statement(cond_blocks, else_block.as_deref()),
+            Statement::When(blocks) => self.visit_when_statement(blocks),
+            Statement::FunctionCall {
+                comp,
+                args,
+                outputs,
+            } => self.visit_statement_function_call(comp, args, outputs),
+            Statement::Reinit { variable, value } => self.visit_reinit(variable, value),
+            Statement::Assert {
+                condition,
+                message,
+                level,
+            } => self.visit_assert(condition, message, level.as_ref()),
+        }
+    }
+
+    fn visit_assignment(&mut self, comp: &ComponentReference, value: &Expression) {
+        self.visit_component_reference(comp);
+        self.visit_expression(value);
+    }
+
+    fn visit_for_statement(&mut self, indices: &[ForIndex], statements: &[Statement]) {
+        for index in indices {
+            self.visit_expression(&index.range);
+        }
+        for stmt in statements {
+            self.visit_statement(stmt);
+        }
+    }
+
+    fn visit_if_statement(
+        &mut self,
+        cond_blocks: &[StatementBlock],
+        else_block: Option<&[Statement]>,
+    ) {
+        for block in cond_blocks {
+            self.visit_statement_block(block);
+        }
+        if let Some(else_statements) = else_block {
+            for stmt in else_statements {
+                self.visit_statement(stmt);
+            }
+        }
+    }
+
+    fn visit_when_statement(&mut self, blocks: &[StatementBlock]) {
+        for block in blocks {
+            self.visit_statement_block(block);
+        }
+    }
+
+    fn visit_statement_function_call(
+        &mut self,
+        comp: &ComponentReference,
+        args: &[Expression],
+        outputs: &[Expression],
+    ) {
+        self.visit_component_reference(comp);
+        for arg in args {
+            self.visit_expression(arg);
+        }
+        for output in outputs {
+            self.visit_expression(output);
+        }
+    }
+
+    fn visit_reinit(&mut self, variable: &ComponentReference, value: &Expression) {
+        self.visit_component_reference(variable);
+        self.visit_expression(value);
+    }
+
+    fn visit_assert(
+        &mut self,
+        condition: &Expression,
+        message: &Expression,
+        level: Option<&Expression>,
+    ) {
+        self.visit_expression(condition);
+        self.visit_expression(message);
+        if let Some(level_expr) = level {
+            self.visit_expression(level_expr);
+        }
+    }
+
+    fn visit_component_reference(&mut self, comp: &ComponentReference) {
+        for part in &comp.parts {
+            for subscript in &part.subs {
+                self.visit_subscript(subscript);
+            }
+        }
+    }
+
+    fn visit_statement_block(&mut self, block: &StatementBlock) {
+        self.visit_expression(&block.cond);
+        for stmt in &block.stmts {
+            self.visit_statement(stmt);
+        }
+    }
+}
+
+/// Collects user-defined state variables referenced by `der(...)`.
+pub struct StateVariableCollector {
+    states: std::collections::HashSet<VarName>,
+}
+
+impl StateVariableCollector {
+    pub fn new() -> Self {
+        Self {
+            states: std::collections::HashSet::new(),
+        }
+    }
+
+    pub fn into_states(self) -> std::collections::HashSet<VarName> {
+        self.states
+    }
+}
+
+impl Default for StateVariableCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExpressionVisitor for StateVariableCollector {
+    fn visit_builtin_call(&mut self, function: &BuiltinFunction, args: &[Expression]) {
+        if *function == BuiltinFunction::Der
+            && let Some(Expression::VarRef { name, .. }) = args.first()
+        {
+            self.states.insert(name.clone());
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+}
+
+/// Collects all variable references in expression trees.
+pub struct VarRefCollector {
+    vars: std::collections::HashSet<VarName>,
+}
+
+impl VarRefCollector {
+    pub fn new() -> Self {
+        Self {
+            vars: std::collections::HashSet::new(),
+        }
+    }
+
+    pub fn into_vars(self) -> std::collections::HashSet<VarName> {
+        self.vars
+    }
+}
+
+impl Default for VarRefCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExpressionVisitor for VarRefCollector {
+    fn visit_var_ref(&mut self, name: &VarName, subscripts: &[Subscript]) {
+        self.vars.insert(name.clone());
+        for subscript in subscripts {
+            self.visit_subscript(subscript);
+        }
+    }
+}
+
+/// Collects variable references with explicit subscript payloads.
+pub struct VarRefWithSubscriptsCollector {
+    refs: Vec<(VarName, Vec<Subscript>)>,
+}
+
+impl VarRefWithSubscriptsCollector {
+    pub fn new() -> Self {
+        Self { refs: Vec::new() }
+    }
+
+    pub fn into_refs(self) -> Vec<(VarName, Vec<Subscript>)> {
+        self.refs
+    }
+}
+
+impl Default for VarRefWithSubscriptsCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExpressionVisitor for VarRefWithSubscriptsCollector {
+    fn visit_var_ref(&mut self, name: &VarName, subscripts: &[Subscript]) {
+        self.refs.push((name.clone(), subscripts.to_vec()));
+        for subscript in subscripts {
+            self.visit_subscript(subscript);
+        }
+    }
+}
+
+/// Short-circuit checker for any `der(...)` occurrence.
+pub struct ContainsDerChecker {
+    found: bool,
+}
+
+impl ContainsDerChecker {
+    pub fn check(expr: &Expression) -> bool {
+        let mut checker = Self { found: false };
+        checker.visit_expression(expr);
+        checker.found
+    }
+}
+
+impl ExpressionVisitor for ContainsDerChecker {
+    fn visit_expression(&mut self, expr: &Expression) {
+        if !self.found {
+            self.walk_expression(expr);
+        }
+    }
+
+    fn visit_builtin_call(&mut self, function: &BuiltinFunction, args: &[Expression]) {
+        if *function == BuiltinFunction::Der {
+            self.found = true;
+            return;
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+}
+
+/// Short-circuit checker for `der(state_var)` occurrences.
+pub struct ContainsDerOfStateChecker<'a> {
+    state_vars: &'a std::collections::HashSet<VarName>,
+    found: bool,
+}
+
+impl<'a> ContainsDerOfStateChecker<'a> {
+    pub fn check(expr: &Expression, state_vars: &'a std::collections::HashSet<VarName>) -> bool {
+        let mut checker = Self {
+            state_vars,
+            found: false,
+        };
+        checker.visit_expression(expr);
+        checker.found
+    }
+}
+
+impl ExpressionVisitor for ContainsDerOfStateChecker<'_> {
+    fn visit_expression(&mut self, expr: &Expression) {
+        if !self.found {
+            self.walk_expression(expr);
+        }
+    }
+
+    fn visit_builtin_call(&mut self, function: &BuiltinFunction, args: &[Expression]) {
+        if *function == BuiltinFunction::Der
+            && let Some(Expression::VarRef { name, .. }) = args.first()
+            && self.state_vars.contains(name)
+        {
+            self.found = true;
+            return;
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+}
+
+/// Short-circuit checker for implicit `sample(expr)` calls (single-arg only).
+pub struct ImplicitSampleChecker {
+    found: bool,
+}
+
+impl ImplicitSampleChecker {
+    pub fn check(expr: &Expression) -> bool {
+        let mut checker = Self { found: false };
+        checker.visit_expression(expr);
+        checker.found
+    }
+}
+
+impl ExpressionVisitor for ImplicitSampleChecker {
+    fn visit_expression(&mut self, expr: &Expression) {
+        if !self.found {
+            self.walk_expression(expr);
+        }
+    }
+
+    fn visit_builtin_call(&mut self, function: &BuiltinFunction, args: &[Expression]) {
+        if matches!(function, BuiltinFunction::Sample) && args.len() == 1 {
+            self.found = true;
+            return;
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+
+    fn visit_function_call(&mut self, name: &VarName, args: &[Expression], _is_constructor: bool) {
+        let short = name.as_str().rsplit('.').next().unwrap_or(name.as_str());
+        if short == "sample" && args.len() == 1 {
+            self.found = true;
+            return;
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+}
+
+/// Collects algorithm outputs from statement trees.
+pub struct AlgorithmOutputCollector {
+    outputs: IndexSet<VarName>,
+}
+
+impl AlgorithmOutputCollector {
+    pub fn new() -> Self {
+        Self {
+            outputs: IndexSet::new(),
+        }
+    }
+
+    pub fn into_outputs(self) -> Vec<VarName> {
+        self.outputs.into_iter().collect()
+    }
+}
+
+impl Default for AlgorithmOutputCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExpressionVisitor for AlgorithmOutputCollector {}
+
+impl StatementVisitor for AlgorithmOutputCollector {
+    fn visit_assignment(&mut self, comp: &ComponentReference, value: &Expression) {
+        self.outputs
+            .insert(crate::types::component_ref_to_base_var_name(comp));
+        self.visit_expression(value);
+    }
+
+    fn visit_statement_function_call(
+        &mut self,
+        comp: &ComponentReference,
+        args: &[Expression],
+        outputs: &[Expression],
+    ) {
+        self.visit_component_reference(comp);
+        for arg in args {
+            self.visit_expression(arg);
+        }
+        for output in outputs {
+            if let Expression::VarRef { name, .. } = output {
+                self.outputs.insert(name.clone());
+            }
+            self.visit_expression(output);
+        }
+    }
+
+    fn visit_reinit(&mut self, variable: &ComponentReference, value: &Expression) {
+        self.outputs
+            .insert(crate::types::component_ref_to_base_var_name(variable));
+        self.visit_expression(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn var(name: &str) -> Expression {
+        Expression::VarRef {
+            name: VarName::new(name),
+            subscripts: vec![],
+        }
+    }
+
+    #[test]
+    fn implicit_sample_checker_detects_single_arg_sample_call() {
+        let expr = Expression::FunctionCall {
+            name: VarName::new("Modelica.sample"),
+            args: vec![var("x")],
+            is_constructor: false,
+        };
+        assert!(ImplicitSampleChecker::check(&expr));
+
+        let non_implicit = Expression::BuiltinCall {
+            function: BuiltinFunction::Sample,
+            args: vec![var("x"), var("dt")],
+        };
+        assert!(!ImplicitSampleChecker::check(&non_implicit));
+    }
+
+    #[test]
+    fn var_ref_with_subscripts_collector_recurses_into_subscript_exprs() {
+        let expr = Expression::VarRef {
+            name: VarName::new("x"),
+            subscripts: vec![Subscript::Expr(Box::new(var("i")))],
+        };
+
+        let mut collector = VarRefWithSubscriptsCollector::new();
+        collector.visit_expression(&expr);
+        let refs = collector.into_refs();
+        let names: std::collections::HashSet<_> = refs.into_iter().map(|(name, _)| name).collect();
+
+        assert!(names.contains(&VarName::new("x")));
+        assert!(names.contains(&VarName::new("i")));
+    }
+
+    #[test]
+    fn algorithm_output_collector_tracks_nested_assignments() {
+        let statements = vec![Statement::For {
+            indices: vec![ForIndex {
+                ident: "k".to_string(),
+                range: Expression::Literal(crate::Literal::Integer(1)),
+            }],
+            equations: vec![
+                Statement::Assignment {
+                    comp: ComponentReference {
+                        local: false,
+                        parts: vec![crate::ComponentRefPart {
+                            ident: "x".to_string(),
+                            subs: vec![Subscript::Index(1)],
+                        }],
+                        def_id: None,
+                    },
+                    value: var("u"),
+                },
+                Statement::Reinit {
+                    variable: ComponentReference {
+                        local: false,
+                        parts: vec![crate::ComponentRefPart {
+                            ident: "y".to_string(),
+                            subs: vec![],
+                        }],
+                        def_id: None,
+                    },
+                    value: var("v"),
+                },
+            ],
+        }];
+
+        let mut collector = AlgorithmOutputCollector::new();
+        for statement in &statements {
+            collector.visit_statement(statement);
+        }
+        let outputs = collector.into_outputs();
+
+        assert!(outputs.contains(&VarName::new("x")));
+        assert!(outputs.contains(&VarName::new("y")));
+    }
+}

--- a/crates/rumoca-ir-flat/src/lib.rs
+++ b/crates/rumoca-ir-flat/src/lib.rs
@@ -28,7 +28,7 @@ use convert_from_ast::{
     convert_function_call, convert_function_call_with_def_map, convert_if_with_def_map,
     convert_terminal, function_component_ref_from_ast,
 };
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 use rumoca_core::{DefId, Span, TypeId};
 #[cfg(test)]
 use rumoca_ir_ast as ast;
@@ -124,8 +124,8 @@ pub use name_utils::component_base_name;
 
 // Re-export visitor types
 pub use visitor::{
-    ContainsDerChecker, ExpressionVisitor, FunctionCallCollector, StateVariableCollector,
-    VarRefCollector,
+    AlgorithmOutputCollector, ContainsDerChecker, ExpressionVisitor, FunctionCallCollector,
+    StateVariableCollector, StatementVisitor, VarRefCollector,
 };
 
 /// A globally unique variable name in the flat model.
@@ -1017,11 +1017,13 @@ pub enum Statement {
 ///
 /// For array element assignments like `x[i] := ...`, the base variable `x` is returned.
 pub fn extract_algorithm_outputs(statements: &[Statement]) -> Vec<VarName> {
-    let mut outputs = IndexSet::new();
-    for stmt in statements {
-        collect_algorithm_outputs_from_statement(stmt, &mut outputs);
+    use crate::visitor::{AlgorithmOutputCollector, StatementVisitor};
+
+    let mut collector = AlgorithmOutputCollector::new();
+    for statement in statements {
+        collector.visit_statement(statement);
     }
-    outputs.into_iter().collect()
+    collector.into_outputs()
 }
 
 /// Convert a component reference to its base variable name.
@@ -1030,57 +1032,6 @@ pub fn extract_algorithm_outputs(statements: &[Statement]) -> Vec<VarName> {
 pub fn component_ref_to_base_var_name(comp: &ComponentReference) -> VarName {
     let parts: Vec<String> = comp.parts.iter().map(|p| p.ident.to_string()).collect();
     VarName::new(parts.join("."))
-}
-
-fn collect_algorithm_outputs_from_statement(stmt: &Statement, outputs: &mut IndexSet<VarName>) {
-    match stmt {
-        Statement::Assignment { comp, .. } => {
-            outputs.insert(component_ref_to_base_var_name(comp));
-        }
-        Statement::For { equations, .. } => {
-            for s in equations {
-                collect_algorithm_outputs_from_statement(s, outputs);
-            }
-        }
-        Statement::While(block) => {
-            for s in &block.stmts {
-                collect_algorithm_outputs_from_statement(s, outputs);
-            }
-        }
-        Statement::If {
-            cond_blocks,
-            else_block,
-        } => {
-            for block in cond_blocks {
-                for s in &block.stmts {
-                    collect_algorithm_outputs_from_statement(s, outputs);
-                }
-            }
-            if let Some(stmts) = else_block {
-                for s in stmts {
-                    collect_algorithm_outputs_from_statement(s, outputs);
-                }
-            }
-        }
-        Statement::When(blocks) => {
-            for block in blocks {
-                for s in &block.stmts {
-                    collect_algorithm_outputs_from_statement(s, outputs);
-                }
-            }
-        }
-        Statement::FunctionCall { outputs: outs, .. } => {
-            for out in outs {
-                if let Expression::VarRef { name, .. } = out {
-                    outputs.insert(name.clone());
-                }
-            }
-        }
-        Statement::Reinit { variable, .. } => {
-            outputs.insert(component_ref_to_base_var_name(variable));
-        }
-        Statement::Empty | Statement::Return | Statement::Break | Statement::Assert { .. } => {}
-    }
 }
 
 /// Strip surrounding quotes from a string if present.

--- a/crates/rumoca-ir-flat/src/visitor.rs
+++ b/crates/rumoca-ir-flat/src/visitor.rs
@@ -25,7 +25,8 @@
 //! ```
 
 use crate::{
-    BuiltinFunction, ComprehensionIndex, Expression, Literal, OpBinary, Subscript, VarName,
+    BuiltinFunction, ComponentReference, ComprehensionIndex, Expression, ForIndex, Literal,
+    OpBinary, Statement, StatementBlock, Subscript, VarName,
 };
 
 /// Trait for visiting Expression trees without modification.
@@ -265,6 +266,121 @@ pub trait ExpressionVisitor {
     }
 }
 
+/// Visitor for flat algorithm statements.
+pub trait StatementVisitor: ExpressionVisitor {
+    fn visit_statement(&mut self, stmt: &Statement) {
+        self.walk_statement(stmt);
+    }
+
+    fn walk_statement(&mut self, stmt: &Statement) {
+        match stmt {
+            Statement::Empty | Statement::Return | Statement::Break => {}
+            Statement::Assignment { comp, value } => self.visit_assignment(comp, value),
+            Statement::For { indices, equations } => self.visit_for_statement(indices, equations),
+            Statement::While(block) => self.visit_statement_block(block),
+            Statement::If {
+                cond_blocks,
+                else_block,
+            } => self.visit_if_statement(cond_blocks, else_block.as_deref()),
+            Statement::When(blocks) => self.visit_when_statement(blocks),
+            Statement::FunctionCall {
+                comp,
+                args,
+                outputs,
+            } => self.visit_statement_function_call(comp, args, outputs),
+            Statement::Reinit { variable, value } => self.visit_reinit(variable, value),
+            Statement::Assert {
+                condition,
+                message,
+                level,
+            } => self.visit_assert(condition, message, level.as_ref()),
+        }
+    }
+
+    fn visit_assignment(&mut self, comp: &ComponentReference, value: &Expression) {
+        self.visit_component_reference(comp);
+        self.visit_expression(value);
+    }
+
+    fn visit_for_statement(&mut self, indices: &[ForIndex], statements: &[Statement]) {
+        for index in indices {
+            self.visit_expression(&index.range);
+        }
+        for stmt in statements {
+            self.visit_statement(stmt);
+        }
+    }
+
+    fn visit_if_statement(
+        &mut self,
+        cond_blocks: &[StatementBlock],
+        else_block: Option<&[Statement]>,
+    ) {
+        for block in cond_blocks {
+            self.visit_statement_block(block);
+        }
+        if let Some(else_statements) = else_block {
+            for stmt in else_statements {
+                self.visit_statement(stmt);
+            }
+        }
+    }
+
+    fn visit_when_statement(&mut self, blocks: &[StatementBlock]) {
+        for block in blocks {
+            self.visit_statement_block(block);
+        }
+    }
+
+    fn visit_statement_function_call(
+        &mut self,
+        comp: &ComponentReference,
+        args: &[Expression],
+        outputs: &[Expression],
+    ) {
+        self.visit_component_reference(comp);
+        for arg in args {
+            self.visit_expression(arg);
+        }
+        for output in outputs {
+            self.visit_expression(output);
+        }
+    }
+
+    fn visit_reinit(&mut self, variable: &ComponentReference, value: &Expression) {
+        self.visit_component_reference(variable);
+        self.visit_expression(value);
+    }
+
+    fn visit_assert(
+        &mut self,
+        condition: &Expression,
+        message: &Expression,
+        level: Option<&Expression>,
+    ) {
+        self.visit_expression(condition);
+        self.visit_expression(message);
+        if let Some(level_expr) = level {
+            self.visit_expression(level_expr);
+        }
+    }
+
+    fn visit_component_reference(&mut self, comp: &ComponentReference) {
+        for part in &comp.parts {
+            for subscript in &part.subs {
+                self.visit_subscript(subscript);
+            }
+        }
+    }
+
+    fn visit_statement_block(&mut self, block: &StatementBlock) {
+        self.visit_expression(&block.cond);
+        for stmt in &block.stmts {
+            self.visit_statement(stmt);
+        }
+    }
+}
+
 // =============================================================================
 // Common visitor implementations
 // =============================================================================
@@ -310,6 +426,70 @@ impl ExpressionVisitor for FunctionCallCollector {
     fn visit_function_call(&mut self, name: &VarName, args: &[Expression]) {
         self.names.insert(name.to_string());
         self.walk_function_call(name, args);
+    }
+}
+
+/// Collector for algorithm output variables from statement trees.
+pub struct AlgorithmOutputCollector {
+    outputs: indexmap::IndexSet<VarName>,
+}
+
+impl AlgorithmOutputCollector {
+    /// Create a new algorithm output collector.
+    pub fn new() -> Self {
+        Self {
+            outputs: indexmap::IndexSet::new(),
+        }
+    }
+
+    /// Consume the collector and return collected outputs in first-seen order.
+    pub fn into_outputs(self) -> Vec<VarName> {
+        self.outputs.into_iter().collect()
+    }
+
+    /// Get a reference to collected outputs.
+    pub fn outputs(&self) -> &indexmap::IndexSet<VarName> {
+        &self.outputs
+    }
+}
+
+impl Default for AlgorithmOutputCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExpressionVisitor for AlgorithmOutputCollector {}
+
+impl StatementVisitor for AlgorithmOutputCollector {
+    fn visit_assignment(&mut self, comp: &ComponentReference, value: &Expression) {
+        self.outputs
+            .insert(crate::component_ref_to_base_var_name(comp));
+        self.visit_expression(value);
+    }
+
+    fn visit_statement_function_call(
+        &mut self,
+        comp: &ComponentReference,
+        args: &[Expression],
+        outputs: &[Expression],
+    ) {
+        self.visit_component_reference(comp);
+        for arg in args {
+            self.visit_expression(arg);
+        }
+        for output in outputs {
+            if let Expression::VarRef { name, .. } = output {
+                self.outputs.insert(name.clone());
+            }
+            self.visit_expression(output);
+        }
+    }
+
+    fn visit_reinit(&mut self, variable: &ComponentReference, value: &Expression) {
+        self.outputs
+            .insert(crate::component_ref_to_base_var_name(variable));
+        self.visit_expression(value);
     }
 }
 
@@ -631,5 +811,48 @@ mod tests {
         assert!(vars.contains(&VarName::new("x")));
         assert!(vars.contains(&VarName::new("y")));
         assert!(vars.contains(&VarName::new("z")));
+    }
+
+    #[test]
+    fn test_algorithm_output_collector() {
+        let stmts = vec![Statement::For {
+            indices: vec![ForIndex {
+                ident: "i".to_string(),
+                range: Expression::Literal(Literal::Integer(1)),
+            }],
+            equations: vec![
+                Statement::Assignment {
+                    comp: ComponentReference {
+                        local: false,
+                        parts: vec![crate::ComponentRefPart {
+                            ident: "x".to_string(),
+                            subs: vec![Subscript::Index(1)],
+                        }],
+                        def_id: None,
+                    },
+                    value: make_var("u"),
+                },
+                Statement::Reinit {
+                    variable: ComponentReference {
+                        local: false,
+                        parts: vec![crate::ComponentRefPart {
+                            ident: "y".to_string(),
+                            subs: vec![],
+                        }],
+                        def_id: None,
+                    },
+                    value: make_var("v"),
+                },
+            ],
+        }];
+
+        let mut collector = AlgorithmOutputCollector::new();
+        for stmt in &stmts {
+            collector.visit_statement(stmt);
+        }
+        let outputs = collector.into_outputs();
+
+        assert!(outputs.contains(&VarName::new("x")));
+        assert!(outputs.contains(&VarName::new("y")));
     }
 }

--- a/crates/rumoca-phase-dae/src/appendix_b_validation.rs
+++ b/crates/rumoca-phase-dae/src/appendix_b_validation.rs
@@ -378,79 +378,47 @@ fn resolve_assignment_target(
         .find(|candidate| targets.contains(candidate))
 }
 
-fn collect_current_var_refs(expr: &dae::Expression, out: &mut HashSet<dae::VarName>) {
-    match expr {
-        dae::Expression::VarRef { name, .. } => {
-            out.insert(name.clone());
+struct CurrentVarRefCollector<'a> {
+    out: &'a mut HashSet<dae::VarName>,
+}
+
+impl dae::ExpressionVisitor for CurrentVarRefCollector<'_> {
+    fn visit_var_ref(&mut self, name: &dae::VarName, subscripts: &[dae::Subscript]) {
+        self.out.insert(name.clone());
+        for subscript in subscripts {
+            self.visit_subscript(subscript);
         }
-        dae::Expression::BuiltinCall { function, args } => {
-            if matches!(function, dae::BuiltinFunction::Pre) {
-                return;
-            }
-            for arg in args {
-                collect_current_var_refs(arg, out);
-            }
-        }
-        dae::Expression::FunctionCall { name, args, .. } => {
-            let short_name = name.as_str().rsplit('.').next().unwrap_or(name.as_str());
-            if short_name == "previous" {
-                return;
-            }
-            for arg in args {
-                collect_current_var_refs(arg, out);
-            }
-        }
-        dae::Expression::Binary { lhs, rhs, .. } => {
-            collect_current_var_refs(lhs, out);
-            collect_current_var_refs(rhs, out);
-        }
-        dae::Expression::Unary { rhs, .. } => collect_current_var_refs(rhs, out),
-        dae::Expression::If {
-            branches,
-            else_branch,
-        } => {
-            for (cond, value) in branches {
-                collect_current_var_refs(cond, out);
-                collect_current_var_refs(value, out);
-            }
-            collect_current_var_refs(else_branch, out);
-        }
-        dae::Expression::Array { elements, .. } | dae::Expression::Tuple { elements } => {
-            for element in elements {
-                collect_current_var_refs(element, out);
-            }
-        }
-        dae::Expression::Range { start, step, end } => {
-            collect_current_var_refs(start, out);
-            if let Some(step_expr) = step {
-                collect_current_var_refs(step_expr, out);
-            }
-            collect_current_var_refs(end, out);
-        }
-        dae::Expression::ArrayComprehension {
-            expr,
-            indices,
-            filter,
-        } => {
-            collect_current_var_refs(expr, out);
-            for index in indices {
-                collect_current_var_refs(&index.range, out);
-            }
-            if let Some(filter_expr) = filter {
-                collect_current_var_refs(filter_expr, out);
-            }
-        }
-        dae::Expression::Index { base, subscripts } => {
-            collect_current_var_refs(base, out);
-            for subscript in subscripts {
-                if let dae::Subscript::Expr(expr) = subscript {
-                    collect_current_var_refs(expr, out);
-                }
-            }
-        }
-        dae::Expression::FieldAccess { base, .. } => collect_current_var_refs(base, out),
-        dae::Expression::Literal(_) | dae::Expression::Empty => {}
     }
+
+    fn visit_builtin_call(&mut self, function: &dae::BuiltinFunction, args: &[dae::Expression]) {
+        if matches!(function, dae::BuiltinFunction::Pre) {
+            return;
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+
+    fn visit_function_call(
+        &mut self,
+        name: &dae::VarName,
+        args: &[dae::Expression],
+        is_constructor: bool,
+    ) {
+        let short_name = name.as_str().rsplit('.').next().unwrap_or(name.as_str());
+        if short_name == "previous" {
+            return;
+        }
+        let _ = is_constructor;
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+}
+
+fn collect_current_var_refs(expr: &dae::Expression, out: &mut HashSet<dae::VarName>) {
+    let mut collector = CurrentVarRefCollector { out };
+    dae::ExpressionVisitor::visit_expression(&mut collector, expr);
 }
 
 fn find_cycle(deps: &HashMap<dae::VarName, Vec<dae::VarName>>) -> Option<Vec<dae::VarName>> {

--- a/crates/rumoca-phase-dae/src/runtime_precompute/clock.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/clock.rs
@@ -4,6 +4,7 @@ use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 
 use rumoca_ir_dae as dae;
+use rumoca_ir_dae::{ExpressionVisitor, ImplicitSampleChecker, VarRefWithSubscriptsCollector};
 
 type SourceMap<'a> = HashMap<String, Vec<&'a dae::Expression>>;
 type ClockRuntimeMetadata = (
@@ -202,8 +203,9 @@ fn collect_unique_clock_var_refs(
     expr: &dae::Expression,
     constants: &HashMap<String, f64>,
 ) -> Vec<(dae::VarName, Vec<dae::Subscript>, String)> {
-    let mut refs = Vec::new();
-    collect_clock_var_refs(expr, &mut refs);
+    let mut collector = VarRefWithSubscriptsCollector::new();
+    collector.visit_expression(expr);
+    let refs = collector.into_refs();
     let mut seen = HashSet::new();
     refs.into_iter()
         .filter_map(|(name, subscripts)| {
@@ -216,77 +218,6 @@ fn collect_unique_clock_var_refs(
             }
         })
         .collect()
-}
-
-fn collect_clock_var_refs(
-    expr: &dae::Expression,
-    out: &mut Vec<(dae::VarName, Vec<dae::Subscript>)>,
-) {
-    match expr {
-        dae::Expression::VarRef { name, subscripts } => {
-            out.push((name.clone(), subscripts.clone()));
-            for subscript in subscripts {
-                if let dae::Subscript::Expr(index_expr) = subscript {
-                    collect_clock_var_refs(index_expr, out);
-                }
-            }
-        }
-        dae::Expression::Binary { lhs, rhs, .. } => {
-            collect_clock_var_refs(lhs, out);
-            collect_clock_var_refs(rhs, out);
-        }
-        dae::Expression::Unary { rhs, .. } => collect_clock_var_refs(rhs, out),
-        dae::Expression::BuiltinCall { args, .. } | dae::Expression::FunctionCall { args, .. } => {
-            for arg in args {
-                collect_clock_var_refs(arg, out);
-            }
-        }
-        dae::Expression::If {
-            branches,
-            else_branch,
-        } => {
-            for (cond, value) in branches {
-                collect_clock_var_refs(cond, out);
-                collect_clock_var_refs(value, out);
-            }
-            collect_clock_var_refs(else_branch, out);
-        }
-        dae::Expression::Array { elements, .. } | dae::Expression::Tuple { elements } => {
-            for element in elements {
-                collect_clock_var_refs(element, out);
-            }
-        }
-        dae::Expression::Range { start, step, end } => {
-            collect_clock_var_refs(start, out);
-            if let Some(step_expr) = step {
-                collect_clock_var_refs(step_expr, out);
-            }
-            collect_clock_var_refs(end, out);
-        }
-        dae::Expression::ArrayComprehension {
-            expr,
-            indices,
-            filter,
-        } => {
-            collect_clock_var_refs(expr, out);
-            for idx in indices {
-                collect_clock_var_refs(&idx.range, out);
-            }
-            if let Some(filter_expr) = filter {
-                collect_clock_var_refs(filter_expr, out);
-            }
-        }
-        dae::Expression::Index { base, subscripts } => {
-            collect_clock_var_refs(base, out);
-            for subscript in subscripts {
-                if let dae::Subscript::Expr(expr) = subscript {
-                    collect_clock_var_refs(expr, out);
-                }
-            }
-        }
-        dae::Expression::FieldAccess { base, .. } => collect_clock_var_refs(base, out),
-        dae::Expression::Literal(_) | dae::Expression::Empty => {}
-    }
 }
 
 pub(super) fn dedupe_expressions_in_place(expressions: &mut Vec<dae::Expression>) {
@@ -852,76 +783,7 @@ fn variable_has_implicit_clock_source(
 }
 
 fn expression_uses_implicit_clock_sample(expr: &dae::Expression) -> bool {
-    match expr {
-        dae::Expression::BuiltinCall { function, args } => {
-            if matches!(function, dae::BuiltinFunction::Sample) && args.len() == 1 {
-                return true;
-            }
-            args.iter().any(expression_uses_implicit_clock_sample)
-        }
-        dae::Expression::FunctionCall { name, args, .. } => {
-            let short = name.as_str().rsplit('.').next().unwrap_or(name.as_str());
-            if short == "sample" && args.len() == 1 {
-                return true;
-            }
-            args.iter().any(expression_uses_implicit_clock_sample)
-        }
-        dae::Expression::Binary { lhs, rhs, .. } => {
-            expression_uses_implicit_clock_sample(lhs) || expression_uses_implicit_clock_sample(rhs)
-        }
-        dae::Expression::Unary { rhs, .. } => expression_uses_implicit_clock_sample(rhs),
-        dae::Expression::If {
-            branches,
-            else_branch,
-        } => {
-            branches.iter().any(|(cond, value)| {
-                expression_uses_implicit_clock_sample(cond)
-                    || expression_uses_implicit_clock_sample(value)
-            }) || expression_uses_implicit_clock_sample(else_branch)
-        }
-        dae::Expression::Array { elements, .. } | dae::Expression::Tuple { elements } => {
-            elements.iter().any(expression_uses_implicit_clock_sample)
-        }
-        dae::Expression::Range { start, step, end } => {
-            expression_uses_implicit_clock_sample(start)
-                || step
-                    .as_ref()
-                    .is_some_and(|value| expression_uses_implicit_clock_sample(value))
-                || expression_uses_implicit_clock_sample(end)
-        }
-        dae::Expression::ArrayComprehension {
-            expr,
-            indices,
-            filter,
-        } => {
-            expression_uses_implicit_clock_sample(expr)
-                || indices
-                    .iter()
-                    .any(|idx| expression_uses_implicit_clock_sample(&idx.range))
-                || filter
-                    .as_ref()
-                    .is_some_and(|value| expression_uses_implicit_clock_sample(value))
-        }
-        dae::Expression::Index { base, subscripts } => {
-            expression_uses_implicit_clock_sample(base)
-                || subscripts.iter().any(|subscript| match subscript {
-                    dae::Subscript::Colon => false,
-                    dae::Subscript::Index(_) => false,
-                    dae::Subscript::Expr(value) => expression_uses_implicit_clock_sample(value),
-                })
-        }
-        dae::Expression::FieldAccess { base, field: _ } => {
-            expression_uses_implicit_clock_sample(base)
-        }
-        dae::Expression::VarRef { subscripts, .. } => subscripts.iter().any(|subscript| {
-            if let dae::Subscript::Expr(value) = subscript {
-                expression_uses_implicit_clock_sample(value)
-            } else {
-                false
-            }
-        }),
-        dae::Expression::Literal(_) | dae::Expression::Empty => false,
-    }
+    ImplicitSampleChecker::check(expr)
 }
 
 fn infer_clock_timing_next(
@@ -1479,86 +1341,57 @@ fn infer_clock_timing_from_expr_inner(
     }
 }
 
+struct ClockConstructorExprCollector<'a> {
+    constants: &'a HashMap<String, f64>,
+    out: &'a mut Vec<dae::Expression>,
+}
+
+impl ExpressionVisitor for ClockConstructorExprCollector<'_> {
+    fn visit_function_call(
+        &mut self,
+        name: &dae::VarName,
+        args: &[dae::Expression],
+        is_constructor: bool,
+    ) {
+        let short = name.as_str().rsplit('.').next().unwrap_or(name.as_str());
+        if is_clock_constructor_function_name(short) {
+            self.out.push(dae::Expression::FunctionCall {
+                name: name.clone(),
+                args: args.to_vec(),
+                is_constructor,
+            });
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+
+    fn visit_if(
+        &mut self,
+        branches: &[(dae::Expression, dae::Expression)],
+        else_branch: &dae::Expression,
+    ) {
+        for (cond, value) in branches {
+            let cond_value = eval_scalar_const_expr(cond, self.constants);
+            if cond_value == Some(0.0) {
+                continue;
+            }
+            if cond_value.is_some() {
+                self.visit_expression(value);
+                return;
+            }
+            self.visit_expression(cond);
+            self.visit_expression(value);
+        }
+        self.visit_expression(else_branch);
+    }
+}
+
 fn collect_clock_constructor_exprs(
     expr: &dae::Expression,
     constants: &HashMap<String, f64>,
     out: &mut Vec<dae::Expression>,
 ) {
-    match expr {
-        dae::Expression::FunctionCall { name, args, .. } => {
-            let short = name.as_str().rsplit('.').next().unwrap_or(name.as_str());
-            if is_clock_constructor_function_name(short) {
-                out.push(expr.clone());
-            }
-            for arg in args {
-                collect_clock_constructor_exprs(arg, constants, out);
-            }
-        }
-        dae::Expression::BuiltinCall { args, .. } => {
-            for arg in args {
-                collect_clock_constructor_exprs(arg, constants, out);
-            }
-        }
-        dae::Expression::Binary { lhs, rhs, .. } => {
-            collect_clock_constructor_exprs(lhs, constants, out);
-            collect_clock_constructor_exprs(rhs, constants, out);
-        }
-        dae::Expression::Unary { rhs, .. } => collect_clock_constructor_exprs(rhs, constants, out),
-        dae::Expression::If {
-            branches,
-            else_branch,
-        } => {
-            for (cond, value) in branches {
-                match eval_scalar_const_expr(cond, constants) {
-                    Some(flag) if flag != 0.0 => {
-                        collect_clock_constructor_exprs(value, constants, out);
-                        return;
-                    }
-                    Some(_) => continue,
-                    None => {
-                        collect_clock_constructor_exprs(cond, constants, out);
-                        collect_clock_constructor_exprs(value, constants, out);
-                    }
-                }
-            }
-            collect_clock_constructor_exprs(else_branch, constants, out);
-        }
-        dae::Expression::Array { elements, .. } | dae::Expression::Tuple { elements } => {
-            for element in elements {
-                collect_clock_constructor_exprs(element, constants, out);
-            }
-        }
-        dae::Expression::Range { start, step, end } => {
-            collect_clock_constructor_exprs(start, constants, out);
-            if let Some(step_expr) = step {
-                collect_clock_constructor_exprs(step_expr, constants, out);
-            }
-            collect_clock_constructor_exprs(end, constants, out);
-        }
-        dae::Expression::ArrayComprehension {
-            expr,
-            indices,
-            filter,
-        } => {
-            collect_clock_constructor_exprs(expr, constants, out);
-            for idx in indices {
-                collect_clock_constructor_exprs(&idx.range, constants, out);
-            }
-            if let Some(filter_expr) = filter {
-                collect_clock_constructor_exprs(filter_expr, constants, out);
-            }
-        }
-        dae::Expression::Index { base, subscripts } => {
-            collect_clock_constructor_exprs(base, constants, out);
-            for subscript in subscripts {
-                if let dae::Subscript::Expr(expr) = subscript {
-                    collect_clock_constructor_exprs(expr, constants, out);
-                }
-            }
-        }
-        dae::Expression::FieldAccess { base, .. } => {
-            collect_clock_constructor_exprs(base, constants, out);
-        }
-        dae::Expression::VarRef { .. } | dae::Expression::Literal(_) | dae::Expression::Empty => {}
-    }
+    let mut collector = ClockConstructorExprCollector { constants, out };
+    collector.visit_expression(expr);
 }

--- a/crates/rumoca-phase-dae/src/scalar_inference/parts.rs
+++ b/crates/rumoca-phase-dae/src/scalar_inference/parts.rs
@@ -115,92 +115,53 @@ pub(crate) fn infer_scalar_count_from_collected_varrefs(
     }
 }
 
+struct VarRefCollectionVisitor<'a> {
+    vars: &'a mut Vec<CollectedVarRef>,
+    skip_function_args: bool,
+}
+
+impl<'a> VarRefCollectionVisitor<'a> {
+    fn new(vars: &'a mut Vec<CollectedVarRef>, skip_function_args: bool) -> Self {
+        Self {
+            vars,
+            skip_function_args,
+        }
+    }
+}
+
+impl flat::ExpressionVisitor for VarRefCollectionVisitor<'_> {
+    fn visit_var_ref(&mut self, name: &VarName, subscripts: &[Subscript]) {
+        self.vars.push(CollectedVarRef {
+            name: name.clone(),
+            subscripts: subscripts.to_vec(),
+        });
+        self.walk_var_ref(name, subscripts);
+    }
+
+    fn visit_builtin_call(&mut self, function: &BuiltinFunction, args: &[Expression]) {
+        if is_reduction_builtin(function) {
+            // Reduction output is scalar regardless of input size.
+            return;
+        }
+        self.walk_builtin_call(function, args);
+    }
+
+    fn visit_function_call(&mut self, name: &VarName, args: &[Expression]) {
+        if self.skip_function_args {
+            // Function arguments are not shaped like function output.
+            return;
+        }
+        self.walk_function_call(name, args);
+    }
+}
+
 /// Collect VarRefs from an expression, skipping arguments to reduction builtins.
 ///
 /// Reduction builtins like sum(), product() reduce arrays to scalars (MLS §10.3.4),
 /// so their array arguments should not inflate the equation's scalar count.
 pub(crate) fn collect_var_refs_skip_reductions(expr: &Expression, vars: &mut Vec<CollectedVarRef>) {
-    match expr {
-        Expression::VarRef { name, subscripts } => {
-            vars.push(CollectedVarRef {
-                name: name.clone(),
-                subscripts: subscripts.clone(),
-            });
-            for sub in subscripts {
-                if let Subscript::Expr(e) = sub {
-                    collect_var_refs_skip_reductions(e, vars);
-                }
-            }
-        }
-        Expression::BuiltinCall { function, args } => {
-            if is_reduction_builtin(function) {
-                // Skip args — reduction output is scalar regardless of input size
-                return;
-            }
-            for arg in args {
-                collect_var_refs_skip_reductions(arg, vars);
-            }
-        }
-        Expression::Binary { lhs, rhs, .. } => {
-            collect_var_refs_skip_reductions(lhs, vars);
-            collect_var_refs_skip_reductions(rhs, vars);
-        }
-        Expression::Unary { rhs, .. } => {
-            collect_var_refs_skip_reductions(rhs, vars);
-        }
-        Expression::FunctionCall { args, .. } => {
-            for arg in args {
-                collect_var_refs_skip_reductions(arg, vars);
-            }
-        }
-        Expression::If {
-            branches,
-            else_branch,
-        } => {
-            for (cond, then_expr) in branches {
-                collect_var_refs_skip_reductions(cond, vars);
-                collect_var_refs_skip_reductions(then_expr, vars);
-            }
-            collect_var_refs_skip_reductions(else_branch, vars);
-        }
-        Expression::Array { elements, .. } | Expression::Tuple { elements } => {
-            for e in elements {
-                collect_var_refs_skip_reductions(e, vars);
-            }
-        }
-        Expression::Range { start, step, end } => {
-            collect_var_refs_skip_reductions(start, vars);
-            if let Some(s) = step {
-                collect_var_refs_skip_reductions(s, vars);
-            }
-            collect_var_refs_skip_reductions(end, vars);
-        }
-        Expression::Index { base, subscripts } => {
-            collect_var_refs_skip_reductions(base, vars);
-            for sub in subscripts {
-                if let Subscript::Expr(e) = sub {
-                    collect_var_refs_skip_reductions(e, vars);
-                }
-            }
-        }
-        Expression::FieldAccess { base, .. } => {
-            collect_var_refs_skip_reductions(base, vars);
-        }
-        Expression::ArrayComprehension {
-            expr,
-            indices,
-            filter,
-        } => {
-            for index in indices {
-                collect_var_refs_skip_reductions(&index.range, vars);
-            }
-            collect_var_refs_skip_reductions(expr, vars);
-            if let Some(filter_expr) = filter.as_ref() {
-                collect_var_refs_skip_reductions(filter_expr, vars);
-            }
-        }
-        Expression::Literal(_) | Expression::Empty => {}
-    }
+    let mut collector = VarRefCollectionVisitor::new(vars, false);
+    flat::ExpressionVisitor::visit_expression(&mut collector, expr);
 }
 
 /// Collect VarRefs from an expression while skipping function-call arguments.
@@ -212,84 +173,8 @@ pub(crate) fn collect_var_refs_skip_reductions_and_function_args(
     expr: &Expression,
     vars: &mut Vec<CollectedVarRef>,
 ) {
-    match expr {
-        Expression::VarRef { name, subscripts } => {
-            vars.push(CollectedVarRef {
-                name: name.clone(),
-                subscripts: subscripts.clone(),
-            });
-            for sub in subscripts {
-                if let Subscript::Expr(e) = sub {
-                    collect_var_refs_skip_reductions_and_function_args(e, vars);
-                }
-            }
-        }
-        Expression::BuiltinCall { function, args } => {
-            if is_reduction_builtin(function) {
-                return;
-            }
-            for arg in args {
-                collect_var_refs_skip_reductions_and_function_args(arg, vars);
-            }
-        }
-        Expression::FunctionCall { .. } => {
-            // Intentionally skip function arguments.
-        }
-        Expression::Binary { lhs, rhs, .. } => {
-            collect_var_refs_skip_reductions_and_function_args(lhs, vars);
-            collect_var_refs_skip_reductions_and_function_args(rhs, vars);
-        }
-        Expression::Unary { rhs, .. } => {
-            collect_var_refs_skip_reductions_and_function_args(rhs, vars);
-        }
-        Expression::If {
-            branches,
-            else_branch,
-        } => {
-            for (cond, then_expr) in branches {
-                collect_var_refs_skip_reductions_and_function_args(cond, vars);
-                collect_var_refs_skip_reductions_and_function_args(then_expr, vars);
-            }
-            collect_var_refs_skip_reductions_and_function_args(else_branch, vars);
-        }
-        Expression::Array { elements, .. } | Expression::Tuple { elements } => {
-            for e in elements {
-                collect_var_refs_skip_reductions_and_function_args(e, vars);
-            }
-        }
-        Expression::Range { start, step, end } => {
-            collect_var_refs_skip_reductions_and_function_args(start, vars);
-            if let Some(s) = step {
-                collect_var_refs_skip_reductions_and_function_args(s, vars);
-            }
-            collect_var_refs_skip_reductions_and_function_args(end, vars);
-        }
-        Expression::Index { base, subscripts } => {
-            collect_var_refs_skip_reductions_and_function_args(base, vars);
-            for sub in subscripts {
-                if let Subscript::Expr(e) = sub {
-                    collect_var_refs_skip_reductions_and_function_args(e, vars);
-                }
-            }
-        }
-        Expression::FieldAccess { base, .. } => {
-            collect_var_refs_skip_reductions_and_function_args(base, vars);
-        }
-        Expression::ArrayComprehension {
-            expr,
-            indices,
-            filter,
-        } => {
-            for index in indices {
-                collect_var_refs_skip_reductions_and_function_args(&index.range, vars);
-            }
-            collect_var_refs_skip_reductions_and_function_args(expr, vars);
-            if let Some(filter_expr) = filter.as_ref() {
-                collect_var_refs_skip_reductions_and_function_args(filter_expr, vars);
-            }
-        }
-        Expression::Literal(_) | Expression::Empty => {}
-    }
+    let mut collector = VarRefCollectionVisitor::new(vars, true);
+    flat::ExpressionVisitor::visit_expression(&mut collector, expr);
 }
 
 /// Check if a builtin function is an array reduction (MLS §10.3.4).

--- a/crates/rumoca-phase-instantiate/src/inheritance.rs
+++ b/crates/rumoca-phase-instantiate/src/inheritance.rs
@@ -29,6 +29,10 @@ use rumoca_ir_ast as ast;
 use std::sync::Arc;
 
 use crate::errors::{InstantiateError, InstantiateResult};
+use crate::traversal_adapter::{
+    nested_target_modifications, redeclare_target_value, walk_extend_modifications,
+    walk_nested_classes,
+};
 
 const CONSTRAINEDBY_MOD_PREFIX: &str = "__constrainedby__.";
 
@@ -939,17 +943,17 @@ pub fn process_extends_with_cache(
 /// This post-merge pass ensures modifications like `extends Mid(c(k=2))` also
 /// apply when `c` is declared in a grandparent class.
 fn apply_extends_modifications(target: &mut InheritedContent, extend: &ast::Extend) {
-    for modification in &extend.modifications {
+    walk_extend_modifications(extend, |modification| {
         let Some((name, value)) = try_extract_value_modification_any(modification) else {
-            continue;
+            return;
         };
         let Some(comp) = target.components.get_mut(&name) else {
-            continue;
+            return;
         };
         comp.start = value.clone();
         comp.binding = Some(value);
         comp.has_explicit_binding = true;
-    }
+    });
 
     merge_nested_extends_modifications(target, extend);
 }
@@ -1149,31 +1153,41 @@ fn collect_redeclarations(
     extend_span: Span,
 ) -> InstantiateResult<IndexMap<String, String>> {
     let mut redeclare_types = IndexMap::new();
+    let mut validation_error: Option<Box<InstantiateError>> = None;
 
-    for modification in &extend.modifications {
-        if !modification.redeclare {
-            continue;
+    walk_extend_modifications(extend, |modification| {
+        let Some((target_name, _value_expr)) = redeclare_target_value(modification) else {
+            return;
+        };
+        if validation_error.is_some() {
+            return;
         }
-        let Some(target_name) = extract_modification_target(&modification.expr) else {
-            continue;
-        };
+        let target_name_owned = target_name.to_string();
         let new_type = extract_redeclare_type_qualified(&modification.expr, tree);
-        let Some(component) = class.components.get(&target_name) else {
-            continue;
+        let Some(component) = class.components.get(&target_name_owned) else {
+            return;
         };
 
-        validate_redeclaration(
+        if let Err(err) = validate_redeclaration(
             tree,
             component,
-            &target_name,
+            &target_name_owned,
             new_type.as_deref(),
             extend_span,
-        )?;
+        ) {
+            validation_error = Some(err);
+            return;
+        }
 
         if let Some(new_type_name) = new_type {
-            redeclare_types.insert(target_name, new_type_name);
+            redeclare_types.insert(target_name_owned, new_type_name);
         }
+    });
+
+    if let Some(err) = validation_error {
+        return Err(err);
     }
+
     Ok(redeclare_types)
 }
 
@@ -1215,11 +1229,12 @@ fn merge_class_content(
 
     // MLS §7.2: Collect value modifications (non-redeclare) from extends clause
     // These override default bindings in inherited components, e.g., extends Foo(n=2)
-    let value_modifications: IndexMap<String, ast::Expression> = extend
-        .modifications
-        .iter()
-        .filter_map(|m| try_extract_value_modification(m, class))
-        .collect();
+    let mut value_modifications: IndexMap<String, ast::Expression> = IndexMap::new();
+    walk_extend_modifications(extend, |modification| {
+        if let Some((name, value)) = try_extract_value_modification(modification, class) {
+            value_modifications.insert(name, value);
+        }
+    });
 
     // MLS §7.3: Validate redeclarations and collect type changes
     let redeclare_types = collect_redeclarations(tree, class, extend, extend_span)?;
@@ -1311,13 +1326,13 @@ fn merge_class_content(
         .extend(class.initial_algorithms.clone());
 
     // Merge nested classes
-    for (name, nested) in &class.classes {
+    walk_nested_classes(class, |name, nested| {
         if !target.classes.contains_key(name) {
             let mut inherited_class = nested.clone();
             apply_protected_class_visibility(&mut inherited_class, extend.is_protected);
-            target.classes.insert(name.clone(), inherited_class);
+            target.classes.insert(name.to_string(), inherited_class);
         }
-    }
+    });
 
     Ok(())
 }
@@ -1363,7 +1378,7 @@ fn activate_constrainedby_defaults_for_redeclare(comp: &mut ast::Component) {
 /// that when `friction` is later instantiated, the modification `useHeatPort=true`
 /// is visible via `shift_modifications_down` and `populate_modification_environment`.
 fn merge_nested_extends_modifications(target: &mut InheritedContent, extend: &ast::Extend) {
-    for modification in &extend.modifications {
+    walk_extend_modifications(extend, |modification| {
         // Extract target name and nested modifications from the expression.
         // Two formats exist:
         //   1. ClassModification { target: comp_name, modifications: [...] }
@@ -1371,38 +1386,16 @@ fn merge_nested_extends_modifications(target: &mut InheritedContent, extend: &as
         //   2. Modification { target: comp_name, value: ClassModification { target: TypeName, modifications: [...] } }
         //      For: extends Foo(redeclare final NewType comp(nested=val))
         //      Type changes are handled by collect_redeclarations(); here we merge nested mods.
-        let (target_name, modifications) = match &modification.expr {
-            ast::Expression::ClassModification {
-                target: mod_target,
-                modifications,
-            } => {
-                let Some(name) = mod_target.parts.first().map(|p| p.ident.text.to_string()) else {
-                    continue;
-                };
-                (name, modifications.as_slice())
-            }
-            ast::Expression::Modification {
-                target: mod_target,
-                value,
-            } => {
-                let Some(name) = mod_target.parts.first().map(|p| p.ident.text.to_string()) else {
-                    continue;
-                };
-                if let ast::Expression::ClassModification { modifications, .. } = value.as_ref() {
-                    (name, modifications.as_slice())
-                } else {
-                    continue;
-                }
-            }
-            _ => continue,
+        let Some((target_name, modifications)) = nested_target_modifications(modification) else {
+            return;
         };
-        let Some(comp) = target.components.get_mut(&target_name) else {
-            continue;
+        let Some(comp) = target.components.get_mut(target_name) else {
+            return;
         };
         for nested_mod in modifications {
             insert_nested_modification(comp, nested_mod);
         }
-    }
+    });
 }
 
 /// Insert a single nested modification into a component's modifications map.

--- a/crates/rumoca-phase-instantiate/src/lib.rs
+++ b/crates/rumoca-phase-instantiate/src/lib.rs
@@ -44,6 +44,7 @@ mod inheritance;
 mod mod_env;
 mod nested_scope;
 mod templates;
+mod traversal_adapter;
 mod type_lookup;
 mod type_overrides;
 

--- a/crates/rumoca-phase-instantiate/src/traversal_adapter.rs
+++ b/crates/rumoca-phase-instantiate/src/traversal_adapter.rs
@@ -1,0 +1,81 @@
+use rumoca_ir_ast as ast;
+
+/// Walk direct nested classes declared in `class`.
+pub(super) fn walk_nested_classes<'a>(
+    class: &'a ast::ClassDef,
+    mut callback: impl FnMut(&'a str, &'a ast::ClassDef),
+) {
+    for (name, nested) in &class.classes {
+        callback(name, nested);
+    }
+}
+
+/// Walk direct `extends` clauses declared in `class`.
+pub(super) fn walk_extends<'a>(
+    class: &'a ast::ClassDef,
+    mut callback: impl FnMut(&'a ast::Extend),
+) {
+    for extend in &class.extends {
+        callback(extend);
+    }
+}
+
+/// Walk all modifications in an `extends` clause.
+pub(super) fn walk_extend_modifications<'a>(
+    extend: &'a ast::Extend,
+    mut callback: impl FnMut(&'a ast::ExtendModification),
+) {
+    for modification in &extend.modifications {
+        callback(modification);
+    }
+}
+
+/// Walk all `extends` modifications in a class.
+pub(super) fn walk_class_extends_modifications<'a>(
+    class: &'a ast::ClassDef,
+    mut callback: impl FnMut(&'a ast::Extend, &'a ast::ExtendModification),
+) {
+    walk_extends(class, |extend| {
+        walk_extend_modifications(extend, |modification| callback(extend, modification));
+    });
+}
+
+/// Parse a redeclare-value modification:
+/// `redeclare ... target = value`.
+pub(super) fn redeclare_target_value(
+    modification: &ast::ExtendModification,
+) -> Option<(&str, &ast::Expression)> {
+    if !modification.redeclare {
+        return None;
+    }
+    let ast::Expression::Modification { target, value } = &modification.expr else {
+        return None;
+    };
+    let first_target = target.parts.first()?;
+    Some((first_target.ident.text.as_ref(), value.as_ref()))
+}
+
+/// Parse nested class-style modifications from an extends-modification:
+/// - `comp(a=1)` represented as `ClassModification`
+/// - `comp = Type(...mods...)` represented as `Modification` with class-mod value
+pub(super) fn nested_target_modifications(
+    modification: &ast::ExtendModification,
+) -> Option<(&str, &[ast::Expression])> {
+    match &modification.expr {
+        ast::Expression::ClassModification {
+            target,
+            modifications,
+        } => {
+            let name = target.parts.first()?.ident.text.as_ref();
+            Some((name, modifications.as_slice()))
+        }
+        ast::Expression::Modification { target, value } => {
+            let name = target.parts.first()?.ident.text.as_ref();
+            let ast::Expression::ClassModification { modifications, .. } = value.as_ref() else {
+                return None;
+            };
+            Some((name, modifications.as_slice()))
+        }
+        _ => None,
+    }
+}

--- a/crates/rumoca-phase-instantiate/src/type_overrides.rs
+++ b/crates/rumoca-phase-instantiate/src/type_overrides.rs
@@ -1,4 +1,7 @@
 use super::find_class_in_tree;
+use super::traversal_adapter::{
+    redeclare_target_value, walk_class_extends_modifications, walk_nested_classes,
+};
 use super::type_lookup::{find_member_type_in_class, find_member_type_path_in_class};
 use indexmap::IndexMap;
 use rumoca_core::DefId;
@@ -23,11 +26,11 @@ pub(super) fn build_type_override_map(
     let mut overrides = IndexMap::new();
 
     // 1. Collect from the class's own nested classes
-    for (name, nested) in &class.classes {
+    walk_nested_classes(class, |name, nested| {
         if let Some(def_id) = nested.def_id {
-            overrides.insert(name.clone(), def_id);
+            overrides.insert(name.to_string(), def_id);
         }
-    }
+    });
 
     // 2. Collect from the enclosing class's nested classes.
     // This handles the pattern where a record type (like ThermodynamicState)
@@ -109,24 +112,15 @@ fn insert_extends_redeclare_overrides(
     mod_env: Option<&ast::ModificationEnvironment>,
     overrides: &mut IndexMap<String, DefId>,
 ) {
-    for ext in &class.extends {
-        for ext_mod in &ext.modifications {
-            if !ext_mod.redeclare {
-                continue;
-            }
-            let ast::Expression::Modification { target, value } = &ext_mod.expr else {
-                continue;
-            };
-            let Some(first_target) = target.parts.first() else {
-                continue;
-            };
-            let target_name = first_target.ident.text.to_string();
-            let Some(def_id) = resolve_redeclare_value_def_id(tree, value, mod_env) else {
-                continue;
-            };
-            overrides.entry(target_name).or_insert(def_id);
-        }
-    }
+    walk_class_extends_modifications(class, |_, ext_mod| {
+        let Some((target_name, value_expr)) = redeclare_target_value(ext_mod) else {
+            return;
+        };
+        let Some(def_id) = resolve_redeclare_value_def_id(tree, value_expr, mod_env) else {
+            return;
+        };
+        overrides.entry(target_name.to_string()).or_insert(def_id);
+    });
 }
 
 fn is_visited_class(
@@ -141,12 +135,12 @@ fn is_visited_class(
 }
 
 fn insert_nested_class_overrides(class: &ast::ClassDef, overrides: &mut IndexMap<String, DefId>) {
-    for (name, nested) in &class.classes {
+    walk_nested_classes(class, |name, nested| {
         if let Some(def_id) = nested.def_id {
             // Keep nearest declaration if names repeat in deeper bases.
-            overrides.entry(name.clone()).or_insert(def_id);
+            overrides.entry(name.to_string()).or_insert(def_id);
         }
-    }
+    });
 }
 
 fn extends_base_classes<'a>(
@@ -175,26 +169,14 @@ fn collect_extends_redeclare_overrides(
     mod_env: Option<&ast::ModificationEnvironment>,
     overrides: &mut IndexMap<String, DefId>,
 ) {
-    for ext in &class.extends {
-        for ext_mod in &ext.modifications {
-            if !ext_mod.redeclare {
-                continue;
-            }
-
-            let ast::Expression::Modification { target, value } = &ext_mod.expr else {
-                continue;
-            };
-            let Some(first_target) = target.parts.first() else {
-                continue;
-            };
-            let target_name = first_target.ident.text.to_string();
-
-            let replacement_def_id = resolve_redeclare_value_def_id(tree, value, mod_env);
-            if let Some(def_id) = replacement_def_id {
-                overrides.insert(target_name, def_id);
-            }
+    walk_class_extends_modifications(class, |_, ext_mod| {
+        let Some((target_name, value_expr)) = redeclare_target_value(ext_mod) else {
+            return;
+        };
+        if let Some(def_id) = resolve_redeclare_value_def_id(tree, value_expr, mod_env) {
+            overrides.insert(target_name.to_string(), def_id);
         }
-    }
+    });
 }
 
 pub(super) fn resolve_redeclare_value_def_id(
@@ -437,7 +419,7 @@ pub(super) fn extract_component_class_overrides(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_cref_def_id;
+    use super::{apply_type_override, resolve_cref_def_id};
     use rumoca_core::DefId;
     use rumoca_ir_ast as ast;
     use std::sync::Arc;
@@ -448,6 +430,13 @@ mod tests {
             location: rumoca_ir_core::Location::default(),
             token_number: 0,
             token_type: 0,
+        }
+    }
+
+    fn make_name(text: &str) -> ast::Name {
+        ast::Name {
+            name: text.split('.').map(make_token).collect(),
+            def_id: None,
         }
     }
 
@@ -523,6 +512,97 @@ mod tests {
             resolve_cref_def_id(&tree, &cref),
             Some(standard_water_id),
             "multi-part class references must resolve to the full path target, not the first segment"
+        );
+    }
+
+    #[test]
+    fn test_apply_type_override_resolves_dotted_type_through_mod_env_alias_chain() {
+        // Covers alias + replaceable package chain behavior:
+        // Medium => MediumAlias, where MediumAlias extends MediumB and
+        // BaseProperties is inherited from MediumB.
+        let medium_b_id = DefId::new(10);
+        let medium_alias_id = DefId::new(11);
+        let base_properties_id = DefId::new(12);
+
+        let base_properties = ast::ClassDef {
+            name: make_token("BaseProperties"),
+            class_type: ast::ClassType::Model,
+            def_id: Some(base_properties_id),
+            ..Default::default()
+        };
+
+        let mut medium_b = ast::ClassDef {
+            name: make_token("MediumB"),
+            class_type: ast::ClassType::Package,
+            def_id: Some(medium_b_id),
+            ..Default::default()
+        };
+        medium_b
+            .classes
+            .insert("BaseProperties".to_string(), base_properties);
+
+        let medium_alias = ast::ClassDef {
+            name: make_token("MediumAlias"),
+            class_type: ast::ClassType::Package,
+            def_id: Some(medium_alias_id),
+            extends: vec![ast::Extend {
+                base_name: make_name("MediumB"),
+                base_def_id: Some(medium_b_id),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut tree = ast::ClassTree::default();
+        tree.definitions
+            .classes
+            .insert("MediumB".to_string(), medium_b);
+        tree.definitions
+            .classes
+            .insert("MediumAlias".to_string(), medium_alias);
+        for (name, def_id) in [
+            ("MediumB", medium_b_id),
+            ("MediumB.BaseProperties", base_properties_id),
+            ("MediumAlias", medium_alias_id),
+        ] {
+            tree.name_map.insert(name.to_string(), def_id);
+            tree.def_map.insert(def_id, name.to_string());
+        }
+
+        let comp = ast::Component {
+            name: "state".to_string(),
+            type_name: make_name("Medium.BaseProperties"),
+            type_def_id: None,
+            ..Default::default()
+        };
+
+        let mut mod_env = ast::ModificationEnvironment::new();
+        mod_env.add(
+            ast::QualifiedName::from_ident("Medium"),
+            ast::ModificationValue::simple(ast::Expression::ComponentReference(
+                ast::ComponentReference {
+                    local: false,
+                    parts: vec![ast::ComponentRefPart {
+                        ident: make_token("MediumAlias"),
+                        subs: None,
+                    }],
+                    def_id: Some(medium_alias_id),
+                },
+            )),
+        );
+
+        let overridden = apply_type_override(
+            &tree,
+            &comp,
+            &indexmap::IndexMap::new(),
+            "Medium.BaseProperties",
+            Some(&mod_env),
+        );
+
+        assert_eq!(
+            overridden.type_def_id,
+            Some(base_properties_id),
+            "dotted type should resolve through mod-env package alias chain"
         );
     }
 }

--- a/crates/rumoca-phase-resolve/src/contents.rs
+++ b/crates/rumoca-phase-resolve/src/contents.rs
@@ -4,18 +4,40 @@
 //! component start/modification expressions.
 
 use crate::Resolver;
+use crate::traversal_adapter::{
+    ResolveTraversalCallbacks, walk_equations, walk_expression, walk_expressions, walk_statements,
+    walk_subscripts,
+};
 use rumoca_core::{DefId, ScopeId};
 use rumoca_ir_ast as ast;
-use std::sync::Arc;
 
 type ClassDef = ast::ClassDef;
 type ComponentRefPart = ast::ComponentRefPart;
 type ComponentReference = ast::ComponentReference;
-type Equation = ast::Equation;
 type Expression = ast::Expression;
 type ScopeKind = ast::ScopeKind;
-type Statement = ast::Statement;
 type StoredDefinition = ast::StoredDefinition;
+
+impl ResolveTraversalCallbacks for Resolver {
+    fn create_loop_scope(&mut self, parent_scope: ScopeId) -> ScopeId {
+        self.scope_tree
+            .create_scope(parent_scope, ScopeKind::ForLoop)
+    }
+
+    fn bind_loop_index_name(&mut self, loop_scope: ScopeId, index_name: &str) {
+        let def_id = self.alloc_def_id(index_name.to_string());
+        self.scope_tree
+            .add_member(loop_scope, index_name.to_string(), def_id);
+    }
+
+    fn on_component_reference(&mut self, comp: &mut ComponentReference, scope: ScopeId) {
+        self.resolve_component_reference(comp, scope);
+    }
+
+    fn on_function_reference(&mut self, comp: &mut ComponentReference, scope: ScopeId) {
+        self.resolve_function_reference(comp, scope);
+    }
+}
 
 impl Resolver {
     /// Resolve equations, statements, expressions in a StoredDefinition (Phase 2b).
@@ -46,24 +68,37 @@ impl Resolver {
             .scope_id
             .expect("Class scope should be set in registration phase");
 
+        if let Some(constrainedby) = class.constrainedby.as_mut()
+            && let Some(def_id) = self.resolve_qualified_name(constrainedby, class_scope)
+        {
+            constrainedby.def_id = Some(def_id);
+        }
+
+        for ext in class.extends.iter_mut() {
+            for modification in ext.modifications.iter_mut() {
+                self.resolve_expression(&mut modification.expr, class_scope);
+            }
+        }
+
+        self.resolve_subscripts(&mut class.array_subscripts, class_scope);
+
         // Resolve component references in equations and algorithms
         // MLS §5.3: Full name lookup happens during instantiation/flattening,
         // but we can do partial resolution here for the Class Tree.
-        for eq in class.equations.iter_mut() {
-            self.resolve_equation(eq, class_scope);
+        walk_equations(self, &mut class.equations, class_scope);
+        walk_equations(self, &mut class.initial_equations, class_scope);
+        for algorithm_section in class.algorithms.iter_mut() {
+            walk_statements(self, algorithm_section, class_scope);
         }
-        for eq in class.initial_equations.iter_mut() {
-            self.resolve_equation(eq, class_scope);
+        for algorithm_section in class.initial_algorithms.iter_mut() {
+            walk_statements(self, algorithm_section, class_scope);
         }
-        for alg in class.algorithms.iter_mut() {
-            for stmt in alg.iter_mut() {
-                self.resolve_statement(stmt, class_scope);
+
+        if let Some(external) = class.external.as_mut() {
+            if let Some(output) = external.output.as_mut() {
+                self.resolve_component_reference(output, class_scope);
             }
-        }
-        for alg in class.initial_algorithms.iter_mut() {
-            for stmt in alg.iter_mut() {
-                self.resolve_statement(stmt, class_scope);
-            }
+            self.resolve_expressions(&mut external.args, class_scope);
         }
 
         // Resolve component start/modification expressions and type names
@@ -75,8 +110,14 @@ impl Resolver {
             for mod_expr in comp.modifications.values_mut() {
                 self.resolve_expression(mod_expr, class_scope);
             }
+            self.resolve_subscripts(&mut comp.shape_expr, class_scope);
             if let Some(ref mut cond) = comp.condition {
                 self.resolve_expression(cond, class_scope);
+            }
+            if let Some(constrainedby) = comp.constrainedby.as_mut()
+                && let Some(def_id) = self.resolve_qualified_name(constrainedby, class_scope)
+            {
+                constrainedby.def_id = Some(def_id);
             }
 
             // Resolve the component's type name to its DefId (MLS §5.3).
@@ -84,6 +125,13 @@ impl Resolver {
             // Builtins are registered in global scope, so normal lookup finds them.
             if let Some(type_def_id) = self.resolve_qualified_name(&comp.type_name, class_scope) {
                 // Full resolution succeeded
+                comp.type_name.def_id = Some(type_def_id);
+                comp.type_def_id = Some(type_def_id);
+                self.stats.types_fully_resolved += 1;
+            } else if let Some(type_def_id) =
+                self.resolve_type_name_with_inheritance(&comp.type_name, class_scope)
+            {
+                // Full resolution via inherited members succeeded.
                 comp.type_name.def_id = Some(type_def_id);
                 comp.type_def_id = Some(type_def_id);
                 self.stats.types_fully_resolved += 1;
@@ -115,7 +163,9 @@ impl Resolver {
         let first_part = &comp.type_name.name[0].text;
 
         // First check direct scope lookup
-        if let Some(first_def_id) = self.scope_tree.lookup(class_scope, first_part) {
+        if let Some(first_def_id) = self.scope_tree.lookup(class_scope, first_part)
+            && self.partial_type_root_ids.contains(&first_def_id)
+        {
             comp.type_name.def_id = Some(first_def_id);
             self.stats.types_partial_direct += 1;
             return;
@@ -123,7 +173,9 @@ impl Resolver {
 
         // If not in direct scope, check inherited members from base classes.
         // We need to search the entire enclosing class hierarchy.
-        if let Some(def_id) = self.find_inherited_type(qualified_name, first_part) {
+        if let Some(def_id) = self.find_inherited_type(qualified_name, first_part)
+            && self.partial_type_root_ids.contains(&def_id)
+        {
             comp.type_name.def_id = Some(def_id);
             self.stats.types_partial_inherited += 1;
             return;
@@ -159,260 +211,14 @@ impl Resolver {
         None
     }
 
-    /// Resolve references in an equation.
-    pub(crate) fn resolve_equation(&mut self, eq: &mut Equation, scope: ScopeId) {
-        match eq {
-            Equation::Simple { lhs, rhs } => {
-                self.resolve_expression(lhs, scope);
-                self.resolve_expression(rhs, scope);
-            }
-            Equation::Connect { lhs, rhs } => {
-                self.resolve_component_reference(lhs, scope);
-                self.resolve_component_reference(rhs, scope);
-            }
-            Equation::For { indices, equations } => {
-                // Create a for-loop scope for the index variables
-                let for_scope = self.scope_tree.create_scope(scope, ScopeKind::ForLoop);
-                for idx in indices {
-                    let name = idx.ident.text.to_string();
-                    let def_id = self.alloc_def_id(name.clone());
-                    self.scope_tree.add_member(for_scope, name, def_id);
-                    self.resolve_expression(&mut idx.range, for_scope);
-                }
-                self.resolve_equations(equations, for_scope);
-            }
-            Equation::If {
-                cond_blocks,
-                else_block,
-            } => {
-                for block in cond_blocks.iter_mut() {
-                    self.resolve_equation_block(block, scope);
-                }
-                if let Some(else_body) = else_block {
-                    self.resolve_equations(else_body, scope);
-                }
-            }
-            Equation::When(blocks) => {
-                for block in blocks.iter_mut() {
-                    self.resolve_equation_block(block, scope);
-                }
-            }
-            Equation::FunctionCall { comp, args } => {
-                self.resolve_function_reference(comp, scope);
-                self.resolve_expressions(args, scope);
-            }
-            Equation::Assert {
-                condition,
-                message,
-                level,
-            } => {
-                self.resolve_expression(condition, scope);
-                self.resolve_expression(message, scope);
-                if let Some(lvl) = level {
-                    self.resolve_expression(lvl, scope);
-                }
-            }
-            Equation::Empty => {}
-        }
-    }
-
-    /// Resolve references in a list of equations.
-    fn resolve_equations(&mut self, equations: &mut [Equation], scope: ScopeId) {
-        for eq in equations.iter_mut() {
-            self.resolve_equation(eq, scope);
-        }
-    }
-
-    /// Resolve references in an equation block (condition + equations).
-    fn resolve_equation_block(&mut self, block: &mut rumoca_ir_ast::EquationBlock, scope: ScopeId) {
-        self.resolve_expression(&mut block.cond, scope);
-        self.resolve_equations(&mut block.eqs, scope);
-    }
-
     /// Resolve references in a list of expressions.
     fn resolve_expressions(&mut self, exprs: &mut [Expression], scope: ScopeId) {
-        for expr in exprs.iter_mut() {
-            self.resolve_expression(expr, scope);
-        }
-    }
-
-    /// Resolve references in a statement.
-    pub(crate) fn resolve_statement(&mut self, stmt: &mut Statement, scope: ScopeId) {
-        match stmt {
-            Statement::Assignment { comp, value } => {
-                self.resolve_component_reference(comp, scope);
-                self.resolve_expression(value, scope);
-            }
-            Statement::FunctionCall {
-                comp,
-                args,
-                outputs,
-            } => {
-                self.resolve_function_reference(comp, scope);
-                self.resolve_expressions(args, scope);
-                self.resolve_expressions(outputs, scope);
-            }
-            Statement::If {
-                cond_blocks,
-                else_block,
-            } => {
-                for block in cond_blocks.iter_mut() {
-                    self.resolve_statement_block(block, scope);
-                }
-                if let Some(else_body) = else_block {
-                    self.resolve_statements(else_body, scope);
-                }
-            }
-            Statement::For { indices, equations } => {
-                let for_scope = self.scope_tree.create_scope(scope, ScopeKind::ForLoop);
-                for idx in indices {
-                    let name = idx.ident.text.to_string();
-                    let def_id = self.alloc_def_id(name.clone());
-                    self.scope_tree.add_member(for_scope, name, def_id);
-                    self.resolve_expression(&mut idx.range, for_scope);
-                }
-                self.resolve_statements(equations, for_scope);
-            }
-            Statement::While(block) => {
-                self.resolve_expression(&mut block.cond, scope);
-                self.resolve_statements(&mut block.stmts, scope);
-            }
-            Statement::When(blocks) => {
-                for block in blocks.iter_mut() {
-                    self.resolve_statement_block(block, scope);
-                }
-            }
-            Statement::Reinit { variable, value } => {
-                self.resolve_component_reference(variable, scope);
-                self.resolve_expression(value, scope);
-            }
-            Statement::Assert {
-                condition,
-                message,
-                level,
-            } => {
-                self.resolve_expression(condition, scope);
-                self.resolve_expression(message, scope);
-                if let Some(lvl) = level {
-                    self.resolve_expression(lvl, scope);
-                }
-            }
-            Statement::Return { .. } | Statement::Break { .. } | Statement::Empty => {}
-        }
-    }
-
-    /// Resolve references in a list of statements.
-    fn resolve_statements(&mut self, statements: &mut [Statement], scope: ScopeId) {
-        for stmt in statements.iter_mut() {
-            self.resolve_statement(stmt, scope);
-        }
-    }
-
-    /// Resolve references in a statement block (condition + statements).
-    fn resolve_statement_block(
-        &mut self,
-        block: &mut rumoca_ir_ast::StatementBlock,
-        scope: ScopeId,
-    ) {
-        self.resolve_expression(&mut block.cond, scope);
-        self.resolve_statements(&mut block.stmts, scope);
+        walk_expressions(self, exprs, scope);
     }
 
     /// Resolve references in an expression.
     pub(crate) fn resolve_expression(&mut self, expr: &mut Expression, scope: ScopeId) {
-        match expr {
-            Expression::ComponentReference(comp) => {
-                self.resolve_component_reference(comp, scope);
-            }
-            Expression::FunctionCall { comp, args } => {
-                self.resolve_function_reference(comp, scope);
-                for arg in args.iter_mut() {
-                    self.resolve_expression(arg, scope);
-                }
-            }
-            Expression::Binary { lhs, rhs, .. } => {
-                // Arc::make_mut clones if shared, returns &mut
-                self.resolve_expression(Arc::make_mut(lhs), scope);
-                self.resolve_expression(Arc::make_mut(rhs), scope);
-            }
-            Expression::Unary { rhs, .. } => {
-                self.resolve_expression(Arc::make_mut(rhs), scope);
-            }
-            Expression::Range { start, step, end } => {
-                self.resolve_expression(Arc::make_mut(start), scope);
-                if let Some(s) = step {
-                    self.resolve_expression(Arc::make_mut(s), scope);
-                }
-                self.resolve_expression(Arc::make_mut(end), scope);
-            }
-            Expression::Array { elements, .. } => {
-                for elem in elements.iter_mut() {
-                    self.resolve_expression(elem, scope);
-                }
-            }
-            Expression::If {
-                branches,
-                else_branch,
-            } => {
-                for (cond, then_expr) in branches.iter_mut() {
-                    self.resolve_expression(cond, scope);
-                    self.resolve_expression(then_expr, scope);
-                }
-                self.resolve_expression(Arc::make_mut(else_branch), scope);
-            }
-            Expression::ClassModification {
-                target,
-                modifications,
-            } => {
-                self.resolve_function_reference(target, scope);
-                for m in modifications.iter_mut() {
-                    self.resolve_expression(m, scope);
-                }
-            }
-            Expression::Modification { target, value } => {
-                self.resolve_component_reference(target, scope);
-                self.resolve_expression(Arc::make_mut(value), scope);
-            }
-            Expression::NamedArgument { value, .. } => {
-                self.resolve_expression(Arc::make_mut(value), scope);
-            }
-            Expression::Tuple { elements } => {
-                for elem in elements.iter_mut() {
-                    self.resolve_expression(elem, scope);
-                }
-            }
-            Expression::Parenthesized { inner } => {
-                self.resolve_expression(Arc::make_mut(inner), scope);
-            }
-            Expression::ArrayComprehension {
-                expr,
-                indices,
-                filter,
-            } => {
-                // Array comprehension loop indices introduce a local scope,
-                // similar to for-equation/for-statement indices.
-                let comp_scope = self.scope_tree.create_scope(scope, ScopeKind::ForLoop);
-                for idx in indices {
-                    let name = idx.ident.text.to_string();
-                    let def_id = self.alloc_def_id(name.clone());
-                    self.scope_tree.add_member(comp_scope, name, def_id);
-                    self.resolve_expression(&mut idx.range, comp_scope);
-                }
-                self.resolve_expression(Arc::make_mut(expr), comp_scope);
-                if let Some(filt) = filter {
-                    self.resolve_expression(Arc::make_mut(filt), comp_scope);
-                }
-            }
-            Expression::ArrayIndex { base, subscripts } => {
-                self.resolve_expression(Arc::make_mut(base), scope);
-                self.resolve_subscripts(subscripts, scope);
-            }
-            Expression::FieldAccess { base, .. } => {
-                self.resolve_expression(Arc::make_mut(base), scope);
-            }
-            // Terminal expressions don't contain references.
-            Expression::Terminal { .. } | Expression::Empty => {}
-        }
+        walk_expression(self, expr, scope);
     }
 
     /// Resolve a component reference.
@@ -528,16 +334,38 @@ impl Resolver {
         Some((current_def_id, current_qualified))
     }
 
+    fn resolve_type_name_with_inheritance(
+        &self,
+        name: &rumoca_ir_ast::Name,
+        scope: ScopeId,
+    ) -> Option<rumoca_core::DefId> {
+        let first_part = name.name.first()?.text.as_ref();
+        let mut current_def_id = self
+            .scope_tree
+            .lookup(scope, first_part)
+            .or_else(|| self.resolve_function_first_part(first_part, scope))?;
+        let mut current_qualified = self.def_names.get(&current_def_id)?.clone();
+
+        for part in name.name.iter().skip(1) {
+            let member = part.text.as_ref();
+            let direct_name = format!("{current_qualified}.{member}");
+            if let Some(&next_def_id) = self.name_to_def.get(&direct_name) {
+                current_def_id = next_def_id;
+                current_qualified = self.def_names.get(&next_def_id)?.clone();
+                continue;
+            }
+
+            let inherited_def_id = self.lookup_inherited_member(&current_qualified, member)?;
+            current_def_id = inherited_def_id;
+            current_qualified = self.def_names.get(&inherited_def_id)?.clone();
+        }
+
+        Some(current_def_id)
+    }
+
     /// Resolve references in a list of subscripts.
     fn resolve_subscripts(&mut self, subs: &mut [rumoca_ir_ast::Subscript], scope: ScopeId) {
-        for sub in subs.iter_mut() {
-            match sub {
-                rumoca_ir_ast::Subscript::Expression(expr) => {
-                    self.resolve_expression(expr, scope);
-                }
-                rumoca_ir_ast::Subscript::Range { .. } | rumoca_ir_ast::Subscript::Empty => {}
-            }
-        }
+        walk_subscripts(self, subs, scope);
     }
 }
 

--- a/crates/rumoca-phase-resolve/src/extends.rs
+++ b/crates/rumoca-phase-resolve/src/extends.rs
@@ -331,7 +331,9 @@ impl Resolver {
                     self.emit_unresolved_import(import);
                     return None;
                 };
-                let resolved_names = self.resolve_selective_names(pkg_qualified, names);
+                let pkg_qualified = pkg_qualified.clone();
+                let resolved_names =
+                    self.resolve_selective_import_entries(import, &pkg_qualified, names)?;
                 ast::scope::Import::Unqualified {
                     path: path.name.iter().map(|t| t.text.to_string()).collect(),
                     names: resolved_names,
@@ -357,6 +359,47 @@ impl Resolver {
             ),
             PrimaryLabel::new(span).with_message("import could not be resolved"),
         ));
+    }
+
+    fn emit_unresolved_selective_import_member(
+        &mut self,
+        import: &ast::Import,
+        name_token: &rumoca_ir_core::Token,
+    ) {
+        let span = crate::location_to_span(&name_token.location, &self.source_map);
+        self.diagnostics.emit(Diagnostic::error(
+            "ER002",
+            format!(
+                "unresolved import member: '{}' in '{}'",
+                name_token.text,
+                Self::format_import_clause(import)
+            ),
+            PrimaryLabel::new(span).with_message("import member could not be resolved"),
+        ));
+    }
+
+    fn resolve_selective_import_entries(
+        &mut self,
+        import: &ast::Import,
+        pkg_qualified: &str,
+        names: &[rumoca_ir_core::Token],
+    ) -> Option<IndexMap<String, DefId>> {
+        let mut resolved_names = IndexMap::new();
+        let mut has_missing_name = false;
+        for name_token in names {
+            let full_name = format!("{pkg_qualified}.{}", name_token.text);
+            if let Some(&def_id) = self.name_to_def.get(&full_name) {
+                resolved_names.insert(name_token.text.to_string(), def_id);
+            } else {
+                has_missing_name = true;
+                self.emit_unresolved_selective_import_member(import, name_token);
+            }
+        }
+        if has_missing_name {
+            None
+        } else {
+            Some(resolved_names)
+        }
     }
 
     fn import_span(&self, import: &ast::Import) -> rumoca_core::Span {
@@ -409,21 +452,5 @@ impl Resolver {
             .get(pkg_qualified)
             .cloned()
             .unwrap_or_default()
-    }
-
-    /// Resolve specific names from a package for selective imports.
-    fn resolve_selective_names(
-        &self,
-        pkg_qualified: &str,
-        names: &[rumoca_ir_core::Token],
-    ) -> IndexMap<String, DefId> {
-        let mut resolved_names = IndexMap::new();
-        for name_token in names {
-            let full_name = format!("{}.{}", pkg_qualified, name_token.text);
-            if let Some(&def_id) = self.name_to_def.get(&full_name) {
-                resolved_names.insert(name_token.text.to_string(), def_id);
-            }
-        }
-        resolved_names
     }
 }

--- a/crates/rumoca-phase-resolve/src/lib.rs
+++ b/crates/rumoca-phase-resolve/src/lib.rs
@@ -27,6 +27,7 @@ mod extends;
 mod lookup;
 mod registration;
 pub mod semantic_checks;
+mod traversal_adapter;
 pub mod validation;
 
 pub use errors::{ResolveError, ResolveResult};
@@ -191,6 +192,8 @@ pub struct Resolver {
     pub(crate) class_to_bases: IndexMap<DefId, Vec<DefId>>,
     /// Map class scope id -> class DefId for inherited lookups from nested scopes.
     pub(crate) scope_to_class_def: std::collections::HashMap<ScopeId, DefId>,
+    /// DefIds that can legitimately anchor partial type resolution (replaceable roots).
+    pub(crate) partial_type_root_ids: std::collections::HashSet<DefId>,
     /// Number of builtin DefIds (0..builtin_count are builtins).
     builtin_count: u32,
     /// Statistics collected during resolution.
@@ -212,6 +215,7 @@ impl Resolver {
             inheritance_edges: Vec::new(),
             class_to_bases: IndexMap::new(),
             scope_to_class_def: std::collections::HashMap::new(),
+            partial_type_root_ids: std::collections::HashSet::new(),
             builtin_count: 0,
             stats: ResolutionStats::default(),
         };
@@ -706,6 +710,61 @@ end Ball;
             !unresolved_type.labels.is_empty(),
             "unresolved type reference should include a source label"
         );
+    }
+
+    #[test]
+    fn test_unresolved_selective_import_member_is_error() {
+        let source = r#"
+package P
+  model A
+  end A;
+end P;
+
+model M
+  import P.{A, B};
+end M;
+"#;
+        let ast = parse_to_ast(source, "test.mo").expect("parse should succeed");
+        let result = resolve_parsed(ast);
+        assert!(result.is_err(), "resolution should fail");
+
+        let diags = result.expect_err("expected resolve diagnostics");
+        let import = diags
+            .iter()
+            .find(|d| d.message.contains("unresolved import member") && d.message.contains("B"))
+            .expect("missing unresolved selective import member diagnostic");
+
+        assert_eq!(import.code.as_deref(), Some("ER002"));
+        assert!(
+            !import.labels.is_empty(),
+            "unresolved selective import member should include source label"
+        );
+    }
+
+    #[test]
+    fn test_non_replaceable_partial_type_path_is_unresolved() {
+        let source = r#"
+model M
+  package P
+  end P;
+  P.Missing x;
+equation
+  x = 0;
+end M;
+"#;
+        let ast = parse_to_ast(source, "test.mo").expect("parse should succeed");
+        let result = resolve_parsed(ast);
+        assert!(
+            result.is_err(),
+            "resolution should fail for non-replaceable partial type path"
+        );
+
+        let diags = result.expect_err("expected resolve diagnostics");
+        assert!(diags.iter().any(|d| {
+            d.code.as_deref() == Some("ER002")
+                && d.message.contains("unresolved type reference")
+                && d.message.contains("P.Missing")
+        }));
     }
 
     #[test]

--- a/crates/rumoca-phase-resolve/src/registration.rs
+++ b/crates/rumoca-phase-resolve/src/registration.rs
@@ -20,6 +20,9 @@ impl Resolver {
             let def_id = self.alloc_def_id(format!("{}{}", prefix, name));
             class.def_id = Some(def_id);
             self.scope_tree.add_member(scope, name.clone(), def_id);
+            if class.is_replaceable {
+                self.partial_type_root_ids.insert(def_id);
+            }
         }
 
         // Recursively register nested classes
@@ -58,6 +61,9 @@ impl Resolver {
             comp.def_id = Some(def_id);
             self.scope_tree
                 .add_member(class_scope, name.clone(), def_id);
+            if comp.is_replaceable {
+                self.partial_type_root_ids.insert(def_id);
+            }
         }
 
         // Register nested class names
@@ -66,6 +72,9 @@ impl Resolver {
             nested.def_id = Some(def_id);
             self.scope_tree
                 .add_member(class_scope, name.clone(), def_id);
+            if nested.is_replaceable {
+                self.partial_type_root_ids.insert(def_id);
+            }
         }
 
         // Recursively register nested classes

--- a/crates/rumoca-phase-resolve/src/semantic_checks.rs
+++ b/crates/rumoca-phase-resolve/src/semantic_checks.rs
@@ -6,6 +6,7 @@
 
 use rumoca_core::{Diagnostic, PrimaryLabel, SourceId, SourceMap, Span};
 use rumoca_ir_ast as ast;
+use rumoca_ir_ast::Visitor;
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
@@ -31,6 +32,138 @@ type StoredDefinition = ast::StoredDefinition;
 type TerminalType = ast::TerminalType;
 type Token = rumoca_ir_core::Token;
 type Variability = rumoca_ir_core::Variability;
+
+fn walk_expression_default<V: Visitor + ?Sized>(
+    visitor: &mut V,
+    expr: &Expression,
+) -> std::ops::ControlFlow<()> {
+    match expr {
+        Expression::Empty | Expression::Terminal { .. } => std::ops::ControlFlow::Continue(()),
+        Expression::Range { start, step, end } => {
+            visitor.visit_expression(start)?;
+            if let Some(s) = step {
+                visitor.visit_expression(s)?;
+            }
+            visitor.visit_expression(end)
+        }
+        Expression::Unary { rhs, .. } => visitor.visit_expression(rhs),
+        Expression::Binary { lhs, rhs, .. } => {
+            visitor.visit_expression(lhs)?;
+            visitor.visit_expression(rhs)
+        }
+        Expression::ComponentReference(cr) => {
+            visitor.visit_component_reference_ctx(cr, ast::ComponentReferenceContext::Expression)
+        }
+        Expression::FunctionCall { comp, args } => {
+            visitor.visit_expr_function_call_ctx(comp, args, ast::FunctionCallContext::Expression)
+        }
+        Expression::ClassModification {
+            target,
+            modifications,
+        } => {
+            visitor.visit_component_reference_ctx(
+                target,
+                ast::ComponentReferenceContext::ClassModificationTarget,
+            )?;
+            visitor.visit_each(modifications, V::visit_expression)
+        }
+        Expression::NamedArgument { value, .. } => visitor.visit_expression(value),
+        Expression::Modification { target, value } => {
+            visitor.visit_component_reference_ctx(
+                target,
+                ast::ComponentReferenceContext::ModificationTarget,
+            )?;
+            visitor.visit_expression(value)
+        }
+        Expression::Array { elements, .. } | Expression::Tuple { elements } => {
+            visitor.visit_each(elements, V::visit_expression)
+        }
+        Expression::If {
+            branches,
+            else_branch,
+        } => {
+            for (cond, then_expr) in branches {
+                visitor.visit_expression(cond)?;
+                visitor.visit_expression(then_expr)?;
+            }
+            visitor.visit_expression(else_branch)
+        }
+        Expression::Parenthesized { inner } => visitor.visit_expression(inner),
+        Expression::ArrayComprehension {
+            expr,
+            indices,
+            filter,
+        } => {
+            visitor.visit_expression(expr)?;
+            visitor.visit_each(indices, V::visit_for_index)?;
+            if let Some(f) = filter {
+                visitor.visit_expression(f)?;
+            }
+            std::ops::ControlFlow::Continue(())
+        }
+        Expression::ArrayIndex { base, subscripts } => {
+            visitor.visit_expression(base)?;
+            for subscript in subscripts {
+                visitor.visit_subscript_ctx(subscript, ast::SubscriptContext::ArrayIndex)?;
+            }
+            std::ops::ControlFlow::Continue(())
+        }
+        Expression::FieldAccess { base, .. } => visitor.visit_expression(base),
+    }
+}
+
+fn walk_equation_default<V: Visitor + ?Sized>(
+    visitor: &mut V,
+    eq: &Equation,
+) -> std::ops::ControlFlow<()> {
+    match eq {
+        Equation::Empty => std::ops::ControlFlow::Continue(()),
+        Equation::Simple { lhs, rhs } => visitor.visit_simple_equation(lhs, rhs),
+        Equation::Connect { lhs, rhs } => visitor.visit_connect(lhs, rhs),
+        Equation::For { indices, equations } => visitor.visit_for_equation(indices, equations),
+        Equation::When(blocks) => visitor.visit_when_equation(blocks),
+        Equation::If {
+            cond_blocks,
+            else_block,
+        } => visitor.visit_if_equation(cond_blocks, else_block.as_deref()),
+        Equation::FunctionCall { comp, args } => visitor.visit_equation_function_call(comp, args),
+        Equation::Assert {
+            condition,
+            message,
+            level,
+        } => visitor.visit_equation_assert(condition, message, level.as_ref()),
+    }
+}
+
+fn walk_statement_default<V: Visitor + ?Sized>(
+    visitor: &mut V,
+    stmt: &Statement,
+) -> std::ops::ControlFlow<()> {
+    match stmt {
+        Statement::Empty | Statement::Return { .. } | Statement::Break { .. } => {
+            std::ops::ControlFlow::Continue(())
+        }
+        Statement::Assignment { comp, value } => visitor.visit_assignment(comp, value),
+        Statement::For { indices, equations } => visitor.visit_for_statement(indices, equations),
+        Statement::While(block) => visitor.visit_statement_block(block),
+        Statement::If {
+            cond_blocks,
+            else_block,
+        } => visitor.visit_if_statement(cond_blocks, else_block.as_deref()),
+        Statement::When(blocks) => visitor.visit_when_statement(blocks),
+        Statement::FunctionCall {
+            comp,
+            args,
+            outputs,
+        } => visitor.visit_statement_function_call(comp, args, outputs),
+        Statement::Reinit { variable, value } => visitor.visit_reinit(variable, value),
+        Statement::Assert {
+            condition,
+            message,
+            level,
+        } => visitor.visit_statement_assert(condition, message, level.as_ref()),
+    }
+}
 
 // Resolve-phase semantic diagnostic codes (ER005+ reserved for semantic checks).
 const ER005_PARTIAL_CLASS_INSTANTIATION: &str = "ER005";
@@ -207,83 +340,77 @@ pub fn check_all_semantics(def: &StoredDefinition, source_map: &SourceMap) -> Ve
 fn run_semantic_checks(def: &StoredDefinition) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
     let mut ctx = CheckContext::new();
-    for class in def.classes.values() {
-        check_class(class, def, &mut ctx, &mut diags);
-    }
+    let mut visitor = SemanticClassCheckVisitor {
+        def,
+        ctx: &mut ctx,
+        diags: &mut diags,
+    };
+    let _ = visitor.visit_stored_definition(def);
     diags
 }
 
-fn check_class(
-    class: &ClassDef,
-    def: &StoredDefinition,
-    ctx: &mut CheckContext,
-    diags: &mut Vec<Diagnostic>,
-) {
-    check_class_structural(class, def, diags);
+struct SemanticClassCheckVisitor<'a> {
+    def: &'a StoredDefinition,
+    ctx: &'a mut CheckContext,
+    diags: &'a mut Vec<Diagnostic>,
+}
 
-    let was_function = ctx.in_function;
-    if class.class_type == ClassType::Function {
-        ctx.in_function = true;
-    }
+impl ast::Visitor for SemanticClassCheckVisitor<'_> {
+    fn visit_class_def(&mut self, class: &ClassDef) -> std::ops::ControlFlow<()> {
+        check_class_structural(class, self.def, self.diags);
 
-    // DECL-020: Check for der() on discrete variables
-    let discrete_vars: HashSet<String> = class
-        .components
-        .iter()
-        .filter(|(_, c)| matches!(c.variability, Variability::Discrete(_)))
-        .map(|(n, _)| n.clone())
-        .collect();
-
-    // Collect Real-typed variables for EXPR-002 check
-    let real_vars: HashSet<String> = class
-        .components
-        .iter()
-        .filter(|(_, c)| {
-            let tn = c.type_name.to_string();
-            tn == "Real"
-        })
-        .map(|(n, _)| n.clone())
-        .collect();
-
-    // Check equations
-    for eq in &class.equations {
-        check_equation(eq, ctx, diags);
-        check_der_on_discrete_eq(eq, &discrete_vars, diags);
-        check_protected_access_eq(eq, class, def, diags);
-        check_connect_requires_connectors_eq(eq, class, def, diags);
-        check_end_outside_subscript_eq(eq, diags);
-        check_expr_type_issues_eq(eq, class, def, &real_vars, diags);
-    }
-
-    // Check initial equations
-    for eq in &class.initial_equations {
-        check_initial_equation(eq, diags);
-        check_equation(eq, ctx, diags);
-        check_der_on_discrete_eq(eq, &discrete_vars, diags);
-        check_end_outside_subscript_eq(eq, diags);
-    }
-
-    // Check initial algorithms
-    for alg in &class.initial_algorithms {
-        for stmt in alg {
-            check_initial_statement(stmt, diags);
-            check_statement(stmt, ctx, diags);
+        let was_function = self.ctx.in_function;
+        if class.class_type == ClassType::Function {
+            self.ctx.in_function = true;
         }
-    }
 
-    // Check algorithm sections
-    for alg in &class.algorithms {
-        for stmt in alg {
-            check_statement(stmt, ctx, diags);
+        let discrete_vars: HashSet<String> = class
+            .components
+            .iter()
+            .filter(|(_, c)| matches!(c.variability, Variability::Discrete(_)))
+            .map(|(n, _)| n.clone())
+            .collect();
+        let real_vars: HashSet<String> = class
+            .components
+            .iter()
+            .filter(|(_, c)| c.type_name.to_string() == "Real")
+            .map(|(n, _)| n.clone())
+            .collect();
+
+        for eq in &class.equations {
+            check_equation(eq, self.ctx, self.diags);
+            check_der_on_discrete_eq(eq, &discrete_vars, self.diags);
+            check_protected_access_eq(eq, class, self.def, self.diags);
+            check_connect_requires_connectors_eq(eq, class, self.def, self.diags);
+            check_end_outside_subscript_eq(eq, self.diags);
+            check_expr_type_issues_eq(eq, class, self.def, &real_vars, self.diags);
         }
-    }
 
-    // Recurse into nested classes
-    for nested in class.classes.values() {
-        check_class(nested, def, ctx, diags);
-    }
+        for eq in &class.initial_equations {
+            check_initial_equation(eq, self.diags);
+            check_equation(eq, self.ctx, self.diags);
+            check_der_on_discrete_eq(eq, &discrete_vars, self.diags);
+            check_end_outside_subscript_eq(eq, self.diags);
+        }
 
-    ctx.in_function = was_function;
+        for alg in &class.initial_algorithms {
+            for stmt in alg {
+                check_initial_statement(stmt, self.diags);
+                check_statement(stmt, self.ctx, self.diags);
+            }
+        }
+        for alg in &class.algorithms {
+            for stmt in alg {
+                check_statement(stmt, self.ctx, self.diags);
+            }
+        }
+        for nested in class.classes.values() {
+            self.visit_class_def(nested)?;
+        }
+
+        self.ctx.in_function = was_function;
+        std::ops::ControlFlow::Continue(())
+    }
 }
 
 // ============================================================================
@@ -753,50 +880,40 @@ fn check_input_assignment(
     input_names: &std::collections::HashSet<String>,
     diags: &mut Vec<Diagnostic>,
 ) {
-    for stmt in stmts {
-        match stmt {
-            Statement::Assignment { comp, .. } => {
-                if let Some(first) = comp.parts.first()
-                    && input_names.contains(&*first.ident.text)
-                {
-                    diags.push(semantic_error(
-                        ER014_FUNCTION_INPUT_ASSIGNED,
-                        format!(
-                            "cannot assign to input parameter '{}' (MLS §12.2)",
-                            first.ident.text
-                        ),
-                        label_from_token(
-                            &first.ident,
-                            "check_input_assignment/input_assignment",
-                            format!("assignment to input '{}'", first.ident.text),
-                        ),
-                    ));
-                }
+    struct InputAssignmentVisitor<'a> {
+        input_names: &'a std::collections::HashSet<String>,
+        diags: &'a mut Vec<Diagnostic>,
+    }
+
+    impl ast::Visitor for InputAssignmentVisitor<'_> {
+        fn visit_assignment(
+            &mut self,
+            comp: &ComponentReference,
+            _value: &Expression,
+        ) -> std::ops::ControlFlow<()> {
+            if let Some(first) = comp.parts.first()
+                && self.input_names.contains(&*first.ident.text)
+            {
+                self.diags.push(semantic_error(
+                    ER014_FUNCTION_INPUT_ASSIGNED,
+                    format!(
+                        "cannot assign to input parameter '{}' (MLS §12.2)",
+                        first.ident.text
+                    ),
+                    label_from_token(
+                        &first.ident,
+                        "check_input_assignment/input_assignment",
+                        format!("assignment to input '{}'", first.ident.text),
+                    ),
+                ));
             }
-            Statement::For { equations, .. } => {
-                check_input_assignment(equations, input_names, diags);
-            }
-            Statement::If {
-                cond_blocks,
-                else_block,
-            } => {
-                for block in cond_blocks {
-                    check_input_assignment(&block.stmts, input_names, diags);
-                }
-                if let Some(else_stmts) = else_block {
-                    check_input_assignment(else_stmts, input_names, diags);
-                }
-            }
-            Statement::When(blocks) => {
-                for block in blocks {
-                    check_input_assignment(&block.stmts, input_names, diags);
-                }
-            }
-            Statement::While(block) => {
-                check_input_assignment(&block.stmts, input_names, diags);
-            }
-            _ => {}
+            std::ops::ControlFlow::Continue(())
         }
+    }
+
+    let mut visitor = InputAssignmentVisitor { input_names, diags };
+    for stmt in stmts {
+        let _ = visitor.visit_statement(stmt);
     }
 }
 
@@ -1209,54 +1326,53 @@ fn collect_component_refs(
     refs: &mut HashSet<String>,
     skip_if_branches: bool,
 ) {
-    match expr {
-        Expression::ComponentReference(cref) => {
+    struct ComponentRefCollector<'a> {
+        known_params: &'a HashSet<String>,
+        refs: &'a mut HashSet<String>,
+        skip_if_branches: bool,
+    }
+
+    impl ast::Visitor for ComponentRefCollector<'_> {
+        fn visit_component_reference_ctx(
+            &mut self,
+            cref: &ComponentReference,
+            ctx: ast::ComponentReferenceContext,
+        ) -> std::ops::ControlFlow<()> {
+            if !matches!(ctx, ast::ComponentReferenceContext::Expression) {
+                return ast::Visitor::visit_component_reference(self, cref);
+            }
             // Only match single-part references for direct dependencies.
             // Multi-part refs like `system.x` access sub-components, not the param itself.
-            if let [part] = cref.parts.as_slice() {
-                let name = part.ident.text.to_string();
-                if known_params.contains(&name) {
-                    refs.insert(name);
-                }
+            let [part] = cref.parts.as_slice() else {
+                return ast::Visitor::visit_component_reference(self, cref);
+            };
+            let name = part.ident.text.to_string();
+            if self.known_params.contains(&name) {
+                self.refs.insert(name);
             }
+            ast::Visitor::visit_component_reference(self, cref)
         }
-        Expression::Binary { lhs, rhs, .. } => {
-            collect_component_refs(lhs, known_params, refs, skip_if_branches);
-            collect_component_refs(rhs, known_params, refs, skip_if_branches);
-        }
-        Expression::Unary { rhs, .. } => {
-            collect_component_refs(rhs, known_params, refs, skip_if_branches);
-        }
-        Expression::FunctionCall { args, .. } => {
-            for arg in args {
-                collect_component_refs(arg, known_params, refs, skip_if_branches);
+
+        fn visit_expression(&mut self, expr: &Expression) -> std::ops::ControlFlow<()> {
+            if !self.skip_if_branches {
+                return walk_expression_default(self, expr);
             }
-        }
-        Expression::If {
-            branches,
-            else_branch,
-            ..
-        } => {
-            for (cond, then_expr) in branches {
-                collect_component_refs(cond, known_params, refs, skip_if_branches);
-                if !skip_if_branches {
-                    collect_component_refs(then_expr, known_params, refs, skip_if_branches);
-                }
+            let Expression::If { branches, .. } = expr else {
+                return walk_expression_default(self, expr);
+            };
+            for (cond, _) in branches {
+                self.visit_expression(cond)?;
             }
-            if !skip_if_branches {
-                collect_component_refs(else_branch, known_params, refs, skip_if_branches);
-            }
+            std::ops::ControlFlow::Continue(())
         }
-        Expression::Array { elements, .. } => {
-            for elem in elements {
-                collect_component_refs(elem, known_params, refs, skip_if_branches);
-            }
-        }
-        Expression::Parenthesized { inner, .. } => {
-            collect_component_refs(inner, known_params, refs, skip_if_branches);
-        }
-        _ => {}
     }
+
+    let mut collector = ComponentRefCollector {
+        known_params,
+        refs,
+        skip_if_branches,
+    };
+    let _ = collector.visit_expression(expr);
 }
 
 // ============================================================================
@@ -1265,250 +1381,197 @@ fn collect_component_refs(
 
 /// Check equations for context-sensitive issues.
 fn check_equation(eq: &Equation, ctx: &mut CheckContext, diags: &mut Vec<Diagnostic>) {
-    match eq {
-        Equation::When(blocks) => {
-            // EQN-005: Nested when-equations
-            if ctx.in_when_equation
-                && let Some(label) = label_from_equation(
-                    eq,
-                    "check_equation/nested_when_equation",
-                    "nested when-equation is not allowed",
-                )
-            {
-                diags.push(semantic_error(
-                    ER017_NESTED_WHEN_EQUATION,
-                    "when-equations cannot be nested (MLS §8.3.5)",
-                    label,
-                ));
-            }
+    let mut visitor = ContextSensitiveVisitor { ctx, diags };
+    let _ = visitor.visit_equation(eq);
+}
 
-            let was = ctx.in_when_equation;
-            ctx.in_when_equation = true;
-            for block in blocks {
-                for inner_eq in &block.eqs {
-                    check_equation(inner_eq, ctx, diags);
-                }
-            }
-            ctx.in_when_equation = was;
-        }
-        Equation::For {
-            indices, equations, ..
-        } => {
-            // EQN-010: Track for-loop variables
-            let new_vars: Vec<String> = indices.iter().map(|i| i.ident.text.to_string()).collect();
-            ctx.for_loop_vars.extend(new_vars.clone());
+/// Check statements for context-sensitive issues.
+fn check_statement(stmt: &Statement, ctx: &mut CheckContext, diags: &mut Vec<Diagnostic>) {
+    let mut visitor = ContextSensitiveVisitor { ctx, diags };
+    let _ = visitor.visit_statement(stmt);
+}
 
-            for inner_eq in equations {
-                check_for_variable_assignment_eq(inner_eq, &ctx.for_loop_vars, diags);
-                check_equation(inner_eq, ctx, diags);
-            }
+struct ContextSensitiveVisitor<'a> {
+    ctx: &'a mut CheckContext,
+    diags: &'a mut Vec<Diagnostic>,
+}
 
-            for var in &new_vars {
-                ctx.for_loop_vars.retain(|v| v != var);
-            }
+impl ast::Visitor for ContextSensitiveVisitor<'_> {
+    fn visit_equation(&mut self, eq: &Equation) -> std::ops::ControlFlow<()> {
+        if let Equation::When(_) = eq
+            && self.ctx.in_when_equation
+            && let Some(label) = label_from_equation(
+                eq,
+                "check_equation/nested_when_equation",
+                "nested when-equation is not allowed",
+            )
+        {
+            self.diags.push(semantic_error(
+                ER017_NESTED_WHEN_EQUATION,
+                "when-equations cannot be nested (MLS §8.3.5)",
+                label,
+            ));
         }
-        Equation::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                for inner_eq in &block.eqs {
-                    check_equation(inner_eq, ctx, diags);
-                }
-            }
-            if let Some(else_eqs) = else_block {
-                for inner_eq in else_eqs {
-                    check_equation(inner_eq, ctx, diags);
-                }
-            }
+        if let Equation::FunctionCall { comp, .. } = eq
+            && let Some(first) = comp.parts.first()
+            && &*first.ident.text == "reinit"
+            && !self.ctx.in_when_equation
+        {
+            self.diags.push(semantic_error(
+                ER008_REINIT_OUTSIDE_WHEN,
+                "reinit() can only be used inside when-equations (MLS §8.3.6)",
+                label_from_token(
+                    &first.ident,
+                    "check_equation/reinit_outside_when_equation",
+                    "reinit() used outside when-equation",
+                ),
+            ));
         }
-        Equation::FunctionCall { comp, .. } => {
-            // EQN-015: reinit outside when-equation
-            if let Some(first) = comp.parts.first()
-                && &*first.ident.text == "reinit"
-                && !ctx.in_when_equation
-            {
-                diags.push(semantic_error(
-                    ER008_REINIT_OUTSIDE_WHEN,
-                    "reinit() can only be used inside when-equations (MLS §8.3.6)",
-                    label_from_token(
-                        &first.ident,
-                        "check_equation/reinit_outside_when_equation",
-                        "reinit() used outside when-equation",
-                    ),
-                ));
-            }
+        walk_equation_default(self, eq)
+    }
+
+    fn visit_when_equation(&mut self, blocks: &[ast::EquationBlock]) -> std::ops::ControlFlow<()> {
+        let was = self.ctx.in_when_equation;
+        self.ctx.in_when_equation = true;
+        self.visit_each(blocks, Self::visit_equation_block)?;
+        self.ctx.in_when_equation = was;
+        std::ops::ControlFlow::Continue(())
+    }
+
+    fn visit_for_equation(
+        &mut self,
+        indices: &[ast::ForIndex],
+        equations: &[Equation],
+    ) -> std::ops::ControlFlow<()> {
+        let new_vars: Vec<String> = indices.iter().map(|i| i.ident.text.to_string()).collect();
+        self.ctx.for_loop_vars.extend(new_vars.clone());
+
+        for inner_eq in equations {
+            check_for_variable_assignment_eq(inner_eq, &self.ctx.for_loop_vars, self.diags);
+            self.visit_equation(inner_eq)?;
         }
-        _ => {}
+
+        for var in &new_vars {
+            self.ctx.for_loop_vars.retain(|v| v != var);
+        }
+        std::ops::ControlFlow::Continue(())
+    }
+
+    fn visit_statement(&mut self, stmt: &Statement) -> std::ops::ControlFlow<()> {
+        if let Statement::When(_) = stmt
+            && self.ctx.in_function
+            && let Some(label) = label_from_statement(
+                stmt,
+                "check_statement/when_in_function",
+                "when-statement is not allowed in function",
+            )
+        {
+            self.diags.push(semantic_error(
+                ER015_WHEN_IN_FUNCTION,
+                "when-statements are not allowed in functions (MLS §12.2)",
+                label,
+            ));
+        }
+        if let Statement::When(_) = stmt
+            && self.ctx.in_when_statement
+            && let Some(label) = label_from_statement(
+                stmt,
+                "check_statement/nested_when_statement",
+                "nested when-statement is not allowed",
+            )
+        {
+            self.diags.push(semantic_error(
+                ER016_NESTED_WHEN_STATEMENT,
+                "when-statements cannot be nested (MLS §11.2.7)",
+                label,
+            ));
+        }
+        if matches!(stmt, Statement::Reinit { .. })
+            && !self.ctx.in_when_statement
+            && let Some(label) = label_from_statement(
+                stmt,
+                "check_statement/reinit_outside_when_statement",
+                "reinit() used outside when-statement",
+            )
+        {
+            self.diags.push(semantic_error(
+                ER008_REINIT_OUTSIDE_WHEN,
+                "reinit() can only be used inside when-statements (MLS §8.3.6)",
+                label,
+            ));
+        }
+        walk_statement_default(self, stmt)
+    }
+
+    fn visit_when_statement(
+        &mut self,
+        blocks: &[ast::StatementBlock],
+    ) -> std::ops::ControlFlow<()> {
+        let was = self.ctx.in_when_statement;
+        self.ctx.in_when_statement = true;
+        self.visit_each(blocks, Self::visit_statement_block)?;
+        self.ctx.in_when_statement = was;
+        std::ops::ControlFlow::Continue(())
     }
 }
 
 /// Check initial equations for when-clause presence (EQN-006, EQN-037).
 fn check_initial_equation(eq: &Equation, diags: &mut Vec<Diagnostic>) {
-    match eq {
-        Equation::When(_) => {
-            if let Some(label) = label_from_equation(
-                eq,
-                "check_initial_equation/when_in_initial_equation",
-                "when-equation in initial equation section",
-            ) {
-                diags.push(semantic_error(
-                    ER018_WHEN_IN_INITIAL_SECTION,
-                    "when-equations are not allowed in initial equation sections (MLS §8.6)",
-                    label,
-                ));
-            }
-        }
-        Equation::For { equations, .. } => {
-            for inner in equations {
-                check_initial_equation(inner, diags);
-            }
-        }
-        Equation::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                for inner in &block.eqs {
-                    check_initial_equation(inner, diags);
-                }
-            }
-            if let Some(else_eqs) = else_block {
-                for inner in else_eqs {
-                    check_initial_equation(inner, diags);
-                }
-            }
-        }
-        _ => {}
-    }
+    let mut visitor = InitialEquationVisitor { diags };
+    let _ = visitor.visit_equation(eq);
 }
 
 /// Check initial algorithm statements for when-clause presence (EQN-037).
 fn check_initial_statement(stmt: &Statement, diags: &mut Vec<Diagnostic>) {
-    match stmt {
-        Statement::When(_) => {
-            if let Some(label) = label_from_statement(
-                stmt,
-                "check_initial_statement/when_in_initial_algorithm",
-                "when-statement in initial algorithm section",
-            ) {
-                diags.push(semantic_error(
-                    ER018_WHEN_IN_INITIAL_SECTION,
-                    "when-statements are not allowed in initial algorithm sections (MLS §8.6)",
-                    label,
-                ));
-            }
+    let mut visitor = InitialStatementVisitor { diags };
+    let _ = visitor.visit_statement(stmt);
+}
+
+struct InitialEquationVisitor<'a> {
+    diags: &'a mut Vec<Diagnostic>,
+}
+
+impl ast::Visitor for InitialEquationVisitor<'_> {
+    fn visit_equation(&mut self, eq: &Equation) -> std::ops::ControlFlow<()> {
+        if let Equation::When(_) = eq
+            && let Some(label) = label_from_equation(
+                eq,
+                "check_initial_equation/when_in_initial_equation",
+                "when-equation in initial equation section",
+            )
+        {
+            self.diags.push(semantic_error(
+                ER018_WHEN_IN_INITIAL_SECTION,
+                "when-equations are not allowed in initial equation sections (MLS §8.6)",
+                label,
+            ));
+            return std::ops::ControlFlow::Continue(());
         }
-        Statement::For { equations, .. } => {
-            for inner in equations {
-                check_initial_statement(inner, diags);
-            }
-        }
-        Statement::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                for inner in &block.stmts {
-                    check_initial_statement(inner, diags);
-                }
-            }
-            if let Some(else_stmts) = else_block {
-                for inner in else_stmts {
-                    check_initial_statement(inner, diags);
-                }
-            }
-        }
-        _ => {}
+        walk_equation_default(self, eq)
     }
 }
 
-/// Check statements for context-sensitive issues.
-fn check_statement(stmt: &Statement, ctx: &mut CheckContext, diags: &mut Vec<Diagnostic>) {
-    match stmt {
-        Statement::When(blocks) => {
-            // ALG-007/FUNC-007: When-statement in function
-            if ctx.in_function
-                && let Some(label) = label_from_statement(
-                    stmt,
-                    "check_statement/when_in_function",
-                    "when-statement is not allowed in function",
-                )
-            {
-                diags.push(semantic_error(
-                    ER015_WHEN_IN_FUNCTION,
-                    "when-statements are not allowed in functions (MLS §12.2)",
-                    label,
-                ));
-            }
+struct InitialStatementVisitor<'a> {
+    diags: &'a mut Vec<Diagnostic>,
+}
 
-            // ALG-009: Nested when-statements
-            if ctx.in_when_statement
-                && let Some(label) = label_from_statement(
-                    stmt,
-                    "check_statement/nested_when_statement",
-                    "nested when-statement is not allowed",
-                )
-            {
-                diags.push(semantic_error(
-                    ER016_NESTED_WHEN_STATEMENT,
-                    "when-statements cannot be nested (MLS §11.2.7)",
-                    label,
-                ));
-            }
-
-            let was = ctx.in_when_statement;
-            ctx.in_when_statement = true;
-            for block in blocks {
-                for inner_stmt in &block.stmts {
-                    check_statement(inner_stmt, ctx, diags);
-                }
-            }
-            ctx.in_when_statement = was;
-        }
-        Statement::For { equations, .. } => {
-            for inner_stmt in equations {
-                check_statement(inner_stmt, ctx, diags);
-            }
-        }
-        Statement::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                for inner_stmt in &block.stmts {
-                    check_statement(inner_stmt, ctx, diags);
-                }
-            }
-            if let Some(else_stmts) = else_block {
-                for inner_stmt in else_stmts {
-                    check_statement(inner_stmt, ctx, diags);
-                }
-            }
-        }
-        Statement::While(block) => {
-            for inner_stmt in &block.stmts {
-                check_statement(inner_stmt, ctx, diags);
-            }
-        }
-        Statement::Reinit { .. } if !ctx.in_when_statement => {
-            if let Some(label) = label_from_statement(
+impl ast::Visitor for InitialStatementVisitor<'_> {
+    fn visit_statement(&mut self, stmt: &Statement) -> std::ops::ControlFlow<()> {
+        if let Statement::When(_) = stmt
+            && let Some(label) = label_from_statement(
                 stmt,
-                "check_statement/reinit_outside_when_statement",
-                "reinit() used outside when-statement",
-            ) {
-                diags.push(semantic_error(
-                    ER008_REINIT_OUTSIDE_WHEN,
-                    "reinit() can only be used inside when-statements (MLS §8.3.6)",
-                    label,
-                ));
-            }
+                "check_initial_statement/when_in_initial_algorithm",
+                "when-statement in initial algorithm section",
+            )
+        {
+            self.diags.push(semantic_error(
+                ER018_WHEN_IN_INITIAL_SECTION,
+                "when-statements are not allowed in initial algorithm sections (MLS §8.6)",
+                label,
+            ));
+            return std::ops::ControlFlow::Continue(());
         }
-        _ => {}
+        walk_statement_default(self, stmt)
     }
 }
 

--- a/crates/rumoca-phase-resolve/src/semantic_checks_expr.rs
+++ b/crates/rumoca-phase-resolve/src/semantic_checks_expr.rs
@@ -1,104 +1,47 @@
 use super::*;
+use std::ops::ControlFlow::Continue;
 
 pub(super) fn run_chained_relational_checks(def: &StoredDefinition) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
-    for class in def.classes.values() {
-        check_chained_in_class(class, &mut diags);
-    }
+    let mut visitor = ChainedRelationalVisitor { diags: &mut diags };
+    let _ = visitor.visit_stored_definition(def);
     diags
 }
 
-fn check_chained_in_class(class: &ClassDef, diags: &mut Vec<Diagnostic>) {
-    for eq in &class.equations {
-        check_chained_in_eq(eq, diags);
-    }
-    for eq in &class.initial_equations {
-        check_chained_in_eq(eq, diags);
-    }
-    for alg in &class.algorithms {
-        for stmt in alg {
-            check_chained_in_stmt(stmt, diags);
-        }
-    }
-    for nested in class.classes.values() {
-        check_chained_in_class(nested, diags);
-    }
+struct ChainedRelationalVisitor<'a> {
+    diags: &'a mut Vec<Diagnostic>,
 }
 
-fn check_chained_in_eq(eq: &Equation, diags: &mut Vec<Diagnostic>) {
-    match eq {
-        Equation::Simple { lhs, rhs, .. } => {
-            check_chained_in_expr(lhs, diags);
-            check_chained_in_expr(rhs, diags);
+impl ast::Visitor for ChainedRelationalVisitor<'_> {
+    fn visit_class_def(&mut self, class: &ClassDef) -> std::ops::ControlFlow<()> {
+        self.visit_each(&class.equations, Self::visit_equation)?;
+        self.visit_each(&class.initial_equations, Self::visit_equation)?;
+        for algorithm in &class.algorithms {
+            self.visit_each(algorithm, Self::visit_statement)?;
         }
-        Equation::For { equations, .. } => {
-            for inner in equations {
-                check_chained_in_eq(inner, diags);
-            }
+        for nested in class.classes.values() {
+            self.visit_class_def(nested)?;
         }
-        Equation::When(blocks) => {
-            for block in blocks {
-                check_chained_in_expr(&block.cond, diags);
-                for inner in &block.eqs {
-                    check_chained_in_eq(inner, diags);
-                }
-            }
-        }
-        Equation::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                check_chained_in_expr(&block.cond, diags);
-                for inner in &block.eqs {
-                    check_chained_in_eq(inner, diags);
-                }
-            }
-            if let Some(else_eqs) = else_block {
-                for inner in else_eqs {
-                    check_chained_in_eq(inner, diags);
-                }
-            }
-        }
-        _ => {}
+        Continue(())
     }
-}
 
-fn check_chained_in_stmt(stmt: &Statement, diags: &mut Vec<Diagnostic>) {
-    match stmt {
-        Statement::Assignment { value, .. } => check_chained_in_expr(value, diags),
-        Statement::For { equations, .. } => {
-            for inner in equations {
-                check_chained_in_stmt(inner, diags);
-            }
+    fn visit_expression(&mut self, expr: &Expression) -> std::ops::ControlFlow<()> {
+        if let Expression::Binary { op, lhs, rhs, .. } = expr
+            && is_relational(op)
+            && (expr_is_relational(lhs) || expr_is_relational(rhs))
+            && let Some(token) = relational_op_token(op)
+        {
+            self.diags.push(semantic_error(
+                ER039_CHAINED_RELATIONAL_OPERATOR,
+                "chained relational operators are not allowed (MLS §3.2)",
+                label_from_token(
+                    token,
+                    "check_chained_in_expr/chained_relational",
+                    "chained relational operator",
+                ),
+            ));
         }
-        Statement::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                check_chained_in_expr(&block.cond, diags);
-                for inner in &block.stmts {
-                    check_chained_in_stmt(inner, diags);
-                }
-            }
-            if let Some(else_stmts) = else_block {
-                for inner in else_stmts {
-                    check_chained_in_stmt(inner, diags);
-                }
-            }
-        }
-        Statement::When(blocks) => {
-            for block in blocks {
-                check_chained_in_expr(&block.cond, diags);
-                for inner in &block.stmts {
-                    check_chained_in_stmt(inner, diags);
-                }
-            }
-        }
-        _ => {}
+        walk_expression_default(self, expr)
     }
 }
 
@@ -130,159 +73,61 @@ fn relational_op_token(op: &OpBinary) -> Option<&Token> {
     }
 }
 
-fn check_chained_in_expr(expr: &Expression, diags: &mut Vec<Diagnostic>) {
-    match expr {
-        Expression::Binary { op, lhs, rhs, .. } => {
-            if is_relational(op) && (expr_is_relational(lhs) || expr_is_relational(rhs)) {
-                let Some(token) = relational_op_token(op) else {
-                    return;
-                };
-                diags.push(semantic_error(
-                    ER039_CHAINED_RELATIONAL_OPERATOR,
-                    "chained relational operators are not allowed (MLS §3.2)",
-                    label_from_token(
-                        token,
-                        "check_chained_in_expr/chained_relational",
-                        "chained relational operator",
-                    ),
-                ));
-            }
-            check_chained_in_expr(lhs, diags);
-            check_chained_in_expr(rhs, diags);
-        }
-        Expression::Unary { rhs, .. } => check_chained_in_expr(rhs, diags),
-        Expression::FunctionCall { args, .. } => {
-            for arg in args {
-                check_chained_in_expr(arg, diags);
-            }
-        }
-        Expression::If {
-            branches,
-            else_branch,
-            ..
-        } => {
-            for (cond, then_expr) in branches {
-                check_chained_in_expr(cond, diags);
-                check_chained_in_expr(then_expr, diags);
-            }
-            check_chained_in_expr(else_branch, diags);
-        }
-        Expression::Array { elements, .. } => {
-            for elem in elements {
-                check_chained_in_expr(elem, diags);
-            }
-        }
-        Expression::Parenthesized { inner, .. } => check_chained_in_expr(inner, diags),
-        _ => {}
-    }
-}
-
 pub(super) fn run_der_in_function_checks(def: &StoredDefinition) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
-    for class in def.classes.values() {
-        check_der_in_func_class(class, &mut diags);
-    }
+    let mut visitor = DerInFunctionVisitor {
+        diags: &mut diags,
+        in_function_class: false,
+    };
+    let _ = visitor.visit_stored_definition(def);
     diags
 }
 
-fn check_der_in_func_class(class: &ClassDef, diags: &mut Vec<Diagnostic>) {
-    if class.class_type == ClassType::Function {
-        for alg in &class.algorithms {
-            for stmt in alg {
-                check_der_in_stmt(stmt, diags);
-            }
-        }
-    }
-    for nested in class.classes.values() {
-        check_der_in_func_class(nested, diags);
-    }
+struct DerInFunctionVisitor<'a> {
+    diags: &'a mut Vec<Diagnostic>,
+    in_function_class: bool,
 }
 
-fn check_der_in_stmt(stmt: &Statement, diags: &mut Vec<Diagnostic>) {
-    match stmt {
-        Statement::Assignment { value, .. } => check_der_in_expr(value, diags),
-        Statement::For { equations, .. } => {
-            for inner in equations {
-                check_der_in_stmt(inner, diags);
-            }
-        }
-        Statement::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                check_der_in_expr(&block.cond, diags);
-                for inner in &block.stmts {
-                    check_der_in_stmt(inner, diags);
-                }
-            }
-            if let Some(else_stmts) = else_block {
-                for inner in else_stmts {
-                    check_der_in_stmt(inner, diags);
-                }
-            }
-        }
-        Statement::When(blocks) => {
-            for block in blocks {
-                check_der_in_expr(&block.cond, diags);
-                for inner in &block.stmts {
-                    check_der_in_stmt(inner, diags);
-                }
-            }
-        }
-        Statement::FunctionCall { args, .. } => {
-            for arg in args {
-                check_der_in_expr(arg, diags);
-            }
-        }
-        _ => {}
-    }
-}
+impl ast::Visitor for DerInFunctionVisitor<'_> {
+    fn visit_class_def(&mut self, class: &ClassDef) -> std::ops::ControlFlow<()> {
+        let previous = self.in_function_class;
+        self.in_function_class = class.class_type == ClassType::Function;
 
-fn check_der_in_expr(expr: &Expression, diags: &mut Vec<Diagnostic>) {
-    match expr {
-        Expression::FunctionCall { comp, args, .. } => {
-            if let Some(first) = comp.parts.first()
-                && &*first.ident.text == "der"
-            {
-                diags.push(semantic_error(
-                    ER030_DER_IN_FUNCTION,
-                    "der() is not allowed in functions (MLS §12.2)",
-                    label_from_token(
-                        &first.ident,
-                        "check_der_in_expr/der_in_function",
-                        "der() is not allowed in function algorithms",
-                    ),
-                ));
-            }
-            for arg in args {
-                check_der_in_expr(arg, diags);
+        if self.in_function_class {
+            for algorithm in &class.algorithms {
+                self.visit_each(algorithm, Self::visit_statement)?;
             }
         }
-        Expression::Binary { lhs, rhs, .. } => {
-            check_der_in_expr(lhs, diags);
-            check_der_in_expr(rhs, diags);
+        for nested in class.classes.values() {
+            self.visit_class_def(nested)?;
         }
-        Expression::Unary { rhs, .. } => check_der_in_expr(rhs, diags),
-        Expression::If {
-            branches,
-            else_branch,
-            ..
-        } => {
-            for (cond, then_expr) in branches {
-                check_der_in_expr(cond, diags);
-                check_der_in_expr(then_expr, diags);
-            }
-            check_der_in_expr(else_branch, diags);
+
+        self.in_function_class = previous;
+        Continue(())
+    }
+
+    fn visit_expr_function_call_ctx(
+        &mut self,
+        comp: &ComponentReference,
+        args: &[Expression],
+        ctx: ast::FunctionCallContext,
+    ) -> std::ops::ControlFlow<()> {
+        if self.in_function_class
+            && matches!(ctx, ast::FunctionCallContext::Expression)
+            && let Some(first) = comp.parts.first()
+            && &*first.ident.text == "der"
+        {
+            self.diags.push(semantic_error(
+                ER030_DER_IN_FUNCTION,
+                "der() is not allowed in functions (MLS §12.2)",
+                label_from_token(
+                    &first.ident,
+                    "check_der_in_expr/der_in_function",
+                    "der() is not allowed in function algorithms",
+                ),
+            ));
         }
-        Expression::Array { elements, .. } => {
-            for elem in elements {
-                check_der_in_expr(elem, diags);
-            }
-        }
-        Expression::Parenthesized { inner, .. } => check_der_in_expr(inner, diags),
-        _ => {}
+        self.visit_each(args, Self::visit_expression)
     }
 }
 
@@ -296,102 +141,76 @@ pub(super) fn check_der_on_discrete_eq(
     discrete_vars: &HashSet<String>,
     diags: &mut Vec<Diagnostic>,
 ) {
-    match eq {
-        Equation::Simple { lhs, rhs, .. } => {
-            check_der_on_discrete_expr(lhs, discrete_vars, diags);
-            check_der_on_discrete_expr(rhs, discrete_vars, diags);
-        }
-        Equation::For { equations, .. } => {
-            for inner in equations {
-                check_der_on_discrete_eq(inner, discrete_vars, diags);
-            }
-        }
-        Equation::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                for inner in &block.eqs {
-                    check_der_on_discrete_eq(inner, discrete_vars, diags);
-                }
-            }
-            if let Some(else_eqs) = else_block {
-                for inner in else_eqs {
-                    check_der_on_discrete_eq(inner, discrete_vars, diags);
-                }
-            }
-        }
-        Equation::When(blocks) => {
-            for block in blocks {
-                for inner in &block.eqs {
-                    check_der_on_discrete_eq(inner, discrete_vars, diags);
-                }
-            }
-        }
-        _ => {}
-    }
+    let mut visitor = DerOnDiscreteVisitor {
+        discrete_vars,
+        diags,
+    };
+    let _ = visitor.visit_equation(eq);
 }
 
-fn check_der_on_discrete_expr(
-    expr: &Expression,
-    discrete_vars: &HashSet<String>,
-    diags: &mut Vec<Diagnostic>,
-) {
-    match expr {
-        Expression::FunctionCall { comp, args, .. } => {
-            if let Some(first) = comp.parts.first()
-                && &*first.ident.text == "der"
-            {
-                // Check if the argument is a discrete variable
-                if let Some(arg) = args.first()
-                    && let Expression::ComponentReference(cref) = arg
-                    && let Some(part) = cref.parts.first()
-                    && discrete_vars.contains(&*part.ident.text)
-                {
-                    diags.push(semantic_error(
-                        ER026_DER_ON_DISCRETE,
-                        format!(
-                            "der() cannot be applied to discrete variable '{}' (MLS §3.8.5)",
-                            part.ident.text
-                        ),
-                        label_from_token(
-                            &part.ident,
-                            "check_der_on_discrete_expr/discrete_argument",
-                            format!("discrete variable '{}' passed to der()", part.ident.text),
-                        ),
-                    ));
+struct DerOnDiscreteVisitor<'a> {
+    discrete_vars: &'a HashSet<String>,
+    diags: &'a mut Vec<Diagnostic>,
+}
+
+impl ast::Visitor for DerOnDiscreteVisitor<'_> {
+    fn visit_equation(&mut self, eq: &Equation) -> std::ops::ControlFlow<()> {
+        match eq {
+            Equation::Simple { lhs, rhs } => {
+                self.visit_expression(lhs)?;
+                self.visit_expression(rhs)
+            }
+            Equation::For { equations, .. } => self.visit_each(equations, Self::visit_equation),
+            Equation::If {
+                cond_blocks,
+                else_block,
+            } => {
+                for block in cond_blocks {
+                    self.visit_each(&block.eqs, Self::visit_equation)?;
                 }
+                if let Some(else_eqs) = else_block {
+                    self.visit_each(else_eqs, Self::visit_equation)?;
+                }
+                Continue(())
             }
-            for arg in args {
-                check_der_on_discrete_expr(arg, discrete_vars, diags);
+            Equation::When(blocks) => {
+                for block in blocks {
+                    self.visit_each(&block.eqs, Self::visit_equation)?;
+                }
+                Continue(())
             }
+            _ => Continue(()),
         }
-        Expression::Binary { lhs, rhs, .. } => {
-            check_der_on_discrete_expr(lhs, discrete_vars, diags);
-            check_der_on_discrete_expr(rhs, discrete_vars, diags);
+    }
+
+    fn visit_expr_function_call_ctx(
+        &mut self,
+        comp: &ComponentReference,
+        args: &[Expression],
+        ctx: ast::FunctionCallContext,
+    ) -> std::ops::ControlFlow<()> {
+        if matches!(ctx, ast::FunctionCallContext::Expression)
+            && let Some(first) = comp.parts.first()
+            && &*first.ident.text == "der"
+            && let Some(arg) = args.first()
+            && let Expression::ComponentReference(cref) = arg
+            && let Some(part) = cref.parts.first()
+            && self.discrete_vars.contains(&*part.ident.text)
+        {
+            self.diags.push(semantic_error(
+                ER026_DER_ON_DISCRETE,
+                format!(
+                    "der() cannot be applied to discrete variable '{}' (MLS §3.8.5)",
+                    part.ident.text
+                ),
+                label_from_token(
+                    &part.ident,
+                    "check_der_on_discrete_expr/discrete_argument",
+                    format!("discrete variable '{}' passed to der()", part.ident.text),
+                ),
+            ));
         }
-        Expression::Unary { rhs, .. } => check_der_on_discrete_expr(rhs, discrete_vars, diags),
-        Expression::If {
-            branches,
-            else_branch,
-            ..
-        } => {
-            for (cond, then_expr) in branches {
-                check_der_on_discrete_expr(cond, discrete_vars, diags);
-                check_der_on_discrete_expr(then_expr, discrete_vars, diags);
-            }
-            check_der_on_discrete_expr(else_branch, discrete_vars, diags);
-        }
-        Expression::Array { elements, .. } => {
-            for elem in elements {
-                check_der_on_discrete_expr(elem, discrete_vars, diags);
-            }
-        }
-        Expression::Parenthesized { inner, .. } => {
-            check_der_on_discrete_expr(inner, discrete_vars, diags);
-        }
-        _ => {}
+        self.visit_each(args, Self::visit_expression)
     }
 }
 
@@ -406,85 +225,55 @@ pub(super) fn check_protected_access_eq(
     def: &StoredDefinition,
     diags: &mut Vec<Diagnostic>,
 ) {
-    match eq {
-        Equation::Simple { lhs, rhs, .. } => {
-            check_protected_access_expr(lhs, class, def, diags);
-            check_protected_access_expr(rhs, class, def, diags);
-        }
-        Equation::For { equations, .. } => {
-            for inner in equations {
-                check_protected_access_eq(inner, class, def, diags);
-            }
-        }
-        Equation::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                for inner in &block.eqs {
-                    check_protected_access_eq(inner, class, def, diags);
-                }
-            }
-            if let Some(else_eqs) = else_block {
-                for inner in else_eqs {
-                    check_protected_access_eq(inner, class, def, diags);
-                }
-            }
-        }
-        Equation::When(blocks) => {
-            for block in blocks {
-                for inner in &block.eqs {
-                    check_protected_access_eq(inner, class, def, diags);
-                }
-            }
-        }
-        _ => {}
-    }
+    let mut visitor = ProtectedAccessVisitor { class, def, diags };
+    let _ = visitor.visit_equation(eq);
 }
 
-fn check_protected_access_expr(
-    expr: &Expression,
-    class: &ClassDef,
-    def: &StoredDefinition,
-    diags: &mut Vec<Diagnostic>,
-) {
-    match expr {
-        Expression::ComponentReference(cref) => {
-            check_cref_protected_access(cref, class, def, diags);
-        }
-        Expression::Binary { lhs, rhs, .. } => {
-            check_protected_access_expr(lhs, class, def, diags);
-            check_protected_access_expr(rhs, class, def, diags);
-        }
-        Expression::Unary { rhs, .. } => {
-            check_protected_access_expr(rhs, class, def, diags);
-        }
-        Expression::FunctionCall { args, .. } => {
-            for arg in args {
-                check_protected_access_expr(arg, class, def, diags);
+struct ProtectedAccessVisitor<'a> {
+    class: &'a ClassDef,
+    def: &'a StoredDefinition,
+    diags: &'a mut Vec<Diagnostic>,
+}
+
+impl ast::Visitor for ProtectedAccessVisitor<'_> {
+    fn visit_equation(&mut self, eq: &Equation) -> std::ops::ControlFlow<()> {
+        match eq {
+            Equation::Simple { lhs, rhs } => {
+                self.visit_expression(lhs)?;
+                self.visit_expression(rhs)
             }
-        }
-        Expression::If {
-            branches,
-            else_branch,
-            ..
-        } => {
-            for (cond, then_expr) in branches {
-                check_protected_access_expr(cond, class, def, diags);
-                check_protected_access_expr(then_expr, class, def, diags);
+            Equation::For { equations, .. } => self.visit_each(equations, Self::visit_equation),
+            Equation::If {
+                cond_blocks,
+                else_block,
+            } => {
+                for block in cond_blocks {
+                    self.visit_each(&block.eqs, Self::visit_equation)?;
+                }
+                if let Some(else_eqs) = else_block {
+                    self.visit_each(else_eqs, Self::visit_equation)?;
+                }
+                Continue(())
             }
-            check_protected_access_expr(else_branch, class, def, diags);
-        }
-        Expression::Array { elements, .. } => {
-            for elem in elements {
-                check_protected_access_expr(elem, class, def, diags);
+            Equation::When(blocks) => {
+                for block in blocks {
+                    self.visit_each(&block.eqs, Self::visit_equation)?;
+                }
+                Continue(())
             }
+            _ => Continue(()),
         }
-        Expression::Parenthesized { inner, .. } => {
-            check_protected_access_expr(inner, class, def, diags);
+    }
+
+    fn visit_component_reference_ctx(
+        &mut self,
+        cref: &ComponentReference,
+        ctx: ast::ComponentReferenceContext,
+    ) -> std::ops::ControlFlow<()> {
+        if matches!(ctx, ast::ComponentReferenceContext::Expression) {
+            check_cref_protected_access(cref, self.class, self.def, self.diags);
         }
-        _ => {}
+        ast::Visitor::visit_component_reference(self, cref)
     }
 }
 
@@ -537,33 +326,45 @@ pub(super) fn check_connect_requires_connectors_eq(
     def: &StoredDefinition,
     diags: &mut Vec<Diagnostic>,
 ) {
-    match eq {
-        Equation::Connect { lhs, rhs, .. } => {
-            check_connect_arg_is_connector(lhs, class, def, diags);
-            check_connect_arg_is_connector(rhs, class, def, diags);
-        }
-        Equation::For { equations, .. } => {
-            for inner in equations {
-                check_connect_requires_connectors_eq(inner, class, def, diags);
-            }
-        }
-        Equation::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                for inner in &block.eqs {
-                    check_connect_requires_connectors_eq(inner, class, def, diags);
+    let mut visitor = ConnectRequiresConnectorsVisitor { class, def, diags };
+    let _ = visitor.visit_equation(eq);
+}
+
+struct ConnectRequiresConnectorsVisitor<'a> {
+    class: &'a ClassDef,
+    def: &'a StoredDefinition,
+    diags: &'a mut Vec<Diagnostic>,
+}
+
+impl ast::Visitor for ConnectRequiresConnectorsVisitor<'_> {
+    fn visit_equation(&mut self, eq: &Equation) -> std::ops::ControlFlow<()> {
+        match eq {
+            Equation::Connect { lhs, rhs } => self.visit_connect(lhs, rhs),
+            Equation::For { equations, .. } => self.visit_each(equations, Self::visit_equation),
+            Equation::If {
+                cond_blocks,
+                else_block,
+            } => {
+                for block in cond_blocks {
+                    self.visit_each(&block.eqs, Self::visit_equation)?;
                 }
-            }
-            if let Some(else_eqs) = else_block {
-                for inner in else_eqs {
-                    check_connect_requires_connectors_eq(inner, class, def, diags);
+                if let Some(else_eqs) = else_block {
+                    self.visit_each(else_eqs, Self::visit_equation)?;
                 }
+                Continue(())
             }
+            _ => Continue(()),
         }
-        _ => {}
+    }
+
+    fn visit_connect(
+        &mut self,
+        lhs: &ComponentReference,
+        rhs: &ComponentReference,
+    ) -> std::ops::ControlFlow<()> {
+        check_connect_arg_is_connector(lhs, self.class, self.def, self.diags);
+        check_connect_arg_is_connector(rhs, self.class, self.def, self.diags);
+        Continue(())
     }
 }
 
@@ -631,56 +432,56 @@ fn check_connect_arg_is_connector(
 
 /// Check equations for 'end' used outside of array subscripts.
 pub(super) fn check_end_outside_subscript_eq(eq: &Equation, diags: &mut Vec<Diagnostic>) {
-    match eq {
-        Equation::Simple { lhs, rhs, .. } => {
-            check_end_outside_subscript_expr(lhs, false, diags);
-            check_end_outside_subscript_expr(rhs, false, diags);
-        }
-        Equation::For { equations, .. } => {
-            for inner in equations {
-                check_end_outside_subscript_eq(inner, diags);
-            }
-        }
-        Equation::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                for inner in &block.eqs {
-                    check_end_outside_subscript_eq(inner, diags);
-                }
-            }
-            if let Some(else_eqs) = else_block {
-                for inner in else_eqs {
-                    check_end_outside_subscript_eq(inner, diags);
-                }
-            }
-        }
-        Equation::When(blocks) => {
-            for block in blocks {
-                for inner in &block.eqs {
-                    check_end_outside_subscript_eq(inner, diags);
-                }
-            }
-        }
-        _ => {}
-    }
+    let mut visitor = EndOutsideSubscriptVisitor {
+        diags,
+        subscript_depth: 0,
+    };
+    let _ = visitor.visit_equation(eq);
 }
 
-/// Check an expression for 'end' used outside subscript context.
-/// `in_subscript` tracks whether we're inside a subscript.
-fn check_end_outside_subscript_expr(
-    expr: &Expression,
-    in_subscript: bool,
-    diags: &mut Vec<Diagnostic>,
-) {
-    match expr {
-        Expression::Terminal {
-            terminal_type: TerminalType::End,
-            token,
-        } if !in_subscript => {
-            diags.push(semantic_error(
+struct EndOutsideSubscriptVisitor<'a> {
+    diags: &'a mut Vec<Diagnostic>,
+    subscript_depth: usize,
+}
+
+impl ast::Visitor for EndOutsideSubscriptVisitor<'_> {
+    fn visit_equation(&mut self, eq: &Equation) -> std::ops::ControlFlow<()> {
+        match eq {
+            Equation::Simple { lhs, rhs } => {
+                self.visit_expression(lhs)?;
+                self.visit_expression(rhs)
+            }
+            Equation::For { equations, .. } => self.visit_each(equations, Self::visit_equation),
+            Equation::If {
+                cond_blocks,
+                else_block,
+            } => {
+                for block in cond_blocks {
+                    self.visit_each(&block.eqs, Self::visit_equation)?;
+                }
+                if let Some(else_eqs) = else_block {
+                    self.visit_each(else_eqs, Self::visit_equation)?;
+                }
+                Continue(())
+            }
+            Equation::When(blocks) => {
+                for block in blocks {
+                    self.visit_each(&block.eqs, Self::visit_equation)?;
+                }
+                Continue(())
+            }
+            _ => Continue(()),
+        }
+    }
+
+    fn visit_expression(&mut self, expr: &Expression) -> std::ops::ControlFlow<()> {
+        if self.subscript_depth == 0
+            && let Expression::Terminal {
+                terminal_type: TerminalType::End,
+                token,
+            } = expr
+        {
+            self.diags.push(semantic_error(
                 ER031_END_OUTSIDE_SUBSCRIPT,
                 "'end' can only be used within array subscripts (MLS §10.5.1)",
                 label_from_token(
@@ -690,55 +491,20 @@ fn check_end_outside_subscript_expr(
                 ),
             ));
         }
-        Expression::ComponentReference(cref) => {
-            // Subscripts inside component references count as subscript context
-            let subs = cref.parts.iter().filter_map(|p| p.subs.as_ref()).flatten();
-            for sub in subs {
-                check_end_outside_subscript_subscript(sub, diags);
-            }
-        }
-        Expression::Binary { lhs, rhs, .. } => {
-            check_end_outside_subscript_expr(lhs, in_subscript, diags);
-            check_end_outside_subscript_expr(rhs, in_subscript, diags);
-        }
-        Expression::Unary { rhs, .. } => {
-            check_end_outside_subscript_expr(rhs, in_subscript, diags);
-        }
-        Expression::FunctionCall { args, .. } => {
-            for arg in args {
-                check_end_outside_subscript_expr(arg, in_subscript, diags);
-            }
-        }
-        Expression::If {
-            branches,
-            else_branch,
-            ..
-        } => {
-            for (cond, then_expr) in branches {
-                check_end_outside_subscript_expr(cond, in_subscript, diags);
-                check_end_outside_subscript_expr(then_expr, in_subscript, diags);
-            }
-            check_end_outside_subscript_expr(else_branch, in_subscript, diags);
-        }
-        Expression::Array { elements, .. } => {
-            for elem in elements {
-                check_end_outside_subscript_expr(elem, in_subscript, diags);
-            }
-        }
-        Expression::Parenthesized { inner, .. } => {
-            check_end_outside_subscript_expr(inner, in_subscript, diags);
-        }
-        _ => {}
+        walk_expression_default(self, expr)
     }
-}
 
-fn check_end_outside_subscript_subscript(sub: &Subscript, diags: &mut Vec<Diagnostic>) {
-    match sub {
-        Subscript::Expression(expr) => {
-            // Inside a subscript, 'end' is valid
-            check_end_outside_subscript_expr(expr, true, diags);
+    fn visit_subscript_ctx(
+        &mut self,
+        sub: &Subscript,
+        _ctx: ast::SubscriptContext,
+    ) -> std::ops::ControlFlow<()> {
+        if let Subscript::Expression(expr) = sub {
+            self.subscript_depth += 1;
+            self.visit_expression(expr)?;
+            self.subscript_depth -= 1;
         }
-        Subscript::Empty | Subscript::Range { .. } => {}
+        Continue(())
     }
 }
 
@@ -755,61 +521,62 @@ pub(super) fn check_expr_type_issues_eq(
     real_vars: &HashSet<String>,
     diags: &mut Vec<Diagnostic>,
 ) {
-    match eq {
-        Equation::Simple { lhs, rhs, .. } => {
-            check_expr_type_issues(lhs, class, def, real_vars, diags);
-            check_expr_type_issues(rhs, class, def, real_vars, diags);
-        }
-        Equation::For { equations, .. } => {
-            for inner in equations {
-                check_expr_type_issues_eq(inner, class, def, real_vars, diags);
-            }
-        }
-        Equation::If {
-            cond_blocks,
-            else_block,
-            ..
-        } => {
-            for block in cond_blocks {
-                for inner in &block.eqs {
-                    check_expr_type_issues_eq(inner, class, def, real_vars, diags);
-                }
-            }
-            if let Some(else_eqs) = else_block {
-                for inner in else_eqs {
-                    check_expr_type_issues_eq(inner, class, def, real_vars, diags);
-                }
-            }
-        }
-        Equation::When(blocks) => {
-            for block in blocks {
-                for inner in &block.eqs {
-                    check_expr_type_issues_eq(inner, class, def, real_vars, diags);
-                }
-            }
-        }
-        _ => {}
-    }
+    let mut visitor = ExprTypeIssuesVisitor {
+        class,
+        def,
+        real_vars,
+        diags,
+    };
+    let _ = visitor.visit_equation(eq);
 }
 
-fn check_expr_type_issues(
-    expr: &Expression,
-    class: &ClassDef,
-    def: &StoredDefinition,
-    real_vars: &HashSet<String>,
-    diags: &mut Vec<Diagnostic>,
-) {
-    match expr {
-        // EXPR-002: Real equality/inequality comparison
-        Expression::Binary { op, lhs, rhs, .. } => {
-            if matches!(op, OpBinary::Eq(_) | OpBinary::Neq(_))
-                && (expr_is_real(lhs, real_vars) || expr_is_real(rhs, real_vars))
-            {
-                let op_token = match op {
-                    OpBinary::Eq(token) | OpBinary::Neq(token) => token,
-                    _ => unreachable!(),
-                };
-                diags.push(semantic_error(
+struct ExprTypeIssuesVisitor<'a> {
+    class: &'a ClassDef,
+    def: &'a StoredDefinition,
+    real_vars: &'a HashSet<String>,
+    diags: &'a mut Vec<Diagnostic>,
+}
+
+impl ast::Visitor for ExprTypeIssuesVisitor<'_> {
+    fn visit_equation(&mut self, eq: &Equation) -> std::ops::ControlFlow<()> {
+        match eq {
+            Equation::Simple { lhs, rhs } => {
+                self.visit_expression(lhs)?;
+                self.visit_expression(rhs)
+            }
+            Equation::For { equations, .. } => self.visit_each(equations, Self::visit_equation),
+            Equation::If {
+                cond_blocks,
+                else_block,
+            } => {
+                for block in cond_blocks {
+                    self.visit_each(&block.eqs, Self::visit_equation)?;
+                }
+                if let Some(else_eqs) = else_block {
+                    self.visit_each(else_eqs, Self::visit_equation)?;
+                }
+                Continue(())
+            }
+            Equation::When(blocks) => {
+                for block in blocks {
+                    self.visit_each(&block.eqs, Self::visit_equation)?;
+                }
+                Continue(())
+            }
+            _ => Continue(()),
+        }
+    }
+
+    fn visit_expression(&mut self, expr: &Expression) -> std::ops::ControlFlow<()> {
+        match expr {
+            // EXPR-002: Real equality/inequality comparison
+            Expression::Binary {
+                op: OpBinary::Eq(op_token) | OpBinary::Neq(op_token),
+                lhs,
+                rhs,
+                ..
+            } if expr_is_real(lhs, self.real_vars) || expr_is_real(rhs, self.real_vars) => {
+                self.diags.push(semantic_error(
                     ER029_REAL_EQUALITY_COMPARISON,
                     "equality comparison on Real values is not allowed \
                      outside functions (MLS §3.5)",
@@ -820,72 +587,55 @@ fn check_expr_type_issues(
                     ),
                 ));
             }
-            check_expr_type_issues(lhs, class, def, real_vars, diags);
-            check_expr_type_issues(rhs, class, def, real_vars, diags);
-        }
-        // EXPR-016: non-Boolean if-expression condition
-        Expression::If {
-            branches,
-            else_branch,
-            ..
-        } => {
-            for (cond, then_expr) in branches {
-                if expr_is_numeric_literal(cond)
-                    && let Some(label) = label_from_expression(
-                        cond,
-                        "check_expr_type_issues/non_boolean_if_condition",
-                        "non-Boolean if-expression condition",
-                    )
+            // EXPR-016: non-Boolean if-expression condition
+            Expression::If { branches, .. } => {
+                for (cond, _) in branches {
+                    emit_non_boolean_if_condition(cond, self.diags);
+                }
+            }
+            // TYPE-005: Class name used as value in equation
+            Expression::ComponentReference(cref) if cref.parts.len() == 1 => {
+                let name = &*cref.parts[0].ident.text;
+                if !self.class.components.contains_key(name)
+                    && find_class_by_name(self.def, name).is_some()
                 {
-                    diags.push(semantic_error(
-                        ER010_IF_CONDITION_NOT_BOOLEAN,
-                        "if-expression condition must be Boolean, \
-                         not a numeric value (MLS §3.6.5)",
-                        label,
+                    self.diags.push(semantic_error(
+                        ER011_CLASS_USED_AS_VALUE,
+                        format!(
+                            "'{}' is a class, not a variable; cannot be used as a value (MLS §4.4)",
+                            name
+                        ),
+                        label_from_token(
+                            &cref.parts[0].ident,
+                            "check_expr_type_issues/class_used_as_value",
+                            format!("class '{}' used as value", name),
+                        ),
                     ));
                 }
-                check_expr_type_issues(cond, class, def, real_vars, diags);
-                check_expr_type_issues(then_expr, class, def, real_vars, diags);
             }
-            check_expr_type_issues(else_branch, class, def, real_vars, diags);
+            _ => {}
         }
-        // TYPE-005: Class name used as value in equation
-        Expression::ComponentReference(cref) if cref.parts.len() == 1 => {
-            let name = &*cref.parts[0].ident.text;
-            // Check if this refers to a class rather than a component
-            if !class.components.contains_key(name) && find_class_by_name(def, name).is_some() {
-                diags.push(semantic_error(
-                    ER011_CLASS_USED_AS_VALUE,
-                    format!(
-                        "'{}' is a class, not a variable; cannot be used as a value (MLS §4.4)",
-                        name
-                    ),
-                    label_from_token(
-                        &cref.parts[0].ident,
-                        "check_expr_type_issues/class_used_as_value",
-                        format!("class '{}' used as value", name),
-                    ),
-                ));
-            }
-        }
-        Expression::Unary { rhs, .. } => {
-            check_expr_type_issues(rhs, class, def, real_vars, diags);
-        }
-        Expression::FunctionCall { args, .. } => {
-            for arg in args {
-                check_expr_type_issues(arg, class, def, real_vars, diags);
-            }
-        }
-        Expression::Array { elements, .. } => {
-            for elem in elements {
-                check_expr_type_issues(elem, class, def, real_vars, diags);
-            }
-        }
-        Expression::Parenthesized { inner, .. } => {
-            check_expr_type_issues(inner, class, def, real_vars, diags);
-        }
-        _ => {}
+        walk_expression_default(self, expr)
     }
+}
+
+fn emit_non_boolean_if_condition(cond: &Expression, diags: &mut Vec<Diagnostic>) {
+    if !expr_is_numeric_literal(cond) {
+        return;
+    }
+    let Some(label) = label_from_expression(
+        cond,
+        "check_expr_type_issues/non_boolean_if_condition",
+        "non-Boolean if-expression condition",
+    ) else {
+        return;
+    };
+    diags.push(semantic_error(
+        ER010_IF_CONDITION_NOT_BOOLEAN,
+        "if-expression condition must be Boolean, \
+         not a numeric value (MLS §3.6.5)",
+        label,
+    ));
 }
 
 /// Check if an expression is clearly a Real-typed component reference.

--- a/crates/rumoca-phase-resolve/src/traversal_adapter.rs
+++ b/crates/rumoca-phase-resolve/src/traversal_adapter.rs
@@ -1,0 +1,266 @@
+use rumoca_core::ScopeId;
+use rumoca_ir_ast as ast;
+use std::sync::Arc;
+
+type ComponentReference = ast::ComponentReference;
+type Equation = ast::Equation;
+type Expression = ast::Expression;
+type Statement = ast::Statement;
+
+/// Callback contract for resolve traversal.
+///
+/// Traversal is centralized here while semantic actions stay in callbacks.
+pub(crate) trait ResolveTraversalCallbacks {
+    fn create_loop_scope(&mut self, parent_scope: ScopeId) -> ScopeId;
+    fn bind_loop_index_name(&mut self, loop_scope: ScopeId, index_name: &str);
+    fn on_component_reference(&mut self, comp: &mut ComponentReference, scope: ScopeId);
+    fn on_function_reference(&mut self, comp: &mut ComponentReference, scope: ScopeId);
+}
+
+pub(crate) fn walk_equations<C: ResolveTraversalCallbacks>(
+    callbacks: &mut C,
+    equations: &mut [Equation],
+    scope: ScopeId,
+) {
+    for equation in equations {
+        walk_equation(callbacks, equation, scope);
+    }
+}
+
+pub(crate) fn walk_equation<C: ResolveTraversalCallbacks>(
+    callbacks: &mut C,
+    equation: &mut Equation,
+    scope: ScopeId,
+) {
+    match equation {
+        Equation::Simple { lhs, rhs } => {
+            walk_expression(callbacks, lhs, scope);
+            walk_expression(callbacks, rhs, scope);
+        }
+        Equation::Connect { lhs, rhs } => {
+            callbacks.on_component_reference(lhs, scope);
+            callbacks.on_component_reference(rhs, scope);
+        }
+        Equation::For { indices, equations } => {
+            let loop_scope = callbacks.create_loop_scope(scope);
+            for index in indices {
+                callbacks.bind_loop_index_name(loop_scope, index.ident.text.as_ref());
+                walk_expression(callbacks, &mut index.range, loop_scope);
+            }
+            walk_equations(callbacks, equations, loop_scope);
+        }
+        Equation::If {
+            cond_blocks,
+            else_block,
+        } => {
+            for block in cond_blocks {
+                walk_expression(callbacks, &mut block.cond, scope);
+                walk_equations(callbacks, &mut block.eqs, scope);
+            }
+            if let Some(else_equations) = else_block {
+                walk_equations(callbacks, else_equations, scope);
+            }
+        }
+        Equation::When(blocks) => {
+            for block in blocks {
+                walk_expression(callbacks, &mut block.cond, scope);
+                walk_equations(callbacks, &mut block.eqs, scope);
+            }
+        }
+        Equation::FunctionCall { comp, args } => {
+            callbacks.on_function_reference(comp, scope);
+            walk_expressions(callbacks, args, scope);
+        }
+        Equation::Assert {
+            condition,
+            message,
+            level,
+        } => {
+            walk_expression(callbacks, condition, scope);
+            walk_expression(callbacks, message, scope);
+            if let Some(level_expr) = level {
+                walk_expression(callbacks, level_expr, scope);
+            }
+        }
+        Equation::Empty => {}
+    }
+}
+
+pub(crate) fn walk_statements<C: ResolveTraversalCallbacks>(
+    callbacks: &mut C,
+    statements: &mut [Statement],
+    scope: ScopeId,
+) {
+    for statement in statements {
+        walk_statement(callbacks, statement, scope);
+    }
+}
+
+pub(crate) fn walk_statement<C: ResolveTraversalCallbacks>(
+    callbacks: &mut C,
+    statement: &mut Statement,
+    scope: ScopeId,
+) {
+    match statement {
+        Statement::Assignment { comp, value } => {
+            callbacks.on_component_reference(comp, scope);
+            walk_expression(callbacks, value, scope);
+        }
+        Statement::FunctionCall {
+            comp,
+            args,
+            outputs,
+        } => {
+            callbacks.on_function_reference(comp, scope);
+            walk_expressions(callbacks, args, scope);
+            walk_expressions(callbacks, outputs, scope);
+        }
+        Statement::If {
+            cond_blocks,
+            else_block,
+        } => {
+            for block in cond_blocks {
+                walk_expression(callbacks, &mut block.cond, scope);
+                walk_statements(callbacks, &mut block.stmts, scope);
+            }
+            if let Some(else_statements) = else_block {
+                walk_statements(callbacks, else_statements, scope);
+            }
+        }
+        Statement::For { indices, equations } => {
+            let loop_scope = callbacks.create_loop_scope(scope);
+            for index in indices {
+                callbacks.bind_loop_index_name(loop_scope, index.ident.text.as_ref());
+                walk_expression(callbacks, &mut index.range, loop_scope);
+            }
+            walk_statements(callbacks, equations, loop_scope);
+        }
+        Statement::While(block) => {
+            walk_expression(callbacks, &mut block.cond, scope);
+            walk_statements(callbacks, &mut block.stmts, scope);
+        }
+        Statement::When(blocks) => {
+            for block in blocks {
+                walk_expression(callbacks, &mut block.cond, scope);
+                walk_statements(callbacks, &mut block.stmts, scope);
+            }
+        }
+        Statement::Reinit { variable, value } => {
+            callbacks.on_component_reference(variable, scope);
+            walk_expression(callbacks, value, scope);
+        }
+        Statement::Assert {
+            condition,
+            message,
+            level,
+        } => {
+            walk_expression(callbacks, condition, scope);
+            walk_expression(callbacks, message, scope);
+            if let Some(level_expr) = level {
+                walk_expression(callbacks, level_expr, scope);
+            }
+        }
+        Statement::Return { .. } | Statement::Break { .. } | Statement::Empty => {}
+    }
+}
+
+pub(crate) fn walk_expressions<C: ResolveTraversalCallbacks>(
+    callbacks: &mut C,
+    expressions: &mut [Expression],
+    scope: ScopeId,
+) {
+    for expression in expressions {
+        walk_expression(callbacks, expression, scope);
+    }
+}
+
+pub(crate) fn walk_expression<C: ResolveTraversalCallbacks>(
+    callbacks: &mut C,
+    expression: &mut Expression,
+    scope: ScopeId,
+) {
+    match expression {
+        Expression::ComponentReference(comp) => callbacks.on_component_reference(comp, scope),
+        Expression::FunctionCall { comp, args } => {
+            callbacks.on_function_reference(comp, scope);
+            walk_expressions(callbacks, args, scope);
+        }
+        Expression::Binary { lhs, rhs, .. } => {
+            walk_expression(callbacks, Arc::make_mut(lhs), scope);
+            walk_expression(callbacks, Arc::make_mut(rhs), scope);
+        }
+        Expression::Unary { rhs, .. } => walk_expression(callbacks, Arc::make_mut(rhs), scope),
+        Expression::Range { start, step, end } => {
+            walk_expression(callbacks, Arc::make_mut(start), scope);
+            if let Some(step_expression) = step {
+                walk_expression(callbacks, Arc::make_mut(step_expression), scope);
+            }
+            walk_expression(callbacks, Arc::make_mut(end), scope);
+        }
+        Expression::Array { elements, .. } | Expression::Tuple { elements } => {
+            walk_expressions(callbacks, elements, scope);
+        }
+        Expression::If {
+            branches,
+            else_branch,
+        } => {
+            for (condition, then_expr) in branches {
+                walk_expression(callbacks, condition, scope);
+                walk_expression(callbacks, then_expr, scope);
+            }
+            walk_expression(callbacks, Arc::make_mut(else_branch), scope);
+        }
+        Expression::ClassModification {
+            target,
+            modifications,
+        } => {
+            callbacks.on_function_reference(target, scope);
+            walk_expressions(callbacks, modifications, scope);
+        }
+        Expression::Modification { target, value } => {
+            callbacks.on_component_reference(target, scope);
+            walk_expression(callbacks, Arc::make_mut(value), scope);
+        }
+        Expression::NamedArgument { value, .. } => {
+            walk_expression(callbacks, Arc::make_mut(value), scope);
+        }
+        Expression::Parenthesized { inner } => {
+            walk_expression(callbacks, Arc::make_mut(inner), scope);
+        }
+        Expression::ArrayComprehension {
+            expr,
+            indices,
+            filter,
+        } => {
+            let loop_scope = callbacks.create_loop_scope(scope);
+            for index in indices {
+                callbacks.bind_loop_index_name(loop_scope, index.ident.text.as_ref());
+                walk_expression(callbacks, &mut index.range, loop_scope);
+            }
+            walk_expression(callbacks, Arc::make_mut(expr), loop_scope);
+            if let Some(filter_expr) = filter {
+                walk_expression(callbacks, Arc::make_mut(filter_expr), loop_scope);
+            }
+        }
+        Expression::ArrayIndex { base, subscripts } => {
+            walk_expression(callbacks, Arc::make_mut(base), scope);
+            walk_subscripts(callbacks, subscripts, scope);
+        }
+        Expression::FieldAccess { base, .. } => {
+            walk_expression(callbacks, Arc::make_mut(base), scope);
+        }
+        Expression::Terminal { .. } | Expression::Empty => {}
+    }
+}
+
+pub(crate) fn walk_subscripts<C: ResolveTraversalCallbacks>(
+    callbacks: &mut C,
+    subscripts: &mut [ast::Subscript],
+    scope: ScopeId,
+) {
+    for subscript in subscripts {
+        if let ast::Subscript::Expression(expression) = subscript {
+            walk_expression(callbacks, expression, scope);
+        }
+    }
+}

--- a/crates/rumoca-phase-resolve/src/validation.rs
+++ b/crates/rumoca-phase-resolve/src/validation.rs
@@ -10,11 +10,8 @@ type ClassDef = ast::ClassDef;
 type ClassTree = ast::ClassTree;
 type Component = ast::Component;
 type ComponentReference = ast::ComponentReference;
-type Equation = ast::Equation;
 type Expression = ast::Expression;
 type Extend = ast::Extend;
-type Statement = ast::Statement;
-type StoredDefinition = ast::StoredDefinition;
 
 /// An unresolved symbol found during validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,9 +60,9 @@ impl ValidationResult {
 /// Validate that a ClassTree has all symbols resolved.
 pub fn validate_resolution(tree: &ClassTree) -> ValidationResult {
     let mut v = Validator::default();
-    v.visit_stored_def(&tree.definitions);
+    let _ = ast::Visitor::visit_stored_definition(&mut v, &tree.definitions);
     ValidationResult {
-        unresolved: v.unresolved.into_iter().collect(),
+        unresolved: v.unresolved,
     }
 }
 
@@ -73,48 +70,6 @@ pub fn validate_resolution(tree: &ClassTree) -> ValidationResult {
 struct Validator {
     path: Vec<String>,
     unresolved: Vec<UnresolvedSymbol>,
-}
-
-/// Expression visitor adapter for validation.
-struct ExprVisitor<'a>(&'a mut Validator);
-
-impl ast::Visitor for ExprVisitor<'_> {
-    fn visit_component_reference(&mut self, cr: &ComponentReference) -> ControlFlow<()> {
-        self.0.visit_comp_ref(cr);
-        self.visit_each(&cr.parts, |this, part| {
-            if let Some(subs) = &part.subs {
-                this.visit_each(subs, Self::visit_subscript)
-            } else {
-                ControlFlow::Continue(())
-            }
-        })
-    }
-
-    fn visit_expr_function_call(
-        &mut self,
-        comp: &ComponentReference,
-        args: &[Expression],
-    ) -> ControlFlow<()> {
-        // Function calls should have def_id set (builtins are registered)
-        if comp.def_id.is_none() && !comp.parts.is_empty() {
-            let source_location = comp.parts[0].ident.location.clone();
-            self.0.add(
-                comp.to_string(),
-                UnresolvedKind::FunctionCall,
-                source_location,
-            );
-        }
-        // Visit subscript expressions inside the component path, but avoid
-        // re-reporting the function as an unresolved component reference.
-        self.visit_each(&comp.parts, |this, part| {
-            if let Some(subs) = &part.subs {
-                this.visit_each(subs, Self::visit_subscript)
-            } else {
-                ControlFlow::Continue(())
-            }
-        })?;
-        self.visit_each(args, Self::visit_expression)
-    }
 }
 
 impl Validator {
@@ -148,50 +103,85 @@ impl Validator {
         });
     }
 
-    fn with_scope<F: FnOnce(&mut Self)>(&mut self, name: &str, f: F) {
-        self.path.push(name.to_string());
-        f(self);
-        self.path.pop();
+    fn add_unresolved_name(&mut self, name: &ast::Name, kind: UnresolvedKind, _context: &str) {
+        if name.def_id.is_some() || name.name.is_empty() {
+            return;
+        }
+        let Some(source_location) = name.name.first().map(|token| token.location.clone()) else {
+            return;
+        };
+        self.add(name.to_string(), kind, source_location);
     }
 
-    fn visit_stored_def(&mut self, def: &StoredDefinition) {
-        for (name, class) in &def.classes {
-            self.with_scope(name, |v| v.visit_class(class));
+    fn add_unresolved_component_reference(&mut self, cr: &ComponentReference) {
+        if cr.def_id.is_some() || cr.parts.is_empty() {
+            return;
+        }
+        let source_location = cr.parts[0].ident.location.clone();
+        self.add(
+            cr.parts[0].ident.text.to_string(),
+            UnresolvedKind::ComponentReference,
+            source_location,
+        );
+    }
+
+    fn add_unresolved_function_call(&mut self, cr: &ComponentReference) {
+        if cr.def_id.is_none() && !cr.parts.is_empty() {
+            let source_location = cr.parts[0].ident.location.clone();
+            self.add(
+                cr.parts[0].ident.text.to_string(),
+                UnresolvedKind::FunctionCall,
+                source_location,
+            );
         }
     }
+}
 
-    fn visit_class(&mut self, class: &ClassDef) {
+impl ast::Visitor for Validator {
+    fn visit_class_def(&mut self, class: &ClassDef) -> ControlFlow<()> {
+        self.path.push(class.name.text.to_string());
+
+        if let Some(constrainedby) = &class.constrainedby {
+            self.visit_type_name(constrainedby, ast::TypeNameContext::ClassConstrainedBy)?;
+        }
+
         for ext in &class.extends {
-            self.visit_extend(ext);
+            self.visit_extend(ext)?;
         }
-        for (name, comp) in &class.components {
-            self.with_scope(name, |v| v.visit_component(comp));
+
+        self.visit_each(&class.array_subscripts, Self::visit_subscript)?;
+
+        for component in class.components.values() {
+            self.visit_component(component)?;
         }
-        class
-            .equations
-            .iter()
-            .for_each(|eq| self.visit_equation(eq));
-        class
-            .initial_equations
-            .iter()
-            .for_each(|eq| self.visit_equation(eq));
-        class
-            .algorithms
-            .iter()
-            .flatten()
-            .for_each(|s| self.visit_statement(s));
-        class
-            .initial_algorithms
-            .iter()
-            .flatten()
-            .for_each(|s| self.visit_statement(s));
-        for (name, nested) in &class.classes {
-            self.with_scope(name, |v| v.visit_class(nested));
+        self.visit_each(&class.equations, Self::visit_equation)?;
+        self.visit_each(&class.initial_equations, Self::visit_equation)?;
+        for algorithm_section in &class.algorithms {
+            self.visit_each(algorithm_section, Self::visit_statement)?;
         }
+        for algorithm_section in &class.initial_algorithms {
+            self.visit_each(algorithm_section, Self::visit_statement)?;
+        }
+
+        if let Some(external) = &class.external {
+            if let Some(output) = &external.output {
+                self.visit_component_reference_ctx(
+                    output,
+                    ast::ComponentReferenceContext::Expression,
+                )?;
+            }
+            self.visit_each(&external.args, Self::visit_expression)?;
+        }
+
+        for nested in class.classes.values() {
+            self.visit_class_def(nested)?;
+        }
+
+        self.path.pop();
+        ControlFlow::Continue(())
     }
 
-    fn visit_extend(&mut self, ext: &Extend) {
-        // Extends should have base_def_id set (builtins are now registered with DefIds)
+    fn visit_extend(&mut self, ext: &Extend) -> ControlFlow<()> {
         if ext.base_def_id.is_none() {
             self.add(
                 ext.base_name.to_string(),
@@ -199,142 +189,105 @@ impl Validator {
                 ext.location.clone(),
             );
         }
+        for modification in &ext.modifications {
+            self.visit_expression(&modification.expr)?;
+        }
+        ControlFlow::Continue(())
     }
 
-    fn visit_component(&mut self, comp: &Component) {
-        // Component type should have def_id set (builtins are now registered with DefIds)
-        if comp.type_def_id.is_none() && comp.type_name.def_id.is_none() {
-            let source_location = comp
-                .type_name
-                .name
-                .first()
-                .map(|token| token.location.clone())
-                .expect("component type name must include at least one token");
-            self.add(
-                comp.type_name.to_string(),
-                UnresolvedKind::TypeReference,
-                source_location,
-            );
+    fn visit_component(&mut self, comp: &Component) -> ControlFlow<()> {
+        self.path.push(comp.name.clone());
+
+        self.visit_type_name(&comp.type_name, ast::TypeNameContext::ComponentType)?;
+        if let Some(constrainedby) = &comp.constrainedby {
+            self.visit_type_name(constrainedby, ast::TypeNameContext::ComponentConstrainedBy)?;
         }
+
         if !matches!(comp.start, Expression::Empty) {
-            self.visit_expr(&comp.start);
+            self.visit_expression(&comp.start)?;
         }
-        if let Some(cond) = &comp.condition {
-            self.visit_expr(cond);
+        if let Some(binding) = &comp.binding {
+            self.visit_expression(binding)?;
         }
+        for modification in comp.modifications.values() {
+            self.visit_expression(modification)?;
+        }
+        self.visit_each(&comp.shape_expr, Self::visit_subscript)?;
+        if let Some(condition) = &comp.condition {
+            self.visit_expression(condition)?;
+        }
+
+        self.path.pop();
+        ControlFlow::Continue(())
     }
 
-    fn visit_equation(&mut self, eq: &Equation) {
-        match eq {
-            Equation::Empty => {}
-            Equation::Simple { lhs, rhs } => {
-                self.visit_expr(lhs);
-                self.visit_expr(rhs);
+    fn visit_type_name(&mut self, name: &ast::Name, ctx: ast::TypeNameContext) -> ControlFlow<()> {
+        match ctx {
+            ast::TypeNameContext::ExtendsBase => {}
+            ast::TypeNameContext::ComponentType => {
+                self.add_unresolved_name(
+                    name,
+                    UnresolvedKind::TypeReference,
+                    "component type name",
+                );
             }
-            Equation::Connect { lhs, rhs, .. } => {
-                self.visit_comp_ref(lhs);
-                self.visit_comp_ref(rhs);
+            ast::TypeNameContext::ClassConstrainedBy => {
+                self.add_unresolved_name(
+                    name,
+                    UnresolvedKind::TypeReference,
+                    "class constrainedby",
+                );
             }
-            Equation::For { indices, equations } => {
-                indices.iter().for_each(|i| self.visit_expr(&i.range));
-                equations.iter().for_each(|e| self.visit_equation(e));
-            }
-            Equation::If {
-                cond_blocks,
-                else_block,
-            } => {
-                for b in cond_blocks {
-                    self.visit_expr(&b.cond);
-                    b.eqs.iter().for_each(|e| self.visit_equation(e));
-                }
-                if let Some(eqs) = else_block {
-                    eqs.iter().for_each(|e| self.visit_equation(e));
-                }
-            }
-            Equation::When(blocks) => {
-                for b in blocks {
-                    self.visit_expr(&b.cond);
-                    b.eqs.iter().for_each(|e| self.visit_equation(e));
-                }
-            }
-            Equation::FunctionCall { comp, args } => {
-                self.visit_comp_ref(comp);
-                args.iter().for_each(|a| self.visit_expr(a));
-            }
-            Equation::Assert {
-                condition, message, ..
-            } => {
-                self.visit_expr(condition);
-                self.visit_expr(message);
+            ast::TypeNameContext::ComponentConstrainedBy => {
+                self.add_unresolved_name(
+                    name,
+                    UnresolvedKind::TypeReference,
+                    "component constrainedby",
+                );
             }
         }
+        ControlFlow::Continue(())
     }
 
-    fn visit_statement(&mut self, stmt: &Statement) {
-        match stmt {
-            Statement::Empty | Statement::Return { .. } | Statement::Break { .. } => {}
-            Statement::Assignment { comp, value } => {
-                self.visit_comp_ref(comp);
-                self.visit_expr(value);
-            }
-            Statement::FunctionCall { comp, args, .. } => {
-                self.visit_comp_ref(comp);
-                args.iter().for_each(|a| self.visit_expr(a));
-            }
-            Statement::For { indices, equations } => {
-                indices.iter().for_each(|i| self.visit_expr(&i.range));
-                equations.iter().for_each(|s| self.visit_statement(s));
-            }
-            Statement::If {
-                cond_blocks,
-                else_block,
-            } => {
-                for b in cond_blocks {
-                    self.visit_expr(&b.cond);
-                    b.stmts.iter().for_each(|s| self.visit_statement(s));
-                }
-                if let Some(stmts) = else_block {
-                    stmts.iter().for_each(|s| self.visit_statement(s));
-                }
-            }
-            Statement::While(b) => {
-                self.visit_expr(&b.cond);
-                b.stmts.iter().for_each(|s| self.visit_statement(s));
-            }
-            Statement::When(blocks) => {
-                for b in blocks {
-                    self.visit_expr(&b.cond);
-                    b.stmts.iter().for_each(|s| self.visit_statement(s));
-                }
-            }
-            Statement::Reinit { variable, value } => {
-                self.visit_comp_ref(variable);
-                self.visit_expr(value);
-            }
-            Statement::Assert {
-                condition, message, ..
-            } => {
-                self.visit_expr(condition);
-                self.visit_expr(message);
-            }
+    fn visit_component_reference_ctx(
+        &mut self,
+        cr: &ComponentReference,
+        ctx: ast::ComponentReferenceContext,
+    ) -> ControlFlow<()> {
+        match ctx {
+            ast::ComponentReferenceContext::EquationFunctionCallTarget
+            | ast::ComponentReferenceContext::StatementFunctionCallTarget
+            | ast::ComponentReferenceContext::ClassModificationTarget
+            | ast::ComponentReferenceContext::ModificationTarget => {}
+            _ => self.add_unresolved_component_reference(cr),
         }
+        ast::Visitor::visit_component_reference(self, cr)
     }
 
-    fn visit_expr(&mut self, expr: &Expression) {
-        let mut visitor = ExprVisitor(self);
-        let _ = ast::Visitor::visit_expression(&mut visitor, expr);
-    }
+    fn visit_expr_function_call_ctx(
+        &mut self,
+        comp: &ComponentReference,
+        args: &[Expression],
+        ctx: ast::FunctionCallContext,
+    ) -> ControlFlow<()> {
+        self.add_unresolved_function_call(comp);
 
-    fn visit_comp_ref(&mut self, cr: &ComponentReference) {
-        // Component references should have def_id set (builtins are registered)
-        if cr.def_id.is_none() && !cr.parts.is_empty() {
-            let source_location = cr.parts[0].ident.location.clone();
-            self.add(
-                cr.parts[0].ident.text.to_string(),
-                UnresolvedKind::ComponentReference,
-                source_location,
-            );
+        if matches!(ctx, ast::FunctionCallContext::Expression) {
+            ast::Visitor::visit_component_reference(self, comp)?;
         }
+
+        self.visit_expr_function_call(comp, args)
+    }
+
+    fn visit_expression_ctx(
+        &mut self,
+        expr: &Expression,
+        ctx: ast::ExpressionContext,
+    ) -> ControlFlow<()> {
+        if ctx == ast::ExpressionContext::ComponentAnnotation {
+            return ControlFlow::Continue(());
+        }
+        self.visit_expression(expr)
     }
 }
 
@@ -421,6 +374,246 @@ mod tests {
             result.is_fully_resolved(),
             "Builtin functions should be resolved: {:?}",
             result.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_external_call_argument_in_nested_function() {
+        let r = resolve_for_validation(
+            r#"
+class EOTest
+  extends ExternalObject;
+  function constructor
+    input Boolean verbdose = true;
+    output EOTest env;
+    external "C" env = init(verbose);
+  end constructor;
+end EOTest;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::ComponentReference && s.name == "verbose"),
+            "expected unresolved external-call argument in nested function, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_external_call_output_in_nested_function() {
+        let r = resolve_for_validation(
+            r#"
+class EOTest
+  extends ExternalObject;
+  function constructor
+    input Boolean verbose = true;
+    output EOTest env;
+    external "C" wrong = init(verbose);
+  end constructor;
+end EOTest;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::ComponentReference && s.name == "wrong"),
+            "expected unresolved external-call output reference, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_component_in_assert_level_expression() {
+        let r = resolve_for_validation(
+            r#"
+model T
+equation
+  assert(true, "ok", lvl);
+end T;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::ComponentReference && s.name == "lvl"),
+            "expected unresolved assert-level reference, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_component_in_statement_function_outputs() {
+        let r = resolve_for_validation(
+            r#"
+model T
+  Real x;
+algorithm
+  (x, y) := sin(1.0);
+end T;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::ComponentReference && s.name == "y"),
+            "expected unresolved output reference in statement function call, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_extends_modifier_expression_reference() {
+        let r = resolve_for_validation(
+            r#"
+model Base
+  parameter Real k = 0;
+end Base;
+
+model Derived
+  extends Base(k = missing);
+end Derived;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::ComponentReference && s.name == "missing"),
+            "expected unresolved extends-modifier reference, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_class_constrainedby_type_reference() {
+        let r = resolve_for_validation(
+            r#"
+package RealMedium
+end RealMedium;
+
+model UsesMedium
+  replaceable package Medium = RealMedium constrainedby MissingMedium;
+end UsesMedium;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::TypeReference && s.name == "MissingMedium"),
+            "expected unresolved constrainedby type on class, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_component_constrainedby_type_reference() {
+        let r = resolve_for_validation(
+            r#"
+model M
+  replaceable Real x constrainedby Missing;
+equation
+  x = 0;
+end M;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::TypeReference && s.name == "Missing"),
+            "expected unresolved constrainedby type on component, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_subscript_index_in_assignment_target() {
+        let r = resolve_for_validation(
+            r#"
+model M
+  Real a[2];
+algorithm
+  a[i] := 1;
+end M;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::ComponentReference && s.name == "i"),
+            "expected unresolved subscript index in assignment target, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_equation_function_call_is_classified_as_function_call() {
+        let r = resolve_for_validation(
+            r#"
+model M
+equation
+  unknown(1.0);
+end M;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::FunctionCall && s.name == "unknown"),
+            "expected unresolved equation function call classification, got: {:?}",
+            r.unresolved
+        );
+        assert!(
+            !r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::ComponentReference && s.name == "unknown"),
+            "function call should not also be reported as component reference, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_unresolved_statement_function_call_is_classified_as_function_call() {
+        let r = resolve_for_validation(
+            r#"
+model M
+algorithm
+  unknown(1.0);
+end M;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::FunctionCall && s.name == "unknown"),
+            "expected unresolved statement function call classification, got: {:?}",
+            r.unresolved
+        );
+        assert!(
+            !r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::ComponentReference && s.name == "unknown"),
+            "function call should not also be reported as component reference, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_component_annotation_reference_is_excluded_from_resolution_validation() {
+        let r = resolve_for_validation(
+            r#"
+model M
+  Real x annotation(Dialog(group = missingAnnotationRef));
+equation
+  x = 1;
+end M;
+"#,
+        );
+        assert!(
+            !r.unresolved
+                .iter()
+                .any(|s| s.name == "missingAnnotationRef"),
+            "annotation references should be excluded from resolution validation, got: {:?}",
+            r.unresolved
         );
     }
 }

--- a/crates/rumoca-phase-typecheck/src/lib.rs
+++ b/crates/rumoca-phase-typecheck/src/lib.rs
@@ -30,12 +30,13 @@ use rumoca_core::{
     TypeId,
 };
 use rumoca_ir_ast::{
-    ClassDef, ClassKind, ClassTree, Component, EnumerationType, Equation, Expression,
-    InstanceOverlay, ResolvedTree, ScopeImport, Statement, StoredDefinition, Type, TypeAlias,
-    TypeClassType, TypeTable, TypedTree,
+    ClassDef, ClassKind, ClassTree, Component, EnumerationType, Expression, InstanceOverlay,
+    ResolvedTree, ScopeImport, StoredDefinition, Type, TypeAlias, TypeClassType, TypeTable,
+    TypedTree,
 };
 use std::collections::{HashMap, HashSet};
 use thiserror::Error;
+use typechecker::traversal_adapter::walk_equations;
 
 pub use typechecker::api::{typecheck, typecheck_instanced};
 
@@ -435,12 +436,8 @@ impl TypeChecker {
         // Validate builtin modifier value types with instanced component scope.
         self.check_component_modifier_types_in_class(model_class, type_table);
 
-        for eq in &model_class.equations {
-            self.check_equation(eq, type_table);
-        }
-        for eq in &model_class.initial_equations {
-            self.check_equation(eq, type_table);
-        }
+        walk_equations(self, &model_class.equations, type_table);
+        walk_equations(self, &model_class.initial_equations, type_table);
 
         self.current_component_types = prev_scope_types;
     }

--- a/crates/rumoca-phase-typecheck/src/typechecker/api.rs
+++ b/crates/rumoca-phase-typecheck/src/typechecker/api.rs
@@ -1,4 +1,6 @@
 use super::*;
+use rumoca_ir_ast::Visitor;
+use std::ops::ControlFlow;
 
 /// Collect variable references from for-loop ranges and if-equation conditions.
 ///
@@ -8,29 +10,58 @@ pub(crate) fn collect_structural_refs_from_equations(
     equations: &[rumoca_ir_ast::Equation],
     refs: &mut std::collections::HashSet<String>,
 ) {
-    for eq in equations {
-        match eq {
-            Equation::For { indices, equations } => {
-                for index in indices {
-                    refs.extend(rumoca_eval_ast::eval::collect_variable_refs(&index.range));
+    struct StructuralEquationRefCollector<'a> {
+        refs: &'a mut std::collections::HashSet<String>,
+    }
+
+    impl rumoca_ir_ast::Visitor for StructuralEquationRefCollector<'_> {
+        fn visit_equation(&mut self, eq: &rumoca_ir_ast::Equation) -> ControlFlow<()> {
+            match eq {
+                rumoca_ir_ast::Equation::For { indices, equations } => {
+                    self.visit_for_equation(indices, equations)
                 }
-                collect_structural_refs_from_equations(equations, refs);
+                rumoca_ir_ast::Equation::If {
+                    cond_blocks,
+                    else_block,
+                } => self.visit_if_equation(cond_blocks, else_block.as_deref()),
+                _ => ControlFlow::Continue(()),
             }
-            Equation::If {
-                cond_blocks,
-                else_block,
-            } => {
-                for block in cond_blocks {
-                    refs.extend(rumoca_eval_ast::eval::collect_variable_refs(&block.cond));
-                    collect_structural_refs_from_equations(&block.eqs, refs);
-                }
-                if let Some(else_eqs) = else_block {
-                    collect_structural_refs_from_equations(else_eqs, refs);
-                }
+        }
+
+        fn visit_for_equation(
+            &mut self,
+            indices: &[rumoca_ir_ast::ForIndex],
+            equations: &[rumoca_ir_ast::Equation],
+        ) -> ControlFlow<()> {
+            for index in indices {
+                self.refs
+                    .extend(rumoca_eval_ast::eval::collect_variable_refs(&index.range));
             }
-            _ => {}
+            self.visit_each(equations, Self::visit_equation)
+        }
+
+        fn visit_if_equation(
+            &mut self,
+            cond_blocks: &[rumoca_ir_ast::EquationBlock],
+            else_block: Option<&[rumoca_ir_ast::Equation]>,
+        ) -> ControlFlow<()> {
+            for block in cond_blocks {
+                self.refs
+                    .extend(rumoca_eval_ast::eval::collect_variable_refs(&block.cond));
+                self.visit_each(&block.eqs, Self::visit_equation)?;
+            }
+            if let Some(else_eqs) = else_block {
+                self.visit_each(else_eqs, Self::visit_equation)?;
+            }
+            ControlFlow::Continue(())
         }
     }
+
+    let mut collector = StructuralEquationRefCollector { refs };
+    let _ = collector.visit_each(
+        equations,
+        <StructuralEquationRefCollector<'_> as Visitor>::visit_equation,
+    );
 }
 
 /// Type check a ResolvedTree.
@@ -81,5 +112,44 @@ pub fn typecheck_instanced(
         Err(checker.take_diagnostics())
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_structural_refs_from_equations;
+    use rumoca_phase_parse::parse_to_ast;
+
+    #[test]
+    fn collect_structural_refs_tracks_for_ranges_and_if_conditions_only() {
+        let source = r#"
+model Test
+  parameter Integer n = 2;
+  parameter Integer m = 3;
+  parameter Integer k = 4;
+  Real x[n];
+equation
+  for i in 1:m loop
+    x[i] = 0;
+  end for;
+  if k > 0 then
+    x[1] = 1;
+  end if;
+  when sample(0, n) then
+    x[1] = 2;
+  end when;
+end Test;
+"#;
+        let def = parse_to_ast(source, "test.mo").expect("parse should succeed");
+        let class = def.classes.get("Test").expect("class should exist");
+        let mut refs = std::collections::HashSet::new();
+        collect_structural_refs_from_equations(&class.equations, &mut refs);
+
+        assert!(refs.contains("m"), "for-range ref should be collected");
+        assert!(refs.contains("k"), "if-condition ref should be collected");
+        assert!(
+            !refs.contains("n"),
+            "when-condition refs should remain excluded for parity"
+        );
     }
 }

--- a/crates/rumoca-phase-typecheck/src/typechecker/late_methods.rs
+++ b/crates/rumoca-phase-typecheck/src/typechecker/late_methods.rs
@@ -1,3 +1,6 @@
+use super::traversal_adapter::{
+    TypeCheckTraversalCallbacks, walk_equations, walk_expression, walk_statements,
+};
 use super::*;
 
 #[derive(Clone, Copy)]
@@ -11,6 +14,12 @@ enum ModifierPathAdvance {
     Next(TypeId),
     Complete,
     Invalid,
+}
+
+impl TypeCheckTraversalCallbacks for TypeChecker {
+    fn on_simple_equation(&mut self, lhs: &Expression, rhs: &Expression, type_table: &TypeTable) {
+        self.check_equation_type_compatibility(lhs, rhs, type_table);
+    }
 }
 
 impl TypeChecker {
@@ -480,23 +489,15 @@ impl TypeChecker {
         self.mark_structural_parameters(class);
 
         // Type check equations
-        for equation in &class.equations {
-            self.check_equation(equation, type_table);
-        }
-        for equation in &class.initial_equations {
-            self.check_equation(equation, type_table);
-        }
+        walk_equations(self, &class.equations, type_table);
+        walk_equations(self, &class.initial_equations, type_table);
 
         // Type check algorithms
         for statements in &class.algorithms {
-            for statement in statements {
-                self.check_statement(statement, type_table);
-            }
+            walk_statements(self, statements, type_table);
         }
         for statements in &class.initial_algorithms {
-            for statement in statements {
-                self.check_statement(statement, type_table);
-            }
+            walk_statements(self, statements, type_table);
         }
 
         // Recursively check nested classes
@@ -539,12 +540,12 @@ impl TypeChecker {
 
         // Type check the start expression if not empty
         if !matches!(comp.start, Expression::Empty) {
-            self.check_expression(&comp.start, type_table);
+            walk_expression(self, &comp.start, type_table);
         }
 
         // Type check modification expressions
         for (_name, mod_expr) in &comp.modifications {
-            self.check_expression(mod_expr, type_table);
+            walk_expression(self, mod_expr, type_table);
         }
     }
 
@@ -1300,258 +1301,6 @@ impl TypeChecker {
                         rumoca_core::PrimaryLabel::new(span).with_message("input with binding"),
                     ),
                 );
-            }
-        }
-    }
-
-    /// Type check an equation.
-    pub(crate) fn check_equation(&mut self, equation: &Equation, type_table: &TypeTable) {
-        match equation {
-            Equation::Empty => {}
-            Equation::Simple { lhs, rhs } => {
-                self.check_expression(lhs, type_table);
-                self.check_expression(rhs, type_table);
-                self.check_equation_type_compatibility(lhs, rhs, type_table);
-            }
-            Equation::Connect { lhs: _, rhs: _ } => {
-                // Connector compatibility is validated during connection processing
-            }
-            Equation::For {
-                indices: _,
-                equations,
-            } => {
-                self.check_equations(equations, type_table);
-            }
-            Equation::When(blocks) => {
-                for block in blocks {
-                    self.check_equation_block(block, type_table);
-                }
-            }
-            Equation::If {
-                cond_blocks,
-                else_block,
-            } => {
-                for block in cond_blocks {
-                    self.check_equation_block(block, type_table);
-                }
-                if let Some(equations) = else_block {
-                    self.check_equations(equations, type_table);
-                }
-            }
-            Equation::FunctionCall { comp: _, args } => {
-                self.check_expressions(args, type_table);
-            }
-            Equation::Assert {
-                condition,
-                message,
-                level,
-            } => {
-                self.check_expression(condition, type_table);
-                self.check_expression(message, type_table);
-                if let Some(lvl) = level {
-                    self.check_expression(lvl, type_table);
-                }
-            }
-        }
-    }
-
-    /// Type check a list of equations.
-    pub(crate) fn check_equations(&mut self, equations: &[Equation], type_table: &TypeTable) {
-        for eq in equations {
-            self.check_equation(eq, type_table);
-        }
-    }
-
-    /// Type check an equation block (condition + equations).
-    pub(crate) fn check_equation_block(
-        &mut self,
-        block: &rumoca_ir_ast::EquationBlock,
-        type_table: &TypeTable,
-    ) {
-        self.check_expression(&block.cond, type_table);
-        self.check_equations(&block.eqs, type_table);
-    }
-
-    /// Type check a list of expressions.
-    pub(crate) fn check_expressions(&mut self, exprs: &[Expression], type_table: &TypeTable) {
-        for expr in exprs {
-            self.check_expression(expr, type_table);
-        }
-    }
-
-    /// Type check a statement.
-    pub(crate) fn check_statement(&mut self, statement: &Statement, type_table: &TypeTable) {
-        match statement {
-            Statement::Empty => {}
-            Statement::Assignment { comp: _, value } => {
-                self.check_expression(value, type_table);
-            }
-            Statement::FunctionCall {
-                comp: _,
-                args,
-                outputs,
-            } => {
-                self.check_expressions(args, type_table);
-                self.check_expressions(outputs, type_table);
-            }
-            Statement::Return { .. } => {}
-            Statement::Break { .. } => {}
-            Statement::For {
-                indices: _,
-                equations,
-            } => {
-                self.check_statements(equations, type_table);
-            }
-            Statement::While(block) => {
-                self.check_statement_block(block, type_table);
-            }
-            Statement::When(blocks) => {
-                for block in blocks {
-                    self.check_statement_block(block, type_table);
-                }
-            }
-            Statement::If {
-                cond_blocks,
-                else_block,
-            } => {
-                for block in cond_blocks {
-                    self.check_statement_block(block, type_table);
-                }
-                if let Some(statements) = else_block {
-                    self.check_statements(statements, type_table);
-                }
-            }
-            Statement::Reinit { variable: _, value } => {
-                self.check_expression(value, type_table);
-                // reinit variable must be a continuous-time Real state (MLS §8.3.6)
-                // Validated during flatten/todae where der() usage is known
-            }
-            Statement::Assert {
-                condition,
-                message,
-                level,
-            } => {
-                self.check_expression(condition, type_table);
-                self.check_expression(message, type_table);
-                if let Some(lvl) = level {
-                    self.check_expression(lvl, type_table);
-                }
-            }
-        }
-    }
-
-    /// Type check a list of statements.
-    pub(crate) fn check_statements(&mut self, statements: &[Statement], type_table: &TypeTable) {
-        for stmt in statements {
-            self.check_statement(stmt, type_table);
-        }
-    }
-
-    /// Type check a statement block (condition + statements).
-    pub(crate) fn check_statement_block(
-        &mut self,
-        block: &rumoca_ir_ast::StatementBlock,
-        type_table: &TypeTable,
-    ) {
-        self.check_expression(&block.cond, type_table);
-        self.check_statements(&block.stmts, type_table);
-    }
-
-    /// Type check an expression.
-    pub(crate) fn check_expression(&mut self, expr: &Expression, _type_table: &TypeTable) {
-        match expr {
-            Expression::Empty => {}
-            Expression::Range { start, step, end } => {
-                self.check_expression(start, _type_table);
-                if let Some(s) = step {
-                    self.check_expression(s, _type_table);
-                }
-                self.check_expression(end, _type_table);
-            }
-            Expression::Unary { op: _, rhs } => {
-                self.check_expression(rhs, _type_table);
-            }
-            Expression::Binary { op: _, lhs, rhs } => {
-                self.check_expression(lhs, _type_table);
-                self.check_expression(rhs, _type_table);
-            }
-            Expression::Terminal { .. } => {
-                // Terminals have inherent types (literals)
-            }
-            Expression::ComponentReference(_) => {
-                // Type comes from the referenced component
-            }
-            Expression::FunctionCall { comp: _, args } => {
-                for arg in args {
-                    self.check_expression(arg, _type_table);
-                }
-            }
-            Expression::ClassModification {
-                target: _,
-                modifications,
-            } => {
-                for mod_expr in modifications {
-                    self.check_expression(mod_expr, _type_table);
-                }
-            }
-            Expression::NamedArgument { name: _, value } => {
-                self.check_expression(value, _type_table);
-            }
-            Expression::Modification { target: _, value } => {
-                self.check_expression(value, _type_table);
-            }
-            Expression::Array { elements, .. } => {
-                for elem in elements {
-                    self.check_expression(elem, _type_table);
-                }
-            }
-            Expression::Tuple { elements } => {
-                for elem in elements {
-                    self.check_expression(elem, _type_table);
-                }
-            }
-            Expression::If {
-                branches,
-                else_branch,
-            } => {
-                for (cond, then_expr) in branches {
-                    self.check_expression(cond, _type_table);
-                    self.check_expression(then_expr, _type_table);
-                }
-                self.check_expression(else_branch, _type_table);
-            }
-            Expression::Parenthesized { inner } => {
-                self.check_expression(inner, _type_table);
-            }
-            Expression::ArrayComprehension {
-                expr,
-                indices: _,
-                filter,
-            } => {
-                self.check_expression(expr, _type_table);
-                if let Some(f) = filter {
-                    self.check_expression(f, _type_table);
-                }
-            }
-            Expression::ArrayIndex { base, subscripts } => {
-                self.check_expression(base, _type_table);
-                self.check_subscripts(subscripts, _type_table);
-            }
-            Expression::FieldAccess { base, .. } => {
-                self.check_expression(base, _type_table);
-            }
-        }
-    }
-
-    /// Type check subscript expressions.
-    pub(crate) fn check_subscripts(
-        &mut self,
-        subscripts: &[rumoca_ir_ast::Subscript],
-        type_table: &TypeTable,
-    ) {
-        for sub in subscripts {
-            if let rumoca_ir_ast::Subscript::Expression(e) = sub {
-                self.check_expression(e, type_table);
             }
         }
     }

--- a/crates/rumoca-phase-typecheck/src/typechecker/mod.rs
+++ b/crates/rumoca-phase-typecheck/src/typechecker/mod.rs
@@ -2,3 +2,4 @@ use super::*;
 
 pub(super) mod api;
 pub(super) mod late_methods;
+pub(super) mod traversal_adapter;

--- a/crates/rumoca-phase-typecheck/src/typechecker/traversal_adapter.rs
+++ b/crates/rumoca-phase-typecheck/src/typechecker/traversal_adapter.rs
@@ -1,0 +1,235 @@
+use rumoca_ir_ast as ast;
+
+type Equation = ast::Equation;
+type Expression = ast::Expression;
+type Statement = ast::Statement;
+type TypeTable = ast::TypeTable;
+
+/// Callback contract for typecheck traversal.
+///
+/// Traversal is centralized here while typecheck-specific semantic actions
+/// are injected via callbacks.
+pub(crate) trait TypeCheckTraversalCallbacks {
+    /// Called after both sides of a simple equation are traversed.
+    fn on_simple_equation(&mut self, lhs: &Expression, rhs: &Expression, type_table: &TypeTable);
+}
+
+pub(crate) fn walk_equations<C: TypeCheckTraversalCallbacks>(
+    callbacks: &mut C,
+    equations: &[Equation],
+    type_table: &TypeTable,
+) {
+    for equation in equations {
+        walk_equation(callbacks, equation, type_table);
+    }
+}
+
+pub(crate) fn walk_equation<C: TypeCheckTraversalCallbacks>(
+    callbacks: &mut C,
+    equation: &Equation,
+    type_table: &TypeTable,
+) {
+    match equation {
+        Equation::Empty | Equation::Connect { .. } => {}
+        Equation::Simple { lhs, rhs } => {
+            walk_expression(callbacks, lhs, type_table);
+            walk_expression(callbacks, rhs, type_table);
+            callbacks.on_simple_equation(lhs, rhs, type_table);
+        }
+        Equation::For {
+            indices: _,
+            equations,
+        } => {
+            walk_equations(callbacks, equations, type_table);
+        }
+        Equation::When(blocks) => {
+            for block in blocks {
+                walk_expression(callbacks, &block.cond, type_table);
+                walk_equations(callbacks, &block.eqs, type_table);
+            }
+        }
+        Equation::If {
+            cond_blocks,
+            else_block,
+        } => {
+            for block in cond_blocks {
+                walk_expression(callbacks, &block.cond, type_table);
+                walk_equations(callbacks, &block.eqs, type_table);
+            }
+            if let Some(else_equations) = else_block {
+                walk_equations(callbacks, else_equations, type_table);
+            }
+        }
+        Equation::FunctionCall { comp: _, args } => walk_expressions(callbacks, args, type_table),
+        Equation::Assert {
+            condition,
+            message,
+            level,
+        } => {
+            walk_expression(callbacks, condition, type_table);
+            walk_expression(callbacks, message, type_table);
+            if let Some(level_expression) = level {
+                walk_expression(callbacks, level_expression, type_table);
+            }
+        }
+    }
+}
+
+pub(crate) fn walk_statements<C: TypeCheckTraversalCallbacks>(
+    callbacks: &mut C,
+    statements: &[Statement],
+    type_table: &TypeTable,
+) {
+    for statement in statements {
+        walk_statement(callbacks, statement, type_table);
+    }
+}
+
+pub(crate) fn walk_statement<C: TypeCheckTraversalCallbacks>(
+    callbacks: &mut C,
+    statement: &Statement,
+    type_table: &TypeTable,
+) {
+    match statement {
+        Statement::Empty | Statement::Return { .. } | Statement::Break { .. } => {}
+        Statement::Assignment { comp: _, value } => {
+            walk_expression(callbacks, value, type_table);
+        }
+        Statement::FunctionCall {
+            comp: _,
+            args,
+            outputs,
+        } => {
+            walk_expressions(callbacks, args, type_table);
+            walk_expressions(callbacks, outputs, type_table);
+        }
+        Statement::For {
+            indices: _,
+            equations,
+        } => {
+            walk_statements(callbacks, equations, type_table);
+        }
+        Statement::While(block) => {
+            walk_expression(callbacks, &block.cond, type_table);
+            walk_statements(callbacks, &block.stmts, type_table);
+        }
+        Statement::When(blocks) => {
+            for block in blocks {
+                walk_expression(callbacks, &block.cond, type_table);
+                walk_statements(callbacks, &block.stmts, type_table);
+            }
+        }
+        Statement::If {
+            cond_blocks,
+            else_block,
+        } => {
+            for block in cond_blocks {
+                walk_expression(callbacks, &block.cond, type_table);
+                walk_statements(callbacks, &block.stmts, type_table);
+            }
+            if let Some(else_statements) = else_block {
+                walk_statements(callbacks, else_statements, type_table);
+            }
+        }
+        Statement::Reinit { variable: _, value } => {
+            walk_expression(callbacks, value, type_table);
+        }
+        Statement::Assert {
+            condition,
+            message,
+            level,
+        } => {
+            walk_expression(callbacks, condition, type_table);
+            walk_expression(callbacks, message, type_table);
+            if let Some(level_expression) = level {
+                walk_expression(callbacks, level_expression, type_table);
+            }
+        }
+    }
+}
+
+pub(crate) fn walk_expressions<C: TypeCheckTraversalCallbacks>(
+    callbacks: &mut C,
+    expressions: &[Expression],
+    type_table: &TypeTable,
+) {
+    for expression in expressions {
+        walk_expression(callbacks, expression, type_table);
+    }
+}
+
+pub(crate) fn walk_expression<C: TypeCheckTraversalCallbacks>(
+    callbacks: &mut C,
+    expression: &Expression,
+    type_table: &TypeTable,
+) {
+    match expression {
+        Expression::Empty | Expression::Terminal { .. } | Expression::ComponentReference(_) => {}
+        Expression::Range { start, step, end } => {
+            walk_expression(callbacks, start, type_table);
+            if let Some(step_expression) = step {
+                walk_expression(callbacks, step_expression, type_table);
+            }
+            walk_expression(callbacks, end, type_table);
+        }
+        Expression::Unary { op: _, rhs } => walk_expression(callbacks, rhs, type_table),
+        Expression::Binary { op: _, lhs, rhs } => {
+            walk_expression(callbacks, lhs, type_table);
+            walk_expression(callbacks, rhs, type_table);
+        }
+        Expression::FunctionCall { comp: _, args } => walk_expressions(callbacks, args, type_table),
+        Expression::ClassModification {
+            target: _,
+            modifications,
+        } => walk_expressions(callbacks, modifications, type_table),
+        Expression::NamedArgument { name: _, value } => {
+            walk_expression(callbacks, value, type_table);
+        }
+        Expression::Modification { target: _, value } => {
+            walk_expression(callbacks, value, type_table);
+        }
+        Expression::Array { elements, .. } | Expression::Tuple { elements } => {
+            walk_expressions(callbacks, elements, type_table);
+        }
+        Expression::If {
+            branches,
+            else_branch,
+        } => {
+            for (condition, then_expression) in branches {
+                walk_expression(callbacks, condition, type_table);
+                walk_expression(callbacks, then_expression, type_table);
+            }
+            walk_expression(callbacks, else_branch, type_table);
+        }
+        Expression::Parenthesized { inner } => walk_expression(callbacks, inner, type_table),
+        Expression::ArrayComprehension {
+            expr,
+            indices: _,
+            filter,
+        } => {
+            walk_expression(callbacks, expr, type_table);
+            if let Some(filter_expression) = filter {
+                walk_expression(callbacks, filter_expression, type_table);
+            }
+        }
+        Expression::ArrayIndex { base, subscripts } => {
+            walk_expression(callbacks, base, type_table);
+            walk_subscripts(callbacks, subscripts, type_table);
+        }
+        Expression::FieldAccess { base, .. } => {
+            walk_expression(callbacks, base, type_table);
+        }
+    }
+}
+
+pub(crate) fn walk_subscripts<C: TypeCheckTraversalCallbacks>(
+    callbacks: &mut C,
+    subscripts: &[ast::Subscript],
+    type_table: &TypeTable,
+) {
+    for subscript in subscripts {
+        if let ast::Subscript::Expression(expression) = subscript {
+            walk_expression(callbacks, expression, type_table);
+        }
+    }
+}

--- a/crates/rumoca-session/PIPELINE_INVARIANTS.md
+++ b/crates/rumoca-session/PIPELINE_INVARIANTS.md
@@ -55,6 +55,22 @@ with full modification context (MLS behavior for evaluated dimensions).
 - `error_code` is preserved when available.
 - `CompilationSummary` must be computable from `PhaseResult` values without re-running phases.
 
+## AST Traversal Contract
+
+- `rumoca_ir_ast::Visitor` is the canonical AST traversal contract for analysis and diagnostics.
+- Context-aware callbacks are required for traversal-sensitive semantics:
+  - `visit_type_name(..., TypeNameContext)`
+  - `visit_expr_function_call_ctx(..., FunctionCallContext)`
+  - `visit_component_reference_ctx(..., ComponentReferenceContext)`
+  - `visit_subscript_ctx(..., SubscriptContext)`
+  - `visit_expression_ctx(..., ExpressionContext)`
+- Default visitor behavior must preserve pre-contract traversal semantics:
+  - Expression function-call targets are not traversed as component references by default.
+  - Equation/statement function-call targets are traversed as component references with explicit
+    function-target contexts.
+- Annotation payloads are not part of semantic name resolution, even when traversed for
+  syntax/diagnostic purposes.
+
 ## Experiment Annotation Contract
 
 `CompilationResult` carries normalized simulation metadata extracted from root

--- a/crates/rumoca-session/src/lib.rs
+++ b/crates/rumoca-session/src/lib.rs
@@ -47,6 +47,7 @@ mod parse;
 mod project_config;
 mod runtime_api;
 mod session;
+mod traversal_adapter;
 
 /// Analysis helpers.
 pub mod analysis {

--- a/crates/rumoca-session/src/session/dependency_fingerprint.rs
+++ b/crates/rumoca-session/src/session/dependency_fingerprint.rs
@@ -1,9 +1,9 @@
 use indexmap::{IndexMap, IndexSet};
-use rumoca_core::DefId;
 use rumoca_ir_ast as ast;
 use std::collections::HashMap;
 
 use super::PhaseResult;
+use crate::traversal_adapter::collect_class_dependencies;
 
 pub(crate) type Fingerprint = [u8; 32];
 
@@ -101,380 +101,6 @@ impl DependencyFingerprintCache {
     }
 }
 
-fn collect_class_dependencies(
-    tree: &ast::ClassTree,
-    class: &ast::ClassDef,
-    class_name: &str,
-) -> IndexSet<String> {
-    let mut deps = IndexSet::new();
-
-    for ext in &class.extends {
-        if let Some(base_def_id) = ext.base_def_id {
-            add_class_dep_by_def_id(tree, &mut deps, base_def_id);
-        }
-        add_class_dep_from_name(tree, &mut deps, &ext.base_name);
-        for modification in &ext.modifications {
-            collect_expression_class_deps(tree, &mut deps, &modification.expr);
-        }
-        for annotation in &ext.annotation {
-            collect_expression_class_deps(tree, &mut deps, annotation);
-        }
-    }
-
-    if let Some(constrainedby) = &class.constrainedby {
-        add_class_dep_from_name(tree, &mut deps, constrainedby);
-    }
-    for import in &class.imports {
-        add_class_dep_from_name(tree, &mut deps, import.base_path());
-    }
-    for subscript in &class.array_subscripts {
-        collect_subscript_class_deps(tree, &mut deps, subscript);
-    }
-    for annotation in &class.annotation {
-        collect_expression_class_deps(tree, &mut deps, annotation);
-    }
-
-    for component in class.components.values() {
-        if let Some(type_def_id) = component.type_def_id {
-            add_class_dep_by_def_id(tree, &mut deps, type_def_id);
-        }
-        add_class_dep_from_name(tree, &mut deps, &component.type_name);
-        if let Some(constrainedby) = &component.constrainedby {
-            add_class_dep_from_name(tree, &mut deps, constrainedby);
-        }
-        collect_expression_class_deps(tree, &mut deps, &component.start);
-        if let Some(binding) = &component.binding {
-            collect_expression_class_deps(tree, &mut deps, binding);
-        }
-        for shape in &component.shape_expr {
-            collect_subscript_class_deps(tree, &mut deps, shape);
-        }
-        for annotation in &component.annotation {
-            collect_expression_class_deps(tree, &mut deps, annotation);
-        }
-        for modification in component.modifications.values() {
-            collect_expression_class_deps(tree, &mut deps, modification);
-        }
-        if let Some(condition) = &component.condition {
-            collect_expression_class_deps(tree, &mut deps, condition);
-        }
-    }
-
-    for equation in &class.equations {
-        collect_equation_class_deps(tree, &mut deps, equation);
-    }
-    for equation in &class.initial_equations {
-        collect_equation_class_deps(tree, &mut deps, equation);
-    }
-    for algorithm in &class.algorithms {
-        for statement in algorithm {
-            collect_statement_class_deps(tree, &mut deps, statement);
-        }
-    }
-    for algorithm in &class.initial_algorithms {
-        for statement in algorithm {
-            collect_statement_class_deps(tree, &mut deps, statement);
-        }
-    }
-
-    if let Some(external) = &class.external {
-        if let Some(output) = &external.output {
-            collect_component_ref_class_deps(tree, &mut deps, output);
-        }
-        for arg in &external.args {
-            collect_expression_class_deps(tree, &mut deps, arg);
-        }
-    }
-
-    deps.shift_remove(class_name);
-    deps
-}
-
-fn collect_equation_class_deps(
-    tree: &ast::ClassTree,
-    deps: &mut IndexSet<String>,
-    equation: &ast::Equation,
-) {
-    match equation {
-        ast::Equation::Empty => {}
-        ast::Equation::Simple { lhs, rhs } => {
-            collect_expression_class_deps(tree, deps, lhs);
-            collect_expression_class_deps(tree, deps, rhs);
-        }
-        ast::Equation::Connect { lhs, rhs } => {
-            collect_component_ref_class_deps(tree, deps, lhs);
-            collect_component_ref_class_deps(tree, deps, rhs);
-        }
-        ast::Equation::For { indices, equations } => {
-            for index in indices {
-                collect_expression_class_deps(tree, deps, &index.range);
-            }
-            for nested in equations {
-                collect_equation_class_deps(tree, deps, nested);
-            }
-        }
-        ast::Equation::When(blocks) => {
-            for block in blocks {
-                collect_expression_class_deps(tree, deps, &block.cond);
-                for nested in &block.eqs {
-                    collect_equation_class_deps(tree, deps, nested);
-                }
-            }
-        }
-        ast::Equation::If {
-            cond_blocks,
-            else_block,
-        } => {
-            for block in cond_blocks {
-                collect_expression_class_deps(tree, deps, &block.cond);
-                for nested in &block.eqs {
-                    collect_equation_class_deps(tree, deps, nested);
-                }
-            }
-            if let Some(else_eqs) = else_block {
-                for nested in else_eqs {
-                    collect_equation_class_deps(tree, deps, nested);
-                }
-            }
-        }
-        ast::Equation::FunctionCall { comp, args } => {
-            collect_component_ref_class_deps(tree, deps, comp);
-            for arg in args {
-                collect_expression_class_deps(tree, deps, arg);
-            }
-        }
-        ast::Equation::Assert {
-            condition,
-            message,
-            level,
-        } => {
-            collect_expression_class_deps(tree, deps, condition);
-            collect_expression_class_deps(tree, deps, message);
-            if let Some(level) = level {
-                collect_expression_class_deps(tree, deps, level);
-            }
-        }
-    }
-}
-
-fn collect_statement_class_deps(
-    tree: &ast::ClassTree,
-    deps: &mut IndexSet<String>,
-    statement: &ast::Statement,
-) {
-    match statement {
-        ast::Statement::Empty | ast::Statement::Return { .. } | ast::Statement::Break { .. } => {}
-        ast::Statement::Assignment { comp, value } => {
-            collect_component_ref_class_deps(tree, deps, comp);
-            collect_expression_class_deps(tree, deps, value);
-        }
-        ast::Statement::For { indices, equations } => {
-            for index in indices {
-                collect_expression_class_deps(tree, deps, &index.range);
-            }
-            for nested in equations {
-                collect_statement_class_deps(tree, deps, nested);
-            }
-        }
-        ast::Statement::While(block) => {
-            collect_expression_class_deps(tree, deps, &block.cond);
-            for nested in &block.stmts {
-                collect_statement_class_deps(tree, deps, nested);
-            }
-        }
-        ast::Statement::If {
-            cond_blocks,
-            else_block,
-        } => {
-            for block in cond_blocks {
-                collect_expression_class_deps(tree, deps, &block.cond);
-                for nested in &block.stmts {
-                    collect_statement_class_deps(tree, deps, nested);
-                }
-            }
-            if let Some(else_stmts) = else_block {
-                for nested in else_stmts {
-                    collect_statement_class_deps(tree, deps, nested);
-                }
-            }
-        }
-        ast::Statement::When(blocks) => {
-            for block in blocks {
-                collect_expression_class_deps(tree, deps, &block.cond);
-                for nested in &block.stmts {
-                    collect_statement_class_deps(tree, deps, nested);
-                }
-            }
-        }
-        ast::Statement::FunctionCall {
-            comp,
-            args,
-            outputs,
-        } => {
-            collect_component_ref_class_deps(tree, deps, comp);
-            for arg in args {
-                collect_expression_class_deps(tree, deps, arg);
-            }
-            for output in outputs {
-                collect_expression_class_deps(tree, deps, output);
-            }
-        }
-        ast::Statement::Reinit { variable, value } => {
-            collect_component_ref_class_deps(tree, deps, variable);
-            collect_expression_class_deps(tree, deps, value);
-        }
-        ast::Statement::Assert {
-            condition,
-            message,
-            level,
-        } => {
-            collect_expression_class_deps(tree, deps, condition);
-            collect_expression_class_deps(tree, deps, message);
-            if let Some(level) = level {
-                collect_expression_class_deps(tree, deps, level);
-            }
-        }
-    }
-}
-
-fn collect_expression_class_deps(
-    tree: &ast::ClassTree,
-    deps: &mut IndexSet<String>,
-    expr: &ast::Expression,
-) {
-    match expr {
-        ast::Expression::Empty | ast::Expression::Terminal { .. } => {}
-        ast::Expression::Range { start, step, end } => {
-            collect_expression_class_deps(tree, deps, start);
-            if let Some(step) = step {
-                collect_expression_class_deps(tree, deps, step);
-            }
-            collect_expression_class_deps(tree, deps, end);
-        }
-        ast::Expression::Unary { rhs, .. } => {
-            collect_expression_class_deps(tree, deps, rhs);
-        }
-        ast::Expression::Binary { lhs, rhs, .. } => {
-            collect_expression_class_deps(tree, deps, lhs);
-            collect_expression_class_deps(tree, deps, rhs);
-        }
-        ast::Expression::ComponentReference(comp) => {
-            collect_component_ref_class_deps(tree, deps, comp);
-        }
-        ast::Expression::FunctionCall { comp, args } => {
-            collect_component_ref_class_deps(tree, deps, comp);
-            for arg in args {
-                collect_expression_class_deps(tree, deps, arg);
-            }
-        }
-        ast::Expression::ClassModification {
-            target,
-            modifications,
-        } => {
-            collect_component_ref_class_deps(tree, deps, target);
-            for modification in modifications {
-                collect_expression_class_deps(tree, deps, modification);
-            }
-        }
-        ast::Expression::NamedArgument { value, .. } => {
-            collect_expression_class_deps(tree, deps, value);
-        }
-        ast::Expression::Modification { target, value } => {
-            collect_component_ref_class_deps(tree, deps, target);
-            collect_expression_class_deps(tree, deps, value);
-        }
-        ast::Expression::Array { elements, .. } | ast::Expression::Tuple { elements } => {
-            for element in elements {
-                collect_expression_class_deps(tree, deps, element);
-            }
-        }
-        ast::Expression::If {
-            branches,
-            else_branch,
-        } => {
-            for (condition, value) in branches {
-                collect_expression_class_deps(tree, deps, condition);
-                collect_expression_class_deps(tree, deps, value);
-            }
-            collect_expression_class_deps(tree, deps, else_branch);
-        }
-        ast::Expression::Parenthesized { inner } => {
-            collect_expression_class_deps(tree, deps, inner);
-        }
-        ast::Expression::ArrayComprehension {
-            expr,
-            indices,
-            filter,
-        } => {
-            collect_expression_class_deps(tree, deps, expr);
-            for index in indices {
-                collect_expression_class_deps(tree, deps, &index.range);
-            }
-            if let Some(filter) = filter {
-                collect_expression_class_deps(tree, deps, filter);
-            }
-        }
-        ast::Expression::ArrayIndex { base, subscripts } => {
-            collect_expression_class_deps(tree, deps, base);
-            for subscript in subscripts {
-                collect_subscript_class_deps(tree, deps, subscript);
-            }
-        }
-        ast::Expression::FieldAccess { base, .. } => {
-            collect_expression_class_deps(tree, deps, base);
-        }
-    }
-}
-
-fn collect_component_ref_class_deps(
-    tree: &ast::ClassTree,
-    deps: &mut IndexSet<String>,
-    comp: &ast::ComponentReference,
-) {
-    if let Some(def_id) = comp.def_id {
-        add_class_dep_by_def_id(tree, deps, def_id);
-    }
-    for part in &comp.parts {
-        if let Some(subscripts) = &part.subs {
-            for subscript in subscripts {
-                collect_subscript_class_deps(tree, deps, subscript);
-            }
-        }
-    }
-}
-
-fn collect_subscript_class_deps(
-    tree: &ast::ClassTree,
-    deps: &mut IndexSet<String>,
-    subscript: &ast::Subscript,
-) {
-    if let ast::Subscript::Expression(expr) = subscript {
-        collect_expression_class_deps(tree, deps, expr);
-    }
-}
-
-fn add_class_dep_from_name(tree: &ast::ClassTree, deps: &mut IndexSet<String>, name: &ast::Name) {
-    if let Some(def_id) = name.def_id {
-        add_class_dep_by_def_id(tree, deps, def_id);
-        return;
-    }
-
-    let qualified = name.to_string();
-    let Some(&def_id) = tree.name_map.get(&qualified) else {
-        return;
-    };
-    add_class_dep_by_def_id(tree, deps, def_id);
-}
-
-fn add_class_dep_by_def_id(tree: &ast::ClassTree, deps: &mut IndexSet<String>, def_id: DefId) {
-    let Some(qualified_name) = tree.def_map.get(&def_id) else {
-        return;
-    };
-    if tree.get_class_by_def_id(def_id).is_some() {
-        deps.insert(qualified_name.clone());
-    }
-}
-
 fn class_source_fingerprint(
     tree: &ast::ClassTree,
     class: &ast::ClassDef,
@@ -525,7 +151,7 @@ mod tests {
     use crate::Session;
 
     #[test]
-    fn add_class_dep_from_name_uses_qualified_fallback_lookup() {
+    fn from_tree_collects_import_dependencies() {
         let source = r#"
             package P
               model Dep
@@ -554,14 +180,139 @@ mod tests {
             .ensure_resolved()
             .expect("resolved tree should be cached")
             .0;
-        let import_name = ast::Name::from_string("P.Dep");
-
-        let mut deps = IndexSet::new();
-        add_class_dep_from_name(tree, &mut deps, &import_name);
+        let cache = DependencyFingerprintCache::from_tree(tree);
+        let deps = cache
+            .class_dependencies()
+            .get("P.Root")
+            .cloned()
+            .unwrap_or_default();
 
         assert!(
             deps.iter().any(|dep| dep == "P.Dep"),
-            "qualified fallback lookup should resolve import dependency"
+            "import dependency should be included in class dependency graph"
+        );
+    }
+
+    #[test]
+    fn model_fingerprint_ignores_unreachable_classes() {
+        let source_v1 = r#"
+            package P
+              model Dep
+                Real y;
+              equation
+                y = 1;
+              end Dep;
+
+              model Root
+                Dep d;
+              equation
+                d.y = 2;
+              end Root;
+
+              model Unused
+                Real z;
+              equation
+                z = 3;
+              end Unused;
+            end P;
+        "#;
+
+        let source_v2 = r#"
+            package P
+              model Dep
+                Real y;
+              equation
+                y = 1;
+              end Dep;
+
+              model Root
+                Dep d;
+              equation
+                d.y = 2;
+              end Root;
+
+              model Unused
+                Real z;
+              equation
+                z = 30;
+              end Unused;
+            end P;
+        "#;
+
+        let mut session_v1 = Session::default();
+        session_v1
+            .add_document("test.mo", source_v1)
+            .expect("first document should parse");
+        session_v1
+            .build_resolved()
+            .expect("first tree should resolve");
+        let tree_v1 = &session_v1
+            .ensure_resolved()
+            .expect("first resolved tree should be cached")
+            .0;
+        let mut cache_v1 = DependencyFingerprintCache::from_tree(tree_v1);
+        let fingerprint_v1 = cache_v1.model_fingerprint("P.Root");
+
+        let mut session_v2 = Session::default();
+        session_v2
+            .add_document("test.mo", source_v2)
+            .expect("second document should parse");
+        session_v2
+            .build_resolved()
+            .expect("second tree should resolve");
+        let tree_v2 = &session_v2
+            .ensure_resolved()
+            .expect("second resolved tree should be cached")
+            .0;
+        let mut cache_v2 = DependencyFingerprintCache::from_tree(tree_v2);
+        let fingerprint_v2 = cache_v2.model_fingerprint("P.Root");
+
+        assert_eq!(
+            fingerprint_v1, fingerprint_v2,
+            "reachable model fingerprint should not change when an unreachable class changes"
+        );
+    }
+
+    #[test]
+    fn from_tree_collects_external_function_argument_dependencies() {
+        let source = r#"
+            package P
+              function Helper
+                input Real u;
+                output Real y;
+              algorithm
+                y := u;
+              end Helper;
+
+              function ExternalUser
+                input Real u;
+                output Real y;
+              external "C" y = native_call(Helper(u));
+              end ExternalUser;
+            end P;
+        "#;
+
+        let mut session = Session::default();
+        session
+            .add_document("test.mo", source)
+            .expect("document should parse");
+        session
+            .build_resolved()
+            .expect("resolved tree should be available");
+        let tree = &session
+            .ensure_resolved()
+            .expect("resolved tree should be cached")
+            .0;
+        let cache = DependencyFingerprintCache::from_tree(tree);
+        let deps = cache
+            .class_dependencies()
+            .get("P.ExternalUser")
+            .cloned()
+            .unwrap_or_default();
+
+        assert!(
+            deps.iter().any(|dep| dep == "P.Helper"),
+            "external declaration arguments should participate in dependency collection"
         );
     }
 }

--- a/crates/rumoca-session/src/traversal_adapter.rs
+++ b/crates/rumoca-session/src/traversal_adapter.rs
@@ -1,0 +1,169 @@
+use indexmap::IndexSet;
+use rumoca_core::DefId;
+use rumoca_ir_ast as ast;
+use rumoca_ir_ast::{
+    ComponentReferenceContext, FunctionCallContext, SubscriptContext, TypeNameContext, Visitor,
+};
+use std::ops::ControlFlow::{self, Continue};
+
+pub(crate) fn collect_class_dependencies(
+    tree: &ast::ClassTree,
+    class: &ast::ClassDef,
+    class_name: &str,
+) -> IndexSet<String> {
+    let mut collector = ClassDependencyCollector::new(tree, class_name);
+    collector.collect_class(class);
+    collector.finish()
+}
+
+struct ClassDependencyCollector<'a> {
+    tree: &'a ast::ClassTree,
+    class_name: &'a str,
+    deps: IndexSet<String>,
+}
+
+impl<'a> ClassDependencyCollector<'a> {
+    fn new(tree: &'a ast::ClassTree, class_name: &'a str) -> Self {
+        Self {
+            tree,
+            class_name,
+            deps: IndexSet::new(),
+        }
+    }
+
+    fn finish(mut self) -> IndexSet<String> {
+        self.deps.shift_remove(self.class_name);
+        self.deps
+    }
+
+    fn collect_class(&mut self, class: &ast::ClassDef) {
+        if let Some(constrainedby) = &class.constrainedby {
+            let _ = self.visit_type_name(constrainedby, TypeNameContext::ClassConstrainedBy);
+        }
+        for extend in &class.extends {
+            self.collect_extend(extend);
+        }
+        for import in &class.imports {
+            self.add_class_dep_from_name(import.base_path());
+        }
+        for subscript in &class.array_subscripts {
+            let _ = self.visit_subscript(subscript);
+        }
+        for annotation in &class.annotation {
+            let _ = self.visit_expression(annotation);
+        }
+
+        for component in class.components.values() {
+            self.collect_component(component);
+        }
+
+        for equation in &class.equations {
+            let _ = self.visit_equation(equation);
+        }
+        for equation in &class.initial_equations {
+            let _ = self.visit_equation(equation);
+        }
+        for algorithm in &class.algorithms {
+            for statement in algorithm {
+                let _ = self.visit_statement(statement);
+            }
+        }
+        for algorithm in &class.initial_algorithms {
+            for statement in algorithm {
+                let _ = self.visit_statement(statement);
+            }
+        }
+
+        if let Some(external) = &class.external {
+            self.collect_external(external);
+        }
+    }
+
+    fn collect_extend(&mut self, extend: &ast::Extend) {
+        if let Some(base_def_id) = extend.base_def_id {
+            self.add_class_dep_by_def_id(base_def_id);
+        }
+        let _ = self.visit_extend(extend);
+        for annotation in &extend.annotation {
+            let _ = self.visit_expression(annotation);
+        }
+    }
+
+    fn collect_component(&mut self, component: &ast::Component) {
+        if let Some(type_def_id) = component.type_def_id {
+            self.add_class_dep_by_def_id(type_def_id);
+        }
+        let _ = self.visit_component(component);
+        if let Some(binding) = &component.binding {
+            let _ = self.visit_expression(binding);
+        }
+        for shape in &component.shape_expr {
+            let _ = self.visit_subscript(shape);
+        }
+    }
+
+    fn collect_external(&mut self, external: &ast::ExternalFunction) {
+        if let Some(output) = &external.output {
+            let _ = self.visit_component_reference(output);
+        }
+        for arg in &external.args {
+            let _ = self.visit_expression(arg);
+        }
+    }
+
+    fn add_class_dep_from_name(&mut self, name: &ast::Name) {
+        if let Some(def_id) = name.def_id {
+            self.add_class_dep_by_def_id(def_id);
+            return;
+        }
+
+        let qualified = name.to_string();
+        let Some(&def_id) = self.tree.name_map.get(&qualified) else {
+            return;
+        };
+        self.add_class_dep_by_def_id(def_id);
+    }
+
+    fn add_class_dep_by_def_id(&mut self, def_id: DefId) {
+        let Some(qualified_name) = self.tree.def_map.get(&def_id) else {
+            return;
+        };
+        if self.tree.get_class_by_def_id(def_id).is_some() {
+            self.deps.insert(qualified_name.clone());
+        }
+    }
+}
+
+impl Visitor for ClassDependencyCollector<'_> {
+    fn visit_expr_function_call_ctx(
+        &mut self,
+        comp: &ast::ComponentReference,
+        args: &[ast::Expression],
+        ctx: FunctionCallContext,
+    ) -> ControlFlow<()> {
+        if matches!(ctx, FunctionCallContext::Expression) {
+            self.visit_component_reference_ctx(comp, ComponentReferenceContext::Expression)?;
+        }
+        self.visit_each(args, Self::visit_expression)
+    }
+
+    fn visit_type_name(&mut self, name: &ast::Name, _ctx: TypeNameContext) -> ControlFlow<()> {
+        self.add_class_dep_from_name(name);
+        Continue(())
+    }
+
+    fn visit_component_reference(&mut self, cr: &ast::ComponentReference) -> ControlFlow<()> {
+        if let Some(def_id) = cr.def_id {
+            self.add_class_dep_by_def_id(def_id);
+        }
+        for part in &cr.parts {
+            let Some(subscripts) = &part.subs else {
+                continue;
+            };
+            for subscript in subscripts {
+                self.visit_subscript_ctx(subscript, SubscriptContext::ComponentReferencePart)?;
+            }
+        }
+        Continue(())
+    }
+}

--- a/crates/rumoca-tool-dev/Cargo.toml
+++ b/crates/rumoca-tool-dev/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/main.rs"
 name = "rumoca-msl-tools"
 path = "src/bin/rumoca-msl-tools.rs"
 
+[[bin]]
+name = "rumoca-traversal-policy-check"
+path = "src/bin/rumoca-traversal-policy-check.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
@@ -29,6 +33,7 @@ tar = "0.4"
 tempfile = { workspace = true }
 ureq = "2.9"
 walkdir = "2.5"
+syn = { version = "2.0", features = ["full", "visit"] }
 
 [lints]
 workspace = true

--- a/crates/rumoca-tool-dev/src/bin/rumoca-traversal-policy-check.rs
+++ b/crates/rumoca-tool-dev/src/bin/rumoca-traversal-policy-check.rs
@@ -1,0 +1,409 @@
+use anyhow::{Context, Result, bail};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+use syn::visit::Visit;
+use syn::{
+    FnArg, GenericArgument, ImplItem, Item, ItemFn, ItemImpl, PathArguments, Type, TypeParamBound,
+};
+
+const COVERED_FILES: &[&str] = &[
+    "crates/rumoca-phase-resolve/src/contents.rs",
+    "crates/rumoca-phase-resolve/src/validation.rs",
+    "crates/rumoca-phase-resolve/src/semantic_checks.rs",
+    "crates/rumoca-phase-resolve/src/semantic_checks_expr.rs",
+    "crates/rumoca-phase-typecheck/src/typechecker/late_methods.rs",
+    "crates/rumoca-session/src/session/dependency_fingerprint.rs",
+    "crates/rumoca-tool-lsp/src/handlers/semantic_tokens.rs",
+    "crates/rumoca-tool-lsp/src/handlers/inlay_hints.rs",
+    "crates/rumoca-phase-dae/src/scalar_inference/parts.rs",
+];
+
+fn main() -> Result<()> {
+    let repo_root = repo_root();
+    let mut violations = Vec::new();
+
+    for rel_path in COVERED_FILES {
+        let file_path = repo_root.join(rel_path);
+        let source = fs::read_to_string(&file_path)
+            .with_context(|| format!("failed to read {}", file_path.display()))?;
+        let syntax = syn::parse_file(&source)
+            .with_context(|| format!("failed to parse {}", file_path.display()))?;
+
+        let candidates = collect_candidates(syntax.items);
+
+        if candidates.is_empty() {
+            continue;
+        }
+
+        let allowed_recursive = allowed_recursive_functions(rel_path);
+        let mut graph: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        for function in candidates.values() {
+            if allowed_recursive.contains(function.simple_name.as_str()) {
+                continue;
+            }
+            let outgoing = candidates
+                .values()
+                .filter(|candidate| {
+                    candidate.scope == function.scope
+                        && function.calls.contains(&candidate.simple_name)
+                        && !allowed_recursive.contains(candidate.simple_name.as_str())
+                })
+                .map(|candidate| candidate.key.clone())
+                .collect();
+            graph.insert(function.key.clone(), outgoing);
+        }
+
+        if let Some(cycle) = detect_cycle(&graph) {
+            violations.push(format!(
+                "{}: recursive traversal helpers are disallowed in covered modules: {}",
+                rel_path,
+                cycle.join(" -> ")
+            ));
+        }
+    }
+
+    if !violations.is_empty() {
+        eprintln!("Traversal policy check failed:");
+        for violation in violations {
+            eprintln!("  - {violation}");
+        }
+        bail!("traversal policy violations detected");
+    }
+
+    println!(
+        "Traversal policy check passed for {} covered files.",
+        COVERED_FILES.len()
+    );
+    Ok(())
+}
+
+fn collect_candidates(items: Vec<Item>) -> BTreeMap<String, CandidateFunction> {
+    let mut candidates = BTreeMap::new();
+    for item in items {
+        match item {
+            Item::Fn(item_fn) => {
+                insert_candidate_if_traversal(
+                    &mut candidates,
+                    CandidateFunction::from_top_level_fn(item_fn),
+                );
+            }
+            Item::Impl(item_impl) => {
+                for function in CandidateFunction::from_impl(item_impl) {
+                    insert_candidate_if_traversal(&mut candidates, function);
+                }
+            }
+            _ => {}
+        }
+    }
+    candidates
+}
+
+fn insert_candidate_if_traversal(
+    candidates: &mut BTreeMap<String, CandidateFunction>,
+    function: CandidateFunction,
+) {
+    if !function.is_traversal_candidate {
+        return;
+    }
+    candidates.insert(function.key.clone(), function);
+}
+
+fn allowed_recursive_functions(file: &str) -> BTreeSet<&'static str> {
+    match file {
+        // Class-container recursion over nested classes remains intentional in these modules.
+        "crates/rumoca-phase-resolve/src/contents.rs" => BTreeSet::from(["resolve_contents_class"]),
+        "crates/rumoca-phase-resolve/src/validation.rs" => BTreeSet::from(["visit_class_def"]),
+        "crates/rumoca-phase-resolve/src/semantic_checks.rs" => BTreeSet::from(["visit_class_def"]),
+        "crates/rumoca-phase-resolve/src/semantic_checks_expr.rs" => {
+            BTreeSet::from(["visit_class_def"])
+        }
+        "crates/rumoca-phase-typecheck/src/typechecker/late_methods.rs" => {
+            BTreeSet::from(["check_class", "infer_expression_type"])
+        }
+        // This recursion decomposes nested array literals for scalar sizing.
+        "crates/rumoca-phase-dae/src/scalar_inference/parts.rs" => {
+            BTreeSet::from(["count_array_lhs_scalar_elements"])
+        }
+        _ => BTreeSet::new(),
+    }
+}
+
+fn repo_root() -> PathBuf {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .ancestors()
+        .nth(2)
+        .unwrap_or(manifest_dir)
+        .to_path_buf()
+}
+
+#[derive(Debug, Clone)]
+struct CandidateFunction {
+    key: String,
+    simple_name: String,
+    scope: CandidateScope,
+    is_traversal_candidate: bool,
+    calls: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CandidateScope {
+    TopLevel,
+    Impl(String),
+}
+
+impl CandidateFunction {
+    fn from_top_level_fn(item_fn: ItemFn) -> Self {
+        let simple_name = item_fn.sig.ident.to_string();
+        let is_traversal_candidate = item_fn.sig.inputs.iter().any(is_traversal_param_fn_arg);
+        let mut collector = CallCollector::default();
+        collector.visit_block(&item_fn.block);
+        Self {
+            key: simple_name.clone(),
+            simple_name,
+            scope: CandidateScope::TopLevel,
+            is_traversal_candidate,
+            calls: collector.calls,
+        }
+    }
+
+    fn from_impl(item_impl: ItemImpl) -> Vec<Self> {
+        let scope_name = impl_scope_name(&item_impl);
+        let scope = CandidateScope::Impl(scope_name.clone());
+        let mut functions = Vec::new();
+        for item in item_impl.items {
+            let ImplItem::Fn(item_fn) = item else {
+                continue;
+            };
+            let simple_name = item_fn.sig.ident.to_string();
+            let is_traversal_candidate = item_fn.sig.inputs.iter().any(is_traversal_param_fn_arg);
+            let mut collector = CallCollector::default();
+            collector.visit_block(&item_fn.block);
+            functions.push(Self {
+                key: format!("impl::{scope_name}::{simple_name}"),
+                simple_name,
+                scope: scope.clone(),
+                is_traversal_candidate,
+                calls: collector.calls,
+            });
+        }
+        functions
+    }
+}
+
+fn impl_scope_name(item_impl: &ItemImpl) -> String {
+    let self_ty_name = type_display_name(item_impl.self_ty.as_ref());
+    if let Some((_, path, _)) = &item_impl.trait_ {
+        let trait_name = path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string())
+            .unwrap_or_else(|| "Trait".to_string());
+        format!("{trait_name} for {self_ty_name}")
+    } else {
+        self_ty_name
+    }
+}
+
+fn type_display_name(ty: &Type) -> String {
+    match ty {
+        Type::Path(type_path) => type_path
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string())
+            .unwrap_or_else(|| "Type".to_string()),
+        Type::Reference(reference) => type_display_name(reference.elem.as_ref()),
+        Type::Paren(paren) => type_display_name(paren.elem.as_ref()),
+        Type::Group(group) => type_display_name(group.elem.as_ref()),
+        _ => "Type".to_string(),
+    }
+}
+
+#[derive(Default)]
+struct CallCollector {
+    calls: BTreeSet<String>,
+}
+
+impl<'ast> Visit<'ast> for CallCollector {
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(path_expr) = node.func.as_ref() {
+            let segments = &path_expr.path.segments;
+            let Some(last) = segments.last() else {
+                syn::visit::visit_expr_call(self, node);
+                return;
+            };
+            let accepts_call = path_expr.qself.is_some()
+                || segments.len() == 1
+                || (segments.len() == 2 && segments[0].ident == "Self");
+            if accepts_call {
+                self.calls.insert(last.ident.to_string());
+            }
+        }
+        syn::visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        if receiver_is_self(node.receiver.as_ref()) {
+            self.calls.insert(node.method.to_string());
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn receiver_is_self(expr: &syn::Expr) -> bool {
+    matches!(
+        expr,
+        syn::Expr::Path(path_expr)
+            if path_expr.qself.is_none()
+                && path_expr.path.segments.len() == 1
+                && path_expr.path.segments[0].ident == "self"
+    )
+}
+
+fn is_traversal_param_fn_arg(arg: &FnArg) -> bool {
+    match arg {
+        FnArg::Typed(pat_type) => type_mentions_tree_type(&pat_type.ty),
+        FnArg::Receiver(_) => false,
+    }
+}
+
+fn type_mentions_tree_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => path_mentions_tree_type(&type_path.path),
+        Type::Reference(reference) => type_mentions_tree_type(&reference.elem),
+        Type::Slice(slice) => type_mentions_tree_type(&slice.elem),
+        Type::Array(array) => type_mentions_tree_type(&array.elem),
+        Type::Tuple(tuple) => tuple.elems.iter().any(type_mentions_tree_type),
+        Type::Paren(paren) => type_mentions_tree_type(&paren.elem),
+        Type::Group(group) => type_mentions_tree_type(&group.elem),
+        Type::Ptr(ptr) => type_mentions_tree_type(&ptr.elem),
+        Type::ImplTrait(impl_trait) => impl_trait.bounds.iter().any(bound_mentions_tree_type),
+        Type::TraitObject(trait_object) => trait_object.bounds.iter().any(bound_mentions_tree_type),
+        _ => false,
+    }
+}
+
+fn bound_mentions_tree_type(bound: &TypeParamBound) -> bool {
+    match bound {
+        TypeParamBound::Trait(trait_bound) => path_mentions_tree_type(&trait_bound.path),
+        TypeParamBound::Lifetime(_) => false,
+        _ => false,
+    }
+}
+
+fn path_mentions_tree_type(path: &syn::Path) -> bool {
+    path.segments.iter().any(|segment| {
+        is_tree_type_name(segment.ident.to_string().as_str())
+            || match &segment.arguments {
+                PathArguments::AngleBracketed(args) => args.args.iter().any(|arg| match arg {
+                    GenericArgument::Type(ty) => type_mentions_tree_type(ty),
+                    GenericArgument::AssocType(assoc_type) => {
+                        type_mentions_tree_type(&assoc_type.ty)
+                    }
+                    GenericArgument::Constraint(constraint) => {
+                        constraint.bounds.iter().any(bound_mentions_tree_type)
+                    }
+                    GenericArgument::AssocConst(_)
+                    | GenericArgument::Lifetime(_)
+                    | GenericArgument::Const(_) => false,
+                    _ => false,
+                }),
+                PathArguments::Parenthesized(parenthesized) => {
+                    parenthesized.inputs.iter().any(type_mentions_tree_type)
+                        || match &parenthesized.output {
+                            syn::ReturnType::Default => false,
+                            syn::ReturnType::Type(_, ty) => type_mentions_tree_type(ty),
+                        }
+                }
+                PathArguments::None => false,
+            }
+    })
+}
+
+fn is_tree_type_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Expression"
+            | "Statement"
+            | "Equation"
+            | "Subscript"
+            | "StoredDefinition"
+            | "ClassDef"
+            | "ClassSection"
+            | "Class"
+            | "Element"
+            | "ComponentReference"
+            | "ComprehensionIndex"
+            | "ForIndex"
+            | "StatementBlock"
+            | "TypeName"
+            | "Import"
+            | "NamedArgument"
+            | "ExtendsClause"
+    )
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum VisitState {
+    Visiting,
+    Done,
+}
+
+fn dfs_cycle(
+    node: &str,
+    graph: &BTreeMap<String, BTreeSet<String>>,
+    states: &mut HashMap<String, VisitState>,
+    stack: &mut Vec<String>,
+) -> Option<Vec<String>> {
+    states.insert(node.to_string(), VisitState::Visiting);
+    stack.push(node.to_string());
+
+    if let Some(neighbors) = graph.get(node) {
+        for neighbor in neighbors {
+            if let Some(cycle) = traverse_neighbor(neighbor, graph, states, stack) {
+                return Some(cycle);
+            }
+        }
+    }
+
+    stack.pop();
+    states.insert(node.to_string(), VisitState::Done);
+    None
+}
+
+fn traverse_neighbor(
+    neighbor: &str,
+    graph: &BTreeMap<String, BTreeSet<String>>,
+    states: &mut HashMap<String, VisitState>,
+    stack: &mut Vec<String>,
+) -> Option<Vec<String>> {
+    match states.get(neighbor).copied() {
+        Some(VisitState::Done) => None,
+        Some(VisitState::Visiting) => cycle_from_back_edge(stack, neighbor),
+        None => dfs_cycle(neighbor, graph, states, stack),
+    }
+}
+
+fn cycle_from_back_edge(stack: &[String], neighbor: &str) -> Option<Vec<String>> {
+    let start = stack.iter().position(|name| name == neighbor)?;
+    let mut cycle = stack[start..].to_vec();
+    cycle.push(neighbor.to_string());
+    Some(cycle)
+}
+
+fn detect_cycle(graph: &BTreeMap<String, BTreeSet<String>>) -> Option<Vec<String>> {
+    let mut states: HashMap<String, VisitState> = HashMap::new();
+    let mut stack = Vec::new();
+
+    for node in graph.keys() {
+        if states.contains_key(node) {
+            continue;
+        }
+        if let Some(cycle) = dfs_cycle(node, graph, &mut states, &mut stack) {
+            return Some(cycle);
+        }
+    }
+    None
+}

--- a/crates/rumoca-tool-lsp/src/handlers/diagnostics.rs
+++ b/crates/rumoca-tool-lsp/src/handlers/diagnostics.rs
@@ -885,6 +885,378 @@ mod tests {
     }
 
     #[test]
+    fn diagnostic_target_names_include_nested_functions() {
+        let source = r#"
+class EOTest
+  extends ExternalObject;
+  function constructor
+    input Boolean verbose = true;
+    output EOTest env;
+    external "C" env = init(verbose);
+  end constructor;
+  function destructor
+    input EOTest env;
+    external "C" destroy(env);
+  end destructor;
+end EOTest;
+"#;
+        let ast = parse_source_to_ast_with_errors(source, "input.mo")
+            .expect("expected valid AST for external object with nested functions");
+        let targets = collect_diagnostic_target_names(&ast);
+        assert!(
+            targets.contains(&"EOTest".to_string()),
+            "expected parent class target, got: {targets:?}"
+        );
+        assert!(
+            targets.contains(&"EOTest.constructor".to_string()),
+            "expected nested constructor target, got: {targets:?}"
+        );
+        assert!(
+            targets.contains(&"EOTest.destructor".to_string()),
+            "expected nested destructor target, got: {targets:?}"
+        );
+    }
+
+    #[test]
+    fn parse_diagnostics_include_syntax_errors_in_nested_functions() {
+        let source = r#"
+class EOTest
+  extends ExternalObject;
+  function constructor
+    input Boolean verbose = true
+    output EOTest env;
+    external "C" env = init(verbose);
+  end constructor;
+end EOTest;
+"#;
+        let diagnostics = compute_diagnostics(source, "input.mo", None);
+        let parse_diag = diagnostics
+            .iter()
+            .find(|d| d.code == Some(NumberOrString::String("EP001".to_string())))
+            .unwrap_or_else(|| {
+                panic!("expected parse diagnostic in nested function: {diagnostics:?}")
+            });
+        assert!(
+            parse_diag.range.start.line >= 4,
+            "expected nested-function parse range, got: {:?}",
+            parse_diag.range
+        );
+    }
+
+    #[test]
+    fn unresolved_component_in_nested_external_function_call_is_reported() {
+        let source = r#"
+class EOTest
+  extends ExternalObject;
+  function constructor
+    input Boolean verbdose = true;
+    output EOTest env;
+    external "C" env = init(verbose);
+  end constructor;
+  function destructor
+    input EOTest env;
+    external "C" destroy(env);
+  end destructor;
+end EOTest;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved component reference")
+                    && d.message.contains("verbose")
+            }),
+            "expected unresolved component reference in nested function external call, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_component_in_function_output_binding_is_reported() {
+        let source = r#"
+function F
+  input Real x;
+  output Real y = missing;
+algorithm
+  y := x;
+end F;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved component reference")
+                    && d.message.contains("missing")
+            }),
+            "expected unresolved component reference in function binding, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_component_in_extends_modification_is_reported() {
+        let source = r#"
+model Base
+  parameter Real k = 1;
+end Base;
+
+model Child
+  extends Base(k = missing);
+end Child;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved component reference")
+                    && d.message.contains("missing")
+            }),
+            "expected unresolved component reference in extends modification, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_component_in_assert_level_is_reported() {
+        let source = r#"
+model M
+equation
+  assert(true, "ok", lvl);
+end M;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved component reference")
+                    && d.message.contains("lvl")
+            }),
+            "expected unresolved component reference in assert-level argument, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_component_in_statement_function_outputs_is_reported() {
+        let source = r#"
+model M
+  Real x;
+algorithm
+  (x, y) := sin(1.0);
+end M;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved component reference")
+                    && d.message.contains("y")
+            }),
+            "expected unresolved component reference in statement function outputs, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_class_constrainedby_type_reference_is_reported() {
+        let source = r#"
+package RealMedium
+end RealMedium;
+
+model UsesMedium
+  replaceable package Medium = RealMedium constrainedby MissingMedium;
+end UsesMedium;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved type reference")
+                    && d.message.contains("MissingMedium")
+            }),
+            "expected unresolved type reference for class constrainedby, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_component_constrainedby_type_reference_is_reported() {
+        let source = r#"
+model M
+  replaceable Real x constrainedby Missing;
+equation
+  x = 0;
+end M;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved type reference")
+                    && d.message.contains("Missing")
+            }),
+            "expected unresolved type reference for component constrainedby, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_subscript_index_in_assignment_target_is_reported() {
+        let source = r#"
+model M
+  Real a[2];
+algorithm
+  a[i] := 1;
+end M;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved component reference")
+                    && d.message.contains("i")
+            }),
+            "expected unresolved subscript index diagnostic, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_selective_import_member_is_reported() {
+        let source = r#"
+package P
+  model A
+  end A;
+end P;
+
+model M
+  import P.{A, B};
+end M;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        let unresolved = diagnostics
+            .iter()
+            .find(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved import member")
+                    && d.message.contains("B")
+            })
+            .unwrap_or_else(|| {
+                panic!("expected unresolved selective import member, got: {diagnostics:?}")
+            });
+        assert!(
+            unresolved.range.start.line >= 6,
+            "expected unresolved selective import diagnostic near import line, got: {:?}",
+            unresolved.range
+        );
+    }
+
+    #[test]
+    fn unresolved_equation_function_call_is_reported_as_function_call() {
+        let source = r#"
+model M
+equation
+  unknown(1.0);
+end M;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved function call")
+                    && d.message.contains("unknown")
+            }),
+            "expected unresolved function-call diagnostic for equation call, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_statement_function_call_is_reported_as_function_call() {
+        let source = r#"
+model M
+algorithm
+  unknown(1.0);
+end M;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved function call")
+                    && d.message.contains("unknown")
+            }),
+            "expected unresolved function-call diagnostic for statement call, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_non_replaceable_partial_type_path_is_reported() {
+        let source = r#"
+model M
+  package P
+  end P;
+  P.Missing x;
+equation
+  x = 0;
+end M;
+"#;
+        let mut session = Session::default();
+        let diagnostics = compute_diagnostics(source, "input.mo", Some(&mut session));
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == Some(NumberOrString::String("ER002".to_string()))
+                    && d.message.contains("unresolved type reference")
+                    && d.message.contains("P.Missing")
+            }),
+            "expected unresolved type reference for non-replaceable partial type path, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn nested_external_function_args_are_present_in_ast() {
+        let source = r#"
+class EOTest
+  extends ExternalObject;
+  function constructor
+    input Boolean verbdose = true;
+    output EOTest env;
+    external "C" env = init(verbose);
+  end constructor;
+end EOTest;
+"#;
+        let ast = parse_source_to_ast_with_errors(source, "input.mo")
+            .expect("source should parse for nested external function AST test");
+        let eo = ast
+            .classes
+            .get("EOTest")
+            .expect("EOTest class should exist");
+        let ctor = eo
+            .classes
+            .get("constructor")
+            .expect("constructor should be a nested class");
+        let external = ctor
+            .external
+            .as_ref()
+            .expect("constructor external declaration should be present");
+        assert_eq!(
+            external.args.len(),
+            1,
+            "expected exactly one external call argument in AST"
+        );
+        match &external.args[0] {
+            ast::Expression::ComponentReference(comp) => {
+                assert_eq!(comp.to_string(), "verbose");
+            }
+            other => {
+                panic!("expected external arg to parse as component reference, got: {other:?}")
+            }
+        }
+    }
+
+    #[test]
     fn common_diagnostics_map_spans_to_editor_ranges() {
         let source = "model M\n  Real x;\n  Real y;\nequation\n  x = y;\nend M;\n";
         let mut source_map = SourceMap::new();

--- a/crates/rumoca-tool-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rumoca-tool-lsp/src/handlers/inlay_hints.rs
@@ -2,6 +2,9 @@
 
 use lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, InlayHintTooltip, Position, Range};
 use rumoca_session::parsing::ast;
+use std::ops::ControlFlow;
+
+use crate::traversal_adapter;
 
 /// Handle inlay hints request.
 ///
@@ -13,49 +16,12 @@ pub fn handle_inlay_hints(
     source: &str,
     range: &Range,
 ) -> Vec<InlayHint> {
-    let mut hints = Vec::new();
-    for class in ast.classes.values() {
-        collect_class_hints(class, source, range, &mut hints);
-    }
-    hints
-}
-
-fn collect_class_hints(
-    class: &ast::ClassDef,
-    source: &str,
-    range: &Range,
-    hints: &mut Vec<InlayHint>,
-) {
-    for comp in class.components.values() {
-        if let Some(hint) = component_dimension_hint(comp, range) {
-            hints.push(hint);
-        }
-    }
-
-    for eq in &class.equations {
-        collect_equation_hints(eq, range, hints);
-    }
-    for eq in &class.initial_equations {
-        collect_equation_hints(eq, range, hints);
-    }
-    for section in &class.algorithms {
-        for stmt in section {
-            collect_statement_hints(stmt, range, hints);
-        }
-    }
-    for section in &class.initial_algorithms {
-        for stmt in section {
-            collect_statement_hints(stmt, range, hints);
-        }
-    }
-
-    // Also scan raw source line for direct builtin calls not represented in AST sections.
+    let mut collector = InlayHintCollector::new(range);
+    // Also scan raw source lines for direct builtin calls not represented in AST sections.
     // This keeps hints useful even for partially parsed files during editing.
-    collect_loose_builtin_call_hints(source, range, hints);
-
-    for nested in class.classes.values() {
-        collect_class_hints(nested, source, range, hints);
-    }
+    collect_loose_builtin_call_hints(source, range, &mut collector.hints);
+    let _ = traversal_adapter::walk_stored_definition(&mut collector, ast);
+    collector.hints
 }
 
 fn component_dimension_hint(comp: &ast::Component, range: &Range) -> Option<InlayHint> {
@@ -99,222 +65,44 @@ fn component_dimension_hint(comp: &ast::Component, range: &Range) -> Option<Inla
     })
 }
 
-fn collect_equation_hints(eq: &ast::Equation, range: &Range, hints: &mut Vec<InlayHint>) {
-    match eq {
-        ast::Equation::Simple { lhs, rhs } => {
-            collect_expression_hints(lhs, range, hints);
-            collect_expression_hints(rhs, range, hints);
+struct InlayHintCollector<'a> {
+    range: &'a Range,
+    hints: Vec<InlayHint>,
+}
+
+impl<'a> InlayHintCollector<'a> {
+    fn new(range: &'a Range) -> Self {
+        Self {
+            range,
+            hints: Vec::new(),
         }
-        ast::Equation::Connect { .. } => {}
-        ast::Equation::For {
-            indices: _,
-            equations,
-        } => {
-            for inner in equations {
-                collect_equation_hints(inner, range, hints);
-            }
-        }
-        ast::Equation::When(blocks) => {
-            for block in blocks {
-                collect_expression_hints(&block.cond, range, hints);
-                for inner in &block.eqs {
-                    collect_equation_hints(inner, range, hints);
-                }
-            }
-        }
-        ast::Equation::If {
-            cond_blocks,
-            else_block,
-        } => {
-            for block in cond_blocks {
-                collect_expression_hints(&block.cond, range, hints);
-                for inner in &block.eqs {
-                    collect_equation_hints(inner, range, hints);
-                }
-            }
-            if let Some(else_eqs) = else_block {
-                for inner in else_eqs {
-                    collect_equation_hints(inner, range, hints);
-                }
-            }
-        }
-        ast::Equation::FunctionCall { comp, args } => {
-            collect_function_call_hints(comp, args, range, hints);
-            for arg in args {
-                collect_expression_hints(arg, range, hints);
-            }
-        }
-        ast::Equation::Assert {
-            condition,
-            message,
-            level,
-        } => {
-            collect_expression_hints(condition, range, hints);
-            collect_expression_hints(message, range, hints);
-            if let Some(level) = level {
-                collect_expression_hints(level, range, hints);
-            }
-        }
-        ast::Equation::Empty => {}
     }
 }
 
-fn collect_statement_hints(stmt: &ast::Statement, range: &Range, hints: &mut Vec<InlayHint>) {
-    match stmt {
-        ast::Statement::Assignment { comp: _, value } => {
-            collect_expression_hints(value, range, hints);
-        }
-        ast::Statement::For {
-            indices: _,
-            equations,
-        } => {
-            for inner in equations {
-                collect_statement_hints(inner, range, hints);
-            }
-        }
-        ast::Statement::While(block) => {
-            collect_expression_hints(&block.cond, range, hints);
-            for inner in &block.stmts {
-                collect_statement_hints(inner, range, hints);
-            }
-        }
-        ast::Statement::If {
-            cond_blocks,
-            else_block,
-        } => {
-            for block in cond_blocks {
-                collect_expression_hints(&block.cond, range, hints);
-                for inner in &block.stmts {
-                    collect_statement_hints(inner, range, hints);
-                }
-            }
-            if let Some(else_stmts) = else_block {
-                for inner in else_stmts {
-                    collect_statement_hints(inner, range, hints);
-                }
-            }
-        }
-        ast::Statement::When(blocks) => {
-            for block in blocks {
-                collect_expression_hints(&block.cond, range, hints);
-                for inner in &block.stmts {
-                    collect_statement_hints(inner, range, hints);
-                }
-            }
-        }
-        ast::Statement::FunctionCall {
-            comp,
-            args,
-            outputs,
-        } => {
-            collect_function_call_hints(comp, args, range, hints);
-            for arg in args {
-                collect_expression_hints(arg, range, hints);
-            }
-            for out in outputs {
-                collect_expression_hints(out, range, hints);
-            }
-        }
-        ast::Statement::Reinit { variable: _, value } => {
-            collect_expression_hints(value, range, hints);
-        }
-        ast::Statement::Assert {
-            condition,
-            message,
-            level,
-        } => {
-            collect_expression_hints(condition, range, hints);
-            collect_expression_hints(message, range, hints);
-            if let Some(level) = level {
-                collect_expression_hints(level, range, hints);
-            }
-        }
-        ast::Statement::Return { .. } | ast::Statement::Break { .. } | ast::Statement::Empty => {}
+impl ast::visitor::Visitor for InlayHintCollector<'_> {
+    fn visit_class_def(&mut self, class: &ast::ClassDef) -> ControlFlow<()> {
+        traversal_adapter::walk_class_sections(self, class, false)
     }
-}
 
-fn collect_expression_hints(expr: &ast::Expression, range: &Range, hints: &mut Vec<InlayHint>) {
-    match expr {
-        ast::Expression::Unary { rhs, .. } => collect_expression_hints(rhs, range, hints),
-        ast::Expression::Binary { lhs, rhs, .. } => {
-            collect_expression_hints(lhs, range, hints);
-            collect_expression_hints(rhs, range, hints);
+    fn visit_component(&mut self, component: &ast::Component) -> ControlFlow<()> {
+        if let Some(hint) = component_dimension_hint(component, self.range) {
+            self.hints.push(hint);
         }
-        ast::Expression::FunctionCall { comp, args } => {
-            collect_function_call_hints(comp, args, range, hints);
-            for arg in args {
-                collect_expression_hints(arg, range, hints);
-            }
-        }
-        ast::Expression::ClassModification {
-            target: _,
-            modifications,
-        } => {
-            for m in modifications {
-                collect_expression_hints(m, range, hints);
-            }
-        }
-        ast::Expression::NamedArgument { value, .. } => {
-            collect_expression_hints(value, range, hints)
-        }
-        ast::Expression::Modification { value, .. } => {
-            collect_expression_hints(value, range, hints)
-        }
-        ast::Expression::Array { elements, .. } => {
-            for el in elements {
-                collect_expression_hints(el, range, hints);
-            }
-        }
-        ast::Expression::Tuple { elements } => {
-            for el in elements {
-                collect_expression_hints(el, range, hints);
-            }
-        }
-        ast::Expression::If {
-            branches,
-            else_branch,
-        } => {
-            for (cond, value) in branches {
-                collect_expression_hints(cond, range, hints);
-                collect_expression_hints(value, range, hints);
-            }
-            collect_expression_hints(else_branch, range, hints);
-        }
-        ast::Expression::Parenthesized { inner } => collect_expression_hints(inner, range, hints),
-        ast::Expression::ArrayComprehension {
-            expr,
-            indices,
-            filter,
-        } => {
-            collect_expression_hints(expr, range, hints);
-            for idx in indices {
-                collect_expression_hints(&idx.range, range, hints);
-            }
-            if let Some(filter) = filter {
-                collect_expression_hints(filter, range, hints);
-            }
-        }
-        ast::Expression::ArrayIndex { base, subscripts } => {
-            collect_expression_hints(base, range, hints);
-            for s in subscripts {
-                if let ast::Subscript::Expression(e) = s {
-                    collect_expression_hints(e, range, hints);
-                }
-            }
-        }
-        ast::Expression::FieldAccess { base, field: _ } => {
-            collect_expression_hints(base, range, hints);
-        }
-        ast::Expression::Range { start, step, end } => {
-            collect_expression_hints(start, range, hints);
-            if let Some(step) = step {
-                collect_expression_hints(step, range, hints);
-            }
-            collect_expression_hints(end, range, hints);
-        }
-        ast::Expression::Terminal { .. }
-        | ast::Expression::ComponentReference(_)
-        | ast::Expression::Empty => {}
+        traversal_adapter::walk_component_fields(self, component)
+    }
+
+    fn visit_expr_function_call_ctx(
+        &mut self,
+        comp: &ast::ComponentReference,
+        args: &[ast::Expression],
+        _ctx: ast::visitor::FunctionCallContext,
+    ) -> ControlFlow<()> {
+        collect_function_call_hints(comp, args, self.range, &mut self.hints);
+        self.visit_each(args, Self::visit_expression)
+    }
+
+    fn visit_expression(&mut self, expression: &ast::Expression) -> ControlFlow<()> {
+        traversal_adapter::walk_expression_default(self, expression)
     }
 }
 

--- a/crates/rumoca-tool-lsp/src/handlers/semantic_tokens.rs
+++ b/crates/rumoca-tool-lsp/src/handlers/semantic_tokens.rs
@@ -11,6 +11,8 @@ use lsp_types::{
     SemanticTokensResult,
 };
 
+use crate::traversal_adapter;
+
 type ClassDef = ast::ClassDef;
 type ClassType = ast::ClassType;
 type Component = ast::Component;
@@ -68,7 +70,7 @@ pub fn get_semantic_token_legend() -> SemanticTokensLegend {
 /// Takes a parsed AST from `rumoca-session`.
 pub fn handle_semantic_tokens(ast: &StoredDefinition) -> Option<SemanticTokensResult> {
     let mut collector = SemanticTokenCollector::new();
-    let _ = ast::visitor::Visitor::visit_stored_definition(&mut collector, ast);
+    let _ = traversal_adapter::walk_stored_definition(&mut collector, ast);
 
     // Sort by line then column
     collector
@@ -243,42 +245,12 @@ fn is_modelica_operator_keyword(name: &str) -> bool {
 impl ast::visitor::Visitor for SemanticTokenCollector {
     fn visit_class_def(&mut self, class: &ClassDef) -> ControlFlow<()> {
         self.add_class_tokens(class);
-
-        // Visit children (default behavior)
-        for ext in &class.extends {
-            self.visit_extend(ext)?;
-        }
-        for (_, nested) in &class.classes {
-            self.visit_class_def(nested)?;
-        }
-        for (_, comp) in &class.components {
-            self.visit_component(comp)?;
-        }
-        self.visit_each(&class.equations, Self::visit_equation)?;
-        self.visit_each(&class.initial_equations, Self::visit_equation)?;
-        for section in &class.algorithms {
-            self.visit_each(section, Self::visit_statement)?;
-        }
-        for section in &class.initial_algorithms {
-            self.visit_each(section, Self::visit_statement)?;
-        }
-        Continue(())
+        traversal_adapter::walk_class_sections(self, class, true)
     }
 
     fn visit_component(&mut self, comp: &Component) -> ControlFlow<()> {
         self.add_component_tokens(comp);
-
-        // Visit children (default behavior)
-        if !matches!(comp.start, Expression::Empty) {
-            self.visit_expression(&comp.start)?;
-        }
-        for (_, mod_expr) in &comp.modifications {
-            self.visit_expression(mod_expr)?;
-        }
-        if let Some(cond) = &comp.condition {
-            self.visit_expression(cond)?;
-        }
-        self.visit_each(&comp.annotation, Self::visit_expression)
+        traversal_adapter::walk_component_fields(self, comp)
     }
 
     fn visit_expression(&mut self, expr: &Expression) -> ControlFlow<()> {
@@ -304,8 +276,7 @@ impl ast::visitor::Visitor for SemanticTokenCollector {
             return Continue(());
         }
 
-        // Default recursive behavior for all other expression types
-        default_visit_expression(self, expr)
+        traversal_adapter::walk_expression_default(self, expr)
     }
 
     fn visit_expr_function_call(
@@ -348,80 +319,6 @@ impl ast::visitor::Visitor for SemanticTokenCollector {
         self.add_call_head_tokens(comp);
         self.visit_each(args, Self::visit_expression)?;
         self.visit_each(outputs, Self::visit_expression)
-    }
-}
-
-/// Default expression visitor behavior (copied from trait to allow override).
-fn default_visit_expression(v: &mut SemanticTokenCollector, expr: &Expression) -> ControlFlow<()> {
-    match expr {
-        Expression::Empty | Expression::Terminal { .. } => Continue(()),
-        Expression::Range { start, step, end } => {
-            ast::visitor::Visitor::visit_expression(v, start)?;
-            if let Some(s) = step {
-                ast::visitor::Visitor::visit_expression(v, s)?;
-            }
-            ast::visitor::Visitor::visit_expression(v, end)
-        }
-        Expression::Unary { rhs, .. } => ast::visitor::Visitor::visit_expression(v, rhs),
-        Expression::Binary { lhs, rhs, .. } => {
-            ast::visitor::Visitor::visit_expression(v, lhs)?;
-            ast::visitor::Visitor::visit_expression(v, rhs)
-        }
-        Expression::ComponentReference(cr) => {
-            ast::visitor::Visitor::visit_component_reference(v, cr)
-        }
-        Expression::FunctionCall { comp, args } => {
-            ast::visitor::Visitor::visit_expr_function_call(v, comp, args)
-        }
-        Expression::ClassModification {
-            target,
-            modifications,
-        } => {
-            ast::visitor::Visitor::visit_component_reference(v, target)?;
-            ast::visitor::Visitor::visit_each(
-                v,
-                modifications,
-                ast::visitor::Visitor::visit_expression,
-            )
-        }
-        Expression::NamedArgument { value, .. } => {
-            ast::visitor::Visitor::visit_expression(v, value)
-        }
-        Expression::Modification { target, value } => {
-            ast::visitor::Visitor::visit_component_reference(v, target)?;
-            ast::visitor::Visitor::visit_expression(v, value)
-        }
-        Expression::Array { elements, .. } | Expression::Tuple { elements } => {
-            ast::visitor::Visitor::visit_each(v, elements, ast::visitor::Visitor::visit_expression)
-        }
-        Expression::If {
-            branches,
-            else_branch,
-        } => {
-            for (cond, then_expr) in branches {
-                ast::visitor::Visitor::visit_expression(v, cond)?;
-                ast::visitor::Visitor::visit_expression(v, then_expr)?;
-            }
-            ast::visitor::Visitor::visit_expression(v, else_branch)
-        }
-        Expression::Parenthesized { inner } => ast::visitor::Visitor::visit_expression(v, inner),
-        Expression::ArrayComprehension {
-            expr,
-            indices,
-            filter,
-        } => {
-            ast::visitor::Visitor::visit_expression(v, expr)?;
-            ast::visitor::Visitor::visit_each(v, indices, ast::visitor::Visitor::visit_for_index)?;
-            if let Some(f) = filter {
-                ast::visitor::Visitor::visit_expression(v, f)?;
-            }
-            Continue(())
-        }
-        Expression::ArrayIndex { base, subscripts } => {
-            ast::visitor::Visitor::visit_expression(v, base)?;
-            ast::visitor::Visitor::visit_each(v, subscripts, ast::visitor::Visitor::visit_subscript)
-        }
-        Expression::FieldAccess { base, .. } => ast::visitor::Visitor::visit_expression(v, base),
     }
 }
 

--- a/crates/rumoca-tool-lsp/src/lib.rs
+++ b/crates/rumoca-tool-lsp/src/lib.rs
@@ -23,6 +23,7 @@
 
 pub mod handlers;
 pub mod helpers;
+mod traversal_adapter;
 
 #[cfg(feature = "server")]
 mod server;

--- a/crates/rumoca-tool-lsp/src/traversal_adapter.rs
+++ b/crates/rumoca-tool-lsp/src/traversal_adapter.rs
@@ -1,0 +1,140 @@
+use rumoca_session::parsing::ast;
+use rumoca_session::parsing::ast::{
+    ComponentReferenceContext, ExpressionContext, FunctionCallContext, SubscriptContext,
+};
+use std::ops::ControlFlow::{self, Continue};
+
+pub(crate) fn walk_stored_definition<V: ast::visitor::Visitor>(
+    visitor: &mut V,
+    def: &ast::StoredDefinition,
+) -> ControlFlow<()> {
+    for (_, class) in &def.classes {
+        visitor.visit_class_def(class)?;
+    }
+    Continue(())
+}
+
+pub(crate) fn walk_class_sections<V: ast::visitor::Visitor>(
+    visitor: &mut V,
+    class: &ast::ClassDef,
+    include_extends: bool,
+) -> ControlFlow<()> {
+    if include_extends {
+        for ext in &class.extends {
+            visitor.visit_extend(ext)?;
+        }
+    }
+    for (_, comp) in &class.components {
+        visitor.visit_component(comp)?;
+    }
+    visitor.visit_each(&class.equations, V::visit_equation)?;
+    visitor.visit_each(&class.initial_equations, V::visit_equation)?;
+    for section in &class.algorithms {
+        visitor.visit_each(section, V::visit_statement)?;
+    }
+    for section in &class.initial_algorithms {
+        visitor.visit_each(section, V::visit_statement)?;
+    }
+    for (_, nested) in &class.classes {
+        visitor.visit_class_def(nested)?;
+    }
+    Continue(())
+}
+
+pub(crate) fn walk_component_fields<V: ast::visitor::Visitor>(
+    visitor: &mut V,
+    component: &ast::Component,
+) -> ControlFlow<()> {
+    if !matches!(component.start, ast::Expression::Empty) {
+        visitor.visit_expression_ctx(&component.start, ExpressionContext::ComponentStart)?;
+    }
+    for (_, mod_expr) in &component.modifications {
+        visitor.visit_expression_ctx(mod_expr, ExpressionContext::ComponentModification)?;
+    }
+    if let Some(cond) = &component.condition {
+        visitor.visit_expression_ctx(cond, ExpressionContext::ComponentCondition)?;
+    }
+    for annotation in &component.annotation {
+        visitor.visit_expression_ctx(annotation, ExpressionContext::ComponentAnnotation)?;
+    }
+    Continue(())
+}
+
+pub(crate) fn walk_expression_default<V: ast::visitor::Visitor>(
+    visitor: &mut V,
+    expression: &ast::Expression,
+) -> ControlFlow<()> {
+    match expression {
+        ast::Expression::Empty | ast::Expression::Terminal { .. } => Continue(()),
+        ast::Expression::Range { start, step, end } => {
+            visitor.visit_expression(start)?;
+            if let Some(s) = step {
+                visitor.visit_expression(s)?;
+            }
+            visitor.visit_expression(end)
+        }
+        ast::Expression::Unary { rhs, .. } => visitor.visit_expression(rhs),
+        ast::Expression::Binary { lhs, rhs, .. } => {
+            visitor.visit_expression(lhs)?;
+            visitor.visit_expression(rhs)
+        }
+        ast::Expression::ComponentReference(cr) => {
+            visitor.visit_component_reference_ctx(cr, ComponentReferenceContext::Expression)
+        }
+        ast::Expression::FunctionCall { comp, args } => {
+            visitor.visit_expr_function_call_ctx(comp, args, FunctionCallContext::Expression)
+        }
+        ast::Expression::ClassModification {
+            target,
+            modifications,
+        } => {
+            visitor.visit_component_reference_ctx(
+                target,
+                ComponentReferenceContext::ClassModificationTarget,
+            )?;
+            visitor.visit_each(modifications, V::visit_expression)
+        }
+        ast::Expression::NamedArgument { value, .. } => visitor.visit_expression(value),
+        ast::Expression::Modification { target, value } => {
+            visitor.visit_component_reference_ctx(
+                target,
+                ComponentReferenceContext::ModificationTarget,
+            )?;
+            visitor.visit_expression(value)
+        }
+        ast::Expression::Array { elements, .. } | ast::Expression::Tuple { elements } => {
+            visitor.visit_each(elements, V::visit_expression)
+        }
+        ast::Expression::If {
+            branches,
+            else_branch,
+        } => {
+            for (cond, then_expr) in branches {
+                visitor.visit_expression(cond)?;
+                visitor.visit_expression(then_expr)?;
+            }
+            visitor.visit_expression(else_branch)
+        }
+        ast::Expression::Parenthesized { inner } => visitor.visit_expression(inner),
+        ast::Expression::ArrayComprehension {
+            expr,
+            indices,
+            filter,
+        } => {
+            visitor.visit_expression(expr)?;
+            visitor.visit_each(indices, V::visit_for_index)?;
+            if let Some(f) = filter {
+                visitor.visit_expression(f)?;
+            }
+            Continue(())
+        }
+        ast::Expression::ArrayIndex { base, subscripts } => {
+            visitor.visit_expression(base)?;
+            for subscript in subscripts {
+                visitor.visit_subscript_ctx(subscript, SubscriptContext::ArrayIndex)?;
+            }
+            Continue(())
+        }
+        ast::Expression::FieldAccess { base, .. } => visitor.visit_expression(base),
+    }
+}


### PR DESCRIPTION
Closes #65, manual traversal was difficult to maintain and prone to missing semantics. The replaces it with visitor patterns across the compiler.