### PR TITLE
feat: preserve top-level model descriptions in DAE IR and template context

### DIFF
--- a/crates/rumoca-ir-dae/src/lib.rs
+++ b/crates/rumoca-ir-dae/src/lib.rs
@@ -254,6 +254,10 @@ pub struct Dae {
     /// tracks the number of excess equation scalars.
     #[serde(default)]
     pub oc_break_edge_scalar_count: usize,
+
+    /// Optional description string from the root class declaration.
+    #[serde(default)]
+    pub model_description: Option<String>,
 }
 
 impl Dae {

--- a/crates/rumoca-phase-codegen/src/codegen.rs
+++ b/crates/rumoca-phase-codegen/src/codegen.rs
@@ -61,6 +61,7 @@ pub fn dae_template_json(dae: &dae::Dae) -> serde_json::Value {
         "oc_break_edge_scalar_count": dae.oc_break_edge_scalar_count,
         "is_partial": dae.is_partial,
         "class_type": &dae.class_type,
+        "model_description": dae.model_description,
     })
 }
 

--- a/crates/rumoca-phase-codegen/src/codegen/codegen_tests.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/codegen_tests.rs
@@ -294,6 +294,18 @@ fn test_render_dae_equation_via_template() {
 }
 
 #[test]
+fn test_dae_template_includes_model_description() {
+    // Test that DAE template includes model description when present
+    let mut dae = dae::Dae::new();
+    dae.model_description = Some("Test model description".to_string());
+
+    // Render template
+    let tmpl = crate::templates::DAE_MODELICA;
+    let result = render_template_with_name(&dae, tmpl, "TestModel").unwrap();
+    assert!(result.contains(r#"class TestModel "Test model description""#));
+}
+
+#[test]
 fn test_render_flat_equation_via_template() {
     // Test render_flat_equation function via template with an empty Model
     let flat = flat::Model::new();

--- a/crates/rumoca-phase-codegen/src/templates/dae_modelica.mo.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/dae_modelica.mo.jinja
@@ -47,7 +47,7 @@
 {%- macro desc(var) -%}
 {%- if var.description %} "{{ var.description }}"{% endif -%}
 {%- endmacro -%}
-class {{ model_name }}
+class {{ model_name }}{% if dae.model_description %} "{{ dae.model_description }}"{% endif %}
 {%- for name, var in dae.parameters | items %}
   parameter Real{{ dims(var) }} {{ name }}{{ var_attrs(var) }}{% if var.start is not none %} = {{ render_expr(var.start, cfg) }}{% endif %}{{ desc(var) }};
 {%- endfor -%}

--- a/crates/rumoca-phase-dae/src/lib.rs
+++ b/crates/rumoca-phase-dae/src/lib.rs
@@ -1247,6 +1247,7 @@ pub fn to_dae_with_options(flat: &Model, options: ToDaeOptions) -> Result<Dae, T
     // MLS §4.7: Propagate partial status and class type for balance checking
     dae.is_partial = flat.is_partial;
     dae.class_type = flat.class_type.clone();
+    dae.model_description = flat.model_description.clone();
 
     // Build prefix-to-children index once for O(1) record field lookups
     let prefix_children = build_prefix_children(flat);

--- a/crates/rumoca-phase-dae/src/tests.rs
+++ b/crates/rumoca-phase-dae/src/tests.rs
@@ -1931,6 +1931,26 @@ fn test_classify_equations_skips_unconnected_flow_for_top_level_overconstrained_
     );
 }
 
+#[test]
+fn test_model_description_propagation() {
+    let mut flat = flat::Model::new();
+    flat.model_description = Some("Test model description".to_string());
+
+    // Add a simple variable to make it valid
+    let var = rumoca_ir_flat::Variable {
+        name: "x".into(),
+        variability: rumoca_ir_core::Variability::Parameter(Default::default()),
+        ..Default::default()
+    };
+    flat.add_variable("x".into(), var);
+
+    let dae = to_dae(&flat).unwrap();
+    assert_eq!(
+        dae.model_description,
+        Some("Test model description".to_string())
+    );
+}
+
 mod tests_embedded_range;
 mod tests_flow_sum;
 mod tests_regressions;


### PR DESCRIPTION
Implements #73: preserve top-level model descriptions in DAE IR and template context.

Changes:
- Add model_description field to Dae struct
- Propagate description from flat to DAE during conversion  
- Expose description in template JSON
- Update DAE_MODELICA template to include description in class declaration
- Add tests for propagation and template rendering

Closes #73