### PR TITLE
vscode: harden bundled lsp deployment on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,15 +439,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+          # Use musl for Linux x64 release artifacts so the bundled VS Code
+          # server does not depend on the remote host glibc version.
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
             rumoca_asset: rumoca-linux-x86_64
             lsp_asset: rumoca-lsp-linux-x86_64
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
             rumoca_asset: rumoca-linux-aarch64
             lsp_asset: rumoca-lsp-linux-aarch64
-            cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
             rumoca_asset: rumoca-macos-x86_64
@@ -472,33 +473,74 @@ jobs:
       - name: Add target
         run: rustup target add ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: matrix.cross
+      - name: Install musl tools (Linux musl)
+        if: contains(matrix.target, 'musl')
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y musl-tools
 
-      - name: Configure cross-compilation (Linux ARM64)
-        if: matrix.cross
+      - name: Configure musl build (Linux musl)
+        if: contains(matrix.target, 'musl')
         run: |
           mkdir -p .cargo
-          echo '[target.aarch64-unknown-linux-gnu]' >> .cargo/config.toml
-          echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml
+          target_env_suffix="$(echo '${{ matrix.target }}' | tr '-' '_')"
+          target_env_upper="$(echo '${{ matrix.target }}' | tr '[:lower:]-' '[:upper:]_')"
+          cat >> .cargo/config.toml <<'EOF'
+          [target.${{ matrix.target }}]
+          linker = "musl-gcc"
+          EOF
+          echo "CC_${target_env_suffix}=musl-gcc" >> $GITHUB_ENV
+          echo "CARGO_TARGET_${target_env_upper}_LINKER=musl-gcc" >> $GITHUB_ENV
 
       - name: Build release binaries
         run: cargo build --release --target ${{ matrix.target }} --bin rumoca --bin rumoca-lsp
 
       - name: Strip binaries (Linux native)
-        if: runner.os == 'Linux' && !matrix.cross
+        if: runner.os == 'Linux'
         run: |
           strip target/${{ matrix.target }}/release/rumoca
           strip target/${{ matrix.target }}/release/rumoca-lsp
 
-      - name: Strip binaries (Linux ARM64 cross)
-        if: matrix.cross
+      - name: Verify Linux musl release artifacts
+        if: contains(matrix.target, 'musl')
         run: |
-          aarch64-linux-gnu-strip target/${{ matrix.target }}/release/rumoca
-          aarch64-linux-gnu-strip target/${{ matrix.target }}/release/rumoca-lsp
+          set -euo pipefail
+
+          rumoca_bin="target/${{ matrix.target }}/release/rumoca"
+          lsp_bin="target/${{ matrix.target }}/release/rumoca-lsp"
+
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-musl)
+              expected_machine="Advanced Micro Devices X86-64"
+              ;;
+            aarch64-unknown-linux-musl)
+              expected_machine="AArch64"
+              ;;
+            *)
+              echo "::error::unexpected musl release target: ${{ matrix.target }}"
+              exit 1
+              ;;
+          esac
+
+          echo "Inspecting $rumoca_bin"
+          file "$rumoca_bin"
+          readelf -h "$rumoca_bin" | grep -F "$expected_machine"
+          if readelf -l "$rumoca_bin" | grep -F "Requesting program interpreter" >/dev/null; then
+            echo "::error::$rumoca_bin unexpectedly depends on a dynamic ELF interpreter"
+            exit 1
+          fi
+          ldd "$rumoca_bin" || true
+          "$rumoca_bin" --version
+
+          echo "Inspecting $lsp_bin"
+          file "$lsp_bin"
+          readelf -h "$lsp_bin" | grep -F "$expected_machine"
+          if readelf -l "$lsp_bin" | grep -F "Requesting program interpreter" >/dev/null; then
+            echo "::error::$lsp_bin unexpectedly depends on a dynamic ELF interpreter"
+            exit 1
+          fi
+          ldd "$lsp_bin" || true
+          "$lsp_bin" --version
 
       - name: Strip binaries (macOS)
         if: runner.os == 'macOS'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,6 +3139,7 @@ name = "rumoca-tool-lsp"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "clap",
  "lsp-types",
  "rumoca-session",
  "rumoca-tool-fmt",

--- a/README.md
+++ b/README.md
@@ -233,6 +233,28 @@ Template files in `examples/templates` are works in progress and need cleanup. T
 
 The VS Code extension is available as **Rumoca Modelica** in the marketplace and includes a bundled `rumoca-lsp` server.
 
+Linux VS Code release binaries are built against `musl` for both `linux-x64` and `linux-arm64`.
+This avoids remote-host `glibc` version mismatches for bundled `rumoca-lsp` deployments (for
+example over Remote/SSH).
+
+Maintainer reproduction commands for Linux release artifacts:
+
+```bash
+# Linux x64 musl
+sudo apt-get update && sudo apt-get install -y musl-tools
+rustup target add x86_64-unknown-linux-musl
+CC_x86_64_unknown_linux_musl=musl-gcc \
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
+cargo build --release --target x86_64-unknown-linux-musl --bin rumoca --bin rumoca-lsp
+
+# Linux arm64 musl (on a native arm64 Linux host/runner)
+sudo apt-get update && sudo apt-get install -y musl-tools
+rustup target add aarch64-unknown-linux-musl
+CC_aarch64_unknown_linux_musl=musl-gcc \
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
+cargo build --release --target aarch64-unknown-linux-musl --bin rumoca --bin rumoca-lsp
+```
+
 - Extension docs: `editors/vscode/README.md`
 - Marketplace: https://marketplace.visualstudio.com/items?itemName=JamesGoppert.rumoca-modelica
 

--- a/crates/rumoca-tool-lsp/Cargo.toml
+++ b/crates/rumoca-tool-lsp/Cargo.toml
@@ -19,6 +19,7 @@ lsp-types = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+clap = { workspace = true }
 
 # Server-only dependencies (not needed for WASM)
 tower-lsp = { workspace = true, optional = true }

--- a/crates/rumoca-tool-lsp/src/main.rs
+++ b/crates/rumoca-tool-lsp/src/main.rs
@@ -1,6 +1,19 @@
 //! Rumoca Language Server Protocol (LSP) binary.
 
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(name = "rumoca-lsp")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(about = "Rumoca Modelica Language Server", long_about = None)]
+struct Cli {
+    /// Increase logging verbosity (reserved for future use)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    _verbose: u8,
+}
+
 #[tokio::main]
 async fn main() {
+    let _ = Cli::parse();
     rumoca_tool_lsp::run_server().await;
 }

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -27,6 +27,10 @@ Search for "Rumoca Modelica" in the VS Code Extensions view (`Ctrl+Shift+X` / `C
 
 The extension includes a bundled `rumoca-lsp` language server, so **no additional installation is required** for most users.
 
+For Linux release builds, the bundled `rumoca-lsp` is shipped as a `musl`-linked binary for both
+`linux-x64` and `linux-arm64`. This is intentional: it reduces breakage from remote-host `glibc`
+version mismatches.
+
 **From VSIX file:**
 
 1. Download the `.vsix` file for your platform from [GitHub Releases](https://github.com/cognipilot/rumoca/releases)
@@ -63,13 +67,13 @@ Set `rumoca.serverPath` to the full path of your custom `rumoca-lsp` binary:
 If you need to install `rumoca-lsp` manually:
 
 ```bash
-# From crates.io
-cargo install rumoca
+# From GitHub Releases installer
+curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/cognipilot/rumoca/main/install/install.sh | bash -s -- --with-lsp
 
 # Or from source
 git clone https://github.com/cognipilot/rumoca.git
 cd rumoca
-cargo install --path .
+cargo install --path crates/rumoca-tool-lsp
 ```
 
 ## Configuration
@@ -113,13 +117,22 @@ These paths are added to the `MODELICAPATH` used for import resolution. Paths co
 
 **Extension shows "Using system-installed rumoca-lsp" warning:**
 
-This means the bundled binary wasn't found (possibly a platform mismatch). You can:
+This means the bundled binary wasn't found or could not execute on your machine. You can:
 1. Set `rumoca.useSystemServer` to `true` to suppress the warning
 2. Install `rumoca-lsp` manually (see above)
 
+**Extension shows a `glibc`/loader error for the bundled server:**
+
+The extension now probes the bundled `rumoca-lsp` before startup and will fall back to a
+system-installed server if one is available. If you still hit this case:
+
+1. update to the latest extension release
+2. install `rumoca-lsp` manually and set `rumoca.useSystemServer` to `true`
+3. report the failing platform/host details if the latest bundled Linux build still does not run
+
 **Extension can't find rumoca-lsp:**
 
-1. The extension will prompt you to install via cargo
+1. Install `rumoca-lsp` with the GitHub Releases installer shown above
 2. Or set `rumoca.serverPath` to the full path of your `rumoca-lsp` binary
 
 **Debug logging:**
@@ -138,7 +151,7 @@ Then check the "Rumoca Modelica" output channel in VS Code.
 
 ```bash
 # Build the LSP server
-cargo build --release
+cargo build --release --bin rumoca-lsp
 
 # Build the extension
 cd editors/vscode

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as vscode from 'vscode';
-import { execSync, spawn } from 'child_process';
+import { execSync, spawn, spawnSync } from 'child_process';
 import {
     LanguageClient,
     LanguageClientOptions,
@@ -451,6 +451,34 @@ function findInPath(command: string): string | undefined {
         // Command not found in PATH
     }
     return undefined;
+}
+
+interface ServerProbeResult {
+    ok: boolean;
+    detail?: string;
+}
+
+function probeServerExecutable(serverPath: string): ServerProbeResult {
+    const result = spawnSync(serverPath, ['--version'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        windowsHide: true
+    });
+    if (result.error) {
+        return { ok: false, detail: result.error.message };
+    }
+
+    if (result.status !== 0) {
+        const detail = [result.stderr, result.stdout]
+            .map(value => value?.trim())
+            .find(value => Boolean(value));
+        return {
+            ok: false,
+            detail: detail || `process exited with status ${result.status ?? 'unknown'}`
+        };
+    }
+
+    return { ok: true };
 }
 
 interface SimulationExecutionSettings {
@@ -5661,6 +5689,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Find the server executable
     let serverPath = config.get<string>('serverPath');
     let usingSystemFallback = false;
+    let usingBundledServer = false;
 
     const elapsed = () => `${Date.now() - startTime}ms`;
 
@@ -5700,6 +5729,7 @@ export async function activate(context: vscode.ExtensionContext) {
         debugLog(`[${elapsed()}] Checking for bundled binary: ${bundledPath}`);
         if (fs.existsSync(bundledPath)) {
             serverPath = bundledPath;
+            usingBundledServer = true;
             log(`Using bundled rumoca-lsp`);
             debugLog(`[${elapsed()}] Found bundled rumoca-lsp: ${serverPath}`);
         } else {
@@ -5749,6 +5779,49 @@ export async function activate(context: vscode.ExtensionContext) {
         const msg = `rumoca-lsp not found at: ${serverPath}`;
         log(`ERROR: ${msg}`);
         vscode.window.showErrorMessage(msg);
+        return;
+    }
+
+    let probeResult = probeServerExecutable(serverPath);
+    if (!probeResult.ok) {
+        const detail = probeResult.detail ?? 'unknown error';
+        log(`ERROR: Failed to execute rumoca-lsp at ${serverPath}: ${detail}`);
+
+        if (usingBundledServer) {
+            const fallbackServerPath = findSystemServer();
+            if (fallbackServerPath && fallbackServerPath !== serverPath) {
+                const fallbackProbeResult = probeServerExecutable(fallbackServerPath);
+                if (fallbackProbeResult.ok) {
+                    serverPath = fallbackServerPath;
+                    probeResult = fallbackProbeResult;
+                    log(`Warning: Bundled rumoca-lsp could not execute; falling back to system server: ${serverPath}`);
+                    vscode.window.showWarningMessage(
+                        'Bundled rumoca-lsp could not execute on this machine. Falling back to the system-installed server.',
+                        'Open Settings'
+                    ).then(selection => {
+                        if (selection === 'Open Settings') {
+                            vscode.commands.executeCommand('workbench.action.openSettings', 'rumoca.useSystemServer');
+                        }
+                    });
+                } else {
+                    const fallbackDetail = fallbackProbeResult.detail ?? 'unknown error';
+                    log(`ERROR: System rumoca-lsp fallback also failed at ${fallbackServerPath}: ${fallbackDetail}`);
+                }
+            }
+        }
+    }
+
+    if (!serverPath || !probeResult.ok) {
+        const probeDetail = probeResult.detail ?? 'unknown error';
+        const msg = `Failed to execute rumoca-lsp: ${probeDetail}`;
+        log(`ERROR: ${msg}`);
+        outputChannel.show();
+        const selection = await vscode.window.showErrorMessage(msg, 'Open Settings', 'Configure Path');
+        if (selection === 'Open Settings') {
+            vscode.commands.executeCommand('workbench.action.openSettings', 'rumoca.useSystemServer');
+        } else if (selection === 'Configure Path') {
+            vscode.commands.executeCommand('workbench.action.openSettings', 'rumoca.serverPath');
+        }
         return;
     }
 


### PR DESCRIPTION
- probe bundled rumoca-lsp before startup and fall back to a system server when it cannot execute
- add a proper rumoca-lsp CLI surface for version probing
- ship Linux VS Code release binaries as musl artifacts on x64 and arm64
- verify Linux musl release artifacts in CI before VSIX packaging
- document the Linux release policy and maintainer reproduction steps

Closes #75 