### PR TITLE
Renaming for templates and built in integrator for casadi templates

### DIFF
--- a/crates/rumoca-phase-codegen/src/templates/c_code.c.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/c_code.c.jinja
@@ -15,31 +15,31 @@
 {% set cfg = {"prefix": "", "power": "pow_op", "and_op": "&&", "or_op": "||", "not_op": "!", "true_val": "1", "false_val": "0", "if_style": "ternary"} %}
 
 /* Model dimensions */
-#define MODEL_N_STATES {{ dae.states | length }}
-#define MODEL_N_ALGEBRAIC {{ dae.algebraics | length }}
-#define MODEL_N_INPUTS {{ dae.inputs | length }}
-#define MODEL_N_PARAMETERS {{ dae.parameters | length }}
+#define MODEL_N_STATES {{ dae.x | length }}
+#define MODEL_N_ALGEBRAIC {{ dae.y | length }}
+#define MODEL_N_INPUTS {{ dae.u | length }}
+#define MODEL_N_PARAMETERS {{ dae.p | length }}
 #define MODEL_N_CONSTANTS {{ dae.constants | length }}
-#define MODEL_N_OUTPUTS {{ dae.outputs | length }}
+#define MODEL_N_OUTPUTS {{ dae.w | length }}
 #define MODEL_N_FUNCTIONS {{ dae.functions | length }}
 
 /* State indices */
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
 #define STATE_{{ name | sanitize | upper }} {{ loop.index0 }}
 {% endfor %}
 
 /* Input indices */
-{% for name, var in dae.inputs | items %}
+{% for name, var in dae.u | items %}
 #define INPUT_{{ name | sanitize | upper }} {{ loop.index0 }}
 {% endfor %}
 
 /* Parameter indices */
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
 #define PARAM_{{ name | sanitize | upper }} {{ loop.index0 }}
 {% endfor %}
 
 /* Output indices */
-{% for name, var in dae.outputs | items %}
+{% for name, var in dae.w | items %}
 #define OUTPUT_{{ name | sanitize | upper }} {{ loop.index0 }}
 {% endfor %}
 
@@ -117,27 +117,27 @@ void model_f_x(
 
 void model_init(model_state_t* state) {
     /* Initialize states */
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
     state->x[{{ loop.index0 }}] = {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %};  /* {{ name }} */
 {% endfor %}
 
     /* Initialize algebraic variables */
-{% for name, var in dae.algebraics | items %}
+{% for name, var in dae.y | items %}
     state->z[{{ loop.index0 }}] = 0.0;  /* {{ name }} */
 {% endfor %}
 
     /* Initialize inputs */
-{% for name, var in dae.inputs | items %}
+{% for name, var in dae.u | items %}
     state->u[{{ loop.index0 }}] = 0.0;  /* {{ name }} */
 {% endfor %}
 
     /* Initialize parameters */
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
     state->p[{{ loop.index0 }}] = {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %};  /* {{ name }} */
 {% endfor %}
 
     /* Initialize outputs */
-{% for name, var in dae.outputs | items %}
+{% for name, var in dae.w | items %}
     state->y[{{ loop.index0 }}] = 0.0;  /* {{ name }} */
 {% endfor %}
 }
@@ -150,22 +150,22 @@ void model_f_x(
     (void)t;  /* May be unused */
 
     /* Unpack state variables */
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
     const double {{ name | sanitize }} = state->x[{{ loop.index0 }}];
 {% endfor %}
 
     /* Unpack algebraic variables */
-{% for name, var in dae.algebraics | items %}
+{% for name, var in dae.y | items %}
     const double {{ name | sanitize }} = state->z[{{ loop.index0 }}];
 {% endfor %}
 
     /* Unpack inputs */
-{% for name, var in dae.inputs | items %}
+{% for name, var in dae.u | items %}
     const double {{ name | sanitize }} = state->u[{{ loop.index0 }}];
 {% endfor %}
 
     /* Unpack parameters */
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
     const double {{ name | sanitize }} = state->p[{{ loop.index0 }}];
 {% endfor %}
 

--- a/crates/rumoca-phase-codegen/src/templates/casadi_mx.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/casadi_mx.py.jinja
@@ -32,16 +32,16 @@ def create_model():
     t = ca.MX.sym('t')
 
     # =========================================================================
-    # State Variables ({{ dae.states | length }} variables)
+    # State Variables ({{ dae.x | length }} variables)
     # =========================================================================
-{%- if dae.states | length > 0 %}
-    n_x = {{ var_size(dae.states) | trim }}
+{%- if dae.x | length > 0 %}
+    n_x = {{ var_size(dae.x) | trim }}
     _x = ca.MX.sym('x', n_x)
     _xdot = ca.MX.sym('xdot', n_x)
 
     # Named slices into _x (0-indexed)
 {%- set ns_x = namespace(offset=0) %}
-{%- for name, var in dae.states | items %}
+{%- for name, var in dae.x | items %}
 {%- if var.dims %}
 {%- set sz = var.dims | product %}
     {{ name | sanitize }} = _x[{{ ns_x.offset }}:{{ ns_x.offset + sz }}]  # {{ name }} ({{ var.dims | join("x") }})
@@ -55,7 +55,7 @@ def create_model():
     # der() maps state variables to _xdot slices via CasADi symbolic comparison
     _der_pairs = [
 {%- set ns_d = namespace(offset=0) %}
-{%- for name, var in dae.states | items %}
+{%- for name, var in dae.x | items %}
 {%- if var.dims %}
 {%- set sz = var.dims | product %}
         ({{ name | sanitize }}, _xdot[{{ ns_d.offset }}:{{ ns_d.offset + sz }}]),
@@ -78,15 +78,15 @@ def create_model():
 {%- endif %}
 
     # =========================================================================
-    # Algebraic Variables ({{ dae.algebraics | length }} variables)
+    # Algebraic Variables ({{ dae.y | length }} variables)
     # =========================================================================
-{%- if dae.algebraics | length > 0 %}
-    n_z = {{ var_size(dae.algebraics) | trim }}
+{%- if dae.y | length > 0 %}
+    n_z = {{ var_size(dae.y) | trim }}
     _z = ca.MX.sym('z', n_z)
 
     # Named slices into _z
 {%- set ns_z = namespace(offset=0) %}
-{%- for name, var in dae.algebraics | items %}
+{%- for name, var in dae.y | items %}
 {%- if var.dims %}
 {%- set sz = var.dims | product %}
     {{ name | sanitize }} = _z[{{ ns_z.offset }}:{{ ns_z.offset + sz }}]  # {{ name }} ({{ var.dims | join("x") }})
@@ -102,15 +102,15 @@ def create_model():
 {%- endif %}
 
     # =========================================================================
-    # Input Variables ({{ dae.inputs | length }} variables)
+    # Input Variables ({{ dae.u | length }} variables)
     # =========================================================================
-{%- if dae.inputs | length > 0 %}
-    n_u = {{ var_size(dae.inputs) | trim }}
+{%- if dae.u | length > 0 %}
+    n_u = {{ var_size(dae.u) | trim }}
     _u = ca.MX.sym('u', n_u)
 
     # Named slices into _u
 {%- set ns_u = namespace(offset=0) %}
-{%- for name, var in dae.inputs | items %}
+{%- for name, var in dae.u | items %}
 {%- if var.dims %}
 {%- set sz = var.dims | product %}
     {{ name | sanitize }} = _u[{{ ns_u.offset }}:{{ ns_u.offset + sz }}]  # {{ name }} ({{ var.dims | join("x") }})
@@ -126,15 +126,15 @@ def create_model():
 {%- endif %}
 
     # =========================================================================
-    # Parameters ({{ dae.parameters | length }} variables)
+    # Parameters ({{ dae.p | length }} variables)
     # =========================================================================
-{%- if dae.parameters | length > 0 %}
-    n_p = {{ var_size(dae.parameters) | trim }}
+{%- if dae.p | length > 0 %}
+    n_p = {{ var_size(dae.p) | trim }}
     _p = ca.MX.sym('p', n_p)
 
     # Named slices into _p
 {%- set ns_p = namespace(offset=0) %}
-{%- for name, var in dae.parameters | items %}
+{%- for name, var in dae.p | items %}
 {%- if var.dims %}
 {%- set sz = var.dims | product %}
     {{ name | sanitize }} = _p[{{ ns_p.offset }}:{{ ns_p.offset + sz }}]  # {{ name }} ({{ var.dims | join("x") }})
@@ -258,6 +258,51 @@ def create_model():
 {%- endif %}
 
     # =========================================================================
+    # Integrator Builder
+    # =========================================================================
+    def build_integrator(dt, opts=None):
+        """Build a CasADi integrator from the implicit DAE.
+
+        Extracts explicit ODE from the implicit residual f_x by computing the
+        mass matrix M = df_x/d(xdot), splitting ODE rows (M nonzero) from
+        algebraic rows (M zero), then solving for xdot = M_ode^{-1} * (-f_x|_{xdot=0}).
+
+        Args:
+            dt: Integration step size.
+            opts: Optional dict of integrator options passed to ca.integrator().
+
+        Returns:
+            A CasADi integrator Function.
+        """
+        _M = ca.jacobian(f_x, _xdot)
+        _p_full = ca.vertcat(_p, _u)
+
+        if n_z == 0:
+            _f0 = ca.substitute(f_x, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M, -_f0)
+            _dae = {'x': _x, 'ode': _ode, 'p': _p_full}
+            _solver = 'cvodes'
+        else:
+            _n_eq = f_x.shape[0]
+            _M_fn = ca.Function('mass_matrix_eval', [_x, _xdot, _z, _u, _p, t], [_M])
+            _M_num = np.array(_M_fn(
+                np.zeros(n_x), np.zeros(n_x), np.zeros(n_z),
+                np.zeros(n_u), np.zeros(n_p), 0.0,
+            ))
+            _ode_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) > 1e-15]
+            _alg_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) <= 1e-15]
+            _f_ode = f_x[_ode_rows, :]
+            _f_alg = f_x[_alg_rows, :]
+            _M_ode = ca.jacobian(_f_ode, _xdot)
+            _f_ode0 = ca.substitute(_f_ode, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M_ode, -_f_ode0)
+            _alg = ca.substitute(_f_alg, _xdot, ca.MX.zeros(n_x))
+            _dae = {'x': _x, 'z': _z, 'ode': _ode, 'alg': _alg, 'p': _p_full}
+            _solver = 'idas'
+
+        return ca.integrator('integrator', _solver, _dae, 0, dt, opts or {})
+
+    # =========================================================================
     # Default Values
     # =========================================================================
     def _flat_start(value, expected_size, var_name):
@@ -271,7 +316,7 @@ def create_model():
         )
 
     _x0_parts = []
-{%- for name, var in dae.states | items %}
+{%- for name, var in dae.x | items %}
     _x0_parts.append(_flat_start(
         {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %},
         {% if var.dims %}{{ var.dims | product }}{% else %}1{% endif %},
@@ -281,7 +326,7 @@ def create_model():
     x0 = np.concatenate(_x0_parts) if _x0_parts else np.array([])
 
     _p0_parts = []
-{%- for name, var in dae.parameters | items %}
+{%- for name, var in dae.p | items %}
     _p0_parts.append(_flat_start(
         {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %},
         {% if var.dims %}{{ var.dims | product }}{% else %}1{% endif %},
@@ -300,6 +345,7 @@ def create_model():
         'p': _p,
         'f_x': f_x,
         'dae_fn': dae_fn,
+        'build_integrator': build_integrator,
 {%- if dae.initial_equations | length > 0 %}
         'init_fn': init_fn,
 {%- endif %}
@@ -315,10 +361,10 @@ def create_model():
         'n_z': n_z,
         'n_u': n_u,
         'n_p': n_p,
-        'state_names': [{% for name, var in dae.states | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
-        'algebraic_names': [{% for name, var in dae.algebraics | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
-        'input_names': [{% for name, var in dae.inputs | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
-        'param_names': [{% for name, var in dae.parameters | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
+        'state_names': [{% for name, var in dae.x | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
+        'algebraic_names': [{% for name, var in dae.y | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
+        'input_names': [{% for name, var in dae.u | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
+        'param_names': [{% for name, var in dae.p | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
     }
 
 

--- a/crates/rumoca-phase-codegen/src/templates/casadi_sx.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/casadi_sx.py.jinja
@@ -31,16 +31,16 @@ def create_model():
     t = ca.SX.sym('t')
 
     # =========================================================================
-    # State Variables ({{ dae.states | length }})
+    # State Variables ({{ dae.x | length }})
     # =========================================================================
-{% if dae.states | length > 0 %}
-    n_x = {{ var_size(dae.states) | trim }}
+{% if dae.x | length > 0 %}
+    n_x = {{ var_size(dae.x) | trim }}
     _x = ca.SX.sym('x', n_x)
     _xdot = ca.SX.sym('xdot', n_x)
 
     # Named slices into _x (0-indexed)
 {% set ns_x = namespace(offset=0) %}
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
 {% if var.dims %}
 {% set sz = var.dims | product %}
     {{ name | sanitize }} = _x[{{ ns_x.offset }}:{{ ns_x.offset + sz }}]  # {{ name }} ({{ var.dims | join("x") }})
@@ -54,7 +54,7 @@ def create_model():
     # der() maps state variables to _xdot slices via symbolic equality
     _der_pairs = [
 {% set ns_d = namespace(offset=0) %}
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
 {% if var.dims %}
 {% set sz = var.dims | product %}
         ({{ name | sanitize }}, _xdot[{{ ns_d.offset }}:{{ ns_d.offset + sz }}]),
@@ -79,15 +79,15 @@ def create_model():
 {% endif %}
 
     # =========================================================================
-    # Algebraic Variables ({{ dae.algebraics | length }})
+    # Algebraic Variables ({{ dae.y | length }})
     # =========================================================================
-{% if dae.algebraics | length > 0 %}
-    n_z = {{ var_size(dae.algebraics) | trim }}
+{% if dae.y | length > 0 %}
+    n_z = {{ var_size(dae.y) | trim }}
     _z = ca.SX.sym('z', n_z)
 
     # Named slices into _z
 {% set ns_z = namespace(offset=0) %}
-{% for name, var in dae.algebraics | items %}
+{% for name, var in dae.y | items %}
 {% if var.dims %}
 {% set sz = var.dims | product %}
     {{ name | sanitize }} = _z[{{ ns_z.offset }}:{{ ns_z.offset + sz }}]  # {{ name }} ({{ var.dims | join("x") }})
@@ -103,15 +103,15 @@ def create_model():
 {% endif %}
 
     # =========================================================================
-    # Input Variables ({{ dae.inputs | length }})
+    # Input Variables ({{ dae.u | length }})
     # =========================================================================
-{% if dae.inputs | length > 0 %}
-    n_u = {{ var_size(dae.inputs) | trim }}
+{% if dae.u | length > 0 %}
+    n_u = {{ var_size(dae.u) | trim }}
     _u = ca.SX.sym('u', n_u)
 
     # Named slices into _u
 {% set ns_u = namespace(offset=0) %}
-{% for name, var in dae.inputs | items %}
+{% for name, var in dae.u | items %}
 {% if var.dims %}
 {% set sz = var.dims | product %}
     {{ name | sanitize }} = _u[{{ ns_u.offset }}:{{ ns_u.offset + sz }}]  # {{ name }} ({{ var.dims | join("x") }})
@@ -127,15 +127,15 @@ def create_model():
 {% endif %}
 
     # =========================================================================
-    # Parameters ({{ dae.parameters | length }})
+    # Parameters ({{ dae.p | length }})
     # =========================================================================
-{% if dae.parameters | length > 0 %}
-    n_p = {{ var_size(dae.parameters) | trim }}
+{% if dae.p | length > 0 %}
+    n_p = {{ var_size(dae.p) | trim }}
     _p = ca.SX.sym('p', n_p)
 
     # Named slices into _p
 {% set ns_p = namespace(offset=0) %}
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
 {% if var.dims %}
 {% set sz = var.dims | product %}
     {{ name | sanitize }} = _p[{{ ns_p.offset }}:{{ ns_p.offset + sz }}]  # {{ name }} ({{ var.dims | join("x") }})
@@ -221,16 +221,61 @@ def create_model():
         ['f_x'])
 
     # =========================================================================
+    # Integrator Builder
+    # =========================================================================
+    def build_integrator(dt, opts=None):
+        """Build a CasADi integrator from the implicit DAE.
+
+        Extracts explicit ODE from the implicit residual f_x by computing the
+        mass matrix M = df_x/d(xdot), splitting ODE rows (M nonzero) from
+        algebraic rows (M zero), then solving for xdot = M_ode^{-1} * (-f_x|_{xdot=0}).
+
+        Args:
+            dt: Integration step size.
+            opts: Optional dict of integrator options passed to ca.integrator().
+
+        Returns:
+            A CasADi integrator Function.
+        """
+        _M = ca.jacobian(f_x, _xdot)
+        _p_full = ca.vertcat(_p, _u)
+
+        if n_z == 0:
+            _f0 = ca.substitute(f_x, _xdot, ca.SX.zeros(n_x))
+            _ode = ca.solve(_M, -_f0)
+            _dae = {'x': _x, 'ode': _ode, 'p': _p_full}
+            _solver = 'cvodes'
+        else:
+            _n_eq = f_x.shape[0]
+            _M_fn = ca.Function('mass_matrix_eval', [_x, _xdot, _z, _u, _p, t], [_M])
+            _M_num = np.array(_M_fn(
+                np.zeros(n_x), np.zeros(n_x), np.zeros(n_z),
+                np.zeros(n_u), np.zeros(n_p), 0.0,
+            ))
+            _ode_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) > 1e-15]
+            _alg_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) <= 1e-15]
+            _f_ode = f_x[_ode_rows, :]
+            _f_alg = f_x[_alg_rows, :]
+            _M_ode = ca.jacobian(_f_ode, _xdot)
+            _f_ode0 = ca.substitute(_f_ode, _xdot, ca.SX.zeros(n_x))
+            _ode = ca.solve(_M_ode, -_f_ode0)
+            _alg = ca.substitute(_f_alg, _xdot, ca.SX.zeros(n_x))
+            _dae = {'x': _x, 'z': _z, 'ode': _ode, 'alg': _alg, 'p': _p_full}
+            _solver = 'idas'
+
+        return ca.integrator('integrator', _solver, _dae, 0, dt, opts or {})
+
+    # =========================================================================
     # Default Values
     # =========================================================================
     x0 = np.array([
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
         {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %}{{ "," if not loop.last else "" }}  # {{ name }}
 {% endfor %}
     ])
 
     p0 = np.array([
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
         {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %}{{ "," if not loop.last else "" }}  # {{ name }}
 {% endfor %}
     ])
@@ -244,6 +289,7 @@ def create_model():
         'p': p,
         'f_x': f_x,
         'dae_fn': dae_fn,
+        'build_integrator': build_integrator,
         'xdot': xdot,
         'g': g,
         'x0': x0,
@@ -252,8 +298,8 @@ def create_model():
         'n_z': n_z,
         'n_u': n_u,
         'n_p': n_p,
-        'state_names': [{% for name, var in dae.states | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
-        'param_names': [{% for name, var in dae.parameters | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
+        'state_names': [{% for name, var in dae.x | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
+        'param_names': [{% for name, var in dae.p | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
     }
 
 

--- a/crates/rumoca-phase-codegen/src/templates/cyecca.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/cyecca.py.jinja
@@ -19,18 +19,18 @@ def create_model():
     # Time
     t = model.time
 
-    # States ({{ dae.states | length }})
-{% for name, var in dae.states | items %}
+    # States ({{ dae.x | length }})
+{% for name, var in dae.x | items %}
     {{ name | sanitize }} = model.add_state('{{ name }}'{% if var.start %}, start={{ render_expr(var.start, cfg) }}{% endif %})
 {% endfor %}
 
-    # Inputs ({{ dae.inputs | length }})
-{% for name, var in dae.inputs | items %}
+    # Inputs ({{ dae.u | length }})
+{% for name, var in dae.u | items %}
     {{ name | sanitize }} = model.add_input('{{ name }}')
 {% endfor %}
 
-    # Parameters ({{ dae.parameters | length }})
-{% for name, var in dae.parameters | items %}
+    # Parameters ({{ dae.p | length }})
+{% for name, var in dae.p | items %}
     {{ name | sanitize }} = model.add_parameter('{{ name }}'{% if var.start %}, value={{ render_expr(var.start, cfg) }}{% endif %})
 {% endfor %}
 
@@ -55,6 +55,6 @@ def create_model():
 
 if __name__ == '__main__':
     model = create_model()
-    print(f"States: {{ dae.states | length }}")
-    print(f"Inputs: {{ dae.inputs | length }}")
-    print(f"Parameters: {{ dae.parameters | length }}")
+    print(f"States: {{ dae.x | length }}")
+    print(f"Inputs: {{ dae.u | length }}")
+    print(f"Parameters: {{ dae.p | length }}")

--- a/crates/rumoca-phase-codegen/src/templates/dae_modelica.mo.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/dae_modelica.mo.jinja
@@ -48,28 +48,28 @@
 {%- if var.description %} "{{ var.description }}"{% endif -%}
 {%- endmacro -%}
 class {{ model_name }}{% if dae.model_description %} "{{ dae.model_description }}"{% endif %}
-{%- for name, var in dae.parameters | items %}
+{%- for name, var in dae.p | items %}
   parameter Real{{ dims(var) }} {{ name }}{{ var_attrs(var) }}{% if var.start is not none %} = {{ render_expr(var.start, cfg) }}{% endif %}{{ desc(var) }};
 {%- endfor -%}
 {%- for name, var in dae.constants | items %}
   constant Real{{ dims(var) }} {{ name }}{{ var_attrs(var) }}{% if var.start is not none %} = {{ render_expr(var.start, cfg) }}{% endif %}{{ desc(var) }};
 {%- endfor -%}
-{%- for name, var in dae.states | items %}
+{%- for name, var in dae.x | items %}
   Real{{ dims(var) }} {{ name }}{{ var_attrs(var) }}{{ desc(var) }};
 {%- endfor -%}
-{%- for name, var in dae.algebraics | items %}
+{%- for name, var in dae.y | items %}
   Real{{ dims(var) }} {{ name }}{{ var_attrs(var) }}{{ desc(var) }};
 {%- endfor -%}
-{%- for name, var in dae.inputs | items %}
+{%- for name, var in dae.u | items %}
   input Real{{ dims(var) }} {{ name }}{{ var_attrs(var) }}{{ desc(var) }};
 {%- endfor -%}
-{%- for name, var in dae.outputs | items %}
+{%- for name, var in dae.w | items %}
   output Real{{ dims(var) }} {{ name }}{{ var_attrs(var) }}{{ desc(var) }};
 {%- endfor -%}
-{%- for name, var in dae.discrete_reals | items %}
+{%- for name, var in dae.z | items %}
   discrete Real{{ dims(var) }} {{ name }}{{ var_attrs(var) }}{{ desc(var) }};
 {%- endfor -%}
-{%- for name, var in dae.derivative_aliases | items %}
+{%- for name, var in dae.x_dot_alias | items %}
   Real{{ dims(var) }} {{ name }}{{ var_attrs(var) }}{{ desc(var) }};
 {%- endfor %}
 equation

--- a/crates/rumoca-phase-codegen/src/templates/jax.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/jax.py.jinja
@@ -17,32 +17,32 @@ from typing import NamedTuple
 
 class ModelParams(NamedTuple):
     """Model parameters."""
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
     {{ name | sanitize }}: float = {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %}
 
 {% endfor %}
-{% if dae.parameters | length == 0 %}
+{% if dae.p | length == 0 %}
     pass  # No parameters
 {% endif %}
 
 
 class ModelState(NamedTuple):
     """Model state variables."""
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
     {{ name | sanitize }}: float = {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %}
 
 {% endfor %}
-{% if dae.states | length == 0 %}
+{% if dae.x | length == 0 %}
     pass  # No states
 {% endif %}
 
 
 class ModelInputs(NamedTuple):
     """Model input variables."""
-{% for name, var in dae.inputs | items %}
+{% for name, var in dae.u | items %}
     {{ name | sanitize }}: float = 0.0
 {% endfor %}
-{% if dae.inputs | length == 0 %}
+{% if dae.u | length == 0 %}
     pass  # No inputs
 {% endif %}
 
@@ -61,17 +61,17 @@ def ode_fn(t, y, args):
     params, inputs = args
 
     # Unpack state variables
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
     {{ name | sanitize }} = y[{{ loop.index0 }}]
 {% endfor %}
 
     # Unpack parameters
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
     {{ name | sanitize }} = params.{{ name | sanitize }}
 {% endfor %}
 
     # Unpack inputs
-{% for name, var in dae.inputs | items %}
+{% for name, var in dae.u | items %}
     {{ name | sanitize }} = inputs.{{ name | sanitize }}
 {% endfor %}
 
@@ -122,7 +122,7 @@ def simulate(x0, t_span, params=None, inputs=None, dt=0.01, save_every=1):
 
     # Convert state to array if needed
     if isinstance(x0, ModelState):
-        y0 = jnp.array([{% for name, var in dae.states | items %}x0.{{ name | sanitize }}{{ ", " if not loop.last else "" }}{% endfor %}])
+        y0 = jnp.array([{% for name, var in dae.x | items %}x0.{{ name | sanitize }}{{ ", " if not loop.last else "" }}{% endfor %}])
     else:
         y0 = jnp.asarray(x0)
 
@@ -149,25 +149,25 @@ def simulate(x0, t_span, params=None, inputs=None, dt=0.01, save_every=1):
 
 def get_state_names():
     """Get list of state variable names."""
-    return [{% for name, var in dae.states | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}]
+    return [{% for name, var in dae.x | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}]
 
 
 def get_param_names():
     """Get list of parameter names."""
-    return [{% for name, var in dae.parameters | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}]
+    return [{% for name, var in dae.p | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}]
 
 
 def get_input_names():
     """Get list of input names."""
-    return [{% for name, var in dae.inputs | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}]
+    return [{% for name, var in dae.u | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}]
 
 
 if __name__ == '__main__':
-    print(f"States ({{ dae.states | length }}): {get_state_names()}")
-    print(f"Parameters ({{ dae.parameters | length }}): {get_param_names()}")
-    print(f"Inputs ({{ dae.inputs | length }}): {get_input_names()}")
+    print(f"States ({{ dae.x | length }}): {get_state_names()}")
+    print(f"Parameters ({{ dae.p | length }}): {get_param_names()}")
+    print(f"Inputs ({{ dae.u | length }}): {get_input_names()}")
 
-{% if dae.states | length > 0 %}
+{% if dae.x | length > 0 %}
     # Example simulation
     x0 = ModelState()
     ts, ys = simulate(x0, (0.0, 10.0))

--- a/crates/rumoca-phase-codegen/src/templates/julia_mtk.jl.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/julia_mtk.jl.jinja
@@ -13,38 +13,38 @@ function create_model()
     # Time variable
     @independent_variables t
 
-    # State variables ({{ dae.states | length }})
-{% if dae.states | length > 0 %}
+    # State variables ({{ dae.x | length }})
+{% if dae.x | length > 0 %}
     @variables begin
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
         {{ name | sanitize }}(t){% if var.start %} = {{ render_expr(var.start, cfg) }}{% endif %}
 
 {% endfor %}
     end
 {% endif %}
 
-    # Algebraic variables ({{ dae.algebraics | length }})
-{% if dae.algebraics | length > 0 %}
+    # Algebraic variables ({{ dae.y | length }})
+{% if dae.y | length > 0 %}
     @variables begin
-{% for name, var in dae.algebraics | items %}
+{% for name, var in dae.y | items %}
         {{ name | sanitize }}(t)
 {% endfor %}
     end
 {% endif %}
 
-    # Input variables ({{ dae.inputs | length }})
-{% if dae.inputs | length > 0 %}
+    # Input variables ({{ dae.u | length }})
+{% if dae.u | length > 0 %}
     @variables begin
-{% for name, var in dae.inputs | items %}
+{% for name, var in dae.u | items %}
         {{ name | sanitize }}(t)
 {% endfor %}
     end
 {% endif %}
 
-    # Parameters ({{ dae.parameters | length }})
-{% if dae.parameters | length > 0 %}
+    # Parameters ({{ dae.p | length }})
+{% if dae.p | length > 0 %}
     @parameters begin
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
         {{ name | sanitize }}{% if var.start %} = {{ render_expr(var.start, cfg) }}{% endif %}
 
 {% endfor %}
@@ -84,14 +84,14 @@ end
 function get_default_values()
     # Initial conditions for states
     x0 = Dict(
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
         "{{ name }}" => {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %}{{ "," if not loop.last else "" }}
 {% endfor %}
     )
 
     # Default parameter values
     p0 = Dict(
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
         "{{ name }}" => {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %}{{ "," if not loop.last else "" }}
 {% endfor %}
     )
@@ -128,8 +128,8 @@ if abspath(PROGRAM_FILE) == @__FILE__
     sys = create_model()
     defaults = get_default_values()
 
-    println("States ({{ dae.states | length }}): ", [{% for name, var in dae.states | items %}"{{ name }}"{{ ", " if not loop.last else "" }}{% endfor %}])
-    println("Parameters ({{ dae.parameters | length }}): ", [{% for name, var in dae.parameters | items %}"{{ name }}"{{ ", " if not loop.last else "" }}{% endfor %}])
+    println("States ({{ dae.x | length }}): ", [{% for name, var in dae.x | items %}"{{ name }}"{{ ", " if not loop.last else "" }}{% endfor %}])
+    println("Parameters ({{ dae.p | length }}): ", [{% for name, var in dae.p | items %}"{{ name }}"{{ ", " if not loop.last else "" }}{% endfor %}])
     println("\nEquations:")
     for eq in equations(sys)
         println("  ", eq)

--- a/crates/rumoca-phase-codegen/src/templates/onnx.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/onnx.py.jinja
@@ -21,13 +21,13 @@ def create_onnx_model(opset_version: int = 17) -> onnx.ModelProto:
     """Create ONNX model for the DAE system.
 
     The model takes inputs:
-        - x: state vector [{{ dae.states | length }}]
-        - u: input vector [{{ dae.inputs | length }}]
-        - p: parameter vector [{{ dae.parameters | length }}]
+        - x: state vector [{{ dae.x | length }}]
+        - u: input vector [{{ dae.u | length }}]
+        - p: parameter vector [{{ dae.p | length }}]
         - t: time scalar [1]
 
     And produces outputs:
-        - xdot: state derivatives [{{ dae.states | length }}]
+        - xdot: state derivatives [{{ dae.x | length }}]
 {% if dae.f_x | length > 0 %}
         - f_x: continuous implicit equation residuals [{{ dae.f_x | length }}]
 {% endif %}
@@ -40,21 +40,21 @@ def create_onnx_model(opset_version: int = 17) -> onnx.ModelProto:
     """
     # Input definitions
     inputs = []
-{% if dae.states | length > 0 %}
-    inputs.append(helper.make_tensor_value_info('x', TensorProto.FLOAT, [{{ dae.states | length }}]))
+{% if dae.x | length > 0 %}
+    inputs.append(helper.make_tensor_value_info('x', TensorProto.FLOAT, [{{ dae.x | length }}]))
 {% endif %}
-{% if dae.inputs | length > 0 %}
-    inputs.append(helper.make_tensor_value_info('u', TensorProto.FLOAT, [{{ dae.inputs | length }}]))
+{% if dae.u | length > 0 %}
+    inputs.append(helper.make_tensor_value_info('u', TensorProto.FLOAT, [{{ dae.u | length }}]))
 {% endif %}
-{% if dae.parameters | length > 0 %}
-    inputs.append(helper.make_tensor_value_info('p', TensorProto.FLOAT, [{{ dae.parameters | length }}]))
+{% if dae.p | length > 0 %}
+    inputs.append(helper.make_tensor_value_info('p', TensorProto.FLOAT, [{{ dae.p | length }}]))
 {% endif %}
     inputs.append(helper.make_tensor_value_info('t', TensorProto.FLOAT, [1]))
 
     # Output definitions
     outputs = []
-{% if dae.states | length > 0 %}
-    outputs.append(helper.make_tensor_value_info('xdot', TensorProto.FLOAT, [{{ dae.states | length }}]))
+{% if dae.x | length > 0 %}
+    outputs.append(helper.make_tensor_value_info('xdot', TensorProto.FLOAT, [{{ dae.x | length }}]))
 {% endif %}
 {% if dae.f_x | length > 0 %}
     outputs.append(helper.make_tensor_value_info('f_x', TensorProto.FLOAT, [{{ dae.f_x | length }}]))
@@ -66,7 +66,7 @@ def create_onnx_model(opset_version: int = 17) -> onnx.ModelProto:
 
     # === Extract individual variables from packed vectors ===
 
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
     # State: {{ name }}
     nodes.append(helper.make_node(
         'Slice',
@@ -78,7 +78,7 @@ def create_onnx_model(opset_version: int = 17) -> onnx.ModelProto:
     initializers.append(numpy_helper.from_array(np.array([{{ loop.index }}], dtype=np.int64), '{{ name | sanitize }}_end'))
 {% endfor %}
 
-{% for name, var in dae.inputs | items %}
+{% for name, var in dae.u | items %}
     # Input: {{ name }}
     nodes.append(helper.make_node(
         'Slice',
@@ -90,7 +90,7 @@ def create_onnx_model(opset_version: int = 17) -> onnx.ModelProto:
     initializers.append(numpy_helper.from_array(np.array([{{ loop.index }}], dtype=np.int64), '{{ name | sanitize }}_end'))
 {% endfor %}
 
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
     # Parameter: {{ name }}
     nodes.append(helper.make_node(
         'Slice',
@@ -169,19 +169,19 @@ def get_default_values() -> dict:
         Dictionary with 'x0' and 'p0' numpy arrays.
     """
     x0 = np.array([
-{% for name, var in dae.states | items %}
+{% for name, var in dae.x | items %}
         {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %}{{ "," if not loop.last else "" }}  # {{ name }}
 {% endfor %}
     ], dtype=np.float32)
 
     p0 = np.array([
-{% for name, var in dae.parameters | items %}
+{% for name, var in dae.p | items %}
         {% if var.start %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %}{{ "," if not loop.last else "" }}  # {{ name }}
 {% endfor %}
     ], dtype=np.float32)
 
     u0 = np.array([
-{% for name, var in dae.inputs | items %}
+{% for name, var in dae.u | items %}
         0.0{{ "," if not loop.last else "" }}  # {{ name }}
 {% endfor %}
     ], dtype=np.float32)
@@ -200,9 +200,9 @@ def get_variable_names() -> dict:
         Dictionary with state_names, param_names, input_names.
     """
     return {
-        'state_names': [{% for name, var in dae.states | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
-        'param_names': [{% for name, var in dae.parameters | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
-        'input_names': [{% for name, var in dae.inputs | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
+        'state_names': [{% for name, var in dae.x | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
+        'param_names': [{% for name, var in dae.p | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
+        'input_names': [{% for name, var in dae.u | items %}'{{ name }}'{{ ", " if not loop.last else "" }}{% endfor %}],
     }
 
 

--- a/crates/rumoca/tests/expected/algorithm_mx.py
+++ b/crates/rumoca/tests/expected/algorithm_mx.py
@@ -89,6 +89,51 @@ def create_model():
         ['f_x'])
 
     # =========================================================================
+    # Integrator Builder
+    # =========================================================================
+    def build_integrator(dt, opts=None):
+        """Build a CasADi integrator from the implicit DAE.
+
+        Extracts explicit ODE from the implicit residual f_x by computing the
+        mass matrix M = df_x/d(xdot), splitting ODE rows (M nonzero) from
+        algebraic rows (M zero), then solving for xdot = M_ode^{-1} * (-f_x|_{xdot=0}).
+
+        Args:
+            dt: Integration step size.
+            opts: Optional dict of integrator options passed to ca.integrator().
+
+        Returns:
+            A CasADi integrator Function.
+        """
+        _M = ca.jacobian(f_x, _xdot)
+        _p_full = ca.vertcat(_p, _u)
+
+        if n_z == 0:
+            _f0 = ca.substitute(f_x, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M, -_f0)
+            _dae = {'x': _x, 'ode': _ode, 'p': _p_full}
+            _solver = 'cvodes'
+        else:
+            _n_eq = f_x.shape[0]
+            _M_fn = ca.Function('mass_matrix_eval', [_x, _xdot, _z, _u, _p, t], [_M])
+            _M_num = np.array(_M_fn(
+                np.zeros(n_x), np.zeros(n_x), np.zeros(n_z),
+                np.zeros(n_u), np.zeros(n_p), 0.0,
+            ))
+            _ode_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) > 1e-15]
+            _alg_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) <= 1e-15]
+            _f_ode = f_x[_ode_rows, :]
+            _f_alg = f_x[_alg_rows, :]
+            _M_ode = ca.jacobian(_f_ode, _xdot)
+            _f_ode0 = ca.substitute(_f_ode, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M_ode, -_f_ode0)
+            _alg = ca.substitute(_f_alg, _xdot, ca.MX.zeros(n_x))
+            _dae = {'x': _x, 'z': _z, 'ode': _ode, 'alg': _alg, 'p': _p_full}
+            _solver = 'idas'
+
+        return ca.integrator('integrator', _solver, _dae, 0, dt, opts or {})
+
+    # =========================================================================
     # Default Values
     # =========================================================================
     def _flat_start(value, expected_size, var_name):
@@ -127,6 +172,7 @@ def create_model():
         'p': _p,
         'f_x': f_x,
         'dae_fn': dae_fn,
+        'build_integrator': build_integrator,
         'x0': x0,
         'p0': p0,
         'n_x': n_x,

--- a/crates/rumoca/tests/expected/dae_model_mx.py
+++ b/crates/rumoca/tests/expected/dae_model_mx.py
@@ -90,6 +90,51 @@ def create_model():
         ['f_x'])
 
     # =========================================================================
+    # Integrator Builder
+    # =========================================================================
+    def build_integrator(dt, opts=None):
+        """Build a CasADi integrator from the implicit DAE.
+
+        Extracts explicit ODE from the implicit residual f_x by computing the
+        mass matrix M = df_x/d(xdot), splitting ODE rows (M nonzero) from
+        algebraic rows (M zero), then solving for xdot = M_ode^{-1} * (-f_x|_{xdot=0}).
+
+        Args:
+            dt: Integration step size.
+            opts: Optional dict of integrator options passed to ca.integrator().
+
+        Returns:
+            A CasADi integrator Function.
+        """
+        _M = ca.jacobian(f_x, _xdot)
+        _p_full = ca.vertcat(_p, _u)
+
+        if n_z == 0:
+            _f0 = ca.substitute(f_x, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M, -_f0)
+            _dae = {'x': _x, 'ode': _ode, 'p': _p_full}
+            _solver = 'cvodes'
+        else:
+            _n_eq = f_x.shape[0]
+            _M_fn = ca.Function('mass_matrix_eval', [_x, _xdot, _z, _u, _p, t], [_M])
+            _M_num = np.array(_M_fn(
+                np.zeros(n_x), np.zeros(n_x), np.zeros(n_z),
+                np.zeros(n_u), np.zeros(n_p), 0.0,
+            ))
+            _ode_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) > 1e-15]
+            _alg_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) <= 1e-15]
+            _f_ode = f_x[_ode_rows, :]
+            _f_alg = f_x[_alg_rows, :]
+            _M_ode = ca.jacobian(_f_ode, _xdot)
+            _f_ode0 = ca.substitute(_f_ode, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M_ode, -_f_ode0)
+            _alg = ca.substitute(_f_alg, _xdot, ca.MX.zeros(n_x))
+            _dae = {'x': _x, 'z': _z, 'ode': _ode, 'alg': _alg, 'p': _p_full}
+            _solver = 'idas'
+
+        return ca.integrator('integrator', _solver, _dae, 0, dt, opts or {})
+
+    # =========================================================================
     # Default Values
     # =========================================================================
     def _flat_start(value, expected_size, var_name):
@@ -133,6 +178,7 @@ def create_model():
         'p': _p,
         'f_x': f_x,
         'dae_fn': dae_fn,
+        'build_integrator': build_integrator,
         'x0': x0,
         'p0': p0,
         'n_x': n_x,

--- a/crates/rumoca/tests/expected/oscillator_mx.py
+++ b/crates/rumoca/tests/expected/oscillator_mx.py
@@ -89,6 +89,51 @@ def create_model():
         ['f_x'])
 
     # =========================================================================
+    # Integrator Builder
+    # =========================================================================
+    def build_integrator(dt, opts=None):
+        """Build a CasADi integrator from the implicit DAE.
+
+        Extracts explicit ODE from the implicit residual f_x by computing the
+        mass matrix M = df_x/d(xdot), splitting ODE rows (M nonzero) from
+        algebraic rows (M zero), then solving for xdot = M_ode^{-1} * (-f_x|_{xdot=0}).
+
+        Args:
+            dt: Integration step size.
+            opts: Optional dict of integrator options passed to ca.integrator().
+
+        Returns:
+            A CasADi integrator Function.
+        """
+        _M = ca.jacobian(f_x, _xdot)
+        _p_full = ca.vertcat(_p, _u)
+
+        if n_z == 0:
+            _f0 = ca.substitute(f_x, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M, -_f0)
+            _dae = {'x': _x, 'ode': _ode, 'p': _p_full}
+            _solver = 'cvodes'
+        else:
+            _n_eq = f_x.shape[0]
+            _M_fn = ca.Function('mass_matrix_eval', [_x, _xdot, _z, _u, _p, t], [_M])
+            _M_num = np.array(_M_fn(
+                np.zeros(n_x), np.zeros(n_x), np.zeros(n_z),
+                np.zeros(n_u), np.zeros(n_p), 0.0,
+            ))
+            _ode_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) > 1e-15]
+            _alg_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) <= 1e-15]
+            _f_ode = f_x[_ode_rows, :]
+            _f_alg = f_x[_alg_rows, :]
+            _M_ode = ca.jacobian(_f_ode, _xdot)
+            _f_ode0 = ca.substitute(_f_ode, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M_ode, -_f_ode0)
+            _alg = ca.substitute(_f_alg, _xdot, ca.MX.zeros(n_x))
+            _dae = {'x': _x, 'z': _z, 'ode': _ode, 'alg': _alg, 'p': _p_full}
+            _solver = 'idas'
+
+        return ca.integrator('integrator', _solver, _dae, 0, dt, opts or {})
+
+    # =========================================================================
     # Default Values
     # =========================================================================
     def _flat_start(value, expected_size, var_name):
@@ -137,6 +182,7 @@ def create_model():
         'p': _p,
         'f_x': f_x,
         'dae_fn': dae_fn,
+        'build_integrator': build_integrator,
         'x0': x0,
         'p0': p0,
         'n_x': n_x,

--- a/crates/rumoca/tests/expected/withfunc_mx.py
+++ b/crates/rumoca/tests/expected/withfunc_mx.py
@@ -97,6 +97,51 @@ def create_model():
         ['f_x'])
 
     # =========================================================================
+    # Integrator Builder
+    # =========================================================================
+    def build_integrator(dt, opts=None):
+        """Build a CasADi integrator from the implicit DAE.
+
+        Extracts explicit ODE from the implicit residual f_x by computing the
+        mass matrix M = df_x/d(xdot), splitting ODE rows (M nonzero) from
+        algebraic rows (M zero), then solving for xdot = M_ode^{-1} * (-f_x|_{xdot=0}).
+
+        Args:
+            dt: Integration step size.
+            opts: Optional dict of integrator options passed to ca.integrator().
+
+        Returns:
+            A CasADi integrator Function.
+        """
+        _M = ca.jacobian(f_x, _xdot)
+        _p_full = ca.vertcat(_p, _u)
+
+        if n_z == 0:
+            _f0 = ca.substitute(f_x, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M, -_f0)
+            _dae = {'x': _x, 'ode': _ode, 'p': _p_full}
+            _solver = 'cvodes'
+        else:
+            _n_eq = f_x.shape[0]
+            _M_fn = ca.Function('mass_matrix_eval', [_x, _xdot, _z, _u, _p, t], [_M])
+            _M_num = np.array(_M_fn(
+                np.zeros(n_x), np.zeros(n_x), np.zeros(n_z),
+                np.zeros(n_u), np.zeros(n_p), 0.0,
+            ))
+            _ode_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) > 1e-15]
+            _alg_rows = [i for i in range(_n_eq) if np.sum(np.abs(_M_num[i, :])) <= 1e-15]
+            _f_ode = f_x[_ode_rows, :]
+            _f_alg = f_x[_alg_rows, :]
+            _M_ode = ca.jacobian(_f_ode, _xdot)
+            _f_ode0 = ca.substitute(_f_ode, _xdot, ca.MX.zeros(n_x))
+            _ode = ca.solve(_M_ode, -_f_ode0)
+            _alg = ca.substitute(_f_alg, _xdot, ca.MX.zeros(n_x))
+            _dae = {'x': _x, 'z': _z, 'ode': _ode, 'alg': _alg, 'p': _p_full}
+            _solver = 'idas'
+
+        return ca.integrator('integrator', _solver, _dae, 0, dt, opts or {})
+
+    # =========================================================================
     # Default Values
     # =========================================================================
     def _flat_start(value, expected_size, var_name):
@@ -130,6 +175,7 @@ def create_model():
         'p': _p,
         'f_x': f_x,
         'dae_fn': dae_fn,
+        'build_integrator': build_integrator,
         'functions': {'sq': sq },
         'x0': x0,
         'p0': p0,


### PR DESCRIPTION
Rename DAE template fields from long-form (states, algebraics, inputs, parameters, outputs, discrete_reals, derivative_aliases) to MLS B.1 short-form (x, y, u, p, w, z, x_dot_alias) across all 8 codegen templates.

Add build_integrator(dt, opts) to CasADi MX and SX templates, which extracts explicit ODE form from the implicit residual using mass matrix classification and selects CVODES or IDAS automatically.