### PR TITLE
ci: restore PyPI publish and update checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       is_release: ${{ steps.detect.outputs.is_release }}
       tag: ${{ steps.detect.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -63,7 +63,7 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         run: |
@@ -90,7 +90,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2025]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         run: |
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         run: |
@@ -203,7 +203,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         run: |
@@ -311,7 +311,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         run: |
@@ -336,7 +336,7 @@ jobs:
     name: Build WASM
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust nightly with rust-src
         run: |
@@ -452,7 +452,7 @@ jobs:
             rumoca_asset: rumoca-windows-x86_64.exe
             lsp_asset: rumoca-lsp-windows-x86_64.exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         run: |
@@ -571,7 +571,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             name: windows-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:
@@ -608,10 +608,9 @@ jobs:
 
   build-python-sdist:
     name: Build Python sdist
-    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:
@@ -648,7 +647,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -708,6 +707,14 @@ jobs:
                 continue
               fi
               cp "$source_file" "release-assets/$artifact_name"
+            fi
+          done
+
+          # Move Python wheels/sdist
+          for dir in artifacts/wheels-*; do
+            if [ -d "$dir" ]; then
+              echo "Processing Python artifact: $dir"
+              find "$dir" -maxdepth 1 -type f \( -name '*.whl' -o -name '*.tar.gz' \) -exec cp {} release-assets/ \;
             fi
           done
 
@@ -790,5 +797,25 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Publish Python packages to PyPI
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip twine
+          shopt -s nullglob
+          python_files=(release-assets/*.whl release-assets/*.tar.gz)
+          if [ "${#python_files[@]}" -eq 0 ]; then
+            echo "::error::No Python distribution artifacts found in release-assets"
+            exit 1
+          fi
+          python -m twine upload --skip-existing "${python_files[@]}"
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
       # Rust binary and VS Code extension artifacts are distributed via GitHub Releases.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         target: [core, ci, dev]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 
@@ -73,7 +73,7 @@ jobs:
       matrix:
         target: [core, ci, dev]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -133,7 +133,7 @@ jobs:
       contents: write
       packages: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Export canonical dev tarball
         shell: bash


### PR DESCRIPTION
## Summary

  This PR fixes the Python release path and updates workflow checkout to the current action
  version.

  It restores two regressions in CI/release behavior:

  - Python sdists were no longer being built on PRs
  - tagged releases were no longer uploading Python distributions to PyPI

  It also updates all workflow checkout steps from actions/checkout@v4 to actions/
  checkout@v6, which is the right response to the recent macOS checkout/auth failures seen
  before any build logic ran.

  ## What changed

  ### CI / Python packaging

  In ci.yml:

  - build-python-sdist
      - removed the if: github.event_name == 'push' gate
      - PRs now get full Python packaging coverage, matching wheel coverage
  - deploy
      - now copies Python wheel/sdist artifacts into release-assets
      - now installs twine
      - now uploads release-assets/*.whl and release-assets/*.tar.gz to PyPI using:
          - TWINE_USERNAME=__token__
          - TWINE_PASSWORD=${{ secrets.PYPI_API_TOKEN }}

  This restores the release behavior that existed in the v0.8.0 era, where tagged releases
  pushed Python packages to PyPI.

  ### Workflow checkout

  In:

  - ci.yml
  - docker-publish.yml

  all actions/checkout usages were updated:

  - from actions/checkout@v4
  - to actions/checkout@v6

  ## Why

  The release regression was real:

  - v0.8.0 still had explicit PyPI upload
  - later workflow cleanup removed the non-binary publish path
  - the result was that newer tagged releases created release assets but did not publish an
    updated PyPI package

  The checkout update is also justified:

  - recent failures on macOS arm runners were occurring inside actions/checkout, before any
    project build steps began
  - the logs showed auth setup happening, but the subsequent fetch still failed
  - moving to the current checkout action is the correct first fix for that class of issue

  ## Validation

  - workflow YAML parses cleanly
  - git diff --check passed
  - pre-commit passed:
      - traversal policy
      - cargo fmt --check
      - workspace clippy
      - rustdoc warnings gate

  ## Result

  After this PR:

  - PRs get full Python packaging coverage
  - v* releases can publish Python wheels/sdists to PyPI again
  - workflow checkout uses the current major version across CI and Docker publish workflows