### PR TITLE
lsp: accept --stdio as a compatibility flag

### DIFF
--- a/crates/rumoca-tool-lsp/src/main.rs
+++ b/crates/rumoca-tool-lsp/src/main.rs
@@ -7,6 +7,10 @@ use clap::Parser;
 #[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(about = "Rumoca Modelica Language Server", long_about = None)]
 struct Cli {
+    /// Compatibility no-op for clients that explicitly pass --stdio.
+    #[arg(long, hide = true)]
+    _stdio: bool,
+
     /// Increase logging verbosity (reserved for future use)
     #[arg(short, long, action = clap::ArgAction::Count)]
     _verbose: u8,
@@ -16,4 +20,24 @@ struct Cli {
 async fn main() {
     let _ = Cli::parse();
     rumoca_tool_lsp::run_server().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn parse_accepts_stdio_flag() {
+        let cli = Cli::try_parse_from(["rumoca-lsp", "--stdio"]).expect("stdio flag should parse");
+        assert!(cli._stdio);
+    }
+
+    #[test]
+    fn parse_accepts_stdio_with_verbosity() {
+        let cli = Cli::try_parse_from(["rumoca-lsp", "--stdio", "-v"])
+            .expect("stdio+verbose should parse");
+        assert!(cli._stdio);
+        assert_eq!(cli._verbose, 1);
+    }
 }


### PR DESCRIPTION
This PR fixes rumoca-lsp crashing when clients explicitly pass --stdio, which was forcing users on some Debian setups to wrap the binary in a shell script. Closes #86 

## What changed:

  - rumoca-lsp now accepts --stdio as a hidden no-op compatibility flag
  - stdio remains the default behavior
  - added parser tests so this stays fixed

## Why:

  - some LSP clients launch servers with --stdio even when stdio is already implied
  - rumoca-lsp previously rejected that argument and exited
  - now it tolerates the flag and starts normally, so the wrapper hack is no longer needed

## Validation:

  - cargo test -p rumoca-tool-lsp --bin rumoca-lsp
  - cargo clippy -p rumoca-tool-lsp --bin rumoca-lsp -- -D warnings
