### PR TITLE
vscode: validate packaged extension startup in install-check

### DIFF
--- a/crates/rumoca-tool-dev/src/main.rs
+++ b/crates/rumoca-tool-dev/src/main.rs
@@ -104,6 +104,25 @@ struct VscodePackageArgs {
 }
 
 #[derive(Debug, Args, Clone)]
+struct VscodeInstallCheckArgs {
+    /// Reuse the latest existing VSIX instead of rebuilding/packaging
+    #[arg(long)]
+    no_build: bool,
+    /// Use system rumoca-lsp when rebuilding the VSIX
+    #[arg(long, short = 's')]
+    system: bool,
+    /// Root directory for the isolated VS Code profile
+    #[arg(long, value_name = "DIR")]
+    profile_root: Option<PathBuf>,
+    /// Modelica file to open after installing the VSIX
+    #[arg(long, value_name = "FILE")]
+    document: Option<PathBuf>,
+    /// Install the VSIX into the isolated profile without opening VS Code
+    #[arg(long)]
+    no_open: bool,
+}
+
+#[derive(Debug, Args, Clone)]
 struct VscodeHostArgs {
     /// Skip rebuilding/copying rumoca-lsp into editors/vscode/bin
     #[arg(long)]
@@ -128,6 +147,8 @@ enum VscodeCommand {
     Build(VscodeBuildArgs),
     /// Package a platform-specific VSIX with bundled release binaries
     Package(VscodePackageArgs),
+    /// Build/package the VSIX if needed, install it into an isolated profile, and open a .mo file
+    InstallCheck(VscodeInstallCheckArgs),
     /// VS Code extension verification gate
     Test,
     /// Watch Rust/TypeScript and launch the Extension Development Host
@@ -398,6 +419,7 @@ fn cmd_vscode(args: VscodeArgs) -> Result<()> {
     match args.command {
         VscodeCommand::Build(args) => vscode_cmd::build_vscode_ext(args),
         VscodeCommand::Package(args) => vscode_cmd::package_vscode_ext(args),
+        VscodeCommand::InstallCheck(args) => vscode_cmd::install_check_vscode_ext(args),
         VscodeCommand::Test => vscode_cmd::run_vscode_ci(&repo_root()),
         VscodeCommand::Edit(args) => vscode_cmd::vscode_dev(args),
     }

--- a/crates/rumoca-tool-dev/src/main_tests.rs
+++ b/crates/rumoca-tool-dev/src/main_tests.rs
@@ -176,6 +176,34 @@ fn cli_parses_vscode_package() {
 }
 
 #[test]
+fn cli_parses_vscode_install_check() {
+    let cli = Cli::try_parse_from([
+        "rum",
+        "vscode",
+        "install-check",
+        "--no-build",
+        "--no-open",
+        "--document",
+        "examples/Ball.mo",
+    ])
+    .expect("parse vscode install-check");
+    match cli.command {
+        Commands::Vscode(args) => match args.command {
+            VscodeCommand::InstallCheck(args) => {
+                assert!(args.no_build);
+                assert!(args.no_open);
+                assert_eq!(
+                    args.document.as_deref(),
+                    Some(Path::new("examples/Ball.mo"))
+                );
+            }
+            other => panic!("expected vscode install-check, got {other:?}"),
+        },
+        other => panic!("expected vscode command, got {other:?}"),
+    }
+}
+
+#[test]
 fn cli_parses_vscode_test() {
     let cli = Cli::try_parse_from(["rum", "vscode", "test"]).expect("parse vscode test");
     match cli.command {

--- a/crates/rumoca-tool-dev/src/vscode_cmd.rs
+++ b/crates/rumoca-tool-dev/src/vscode_cmd.rs
@@ -14,8 +14,8 @@ use tempfile::TempDir;
 use walkdir::WalkDir;
 
 use crate::{
-    VscodeBuildArgs, VscodeHostArgs, VscodePackageArgs, exe_name, newest_prefixed_file,
-    repo_cli_cmd, repo_root, run_status, run_status_quiet,
+    VscodeBuildArgs, VscodeHostArgs, VscodeInstallCheckArgs, VscodePackageArgs, exe_name,
+    newest_prefixed_file, repo_cli_cmd, repo_root, run_status, run_status_quiet,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -165,50 +165,73 @@ pub(crate) struct VscodeMslSmokeSummary {
 
 pub(crate) fn build_vscode_ext(args: VscodeBuildArgs) -> Result<()> {
     let root = repo_root();
-    let vscode_dir = resolve_vscode_dir(&root)?;
-
-    if !args.system {
-        build_and_stage_vscode_lsp(&root, &vscode_dir, true)?;
-    }
-
-    ensure_vscode_npm_dependencies(
-        &vscode_dir,
-        VscodeNpmDependencyMode::IfMissing,
-        false,
-        false,
-    )?;
-
-    println!("Compiling extension TypeScript...");
-    let mut npm_esbuild = Command::new("npm");
-    npm_esbuild
-        .arg("run")
-        .arg("esbuild")
-        .current_dir(&vscode_dir);
-    run_status(npm_esbuild)?;
-
-    println!("Packaging extension...");
-    let mut npm_package = Command::new("npm");
-    npm_package
-        .arg("run")
-        .arg("package")
-        .current_dir(&vscode_dir);
-    run_status(npm_package)?;
-
-    let vsix = newest_prefixed_file(&vscode_dir, "rumoca-modelica-", "vsix")?
-        .context("failed to locate packaged VSCode extension (*.vsix)")?;
+    let vsix = build_vscode_dev_vsix(&root, args.system)?;
     println!("Built VSIX: {}", vsix.display());
 
     if !args.no_install {
         println!("Installing extension in VSCode...");
-        let mut code = Command::new("code");
-        code.arg("--install-extension")
-            .arg(&vsix)
-            .arg("--force")
-            .current_dir(&vscode_dir);
-        run_status(code)?;
+        install_vscode_vsix(&vsix, None, None)?;
     }
 
     Ok(())
+}
+
+pub(crate) fn install_check_vscode_ext(args: VscodeInstallCheckArgs) -> Result<()> {
+    let root = repo_root();
+    let vscode_dir = resolve_vscode_dir(&root)?;
+    ensure!(
+        command_available("code"),
+        "missing `code` CLI in PATH; install VS Code's Shell Command and retry"
+    );
+
+    let profile_root = resolve_install_check_profile_root(&root, args.profile_root.as_deref())?;
+    let document = resolve_install_check_document(&root, args.document.as_deref())?;
+    let smoke_workspace = prepare_install_check_workspace(&profile_root, &document)?;
+    let user_data_dir = profile_root.join("user-data");
+    let extensions_dir = profile_root.join("extensions");
+    let artifacts_dir = profile_root.join("artifacts");
+    fs::create_dir_all(&artifacts_dir)
+        .with_context(|| format!("failed to create {}", artifacts_dir.display()))?;
+
+    let vsix = if args.no_build {
+        newest_prefixed_file(&vscode_dir, "rumoca-modelica-", "vsix")?.context(
+            "failed to locate packaged VSCode extension (*.vsix); rerun without --no-build",
+        )?
+    } else {
+        build_vscode_dev_vsix(&root, args.system)?
+    };
+    println!("Using VSIX: {}", vsix.display());
+
+    println!(
+        "Installing VSIX into isolated profile at {}",
+        profile_root.display()
+    );
+    install_vscode_vsix(&vsix, Some(&user_data_dir), Some(&extensions_dir))?;
+
+    println!("Running installed-extension smoke against packaged VSIX...");
+    let summary_path = artifacts_dir.join("installed-extension-smoke-summary.json");
+    run_installed_vscode_extension_smoke(
+        &vscode_dir,
+        &smoke_workspace,
+        &document,
+        &user_data_dir,
+        &extensions_dir,
+        &summary_path,
+    )?;
+    println!(
+        "Installed-extension smoke passed: {}",
+        summary_path.display()
+    );
+
+    if args.no_open {
+        return Ok(());
+    }
+
+    println!(
+        "Opening VS Code with the isolated install-check profile on {}...",
+        document.display()
+    );
+    launch_vscode_install_check_profile(&document, &user_data_dir, &extensions_dir)
 }
 
 pub(crate) fn package_vscode_ext(args: VscodePackageArgs) -> Result<()> {
@@ -303,8 +326,10 @@ pub(crate) fn run_vscode_msl_smoke_report(
     run_status_quiet(smoke)?;
     let raw = fs::read_to_string(&summary_path)
         .with_context(|| format!("failed to read {}", summary_path.display()))?;
-    serde_json::from_str(&raw)
-        .with_context(|| format!("failed to parse {}", summary_path.display()))
+    let summary = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", summary_path.display()))?;
+    run_vscode_failed_start_command_smoke(root, output_dir, options)?;
+    Ok(summary)
 }
 
 fn prepare_vscode_msl_smoke_command(
@@ -314,6 +339,88 @@ fn prepare_vscode_msl_smoke_command(
     timing_output_path: Option<&Path>,
     options: VscodeSmokeOptions,
 ) -> Result<PreparedVscodeSmokeCommand> {
+    let smoke_stage = prepare_vscode_smoke_stage(root)?;
+    let staged_vscode_dir = smoke_stage.path();
+
+    let mut smoke = new_vscode_smoke_command("node", options)?;
+    smoke
+        .arg("tests/run_msl_extension_smoke.mjs")
+        .env("RUMOCA_VSCODE_MSL_ROOT", msl_root)
+        .current_dir(staged_vscode_dir);
+    if let Some(path) = summary_output_path {
+        smoke.env("RUMOCA_VSCODE_SMOKE_SUMMARY_OUT", path);
+        smoke.env("RUMOCA_VSCODE_SMOKE_ARTIFACT_RESULT", path);
+    }
+    if let Some(path) = timing_output_path {
+        smoke.env("RUMOCA_VSCODE_SMOKE_ARTIFACT_TIMINGS", path);
+    }
+    Ok(PreparedVscodeSmokeCommand {
+        command: smoke,
+        _stage_dir: smoke_stage,
+    })
+}
+
+fn run_vscode_failed_start_command_smoke(
+    root: &Path,
+    output_dir: &Path,
+    options: VscodeSmokeOptions,
+) -> Result<()> {
+    fs::create_dir_all(output_dir)
+        .with_context(|| format!("failed to create {}", output_dir.display()))?;
+    let summary_path = output_dir.join("vscode-failed-start-command-smoke-summary.json");
+    let PreparedVscodeSmokeCommand {
+        command: smoke,
+        _stage_dir,
+    } = prepare_vscode_failed_start_smoke_command(root, Some(&summary_path), options)?;
+    run_status_quiet(smoke)?;
+    let _ = fs::read_to_string(&summary_path)
+        .with_context(|| format!("failed to read {}", summary_path.display()))?;
+    Ok(())
+}
+
+fn run_installed_vscode_extension_smoke(
+    vscode_dir: &Path,
+    workspace_file: &Path,
+    document_path: &Path,
+    user_data_dir: &Path,
+    extensions_dir: &Path,
+    summary_output_path: &Path,
+) -> Result<()> {
+    ensure_vscode_npm_dependencies(vscode_dir, VscodeNpmDependencyMode::IfMissing, false, false)?;
+    let mut smoke = new_vscode_smoke_command("node", VscodeSmokeOptions::default())?;
+    smoke
+        .arg("tests/run_installed_extension_check.mjs")
+        .env("RUMOCA_VSCODE_INSTALL_CHECK_WORKSPACE", workspace_file)
+        .env("RUMOCA_VSCODE_INSTALL_CHECK_DOCUMENT", document_path)
+        .env("RUMOCA_VSCODE_INSTALL_CHECK_USER_DATA_DIR", user_data_dir)
+        .env("RUMOCA_VSCODE_INSTALL_CHECK_EXTENSIONS_DIR", extensions_dir)
+        .env("RUMOCA_VSCODE_INSTALL_CHECK_RESULT", summary_output_path)
+        .current_dir(vscode_dir);
+    run_status_quiet(smoke)
+}
+
+fn prepare_vscode_failed_start_smoke_command(
+    root: &Path,
+    summary_output_path: Option<&Path>,
+    options: VscodeSmokeOptions,
+) -> Result<PreparedVscodeSmokeCommand> {
+    let smoke_stage = prepare_vscode_smoke_stage(root)?;
+    let staged_vscode_dir = smoke_stage.path();
+
+    let mut smoke = new_vscode_smoke_command("node", options)?;
+    smoke
+        .arg("tests/run_failed_start_command_smoke.mjs")
+        .current_dir(staged_vscode_dir);
+    if let Some(path) = summary_output_path {
+        smoke.env("RUMOCA_VSCODE_FAILED_START_ARTIFACT_RESULT", path);
+    }
+    Ok(PreparedVscodeSmokeCommand {
+        command: smoke,
+        _stage_dir: smoke_stage,
+    })
+}
+
+fn prepare_vscode_smoke_stage(root: &Path) -> Result<TempDir> {
     let source_vscode_dir = resolve_vscode_dir(root)?;
     let smoke_stage = stage_vscode_smoke_workspace(&source_vscode_dir)?;
     let staged_vscode_dir = smoke_stage.path();
@@ -337,23 +444,142 @@ fn prepare_vscode_msl_smoke_command(
         .env("RUMOCA_REPO_ROOT", root)
         .current_dir(staged_vscode_dir);
     run_status_quiet(npm_esbuild)?;
+    Ok(smoke_stage)
+}
 
-    let mut smoke = new_vscode_smoke_command("node", options)?;
-    smoke
-        .arg("tests/run_msl_extension_smoke.mjs")
-        .env("RUMOCA_VSCODE_MSL_ROOT", msl_root)
-        .current_dir(staged_vscode_dir);
-    if let Some(path) = summary_output_path {
-        smoke.env("RUMOCA_VSCODE_SMOKE_SUMMARY_OUT", path);
-        smoke.env("RUMOCA_VSCODE_SMOKE_ARTIFACT_RESULT", path);
+fn build_vscode_dev_vsix(root: &Path, system: bool) -> Result<PathBuf> {
+    let vscode_dir = resolve_vscode_dir(root)?;
+
+    if !system {
+        build_and_stage_vscode_lsp(root, &vscode_dir, true)?;
     }
-    if let Some(path) = timing_output_path {
-        smoke.env("RUMOCA_VSCODE_SMOKE_ARTIFACT_TIMINGS", path);
+
+    ensure_vscode_npm_dependencies(
+        &vscode_dir,
+        VscodeNpmDependencyMode::IfMissing,
+        false,
+        false,
+    )?;
+
+    println!("Compiling extension TypeScript...");
+    let mut npm_esbuild = Command::new("npm");
+    npm_esbuild
+        .arg("run")
+        .arg("esbuild")
+        .current_dir(&vscode_dir);
+    run_status(npm_esbuild)?;
+
+    println!("Packaging extension...");
+    let mut npm_package = Command::new("npm");
+    npm_package
+        .arg("run")
+        .arg("package")
+        .current_dir(&vscode_dir);
+    run_status(npm_package)?;
+
+    newest_prefixed_file(&vscode_dir, "rumoca-modelica-", "vsix")?
+        .context("failed to locate packaged VSCode extension (*.vsix)")
+}
+
+fn install_vscode_vsix(
+    vsix: &Path,
+    user_data_dir: Option<&Path>,
+    extensions_dir: Option<&Path>,
+) -> Result<()> {
+    let mut code = Command::new("code");
+    if let Some(dir) = user_data_dir {
+        fs::create_dir_all(dir).with_context(|| format!("failed to create {}", dir.display()))?;
+        code.arg("--user-data-dir").arg(dir);
     }
-    Ok(PreparedVscodeSmokeCommand {
-        command: smoke,
-        _stage_dir: smoke_stage,
-    })
+    if let Some(dir) = extensions_dir {
+        fs::create_dir_all(dir).with_context(|| format!("failed to create {}", dir.display()))?;
+        code.arg("--extensions-dir").arg(dir);
+    }
+    code.arg("--install-extension").arg(vsix).arg("--force");
+    run_status(code)
+}
+
+fn resolve_install_check_profile_root(root: &Path, requested: Option<&Path>) -> Result<PathBuf> {
+    let profile_root = match requested {
+        Some(path) if path.is_absolute() => path.to_path_buf(),
+        Some(path) => root.join(path),
+        None => root.join("target").join("vscode-install-check"),
+    };
+    if profile_root.exists() {
+        fs::remove_dir_all(&profile_root)
+            .with_context(|| format!("failed to remove {}", profile_root.display()))?;
+    }
+    fs::create_dir_all(&profile_root)
+        .with_context(|| format!("failed to create {}", profile_root.display()))?;
+    Ok(profile_root)
+}
+
+fn resolve_install_check_document(root: &Path, requested: Option<&Path>) -> Result<PathBuf> {
+    let candidate = match requested {
+        Some(path) if path.is_absolute() => path.to_path_buf(),
+        Some(path) => root.join(path),
+        None => root.join("examples").join("Ball.mo"),
+    };
+    let resolved = candidate
+        .canonicalize()
+        .unwrap_or_else(|_| candidate.clone());
+    ensure!(
+        resolved.is_file(),
+        "install-check document does not exist or is not a file: {}",
+        resolved.display()
+    );
+    ensure!(
+        resolved.extension().and_then(|ext| ext.to_str()) == Some("mo"),
+        "install-check document must be a .mo file: {}",
+        resolved.display()
+    );
+    Ok(resolved)
+}
+
+fn prepare_install_check_workspace(profile_root: &Path, document: &Path) -> Result<PathBuf> {
+    let workspace_dir = profile_root.join("workspace");
+    fs::create_dir_all(&workspace_dir)
+        .with_context(|| format!("failed to create {}", workspace_dir.display()))?;
+    let workspace_file = workspace_dir.join("install-check.code-workspace");
+    let workspace_folder = document.parent().with_context(|| {
+        format!(
+            "install-check document has no parent directory: {}",
+            document.display()
+        )
+    })?;
+    let missing_server_path = workspace_dir.join(exe_name("missing-rumoca-lsp"));
+    let workspace = serde_json::json!({
+        "folders": [{ "path": workspace_folder }],
+        "settings": {
+            "rumoca.debug": false,
+            "rumoca.serverPath": missing_server_path,
+            "rumoca.sourceRootPaths": [],
+        }
+    });
+    fs::write(
+        &workspace_file,
+        serde_json::to_string_pretty(&workspace)
+            .context("failed to serialize install-check workspace")?,
+    )
+    .with_context(|| format!("failed to write {}", workspace_file.display()))?;
+    Ok(workspace_file)
+}
+
+fn launch_vscode_install_check_profile(
+    document_file: &Path,
+    user_data_dir: &Path,
+    extensions_dir: &Path,
+) -> Result<()> {
+    let mut code = Command::new("code");
+    code.arg("--user-data-dir")
+        .arg(user_data_dir)
+        .arg("--extensions-dir")
+        .arg(extensions_dir)
+        .arg("--new-window")
+        .arg("--disable-workspace-trust")
+        .arg("--wait")
+        .arg(document_file);
+    run_status(code)
 }
 
 fn stage_vscode_smoke_workspace(source_vscode_dir: &Path) -> Result<TempDir> {
@@ -1182,10 +1408,11 @@ mod tests {
         VscodeMslSmokeSummary, VscodeNpmDependencyMode, VscodeNpmInstallPlan, VscodePackageTarget,
         VscodeSmokeEnvironment, VscodeSmokeLaunchMode, VscodeSmokeOptions,
         cargo_target_cc_env_suffix, cargo_target_linker_env_suffix,
-        mirror_cached_vscode_smoke_install, replace_staged_binary, resolve_vscode_npm_install_plan,
-        select_vscode_smoke_launch_mode, should_copy_vscode_smoke_root_entry,
-        should_install_vscode_smoke_prereqs, should_retry_vscode_npm_ci_after_clean,
-        stage_vscode_smoke_workspace,
+        mirror_cached_vscode_smoke_install, prepare_install_check_workspace, replace_staged_binary,
+        resolve_install_check_document, resolve_install_check_profile_root,
+        resolve_vscode_npm_install_plan, select_vscode_smoke_launch_mode,
+        should_copy_vscode_smoke_root_entry, should_install_vscode_smoke_prereqs,
+        should_retry_vscode_npm_ci_after_clean, stage_vscode_smoke_workspace,
     };
     use anyhow::anyhow;
     use serde_json::json;
@@ -1406,6 +1633,61 @@ mod tests {
             cargo_target_linker_env_suffix("x86_64-unknown-linux-musl"),
             "X86_64_UNKNOWN_LINUX_MUSL"
         );
+    }
+
+    #[test]
+    fn install_check_profile_root_defaults_under_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let profile_root =
+            resolve_install_check_profile_root(temp.path(), None).expect("resolve profile root");
+        assert_eq!(
+            profile_root,
+            temp.path().join("target/vscode-install-check")
+        );
+        assert!(profile_root.is_dir());
+    }
+
+    #[test]
+    fn install_check_document_defaults_to_ball_example() {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .expect("workspace root");
+        let document =
+            resolve_install_check_document(&root, None).expect("resolve default install document");
+        assert!(document.ends_with("examples/Ball.mo"));
+        assert!(document.is_file());
+    }
+
+    #[test]
+    fn install_check_workspace_writes_missing_server_override() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let document = temp.path().join("Example.mo");
+        std::fs::write(&document, "model Example end Example;").expect("write model file");
+
+        let workspace =
+            prepare_install_check_workspace(temp.path(), &document).expect("prepare workspace");
+        let raw = std::fs::read_to_string(&workspace).expect("read workspace file");
+        let value: serde_json::Value = serde_json::from_str(&raw).expect("parse workspace json");
+        assert_eq!(
+            value
+                .get("folders")
+                .and_then(|folders| folders.get(0))
+                .and_then(|folder| folder.get("path"))
+                .and_then(serde_json::Value::as_str),
+            document.parent().and_then(|path| path.to_str())
+        );
+        let server_path = value
+            .get("settings")
+            .and_then(|settings| settings.get("rumoca.serverPath"))
+            .and_then(serde_json::Value::as_str)
+            .expect("missing server path override");
+        let expected_name = if cfg!(windows) {
+            "missing-rumoca-lsp.exe"
+        } else {
+            "missing-rumoca-lsp"
+        };
+        assert!(server_path.ends_with(expected_name));
     }
 
     #[test]

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -31,6 +31,7 @@
   ],
   "main": "./out/extension.js",
   "activationEvents": [
+    "onLanguage:modelica",
     "onNotebook:jupyter-notebook",
     "onCommand:rumoca.openSettingsMenu",
     "onCommand:rumoca.renderTemplate",
@@ -261,7 +262,7 @@
   "scripts": {
     "vendor-webview-assets": "node ./scripts/vendor-webview-assets.mjs",
     "vscode:prepublish": "npm run esbuild-base -- --minify",
-    "esbuild-base": "npm run vendor-webview-assets && esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --external:vscode-languageclient --external:vscode-languageclient/node --external:vscode-languageclient/* --format=cjs --platform=node",
+    "esbuild-base": "npm run vendor-webview-assets && esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "compile": "tsc -p ./",
@@ -294,4 +295,3 @@
     }
   }
 }
-

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -2793,10 +2793,11 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     const initialLanguageClient = await startLanguageClient();
-    if (!initialLanguageClient.clientStarted) {
-        return;
+    if (initialLanguageClient.clientStarted) {
+        languageClientRuntime.setServerPath(initialLanguageClient.serverPath);
+    } else {
+        log('Continuing activation without a running language server so commands remain available.');
     }
-    languageClientRuntime.setServerPath(initialLanguageClient.serverPath);
 
     const wireResultsPanelMessageHandling = (panel: vscode.WebviewPanel) => {
         const messageDisposable = panel.webview.onDidReceiveMessage(async (message) => {

--- a/editors/vscode/tests/extension_surface_contract.test.mjs
+++ b/editors/vscode/tests/extension_surface_contract.test.mjs
@@ -318,6 +318,28 @@ test("surface contract: activation commands stay aligned with contributed comman
   );
 });
 
+test("surface contract: modelica files activate the extension", () => {
+  const packageJson = readPackageJson();
+
+  assert.ok(
+    Array.isArray(packageJson.activationEvents)
+      && packageJson.activationEvents.includes("onLanguage:modelica"),
+    "opening a .mo file should activate the extension so LSP features like code lens can appear",
+  );
+});
+
+test("surface contract: packaged VSIX bundles vscode-languageclient runtime", () => {
+  const packageJson = readPackageJson();
+  const esbuildBase = packageJson.scripts?.["esbuild-base"];
+
+  assert.equal(typeof esbuildBase, "string", "package.json scripts.esbuild-base must exist");
+  assert.equal(
+    esbuildBase.includes("--external:vscode-languageclient"),
+    false,
+    "the packaged extension must bundle vscode-languageclient because the VSIX ships without node_modules",
+  );
+});
+
 test("surface contract: editor title command placement stays aligned with the toolbar layout", () => {
   const packageSurface = inventoryPackageSurface(readPackageJson());
 
@@ -357,6 +379,27 @@ test("surface contract: shared settings command opens the unified settings panel
   assert.ok(
     templateSettingsCommandBlock.includes("await openUnifiedSettingsForEditor(editor);"),
     "template settings command should open the unified settings panel",
+  );
+});
+
+test("surface contract: initial language-server startup failure does not skip command registration", () => {
+  const source = readExtensionSource();
+  const initialStartupBlock = sliceFrom(
+    source,
+    "const initialLanguageClient = await startLanguageClient();",
+    "const wireResultsPanelMessageHandling = (panel: vscode.WebviewPanel) => {",
+  );
+
+  assert.equal(
+    initialStartupBlock.includes("if (!initialLanguageClient.clientStarted) {\n        return;\n    }"),
+    false,
+    "initial language-server startup failure should not abort activate() before commands are registered",
+  );
+  assert.ok(
+    initialStartupBlock.includes(
+      "log('Continuing activation without a running language server so commands remain available.');",
+    ),
+    "activation should explicitly continue when the first language-server start fails",
   );
 });
 

--- a/editors/vscode/tests/failed_start_extension_suite.cjs
+++ b/editors/vscode/tests/failed_start_extension_suite.cjs
@@ -1,0 +1,105 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const { performance } = require("node:perf_hooks");
+
+function envPath(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function envMs(name, fallback) {
+  const value = process.env[name];
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`invalid timeout env var ${name}=${value}`);
+  }
+  return parsed;
+}
+
+async function withTimeout(label, promiseFactory, timeoutMs) {
+  return await Promise.race([
+    Promise.resolve().then(promiseFactory),
+    new Promise((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    }),
+  ]);
+}
+
+function writeResult(resultPath, payload) {
+  fs.writeFileSync(resultPath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+exports.run = async function run() {
+  const vscode = require("vscode");
+
+  const documentPath = envPath("RUMOCA_VSCODE_FAILED_START_DOCUMENT");
+  const resultPath = envPath("RUMOCA_VSCODE_FAILED_START_RESULT");
+  const activateMaxMs = envMs("RUMOCA_VSCODE_FAILED_START_ACTIVATE_MAX_MS", 15000);
+  const commandMaxMs = envMs("RUMOCA_VSCODE_FAILED_START_COMMAND_MAX_MS", 10000);
+  const requiredCommands = [
+    "rumoca.simulateModel",
+    "rumoca.renderTemplate",
+    "rumoca.openSettingsMenu",
+  ];
+
+  const extension = vscode.extensions.getExtension("JamesGoppert.rumoca-modelica");
+  assert(extension, "Rumoca extension should be available in the extension host");
+
+  const result = {};
+
+  const activateStart = performance.now();
+  await withTimeout("extension activation", () => extension.activate(), activateMaxMs);
+  result.activateMs = Math.round(performance.now() - activateStart);
+  result.extensionActive = extension.isActive;
+  assert.equal(extension.isActive, true, "extension should stay active even when rumoca-lsp startup fails");
+
+  const uri = vscode.Uri.file(documentPath);
+  const document = await withTimeout(
+    "open text document",
+    () => vscode.workspace.openTextDocument(uri),
+    10000,
+  );
+  await withTimeout(
+    "show text document",
+    () => vscode.window.showTextDocument(document, { preview: false }),
+    10000,
+  );
+
+  const commands = await withTimeout(
+    "get command inventory",
+    () => vscode.commands.getCommands(true),
+    5000,
+  );
+  result.registeredCommands = requiredCommands.filter((command) => commands.includes(command));
+  assert.deepEqual(
+    result.registeredCommands,
+    requiredCommands,
+    "Rumoca editor commands should remain registered after failed initial language-server startup",
+  );
+
+  const simulateStart = performance.now();
+  await withTimeout(
+    "execute rumoca.simulateModel",
+    () => vscode.commands.executeCommand("rumoca.simulateModel"),
+    commandMaxMs,
+  );
+  result.simulateExecuteMs = Math.round(performance.now() - simulateStart);
+
+  const renderStart = performance.now();
+  await withTimeout(
+    "execute rumoca.renderTemplate",
+    () => vscode.commands.executeCommand("rumoca.renderTemplate"),
+    commandMaxMs,
+  );
+  result.renderExecuteMs = Math.round(performance.now() - renderStart);
+
+  writeResult(resultPath, result);
+};

--- a/editors/vscode/tests/install_check_harness/extension.js
+++ b/editors/vscode/tests/install_check_harness/extension.js
@@ -1,0 +1,8 @@
+function activate() {}
+
+function deactivate() {}
+
+module.exports = {
+  activate,
+  deactivate,
+};

--- a/editors/vscode/tests/install_check_harness/package.json
+++ b/editors/vscode/tests/install_check_harness/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "rumoca-install-check-harness",
+  "displayName": "Rumoca Install Check Harness",
+  "version": "0.0.1",
+  "publisher": "JamesGoppert",
+  "private": true,
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "main": "./extension.js",
+  "activationEvents": [
+    "*"
+  ]
+}

--- a/editors/vscode/tests/installed_extension_check_suite.cjs
+++ b/editors/vscode/tests/installed_extension_check_suite.cjs
@@ -1,0 +1,152 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const { performance } = require("node:perf_hooks");
+
+function envPath(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function envMs(name, fallback) {
+  const value = process.env[name];
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`invalid timeout env var ${name}=${value}`);
+  }
+  return parsed;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function withTimeout(label, promiseFactory, timeoutMs) {
+  return await Promise.race([
+    Promise.resolve().then(promiseFactory),
+    new Promise((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    }),
+  ]);
+}
+
+function writeResult(resultPath, payload) {
+  fs.writeFileSync(resultPath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function commandNotFoundMessage(commandId, error) {
+  const message = String(error?.message ?? error ?? "");
+  if (message.includes(`command '${commandId}' not found`)) {
+    return message;
+  }
+  return null;
+}
+
+exports.run = async function run() {
+  const vscode = require("vscode");
+
+  const documentPath = envPath("RUMOCA_VSCODE_INSTALL_CHECK_DOCUMENT");
+  const resultPath = envPath("RUMOCA_VSCODE_INSTALL_CHECK_RESULT");
+  const activateMaxMs = envMs("RUMOCA_VSCODE_INSTALL_CHECK_ACTIVATE_MAX_MS", 15000);
+  const commandMaxMs = envMs("RUMOCA_VSCODE_INSTALL_CHECK_COMMAND_MAX_MS", 10000);
+  const requiredCommands = [
+    "rumoca.simulateModel",
+    "rumoca.renderTemplate",
+    "rumoca.openSettingsMenu",
+  ];
+
+  function rumocaExtension() {
+    return vscode.extensions.getExtension("JamesGoppert.rumoca-modelica");
+  }
+
+  assert(rumocaExtension(), "Installed Rumoca extension should be available in the extension host");
+
+  const result = {};
+  const uri = vscode.Uri.file(documentPath);
+  const document = await withTimeout(
+    "open text document",
+    () => vscode.workspace.openTextDocument(uri),
+    10000,
+  );
+  await withTimeout(
+    "show text document",
+    () => vscode.window.showTextDocument(document, { preview: false }),
+    10000,
+  );
+
+  const activateStart = performance.now();
+  await withTimeout(
+    "installed extension activation on .mo open",
+    async () => {
+      while (!rumocaExtension()?.isActive) {
+        await sleep(100);
+      }
+    },
+    activateMaxMs,
+  );
+  result.activateMs = Math.round(performance.now() - activateStart);
+  result.extensionActive = rumocaExtension()?.isActive ?? false;
+  assert.equal(
+    result.extensionActive,
+    true,
+    "Installed Rumoca extension should activate when a .mo file is opened",
+  );
+
+  const commands = await withTimeout(
+    "get installed rumoca command inventory",
+    async () => {
+      while (true) {
+        const inventory = await vscode.commands.getCommands(true);
+        if (requiredCommands.every((command) => inventory.includes(command))) {
+          return inventory;
+        }
+        await sleep(100);
+      }
+    },
+    commandMaxMs,
+  );
+  result.registeredCommands = requiredCommands.filter((command) => commands.includes(command));
+  assert.deepEqual(
+    result.registeredCommands,
+    requiredCommands,
+    "Installed Rumoca commands should remain registered after failed initial language-server startup",
+  );
+
+  async function executeCommand(commandId) {
+    const start = performance.now();
+    let errorMessage = null;
+    try {
+      await withTimeout(
+        `execute ${commandId}`,
+        () => vscode.commands.executeCommand(commandId),
+        commandMaxMs,
+      );
+    } catch (error) {
+      const missing = commandNotFoundMessage(commandId, error);
+      assert.equal(
+        missing,
+        null,
+        `Installed command ${commandId} should not fail with command-not-found`,
+      );
+      errorMessage = String(error?.message ?? error ?? "");
+    }
+    return {
+      durationMs: Math.round(performance.now() - start),
+      errorMessage,
+    };
+  }
+
+  result.simulate = await executeCommand("rumoca.simulateModel");
+  result.render = await executeCommand("rumoca.renderTemplate");
+
+  writeResult(resultPath, result);
+};

--- a/editors/vscode/tests/run_failed_start_command_smoke.mjs
+++ b/editors/vscode/tests/run_failed_start_command_smoke.mjs
@@ -1,0 +1,114 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runTests } from "@vscode/test-electron";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const vscodeDir = path.resolve(thisDir, "..");
+const suitePath = path.resolve(vscodeDir, "tests", "failed_start_extension_suite.cjs");
+
+async function createWorkspace(rootDir) {
+  const workspaceRoot = path.join(rootDir, "workspace");
+  const workspaceFile = path.join(rootDir, "failed-start.code-workspace");
+  const documentPath = path.join(workspaceRoot, "Failure.mo");
+  const missingServerPath = path.join(
+    rootDir,
+    process.platform === "win32" ? "missing-rumoca-lsp.exe" : "missing-rumoca-lsp",
+  );
+  await mkdir(workspaceRoot, { recursive: true });
+  await writeFile(
+    documentPath,
+    [
+      "model Failure",
+      "  Real x(start=1);",
+      "equation",
+      "  der(x) = -x;",
+      "end Failure;",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    workspaceFile,
+    JSON.stringify(
+      {
+        folders: [{ path: workspaceRoot }],
+        settings: {
+          "rumoca.debug": false,
+          "rumoca.serverPath": missingServerPath,
+          "rumoca.sourceRootPaths": [],
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  return { workspaceFile, documentPath };
+}
+
+async function main() {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "rumoca-vscode-failed-start-"));
+  const userDataDir = path.join(tempRoot, "user-data");
+  const extensionsDir = path.join(tempRoot, "extensions");
+  const resultPath = path.join(tempRoot, "result.json");
+  const artifactResultPath = process.env.RUMOCA_VSCODE_FAILED_START_ARTIFACT_RESULT;
+  const { workspaceFile, documentPath } = await createWorkspace(tempRoot);
+  await mkdir(userDataDir, { recursive: true });
+  await mkdir(extensionsDir, { recursive: true });
+
+  process.env.RUMOCA_VSCODE_FAILED_START_DOCUMENT = documentPath;
+  process.env.RUMOCA_VSCODE_FAILED_START_RESULT = resultPath;
+  process.env.ELECTRON_DISABLE_SANDBOX = "1";
+  process.env.RUMOCA_VSCODE_FAILED_START_ACTIVATE_MAX_MS =
+    process.env.RUMOCA_VSCODE_FAILED_START_ACTIVATE_MAX_MS ?? "15000";
+  process.env.RUMOCA_VSCODE_FAILED_START_COMMAND_MAX_MS =
+    process.env.RUMOCA_VSCODE_FAILED_START_COMMAND_MAX_MS ?? "10000";
+
+  const launchArgs = [
+    workspaceFile,
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-workspace-trust",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    "--disable-updates",
+  ];
+
+  const options = {
+    extensionDevelopmentPath: vscodeDir,
+    extensionTestsPath: suitePath,
+    launchArgs,
+    extensionTestsEnv: { ...process.env },
+  };
+
+  const executable = process.env.RUMOCA_VSCODE_SMOKE_EXECUTABLE;
+  if (executable) {
+    options.vscodeExecutablePath = executable;
+  }
+
+  try {
+    await runTests(options);
+  } finally {
+    try {
+      const raw = await readFile(resultPath, "utf8");
+      if (artifactResultPath) {
+        await mkdir(path.dirname(artifactResultPath), { recursive: true });
+        await writeFile(artifactResultPath, raw, "utf8");
+      }
+    } catch {
+      // Ignore missing/partial result files when the suite fails before persisting metrics.
+    }
+    if (process.env.RUMOCA_VSCODE_SMOKE_KEEP_TEMP !== "1") {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error("[vscode-failed-start-smoke] failed");
+  console.error(error);
+  process.exit(1);
+});

--- a/editors/vscode/tests/run_installed_extension_check.mjs
+++ b/editors/vscode/tests/run_installed_extension_check.mjs
@@ -1,0 +1,72 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runTests } from "@vscode/test-electron";
+
+function envPath(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`missing required env var: ${name}`);
+  }
+  return path.resolve(value);
+}
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const vscodeDir = path.resolve(thisDir, "..");
+const harnessDir = path.resolve(vscodeDir, "tests", "install_check_harness");
+const suitePath = path.resolve(vscodeDir, "tests", "installed_extension_check_suite.cjs");
+
+async function main() {
+  const workspaceFile = envPath("RUMOCA_VSCODE_INSTALL_CHECK_WORKSPACE");
+  const documentPath = envPath("RUMOCA_VSCODE_INSTALL_CHECK_DOCUMENT");
+  const userDataDir = envPath("RUMOCA_VSCODE_INSTALL_CHECK_USER_DATA_DIR");
+  const extensionsDir = envPath("RUMOCA_VSCODE_INSTALL_CHECK_EXTENSIONS_DIR");
+  const resultPath = envPath("RUMOCA_VSCODE_INSTALL_CHECK_RESULT");
+
+  await mkdir(userDataDir, { recursive: true });
+  await mkdir(extensionsDir, { recursive: true });
+
+  process.env.ELECTRON_DISABLE_SANDBOX = "1";
+
+  const launchArgs = [
+    workspaceFile,
+    "--user-data-dir",
+    userDataDir,
+    "--extensions-dir",
+    extensionsDir,
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-workspace-trust",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    "--disable-updates",
+  ];
+
+  const options = {
+    extensionDevelopmentPath: harnessDir,
+    extensionTestsPath: suitePath,
+    launchArgs,
+    extensionTestsEnv: {
+      ...process.env,
+      RUMOCA_VSCODE_INSTALL_CHECK_DOCUMENT: documentPath,
+      RUMOCA_VSCODE_INSTALL_CHECK_RESULT: resultPath,
+    },
+  };
+
+  const executable = process.env.RUMOCA_VSCODE_SMOKE_EXECUTABLE;
+  if (executable) {
+    options.vscodeExecutablePath = executable;
+  }
+
+  await runTests(options);
+  const raw = await readFile(resultPath, "utf8");
+  await mkdir(path.dirname(resultPath), { recursive: true });
+  await writeFile(resultPath, raw, "utf8");
+}
+
+main().catch((error) => {
+  console.error("[vscode-install-check] failed");
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
#  PR Description

  This PR hardens the VS Code release path by validating the packaged VSIX, not just the dev
  extension.

#  What changed

  - Added rum vscode install-check to:
      - build the VSIX if needed
      - install it into an isolated profile
      - run a real packaged-extension smoke test
      - optionally open a clean VS Code window for manual inspection
  - Added installed-VSIX smoke coverage for the failure path that previously shipped:
      - verifies the packaged extension activates
      - verifies Rumoca commands are registered
      - verifies command registration still survives initial LSP startup failure
  - Fixed packaged extension contents so the VSIX includes what it needs at runtime.
  - Fixed extension activation so command registration is not skipped if initial rumoca-lsp
    startup fails.
  - Added onLanguage:modelica activation so opening a .mo file activates the extension.
  - Updated install-check interactive open behavior to:
      - open the real document instead of the intentionally broken smoke workspace
      - disable workspace trust for that launched window so Restricted Mode does not mask
        extension behavior

  # Why

  We had a real marketplace-style regression where the installed VSIX behaved differently from
  the local dev extension. CI and local dev smoke were covering the happy path, but not the
  packaged install path. This PR closes that gap and makes the release check match how users
  actually install the extension.

 # Verification

  Ran locally:

  - cargo test -p rumoca-tool-dev
  - npm test in editors/vscode
  - cargo run --bin rum -- verify lsp-msl-completion-timings
  - cargo run --bin rum -- vscode install-check --no-open

  All passed locally.