### PR TITLE
fix: use instant crate for wasm32 time support

### DIFF
--- a/crates/rumoca-sim/Cargo.toml
+++ b/crates/rumoca-sim/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 rumoca-eval-dae = { workspace = true, features = ["wasm"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/rumoca-sim/src/ic_solve.rs
+++ b/crates/rumoca-sim/src/ic_solve.rs
@@ -7,6 +7,9 @@
 
 use levenberg_marquardt::{LeastSquaresProblem, LevenbergMarquardt};
 use nalgebra::{Dyn, OMatrix, OVector, U1, Vector};
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 use rumoca_eval_dae::runtime::dual::Dual;

--- a/crates/rumoca-sim/src/runtime/timeout.rs
+++ b/crates/rumoca-sim/src/runtime/timeout.rs
@@ -1,6 +1,10 @@
 use std::any::Any;
 use std::cell::Cell;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TimeoutBudget {


### PR DESCRIPTION
# Rumoca PR Review Template

## Summary

- User can run interactive sumulations in browser via rumoca-sim. 

## Code Size Budget (required)

- production_lines_added: 9
- production_lines_deleted: 0
- test_lines_added: 0
- test_lines_deleted: 0
- public_items_added:
- public_items_removed:
- files_touched: 3
- net_added_lines: 

If `net_added_lines` is positive, add:

- std::time::Instant is absant in wasm due to browser's security limitations. rumoca-sim relies on it. Switching in wasm32 to instant::Instant fixes it.


## Design Notes

- It was solved by modifying existing solutions

## Reviewer Checklist

- [ ] Size budget section completed.
- [ ] Positive net diff has explicit compression justification.
- [ ] New APIs are required and minimal.
- [ ] Old/new parallel paths were removed unless explicitly migrating.
