### PR TITLE
update templates to work with unified dae structure (prepared/non-prepared)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ _native.cpython*
 .vscode/
 dev/
 pkg/
+# Staged temporarily by `rum wasm build` so wasm-pack can include crate-local license metadata.
+crates/rumoca-bind-wasm/LICENSE
 perf.data*
 flamegraph.svg
 msl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,6 +3166,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-rayon",
 ]
 
@@ -4618,6 +4619,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,6 +2972,7 @@ checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -2982,6 +2983,7 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -3164,6 +3166,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "wasm-bindgen",
+ "wasm-bindgen-rayon",
 ]
 
 [[package]]
@@ -4641,6 +4644,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
+dependencies = [
+ "crossbeam-channel",
+ "js-sys",
+ "rayon",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4657,6 +4672,17 @@ checksum = "e01164c9dda68301e34fdae536c23ed6fe90ce6d97213ccc171eebbd3d02d6b8"
 dependencies = [
  "leb128fmt",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm_sync"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/rumoca-bind-wasm/Cargo.toml
+++ b/crates/rumoca-bind-wasm/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { workspace = true }
 lsp-types = { workspace = true }
 serde-wasm-bindgen = "0.6"
 js-sys = "0.3"
+wasm-bindgen-futures = "0.4"
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen-rayon = { version = "1.2", optional = true }
 

--- a/crates/rumoca-bind-wasm/Cargo.toml
+++ b/crates/rumoca-bind-wasm/Cargo.toml
@@ -24,9 +24,11 @@ lsp-types = { workspace = true }
 serde-wasm-bindgen = "0.6"
 js-sys = "0.3"
 console_error_panic_hook = { version = "0.1", optional = true }
+wasm-bindgen-rayon = { version = "1.2", optional = true }
 
 [features]
 default = ["console_error_panic_hook"]
+wasm-rayon = ["dep:wasm-bindgen-rayon"]
 
 [lints]
 workspace = true

--- a/crates/rumoca-bind-wasm/bindgen/README.md
+++ b/crates/rumoca-bind-wasm/bindgen/README.md
@@ -39,6 +39,9 @@ to match current artifacts, and packs/publishes from `pkg/`.
 # Build and pack the npm package
 cd crates/rumoca-bind-wasm/bindgen && npm run build
 
+# Faster local iteration build (dev profile) + pack tgz
+cd crates/rumoca-bind-wasm/bindgen && npm run build:dev:pack
+
 # Publish the package to npm
 cd crates/rumoca-bind-wasm/bindgen && npm run publish
 ```
@@ -63,8 +66,8 @@ wasm-pack build crates/rumoca-bind-wasm --release --target nodejs --out-dir pkg
 - For browser usage with Vite, the `web` target generally works best.
 - To use `rumoca-bind-wasm` with the Vite bundler, you likely need
   [`vite-plugin-wasm`](https://www.npmjs.com/package/vite-plugin-wasm) plugin.
-- If you use `rum wasm build`, output naming is normalized to
-  `rumoca.js` / `rumoca_bg.wasm`; the `bindgen` patch script handles this.
+- Package exports use canonical wasm-pack filenames:
+  `rumoca_bind_wasm.js` / `rumoca_bind_wasm_bg.wasm`.
 
 ## Debug Build
 
@@ -72,4 +75,7 @@ To debug Rumoca in the browser, build a development WASM bundle:
 
 ```sh
 wasm-pack build crates/rumoca-bind-wasm --dev --target web --out-dir pkg
+
+# Or via rumoca dev CLI:
+cargo run -p rumoca-tool-dev -- wasm build --dev
 ```

--- a/crates/rumoca-bind-wasm/bindgen/package.json
+++ b/crates/rumoca-bind-wasm/bindgen/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "build:dev": "wasm-pack build .. --dev --target web --out-dir ../../pkg && node ./patch-wasm-pkg.mjs",
+    "build:dev:pack": "npm run build:dev && npm pack ../../../pkg",
     "build": "wasm-pack build .. --release --target web --out-dir ../../pkg",
     "postbuild": "node ./patch-wasm-pkg.mjs && npm pack ../../../pkg",
     "publish": "npm run build && cd ../../../pkg && npm publish"

--- a/crates/rumoca-bind-wasm/bindgen/patch-wasm-pkg.mjs
+++ b/crates/rumoca-bind-wasm/bindgen/patch-wasm-pkg.mjs
@@ -32,41 +32,27 @@ async function main() {
     }
   };
 
-  const hasRenamedJs = await exists(path.join(pkgDir, "rumoca.js"));
-  const hasRenamedWasm = await exists(path.join(pkgDir, "rumoca_bg.wasm"));
   const hasDefaultJs = await exists(path.join(pkgDir, "rumoca_bind_wasm.js"));
   const hasDefaultWasm = await exists(path.join(pkgDir, "rumoca_bind_wasm_bg.wasm"));
 
-  // Provide backward-compatible filenames expected by the frontend imports.
-  // wasm-pack emits rumoca_bind_wasm.* by default; copy them to rumoca.* aliases.
-  if (!hasRenamedJs && hasDefaultJs) {
-    await fs.copyFile(path.join(pkgDir, "rumoca_bind_wasm.js"), path.join(pkgDir, "rumoca.js"));
+  // Strict canonical artifacts only (no aliases, no fallback file names).
+  if (await exists(path.join(pkgDir, "rumoca.js"))) {
+    await fs.rm(path.join(pkgDir, "rumoca.js"));
   }
-  if (!hasRenamedWasm && hasDefaultWasm) {
-    await fs.copyFile(
-      path.join(pkgDir, "rumoca_bind_wasm_bg.wasm"),
-      path.join(pkgDir, "rumoca_bg.wasm"),
+  if (await exists(path.join(pkgDir, "rumoca_bg.wasm"))) {
+    await fs.rm(path.join(pkgDir, "rumoca_bg.wasm"));
+  }
+  if (!hasDefaultJs || !hasDefaultWasm) {
+    throw new Error(
+      "Expected canonical wasm-pack outputs rumoca_bind_wasm.js and rumoca_bind_wasm_bg.wasm",
     );
   }
 
-  // Keep package metadata aligned with whichever build flow produced artifacts:
-  // - rumoca-dev-tools flow: rumoca.js / rumoca_bg.wasm
-  // - plain wasm-pack flow: rumoca_bind_wasm.js / rumoca_bind_wasm_bg.wasm
-  if (hasRenamedJs || hasRenamedWasm) {
-    pkg.main = "rumoca.js";
-    pkg.module = "rumoca.js";
-    addFile("rumoca.js");
-    addFile("rumoca_bg.wasm");
-    addFile("rumoca_bind_wasm.d.ts");
-    addFile("rumoca_bind_wasm.js");
-    addFile("rumoca_bind_wasm_bg.wasm");
-  } else if (hasDefaultJs || hasDefaultWasm) {
-    pkg.main = "rumoca_bind_wasm.js";
-    pkg.module = "rumoca_bind_wasm.js";
-    addFile("rumoca_bind_wasm.js");
-    addFile("rumoca_bind_wasm_bg.wasm");
-    addFile("rumoca_bind_wasm.d.ts");
-  }
+  pkg.main = "rumoca_bind_wasm.js";
+  pkg.module = "rumoca_bind_wasm.js";
+  addFile("rumoca_bind_wasm.js");
+  addFile("rumoca_bind_wasm_bg.wasm");
+  addFile("rumoca_bind_wasm.d.ts");
 
   // Include optional worker helpers when present.
   if (await exists(path.join(pkgDir, "rumoca_worker.js"))) {

--- a/crates/rumoca-bind-wasm/src/lib.rs
+++ b/crates/rumoca-bind-wasm/src/lib.rs
@@ -6,6 +6,7 @@
 mod class_browser_helpers;
 mod simulation_api;
 mod source_root_api;
+mod stepper_api;
 
 use std::{
     collections::BTreeMap,
@@ -47,6 +48,7 @@ use crate::class_browser_helpers::{
     join_path, token_list_to_text,
 };
 use crate::simulation_api::{simulate_model_impl, simulate_model_with_project_sources_impl};
+pub use crate::stepper_api::WasmStepper;
 pub use crate::source_root_api::{
     clear_source_root_cache, compile_with_project_sources, compile_with_source_roots,
     export_parsed_source_roots_binary, get_bundled_source_root_manifest,
@@ -1961,103 +1963,6 @@ pub fn simulate_model_with_project_sources(
         dt,
         solver,
     )
-}
-
-// ==========================================================================
-// Real-time Stepper
-// ==========================================================================
-
-/// Opaque handle to a real-time simulation stepper running in WASM.
-///
-/// Compiles a Modelica model and creates an interactive stepper that can be
-/// driven from JavaScript via `requestAnimationFrame`.
-#[wasm_bindgen]
-pub struct WasmStepper {
-    stepper: rumoca_sim::SimStepper,
-    /// Kept for `reset()` — recreates the stepper from scratch.
-    dae: rumoca_session::compile::Dae,
-}
-
-#[wasm_bindgen]
-impl WasmStepper {
-    /// Compile a Modelica model and create a stepper ready for interactive stepping.
-    ///
-    /// `source` is the full Modelica source text, `model_name` is the class to simulate.
-    #[wasm_bindgen(constructor)]
-    pub fn new(source: &str, model_name: &str) -> Result<WasmStepper, JsValue> {
-        let dae = with_singleton_session(|session| {
-            session.update_document("input.mo", source);
-            let requested_model = qualify_input_model_name(session, model_name);
-            let result = compile_requested_model(session, &requested_model)?;
-            Ok(result.dae)
-        })?;
-
-        let opts = rumoca_sim::StepperOptions {
-            rtol: 1e-3,
-            atol: 1e-3,
-            ..rumoca_sim::StepperOptions::default()
-        };
-        let stepper = rumoca_sim::SimStepper::new(&dae, opts)
-            .map_err(|e| JsValue::from_str(&format!("Stepper creation error: {e}")))?;
-
-        Ok(WasmStepper { stepper, dae })
-    }
-
-    /// Set an input value by name. Takes effect on the next `step()` call.
-    pub fn set_input(&mut self, name: &str, value: f64) -> Result<(), JsValue> {
-        self.stepper
-            .set_input(name, value)
-            .map_err(|e| JsValue::from_str(&format!("{e}")))
-    }
-
-    /// Step the simulation forward by `dt` seconds.
-    pub fn step(&mut self, dt: f64) -> Result<(), JsValue> {
-        self.stepper
-            .step(dt)
-            .map_err(|e| JsValue::from_str(&format!("Step error: {e}")))
-    }
-
-    /// Get the current simulation time.
-    pub fn time(&self) -> f64 {
-        self.stepper.time()
-    }
-
-    /// Read a single variable value by name.
-    pub fn get(&self, name: &str) -> Option<f64> {
-        self.stepper.get(name)
-    }
-
-    /// Get all current variable values as a JSON string `{"time": t, "values": {...}}`.
-    pub fn state_json(&self) -> String {
-        let state = self.stepper.state();
-        serde_json::json!({
-            "time": state.time,
-            "values": state.values,
-        })
-        .to_string()
-    }
-
-    /// Get available input names as a JSON array string.
-    pub fn input_names(&self) -> String {
-        serde_json::to_string(self.stepper.input_names()).unwrap_or_else(|_| "[]".to_string())
-    }
-
-    /// Get all solver variable names as a JSON array string.
-    pub fn variable_names(&self) -> String {
-        serde_json::to_string(self.stepper.variable_names()).unwrap_or_else(|_| "[]".to_string())
-    }
-
-    /// Reset the simulation to initial conditions.
-    pub fn reset(&mut self) -> Result<(), JsValue> {
-        let opts = rumoca_sim::StepperOptions {
-            rtol: 1e-3,
-            atol: 1e-3,
-            ..rumoca_sim::StepperOptions::default()
-        };
-        self.stepper = rumoca_sim::SimStepper::new(&self.dae, opts)
-            .map_err(|e| JsValue::from_str(&format!("Reset failed: {e}")))?;
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/crates/rumoca-bind-wasm/src/lib.rs
+++ b/crates/rumoca-bind-wasm/src/lib.rs
@@ -48,7 +48,6 @@ use crate::class_browser_helpers::{
     join_path, token_list_to_text,
 };
 use crate::simulation_api::{simulate_model_impl, simulate_model_with_project_sources_impl};
-pub use crate::stepper_api::WasmStepper;
 pub use crate::source_root_api::{
     clear_source_root_cache, compile_with_project_sources, compile_with_source_roots,
     export_parsed_source_roots_binary, get_bundled_source_root_manifest,
@@ -56,6 +55,7 @@ pub use crate::source_root_api::{
     load_source_roots, merge_parsed_source_roots, merge_parsed_source_roots_binary,
     parse_source_root_file, sync_project_sources,
 };
+pub use crate::stepper_api::WasmStepper;
 
 /// Global compilation session containing both bundled source-root and user documents.
 static SESSION: Mutex<Option<Session>> = Mutex::new(None);

--- a/crates/rumoca-bind-wasm/src/lib.rs
+++ b/crates/rumoca-bind-wasm/src/lib.rs
@@ -4,6 +4,7 @@
 //! lives in those crates; this module only provides WASM entry points.
 
 mod class_browser_helpers;
+mod simulation_api;
 mod source_root_api;
 
 use std::{
@@ -16,6 +17,8 @@ use std::{
 use js_sys::Date;
 use lsp_types::{Diagnostic as LspDiagnostic, Position, Range, Url};
 use wasm_bindgen::prelude::*;
+#[cfg(all(target_arch = "wasm32", feature = "wasm-rayon"))]
+use wasm_bindgen_futures::JsFuture;
 #[cfg(all(target_arch = "wasm32", feature = "wasm-rayon"))]
 use wasm_bindgen_rayon::init_thread_pool;
 
@@ -30,12 +33,7 @@ use rumoca_session::parsing::{
 };
 use rumoca_session::runtime::templates as runtime_templates;
 use rumoca_session::runtime::{
-    SimOptions, dae_balance, prepare_dae_for_template_codegen, render_dae_template_with_json,
-    simulate_dae,
-};
-use rumoca_sim::results_web::{
-    SimulationRequestSummary, SimulationRunMetrics, build_simulation_metrics_value,
-    build_simulation_payload,
+    dae_balance, prepare_dae_for_template_codegen, render_dae_template_with_json,
 };
 use rumoca_tool_lint::{LintOptions, lint as lint_source};
 use rumoca_tool_lsp::completion_metrics::{
@@ -48,6 +46,7 @@ use crate::class_browser_helpers::{
     class_type_label, component_reference_to_path, expression_path, extract_string_literal,
     join_path, token_list_to_text,
 };
+use crate::simulation_api::{simulate_model_impl, simulate_model_with_project_sources_impl};
 pub use crate::source_root_api::{
     clear_source_root_cache, compile_with_project_sources, compile_with_source_roots,
     export_parsed_source_roots_binary, get_bundled_source_root_manifest,
@@ -120,7 +119,7 @@ pub async fn wasm_init(num_threads: usize) -> Result<bool, JsValue> {
     if num_threads == 0 {
         return Ok(false);
     }
-    init_thread_pool(num_threads).await?;
+    JsFuture::from(init_thread_pool(num_threads)).await?;
     Ok(true)
 }
 
@@ -871,9 +870,8 @@ fn build_compile_response(result: &CompilationResult) -> Result<String, JsValue>
             if augment_prepared_with_native_observables(&dae_native_json, &mut prepared_json)
                 .is_none()
             {
-                prepared_diagnostics.push(
-                    "unable to augment prepared DAE with native observables".to_string(),
-                );
+                prepared_diagnostics
+                    .push("unable to augment prepared DAE with native observables".to_string());
             }
             (prepared_json, None)
         }
@@ -1933,10 +1931,6 @@ pub fn lsp_semantic_token_legend() -> Result<String, JsValue> {
     serde_json::to_string(&legend).map_err(|e| JsValue::from_str(&format!("JSON error: {}", e)))
 }
 
-// ==========================================================================
-// Simulation
-// ==========================================================================
-
 /// Compile and simulate a Modelica model.
 #[wasm_bindgen]
 pub fn simulate_model(
@@ -1946,9 +1940,7 @@ pub fn simulate_model(
     dt: f64,
     solver: &str,
 ) -> Result<String, JsValue> {
-    with_singleton_session(|session| {
-        simulate_model_in_session(session, source, model_name, t_end, dt, solver)
-    })
+    simulate_model_impl(source, model_name, t_end, dt, solver)
 }
 
 /// Compile with additional project-local sources and simulate a Modelica model.
@@ -1961,55 +1953,14 @@ pub fn simulate_model_with_project_sources(
     dt: f64,
     solver: &str,
 ) -> Result<String, JsValue> {
-    with_singleton_session(|session| {
-        crate::source_root_api::load_project_sources_in_session(session, project_sources_json)?;
-        simulate_model_in_session(session, source, model_name, t_end, dt, solver)
-    })
-}
-
-fn simulate_model_in_session(
-    session: &mut Session,
-    source: &str,
-    model_name: &str,
-    t_end: f64,
-    dt: f64,
-    solver: &str,
-) -> Result<String, JsValue> {
-    session.update_document("input.mo", source);
-    let requested_model = qualify_input_model_name(session, model_name);
-    let result = compile_requested_model(session, &requested_model)?;
-
-    let dt_opt = if dt > 0.0 { Some(dt) } else { None };
-    let opts = SimOptions {
+    simulate_model_with_project_sources_impl(
+        source,
+        model_name,
+        project_sources_json,
         t_end,
-        dt: dt_opt,
-        ..SimOptions::default()
-    };
-    let sim_started = wasm_timing_start();
-    let sim = simulate_dae(&result.dae, &opts)
-        .map_err(|e| JsValue::from_str(&format!("Simulation error: {}", e)))?;
-    let metrics = SimulationRunMetrics {
-        simulate_seconds: Some(wasm_elapsed_ms(sim_started) as f64 / 1000.0),
-        ..SimulationRunMetrics::default()
-    };
-    let request = SimulationRequestSummary {
-        solver: if solver.trim().is_empty() {
-            "auto".to_string()
-        } else {
-            solver.trim().to_string()
-        },
-        t_start: opts.t_start,
-        t_end: opts.t_end,
-        dt: opts.dt,
-        rtol: opts.rtol,
-        atol: opts.atol,
-    };
-
-    let output = serde_json::json!({
-        "payload": build_simulation_payload(&sim, &request, &metrics),
-        "metrics": build_simulation_metrics_value(&sim, &metrics),
-    });
-    serde_json::to_string(&output).map_err(|e| JsValue::from_str(&format!("JSON error: {}", e)))
+        dt,
+        solver,
+    )
 }
 
 // ==========================================================================

--- a/crates/rumoca-bind-wasm/src/lib.rs
+++ b/crates/rumoca-bind-wasm/src/lib.rs
@@ -16,6 +16,8 @@ use std::{
 use js_sys::Date;
 use lsp_types::{Diagnostic as LspDiagnostic, Position, Range, Url};
 use wasm_bindgen::prelude::*;
+#[cfg(all(target_arch = "wasm32", feature = "wasm-rayon"))]
+use wasm_bindgen_rayon::init_thread_pool;
 
 use rumoca_session::Session;
 use rumoca_session::compile::{
@@ -108,9 +110,26 @@ pub fn init() {
     console_error_panic_hook::set_once();
 }
 
-/// Initialize the thread pool (no-op, kept for worker API compatibility).
+/// Initialize optional Rayon worker threads for wasm builds.
+///
+/// Returns `true` when the thread pool was initialized and `false` when threading
+/// is unavailable in this build/runtime.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-rayon"))]
 #[wasm_bindgen]
-pub fn wasm_init(_num_threads: usize) {}
+pub async fn wasm_init(num_threads: usize) -> Result<bool, JsValue> {
+    if num_threads == 0 {
+        return Ok(false);
+    }
+    init_thread_pool(num_threads).await?;
+    Ok(true)
+}
+
+/// Fallback thread-pool initializer for non-threaded builds.
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-rayon")))]
+#[wasm_bindgen]
+pub fn wasm_init(_num_threads: usize) -> bool {
+    false
+}
 
 /// Get the Rumoca version string.
 #[wasm_bindgen]
@@ -730,25 +749,145 @@ fn augment_prepared_with_native_observables(
     Some(n)
 }
 
+fn object_len(value: &Value, key: &str) -> usize {
+    value
+        .get(key)
+        .and_then(Value::as_object)
+        .map_or(0, serde_json::Map::len)
+}
+
+fn attach_prepared_template_metadata(
+    prepared_json: &mut Value,
+    native_json: &Value,
+    status: &str,
+    diagnostics: &[String],
+) {
+    let Some(prepared_obj) = as_object_mut(prepared_json) else {
+        return;
+    };
+    let prepared_obj_ref: &Map<String, Value> = prepared_obj;
+    let obj_len = |key: &str| {
+        prepared_obj_ref
+            .get(key)
+            .and_then(Value::as_object)
+            .map_or(0, serde_json::Map::len)
+    };
+    let arr_len = |key: &str| {
+        prepared_obj_ref
+            .get(key)
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len)
+    };
+    let obj_keys = |key: &str| {
+        prepared_obj_ref
+            .get(key)
+            .and_then(Value::as_object)
+            .map(|map| map.keys().cloned().map(Value::String).collect::<Vec<_>>())
+            .unwrap_or_default()
+    };
+    let observable_count = prepared_obj_ref
+        .get("__rumoca_observables")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let hints = serde_json::json!({
+        "variable_counts": {
+            "x": obj_len("x"),
+            "y": obj_len("y"),
+            "z": obj_len("z"),
+            "m": obj_len("m"),
+            "w": obj_len("w"),
+            "u": obj_len("u"),
+            "p": obj_len("p"),
+            "constants": obj_len("constants"),
+            "native_y": object_len(native_json, "y"),
+            "observables": observable_count,
+        },
+        "equation_counts": {
+            "f_x": arr_len("f_x"),
+            "f_c": arr_len("f_c"),
+            "f_z": arr_len("f_z"),
+            "f_m": arr_len("f_m"),
+            "when_clauses": arr_len("when_clauses"),
+            "relation": arr_len("relation"),
+            "initial_equations": arr_len("initial_equations"),
+        },
+        "variable_order": {
+            "x": obj_keys("x"),
+            "y": obj_keys("y"),
+            "z": obj_keys("z"),
+            "m": obj_keys("m"),
+            "w": obj_keys("w"),
+            "u": obj_keys("u"),
+            "p": obj_keys("p"),
+            "constants": obj_keys("constants"),
+        },
+        "events": {
+            "has_conditions": arr_len("f_c") > 0,
+            "has_when_clauses": arr_len("when_clauses") > 0,
+            "has_resets": arr_len("f_z") > 0 || arr_len("f_m") > 0,
+        }
+    });
+
+    prepared_obj.insert(
+        "__rumoca_prepared_status".to_string(),
+        Value::String(status.to_string()),
+    );
+    prepared_obj.insert(
+        "__rumoca_prepared_diagnostics".to_string(),
+        Value::Array(diagnostics.iter().cloned().map(Value::String).collect()),
+    );
+    prepared_obj.insert("__rumoca_solver_hints".to_string(), hints);
+}
+
+fn attach_build_metadata(payload: &mut Value) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    let build = serde_json::json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "git_commit": option_env!("RUMOCA_GIT_COMMIT").unwrap_or("unknown"),
+        "build_time_utc": option_env!("RUMOCA_BUILD_TIME_UTC").unwrap_or("unknown"),
+    });
+    obj.insert("__rumoca_build".to_string(), build);
+}
+
 /// Build a rich compile response with DAE, balance info, and pretty output.
 fn build_compile_response(result: &CompilationResult) -> Result<String, JsValue> {
     let dae = &result.dae;
-    let dae_native_json = serde_json::to_value(dae).ok();
+    let mut dae_native_json =
+        serde_json::to_value(dae).map_err(|e| JsValue::from_str(&format!("JSON error: {}", e)))?;
+    attach_build_metadata(&mut dae_native_json);
+    let mut prepared_diagnostics: Vec<String> = Vec::new();
+    let mut prepared_status = "prepared".to_string();
+
     let prepared = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         prepare_dae_for_template_codegen(dae, true)
     }));
-    let (dae_prepared, dae_prepared_error) = match prepared {
+    let (mut dae_prepared, dae_prepared_error) = match prepared {
         Ok(Ok(prepped)) => {
-            let mut prepared_json = serde_json::to_value(prepped).ok();
-            if let (Some(native), Some(prepared)) =
-                (dae_native_json.as_ref(), prepared_json.as_mut())
+            let mut prepared_json = serde_json::to_value(prepped).map_err(|e| {
+                JsValue::from_str(&format!("JSON error converting prepared DAE: {}", e))
+            })?;
+            if augment_prepared_with_native_observables(&dae_native_json, &mut prepared_json)
+                .is_none()
             {
-                let _ = augment_prepared_with_native_observables(native, prepared);
+                prepared_diagnostics.push(
+                    "unable to augment prepared DAE with native observables".to_string(),
+                );
             }
             (prepared_json, None)
         }
-        Ok(Err(err)) => (None, Some(err.to_string())),
+        Ok(Err(err)) => {
+            prepared_status = "fallback_native".to_string();
+            let msg = err.to_string();
+            prepared_diagnostics.push(format!(
+                "prepare_dae_for_template_codegen failed; using native DAE: {}",
+                msg
+            ));
+            (dae_native_json.clone(), Some(msg))
+        }
         Err(panic_payload) => {
+            prepared_status = "fallback_native".to_string();
             let panic_msg = if let Some(msg) = panic_payload.downcast_ref::<&str>() {
                 (*msg).to_string()
             } else if let Some(msg) = panic_payload.downcast_ref::<String>() {
@@ -756,15 +895,18 @@ fn build_compile_response(result: &CompilationResult) -> Result<String, JsValue>
             } else {
                 "unknown panic payload".to_string()
             };
-            (
-                None,
-                Some(format!(
-                    "prepare_dae_for_template_codegen panicked: {}",
-                    panic_msg
-                )),
-            )
+            let msg = format!("prepare_dae_for_template_codegen panicked: {}", panic_msg);
+            prepared_diagnostics.push(format!("{}; using native DAE", msg));
+            (dae_native_json.clone(), Some(msg))
         }
     };
+    attach_prepared_template_metadata(
+        &mut dae_prepared,
+        &dae_native_json,
+        &prepared_status,
+        &prepared_diagnostics,
+    );
+    attach_build_metadata(&mut dae_prepared);
 
     let num_eqs = dae.num_equations();
     let balance_val = dae_balance(dae);
@@ -779,9 +921,11 @@ fn build_compile_response(result: &CompilationResult) -> Result<String, JsValue>
     let pretty = serde_json::to_string_pretty(dae).unwrap_or_default();
 
     let response = serde_json::json!({
-        "dae": dae,
-        "dae_native": dae,
+        "dae": dae_native_json.clone(),
+        "dae_native": dae_native_json,
         "dae_prepared": dae_prepared,
+        "dae_prepared_status": prepared_status,
+        "dae_prepared_diagnostics": prepared_diagnostics,
         "dae_prepared_error": dae_prepared_error,
         "balance": balance,
         "pretty": pretty,

--- a/crates/rumoca-bind-wasm/src/simulation_api.rs
+++ b/crates/rumoca-bind-wasm/src/simulation_api.rs
@@ -1,0 +1,83 @@
+use rumoca_session::Session;
+use rumoca_session::runtime::{SimOptions, simulate_dae};
+use rumoca_sim::results_web::{
+    SimulationRequestSummary, SimulationRunMetrics, build_simulation_metrics_value,
+    build_simulation_payload,
+};
+use wasm_bindgen::JsValue;
+
+use crate::{
+    compile_requested_model, qualify_input_model_name, wasm_elapsed_ms, wasm_timing_start,
+    with_singleton_session,
+};
+
+pub(crate) fn simulate_model_impl(
+    source: &str,
+    model_name: &str,
+    t_end: f64,
+    dt: f64,
+    solver: &str,
+) -> Result<String, JsValue> {
+    with_singleton_session(|session| {
+        simulate_model_in_session(session, source, model_name, t_end, dt, solver)
+    })
+}
+
+pub(crate) fn simulate_model_with_project_sources_impl(
+    source: &str,
+    model_name: &str,
+    project_sources_json: &str,
+    t_end: f64,
+    dt: f64,
+    solver: &str,
+) -> Result<String, JsValue> {
+    with_singleton_session(|session| {
+        crate::source_root_api::load_project_sources_in_session(session, project_sources_json)?;
+        simulate_model_in_session(session, source, model_name, t_end, dt, solver)
+    })
+}
+
+fn simulate_model_in_session(
+    session: &mut Session,
+    source: &str,
+    model_name: &str,
+    t_end: f64,
+    dt: f64,
+    solver: &str,
+) -> Result<String, JsValue> {
+    session.update_document("input.mo", source);
+    let requested_model = qualify_input_model_name(session, model_name);
+    let result = compile_requested_model(session, &requested_model)?;
+
+    let dt_opt = if dt > 0.0 { Some(dt) } else { None };
+    let opts = SimOptions {
+        t_end,
+        dt: dt_opt,
+        ..SimOptions::default()
+    };
+    let sim_started = wasm_timing_start();
+    let sim = simulate_dae(&result.dae, &opts)
+        .map_err(|e| JsValue::from_str(&format!("Simulation error: {}", e)))?;
+    let metrics = SimulationRunMetrics {
+        simulate_seconds: Some(wasm_elapsed_ms(sim_started) as f64 / 1000.0),
+        ..SimulationRunMetrics::default()
+    };
+    let request = SimulationRequestSummary {
+        solver: if solver.trim().is_empty() {
+            "auto".to_string()
+        } else {
+            solver.trim().to_string()
+        },
+        t_start: opts.t_start,
+        t_end: opts.t_end,
+        dt: opts.dt,
+        rtol: opts.rtol,
+        atol: opts.atol,
+    };
+
+    let output = serde_json::json!({
+        "payload": build_simulation_payload(&sim, &request, &metrics),
+        "metrics": build_simulation_metrics_value(&sim, &metrics),
+    });
+    serde_json::to_string(&output).map_err(|e| JsValue::from_str(&format!("JSON error: {}", e)))
+}

--- a/crates/rumoca-bind-wasm/src/stepper_api.rs
+++ b/crates/rumoca-bind-wasm/src/stepper_api.rs
@@ -1,0 +1,96 @@
+use wasm_bindgen::prelude::*;
+
+use crate::{compile_requested_model, qualify_input_model_name, with_singleton_session};
+
+/// Opaque handle to a real-time simulation stepper running in WASM.
+///
+/// Compiles a Modelica model and creates an interactive stepper that can be
+/// driven from JavaScript via `requestAnimationFrame`.
+#[wasm_bindgen]
+pub struct WasmStepper {
+    stepper: rumoca_sim::SimStepper,
+    /// Kept for `reset()` — recreates the stepper from scratch.
+    dae: rumoca_session::compile::Dae,
+}
+
+#[wasm_bindgen]
+impl WasmStepper {
+    /// Compile a Modelica model and create a stepper ready for interactive stepping.
+    ///
+    /// `source` is the full Modelica source text, `model_name` is the class to simulate.
+    #[wasm_bindgen(constructor)]
+    pub fn new(source: &str, model_name: &str) -> Result<WasmStepper, JsValue> {
+        let dae = with_singleton_session(|session| {
+            session.update_document("input.mo", source);
+            let requested_model = qualify_input_model_name(session, model_name);
+            let result = compile_requested_model(session, &requested_model)?;
+            Ok(result.dae)
+        })?;
+
+        let opts = rumoca_sim::StepperOptions {
+            rtol: 1e-3,
+            atol: 1e-3,
+            ..rumoca_sim::StepperOptions::default()
+        };
+        let stepper = rumoca_sim::SimStepper::new(&dae, opts)
+            .map_err(|e| JsValue::from_str(&format!("Stepper creation error: {e}")))?;
+
+        Ok(WasmStepper { stepper, dae })
+    }
+
+    /// Set an input value by name. Takes effect on the next `step()` call.
+    pub fn set_input(&mut self, name: &str, value: f64) -> Result<(), JsValue> {
+        self.stepper
+            .set_input(name, value)
+            .map_err(|e| JsValue::from_str(&format!("{e}")))
+    }
+
+    /// Step the simulation forward by `dt` seconds.
+    pub fn step(&mut self, dt: f64) -> Result<(), JsValue> {
+        self.stepper
+            .step(dt)
+            .map_err(|e| JsValue::from_str(&format!("Step error: {e}")))
+    }
+
+    /// Get the current simulation time.
+    pub fn time(&self) -> f64 {
+        self.stepper.time()
+    }
+
+    /// Read a single variable value by name.
+    pub fn get(&self, name: &str) -> Option<f64> {
+        self.stepper.get(name)
+    }
+
+    /// Get all current variable values as a JSON string `{"time": t, "values": {...}}`.
+    pub fn state_json(&self) -> String {
+        let state = self.stepper.state();
+        serde_json::json!({
+            "time": state.time,
+            "values": state.values,
+        })
+        .to_string()
+    }
+
+    /// Get available input names as a JSON array string.
+    pub fn input_names(&self) -> String {
+        serde_json::to_string(self.stepper.input_names()).unwrap_or_else(|_| "[]".to_string())
+    }
+
+    /// Get all solver variable names as a JSON array string.
+    pub fn variable_names(&self) -> String {
+        serde_json::to_string(self.stepper.variable_names()).unwrap_or_else(|_| "[]".to_string())
+    }
+
+    /// Reset the simulation to initial conditions.
+    pub fn reset(&mut self) -> Result<(), JsValue> {
+        let opts = rumoca_sim::StepperOptions {
+            rtol: 1e-3,
+            atol: 1e-3,
+            ..rumoca_sim::StepperOptions::default()
+        };
+        self.stepper = rumoca_sim::SimStepper::new(&self.dae, opts)
+            .map_err(|e| JsValue::from_str(&format!("Reset failed: {e}")))?;
+        Ok(())
+    }
+}

--- a/crates/rumoca-bind-wasm/src/tests.rs
+++ b/crates/rumoca-bind-wasm/src/tests.rs
@@ -203,7 +203,7 @@ fn test_init_start_hook_is_safe_to_call() {
 fn test_wasm_init_is_a_noop() {
     let _guard = session_test_guard();
     clear_source_root_cache();
-    wasm_init(4);
+    assert!(!wasm_init(4));
     assert_eq!(get_source_root_document_count(), 0);
 }
 
@@ -1507,6 +1507,66 @@ fn test_render_template_preserves_prepared_observables_from_json_context() {
             "expected rendered observables to contain `{expected}`, got:\n{rendered}"
         );
     }
+}
+
+#[test]
+fn test_compile_to_json_embeds_prepared_status_and_solver_hints() {
+    let mut session = Session::default();
+    let source = r#"
+    model SimpleDecay
+      Real x(start = 1);
+    equation
+      der(x) = -x;
+    end SimpleDecay;
+    "#;
+
+    let json = compile_source_in_session(&mut session, source, "SimpleDecay")
+        .expect("compile should succeed for simple model");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("compile should return valid JSON");
+
+    let status = parsed
+        .get("dae_prepared_status")
+        .and_then(serde_json::Value::as_str)
+        .expect("compile response should include dae_prepared_status");
+    assert!(
+        matches!(status, "prepared" | "fallback_native"),
+        "unexpected dae_prepared_status: {status}"
+    );
+
+    let prepared = parsed
+        .get("dae_prepared")
+        .and_then(serde_json::Value::as_object)
+        .expect("compile response should include dae_prepared object");
+    let embedded_status = prepared
+        .get("__rumoca_prepared_status")
+        .and_then(serde_json::Value::as_str)
+        .expect("dae_prepared should include __rumoca_prepared_status");
+    assert_eq!(
+        embedded_status, status,
+        "top-level and embedded prepared status should match"
+    );
+
+    let diagnostics = prepared
+        .get("__rumoca_prepared_diagnostics")
+        .and_then(serde_json::Value::as_array)
+        .expect("dae_prepared should include __rumoca_prepared_diagnostics");
+    assert!(
+        diagnostics.iter().all(serde_json::Value::is_string),
+        "prepared diagnostics should be an array of strings"
+    );
+
+    let hints = prepared
+        .get("__rumoca_solver_hints")
+        .and_then(serde_json::Value::as_object)
+        .expect("dae_prepared should include __rumoca_solver_hints");
+    assert!(
+        hints.contains_key("variable_counts")
+            && hints.contains_key("equation_counts")
+            && hints.contains_key("variable_order")
+            && hints.contains_key("events"),
+        "solver hints should include variable/equation/order/events sections"
+    );
 }
 
 #[test]

--- a/crates/rumoca-sim/src/with_diffsol/prepare.rs
+++ b/crates/rumoca-sim/src/with_diffsol/prepare.rs
@@ -933,8 +933,7 @@ fn normalize_runtime_aliases_and_update_elim(
 ///
 /// Runs all structural passes (elimination, scalarization, equation reordering,
 /// sign normalization, orphaned variable pinning). The `normalize_aliases` flag
-/// controls whether runtime alias normalization runs (needed for simulation,
-/// skipped for template codegen to avoid unnecessary failure modes in WASM).
+/// controls whether runtime alias normalization runs.
 fn prepare_dae_core(
     dae: &Dae,
     scalarize: bool,
@@ -1046,7 +1045,9 @@ pub(super) fn prepare_dae_for_template_codegen_only(
     scalarize: bool,
     budget: &TimeoutBudget,
 ) -> Result<Dae, SimError> {
-    let (mut dae, _elim, _has_dummy) = prepare_dae_core(dae, scalarize, budget, false)?;
+    // Keep template-prepared structure aligned with runtime simulation preparation
+    // (minus solver-only artifacts like IC plan and mass matrix).
+    let (mut dae, _elim, _has_dummy) = prepare_dae_core(dae, scalarize, budget, true)?;
 
     rumoca_phase_solve::fold_start_values_to_literals(&mut dae);
     rumoca_phase_solve::sort_parameters_by_start_deps(&mut dae);
@@ -1253,6 +1254,77 @@ mod tests {
         assert!(
             expr_contains_var_ref(&dae.f_x[1].rhs, &VarName::new("z")),
             "rewritten non-ODE row should reference the selected derivative expression"
+        );
+    }
+
+    #[test]
+    fn test_template_codegen_prep_normalizes_runtime_aliases_for_event_surfaces() {
+        let mut dae = Dae::new();
+        dae.states
+            .insert(VarName::new("x"), dae::Variable::new(VarName::new("x")));
+        dae.states
+            .insert(VarName::new("v"), dae::Variable::new(VarName::new("v")));
+        dae.algebraics
+            .insert(VarName::new("d"), dae::Variable::new(VarName::new("d")));
+        dae.parameters
+            .insert(VarName::new("r"), dae::Variable::new(VarName::new("r")));
+
+        // der(x) = v
+        dae.f_x.push(eq(sub(
+            dae::Expression::BuiltinCall {
+                function: dae::BuiltinFunction::Der,
+                args: vec![var("x")],
+            },
+            var("v"),
+        )));
+        // d = x - r
+        dae.f_x.push(eq(sub(var("d"), sub(var("x"), var("r")))));
+        // der(v) = if d < 0 then -1 else -2 (shape only; values not important)
+        dae.f_x.push(eq(sub(
+            dae::Expression::BuiltinCall {
+                function: dae::BuiltinFunction::Der,
+                args: vec![var("v")],
+            },
+            dae::Expression::If {
+                branches: vec![(
+                    lt(var("d"), int(0)),
+                    dae::Expression::Unary {
+                        op: rumoca_ir_core::OpUnary::Minus(Default::default()),
+                        rhs: Box::new(int(1)),
+                    },
+                )],
+                else_branch: Box::new(dae::Expression::Unary {
+                    op: rumoca_ir_core::OpUnary::Minus(Default::default()),
+                    rhs: Box::new(int(2)),
+                }),
+            },
+        )));
+
+        let cond = lt(var("d"), int(0));
+        dae.relation.push(cond.clone());
+        dae.f_c.push(eq(cond));
+
+        let budget = TimeoutBudget::new(None);
+        let prepared = prepare_dae_for_template_codegen_only(&dae, true, &budget)
+            .expect("template codegen preparation should succeed");
+
+        assert!(
+            !prepared.algebraics.contains_key(&VarName::new("d")),
+            "template-prepared DAE should normalize runtime alias variable `d` out of algebraics"
+        );
+        assert!(
+            !prepared
+                .relation
+                .iter()
+                .any(|expr| expr_contains_var_ref(expr, &VarName::new("d"))),
+            "template-prepared relation roots should not reference eliminated alias `d`"
+        );
+        assert!(
+            !prepared
+                .f_c
+                .iter()
+                .any(|eq| expr_contains_var_ref(&eq.rhs, &VarName::new("d"))),
+            "template-prepared condition equations should not reference eliminated alias `d`"
         );
     }
 }

--- a/crates/rumoca-tool-dev/src/main.rs
+++ b/crates/rumoca-tool-dev/src/main.rs
@@ -161,10 +161,17 @@ struct WasmArgs {
     command: WasmCommand,
 }
 
+#[derive(Debug, Args, Clone)]
+struct WasmBuildArgs {
+    /// Build with wasm-pack --dev for faster local iteration
+    #[arg(long)]
+    dev: bool,
+}
+
 #[derive(Debug, Subcommand, Clone)]
 enum WasmCommand {
     /// Build the WASM editor bundle
-    Build,
+    Build(WasmBuildArgs),
     /// WASM editor verification gate
     Test,
     /// Build and serve the WASM editor
@@ -427,13 +434,13 @@ fn cmd_vscode(args: VscodeArgs) -> Result<()> {
 
 fn cmd_wasm(args: WasmArgs) -> Result<()> {
     match args.command {
-        WasmCommand::Build => cmd_build_wasm(),
+        WasmCommand::Build(args) => cmd_build_wasm(args),
         WasmCommand::Test => run_wasm_test_suite(&repo_root()),
         WasmCommand::Edit(args) => {
             let root = repo_root();
             if !args.skip_build {
                 ensure_wasm_deps(&root)?;
-                build_wasm(&root)?;
+                build_wasm(&root, WasmBuildProfile::Release)?;
             }
             serve_wasm(&root, args.port)
         }
@@ -1560,10 +1567,15 @@ fn run_cargo_with_args(root: &Path, args: &[String]) -> Result<()> {
     run_status(command)
 }
 
-fn cmd_build_wasm() -> Result<()> {
+fn cmd_build_wasm(args: WasmBuildArgs) -> Result<()> {
     let root = repo_root();
     ensure_wasm_deps(&root)?;
-    build_wasm(&root)
+    let profile = if args.dev {
+        WasmBuildProfile::Dev
+    } else {
+        WasmBuildProfile::Release
+    };
+    build_wasm(&root, profile)
 }
 
 pub(crate) fn run_wasm_test_suite(root: &Path) -> Result<()> {
@@ -1619,7 +1631,7 @@ pub(crate) fn run_wasm_editor_smoke_check(root: &Path) -> Result<()> {
     )?;
 
     ensure_wasm_deps(root)?;
-    build_wasm(root)?;
+    build_wasm(root, WasmBuildProfile::Release)?;
     run_wasm_simulation_smoke(root)?;
     run_wasm_source_root_smoke(root)?;
     Ok(())
@@ -1732,8 +1744,15 @@ fn ensure_wasm_deps(root: &Path) -> Result<()> {
     Ok(())
 }
 
-fn build_wasm(root: &Path) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WasmBuildProfile {
+    Dev,
+    Release,
+}
+
+fn build_wasm(root: &Path, profile: WasmBuildProfile) -> Result<()> {
     let wasm_opt = std::env::var("WASM_OPT").unwrap_or_else(|_| "0".to_string());
+    let wasm_threads = std::env::var("RUMOCA_WASM_THREADS").unwrap_or_else(|_| "1".to_string());
     let wasm_license = root.join("crates/rumoca-bind-wasm/LICENSE");
     let staged_license = !wasm_license.exists();
     if staged_license {
@@ -1761,7 +1780,27 @@ fn build_wasm(root: &Path) -> Result<()> {
         .arg("--out-dir")
         .arg("../../pkg")
         .current_dir(root);
-    if wasm_opt != "1" {
+    match profile {
+        WasmBuildProfile::Dev => {
+            build.arg("--dev");
+        }
+        WasmBuildProfile::Release => {
+            build.arg("--release");
+        }
+    }
+    if wasm_threads != "0" {
+        build.arg("--").arg("--features").arg("wasm-rayon");
+        const THREAD_FLAGS: &str = "-C target-feature=+atomics,+bulk-memory,+mutable-globals";
+        let mut existing_rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
+        if !existing_rustflags.contains("target-feature=+atomics") {
+            if !existing_rustflags.trim().is_empty() {
+                existing_rustflags.push(' ');
+            }
+            existing_rustflags.push_str(THREAD_FLAGS);
+        }
+        build.env("RUSTFLAGS", existing_rustflags);
+    }
+    if profile == WasmBuildProfile::Dev || wasm_opt != "1" {
         build.arg("--no-opt");
     }
     let build_result = run_status(build);

--- a/crates/rumoca-tool-dev/src/main.rs
+++ b/crates/rumoca-tool-dev/src/main.rs
@@ -10,6 +10,7 @@ mod msl_flamegraph_cmd;
 mod msl_tools;
 mod release_cmd;
 mod repo_cli_cmd;
+mod static_server;
 mod test_cmd;
 mod verify_cmd;
 mod vscode_cmd;
@@ -32,9 +33,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env;
 use std::ffi::OsStr;
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
-use std::net::{TcpListener, TcpStream};
-use std::path::{Component, Path, PathBuf};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use verify_cmd::VerifyArgs;
 
@@ -1751,7 +1751,6 @@ enum WasmBuildProfile {
 }
 
 fn build_wasm(root: &Path, profile: WasmBuildProfile) -> Result<()> {
-    let wasm_opt = std::env::var("WASM_OPT").unwrap_or_else(|_| "0".to_string());
     let wasm_threads = std::env::var("RUMOCA_WASM_THREADS").unwrap_or_else(|_| "1".to_string());
     let wasm_license = root.join("crates/rumoca-bind-wasm/LICENSE");
     let staged_license = !wasm_license.exists();
@@ -1800,7 +1799,7 @@ fn build_wasm(root: &Path, profile: WasmBuildProfile) -> Result<()> {
         }
         build.env("RUSTFLAGS", existing_rustflags);
     }
-    if profile == WasmBuildProfile::Dev || wasm_opt != "1" {
+    if profile == WasmBuildProfile::Dev {
         build.arg("--no-opt");
     }
     let build_result = run_status(build);
@@ -1869,136 +1868,7 @@ fn clean_wasm(root: &Path) -> Result<()> {
 }
 
 fn serve_wasm(root: &Path, explicit_port: Option<u16>) -> Result<()> {
-    let port = explicit_port
-        .or_else(|| std::env::var("PORT").ok().and_then(|raw| raw.parse().ok()))
-        .unwrap_or(8080);
-    let listener = TcpListener::bind(("0.0.0.0", port))
-        .with_context(|| format!("failed to bind 0.0.0.0:{port}"))?;
-
-    println!("Serving on http://localhost:{port}");
-    println!("Editor URL: http://localhost:{port}/editors/wasm/index.html");
-    println!("Press Ctrl+C to stop.");
-
-    for stream in listener.incoming() {
-        match stream {
-            Ok(mut stream) => {
-                if let Err(error) = handle_http_request(root, &mut stream) {
-                    eprintln!("serve error: {error:#}");
-                }
-            }
-            Err(error) => eprintln!("accept error: {error}"),
-        }
-    }
-    Ok(())
-}
-
-fn handle_http_request(root: &Path, stream: &mut TcpStream) -> Result<()> {
-    let mut reader = BufReader::new(
-        stream
-            .try_clone()
-            .context("failed to clone TCP stream for request parsing")?,
-    );
-    let mut request_line = String::new();
-    if reader
-        .read_line(&mut request_line)
-        .context("failed to read request line")?
-        == 0
-    {
-        return Ok(());
-    }
-    loop {
-        let mut line = String::new();
-        if reader.read_line(&mut line).is_err() || line == "\r\n" || line.is_empty() {
-            break;
-        }
-    }
-
-    let mut parts = request_line.split_whitespace();
-    let method = parts.next().unwrap_or_default();
-    let target = parts.next().unwrap_or("/");
-    if method != "GET" {
-        return write_http_response(
-            stream,
-            405,
-            "Method Not Allowed",
-            "text/plain",
-            b"method not allowed",
-        );
-    }
-
-    let url = target.split('?').next().unwrap_or("/");
-    if url.starts_with("/proxy/") {
-        return write_http_response(
-            stream,
-            501,
-            "Not Implemented",
-            "text/plain",
-            b"proxy endpoint is not supported in rum",
-        );
-    }
-
-    match resolve_static_path(root, url) {
-        Some(path) if path.is_file() => {
-            let body =
-                fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
-            write_http_response(stream, 200, "OK", mime_for_path(&path), &body)
-        }
-        _ => write_http_response(stream, 404, "Not Found", "text/plain", b"not found"),
-    }
-}
-
-fn write_http_response(
-    stream: &mut TcpStream,
-    code: u16,
-    status: &str,
-    content_type: &str,
-    body: &[u8],
-) -> Result<()> {
-    let headers = format!(
-        "HTTP/1.1 {code} {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\nCross-Origin-Opener-Policy: same-origin\r\nCross-Origin-Embedder-Policy: require-corp\r\nAccess-Control-Allow-Origin: *\r\nCache-Control: no-store, no-cache, must-revalidate, max-age=0\r\nPragma: no-cache\r\nExpires: 0\r\n\r\n",
-        body.len()
-    );
-    stream
-        .write_all(headers.as_bytes())
-        .context("failed writing HTTP headers")?;
-    stream.write_all(body).context("failed writing HTTP body")?;
-    stream.flush().context("failed flushing HTTP response")?;
-    Ok(())
-}
-
-fn resolve_static_path(root: &Path, url: &str) -> Option<PathBuf> {
-    if url == "/" {
-        return Some(root.join("editors/wasm/index.html"));
-    }
-    let relative = url.trim_start_matches('/');
-    let mut safe = PathBuf::new();
-    for component in Path::new(relative).components() {
-        if let Component::Normal(segment) = component {
-            safe.push(segment);
-        }
-    }
-    if safe.as_os_str().is_empty() {
-        return Some(root.join("editors/wasm/index.html"));
-    }
-    let mut path = root.join(safe);
-    if path.is_dir() {
-        path = path.join("index.html");
-    }
-    Some(path)
-}
-
-fn mime_for_path(path: &Path) -> &'static str {
-    match path.extension().and_then(OsStr::to_str).unwrap_or_default() {
-        "html" => "text/html",
-        "js" | "mjs" => "application/javascript",
-        "json" => "application/json",
-        "wasm" => "application/wasm",
-        "css" => "text/css",
-        "svg" => "image/svg+xml",
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        _ => "application/octet-stream",
-    }
+    static_server::serve(root, explicit_port)
 }
 
 #[cfg(unix)]

--- a/crates/rumoca-tool-dev/src/main_tests.rs
+++ b/crates/rumoca-tool-dev/src/main_tests.rs
@@ -241,8 +241,8 @@ fn cli_parses_wasm_build() {
 
 #[test]
 fn cli_parses_wasm_build_dev() {
-    let cli = Cli::try_parse_from(["rum", "wasm", "build", "--dev"])
-        .expect("parse wasm build --dev");
+    let cli =
+        Cli::try_parse_from(["rum", "wasm", "build", "--dev"]).expect("parse wasm build --dev");
     match cli.command {
         Commands::Wasm(args) => match args.command {
             WasmCommand::Build(args) => assert!(args.dev),

--- a/crates/rumoca-tool-dev/src/main_tests.rs
+++ b/crates/rumoca-tool-dev/src/main_tests.rs
@@ -232,8 +232,21 @@ fn cli_parses_wasm_build() {
     let cli = Cli::try_parse_from(["rum", "wasm", "build"]).expect("parse wasm build");
     match cli.command {
         Commands::Wasm(args) => match args.command {
-            WasmCommand::Build => {}
+            WasmCommand::Build(args) => assert!(!args.dev),
             other => panic!("expected wasm build, got {other:?}"),
+        },
+        other => panic!("expected wasm command, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_wasm_build_dev() {
+    let cli = Cli::try_parse_from(["rum", "wasm", "build", "--dev"])
+        .expect("parse wasm build --dev");
+    match cli.command {
+        Commands::Wasm(args) => match args.command {
+            WasmCommand::Build(args) => assert!(args.dev),
+            other => panic!("expected wasm build --dev, got {other:?}"),
         },
         other => panic!("expected wasm command, got {other:?}"),
     }

--- a/crates/rumoca-tool-dev/src/static_server.rs
+++ b/crates/rumoca-tool-dev/src/static_server.rs
@@ -1,0 +1,139 @@
+use anyhow::{Context, Result};
+use std::ffi::OsStr;
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Component, Path, PathBuf};
+
+pub(crate) fn serve(root: &Path, explicit_port: Option<u16>) -> Result<()> {
+    let port = explicit_port
+        .or_else(|| std::env::var("PORT").ok().and_then(|raw| raw.parse().ok()))
+        .unwrap_or(8080);
+    let listener = TcpListener::bind(("0.0.0.0", port))
+        .with_context(|| format!("failed to bind 0.0.0.0:{port}"))?;
+
+    println!("Serving on http://localhost:{port}");
+    println!("Editor URL: http://localhost:{port}/editors/wasm/index.html");
+    println!("Press Ctrl+C to stop.");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(mut stream) => {
+                if let Err(error) = handle_http_request(root, &mut stream) {
+                    eprintln!("serve error: {error:#}");
+                }
+            }
+            Err(error) => eprintln!("accept error: {error}"),
+        }
+    }
+    Ok(())
+}
+
+fn handle_http_request(root: &Path, stream: &mut TcpStream) -> Result<()> {
+    let mut reader = BufReader::new(
+        stream
+            .try_clone()
+            .context("failed to clone TCP stream for request parsing")?,
+    );
+    let mut request_line = String::new();
+    if reader
+        .read_line(&mut request_line)
+        .context("failed to read request line")?
+        == 0
+    {
+        return Ok(());
+    }
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).is_err() || line == "\r\n" || line.is_empty() {
+            break;
+        }
+    }
+
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or("/");
+    if method != "GET" {
+        return write_http_response(
+            stream,
+            405,
+            "Method Not Allowed",
+            "text/plain",
+            b"method not allowed",
+        );
+    }
+
+    let url = target.split('?').next().unwrap_or("/");
+    if url.starts_with("/proxy/") {
+        return write_http_response(
+            stream,
+            501,
+            "Not Implemented",
+            "text/plain",
+            b"proxy endpoint is not supported in rum",
+        );
+    }
+
+    match resolve_static_path(root, url) {
+        Some(path) if path.is_file() => {
+            let body =
+                fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
+            write_http_response(stream, 200, "OK", mime_for_path(&path), &body)
+        }
+        _ => write_http_response(stream, 404, "Not Found", "text/plain", b"not found"),
+    }
+}
+
+fn write_http_response(
+    stream: &mut TcpStream,
+    code: u16,
+    status: &str,
+    content_type: &str,
+    body: &[u8],
+) -> Result<()> {
+    let headers = format!(
+        "HTTP/1.1 {code} {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\nCross-Origin-Opener-Policy: same-origin\r\nCross-Origin-Embedder-Policy: require-corp\r\nAccess-Control-Allow-Origin: *\r\nCache-Control: no-store, no-cache, must-revalidate, max-age=0\r\nPragma: no-cache\r\nExpires: 0\r\n\r\n",
+        body.len()
+    );
+    stream
+        .write_all(headers.as_bytes())
+        .context("failed writing HTTP headers")?;
+    stream.write_all(body).context("failed writing HTTP body")?;
+    stream.flush().context("failed flushing HTTP response")?;
+    Ok(())
+}
+
+fn resolve_static_path(root: &Path, url: &str) -> Option<PathBuf> {
+    if url == "/" {
+        return Some(root.join("editors/wasm/index.html"));
+    }
+    let relative = url.trim_start_matches('/');
+    let mut safe = PathBuf::new();
+    for component in Path::new(relative).components() {
+        if let Component::Normal(segment) = component {
+            safe.push(segment);
+        }
+    }
+    if safe.as_os_str().is_empty() {
+        return Some(root.join("editors/wasm/index.html"));
+    }
+    let mut path = root.join(safe);
+    if path.is_dir() {
+        path = path.join("index.html");
+    }
+    Some(path)
+}
+
+fn mime_for_path(path: &Path) -> &'static str {
+    match path.extension().and_then(OsStr::to_str).unwrap_or_default() {
+        "html" => "text/html",
+        "js" | "mjs" => "application/javascript",
+        "json" => "application/json",
+        "wasm" => "application/wasm",
+        "css" => "text/css",
+        "svg" => "image/svg+xml",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        _ => "application/octet-stream",
+    }
+}

--- a/crates/rumoca-tool-dev/src/test_cmd.rs
+++ b/crates/rumoca-tool-dev/src/test_cmd.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use std::path::Path;
+use std::env;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::run_status;
@@ -9,18 +10,21 @@ pub(crate) fn run_workspace_fmt_check(root: &Path) -> Result<()> {
 }
 
 pub(crate) fn run_workspace_clippy(root: &Path) -> Result<()> {
-    run_cargo(
-        root,
-        &[
-            "clippy",
-            "--workspace",
-            "--all-targets",
-            "--all-features",
-            "--",
-            "-D",
-            "warnings",
-        ],
-    )
+    let mut cmd = Command::new("cargo");
+    cmd.arg("clippy")
+        .arg("--workspace")
+        .arg("--all-targets")
+        .arg("--all-features")
+        .arg("--")
+        .arg("-D")
+        .arg("warnings")
+        .current_dir(root);
+
+    if let Some(python) = resolve_python_for_pyo3() {
+        cmd.env("PYO3_PYTHON", python);
+    }
+
+    run_status(cmd)
 }
 
 pub(crate) fn run_workspace_docs(root: &Path) -> Result<()> {
@@ -70,4 +74,26 @@ fn run_cargo(root: &Path, args: &[&str]) -> Result<()> {
     let mut cmd = Command::new("cargo");
     cmd.args(args).current_dir(root);
     run_status(cmd)
+}
+
+fn resolve_python_for_pyo3() -> Option<PathBuf> {
+    if let Some(from_env) = env::var_os("PYO3_PYTHON") {
+        let path = PathBuf::from(from_env);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+
+    resolve_from_path("python3").or_else(|| resolve_from_path("python"))
+}
+
+fn resolve_from_path(bin: &str) -> Option<PathBuf> {
+    let path_var = env::var_os("PATH")?;
+    for dir in env::split_paths(&path_var) {
+        let candidate = dir.join(bin);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
 }

--- a/crates/rumoca-tool-dev/src/verify_cmd.rs
+++ b/crates/rumoca-tool-dev/src/verify_cmd.rs
@@ -519,7 +519,13 @@ fn start_wasm_smoke_server(root: &Path) -> Result<(u16, ChildGuard)> {
     let rum_exe = resolve_rum_cli_executable(root)?;
     println!("Prebuilding WASM module for browser smoke...");
     let mut build = Command::new(&rum_exe);
-    build.arg("wasm").arg("build").current_dir(root);
+    build
+        .arg("wasm")
+        .arg("build")
+        // Browser smoke validates editor/runtime flows; disable wasm threads here
+        // to avoid CI browser SharedArrayBuffer/Atomics.waitAsync incompatibilities.
+        .env("RUMOCA_WASM_THREADS", "0")
+        .current_dir(root);
     run_status(build)
         .with_context(|| "failed to prebuild `rum wasm build` for browser smoke".to_string())?;
     let mut last_error = None;

--- a/crates/rumoca-tool-lsp/src/server.rs
+++ b/crates/rumoca-tool-lsp/src/server.rs
@@ -96,11 +96,15 @@ enum DiagnosticsTrigger {
 }
 
 impl ModelicaLanguageServer {
+    fn default_session_config() -> SessionConfig {
+        SessionConfig { parallel: true }
+    }
+
     /// Create a new language server instance.
     pub fn new(client: Client) -> Self {
         Self {
             client,
-            session: Arc::new(RwLock::new(Session::new(SessionConfig::default()))),
+            session: Arc::new(RwLock::new(Session::new(Self::default_session_config()))),
             work_lanes: Arc::new(ServerWorkLanes::default()),
             initial_source_root_paths: Arc::new(RwLock::new(Vec::new())),
             source_root_paths: Arc::new(RwLock::new(Vec::new())),

--- a/editors/wasm/rumoca_worker.js
+++ b/editors/wasm/rumoca_worker.js
@@ -38,6 +38,12 @@ let simulate_model = null;
 let simulate_model_with_project_sources = null;
 let wasmModuleLoaded = false;
 
+function canUseSharedWasmThreads() {
+    return typeof self.crossOriginIsolated === 'boolean'
+        && self.crossOriginIsolated
+        && typeof SharedArrayBuffer !== 'undefined';
+}
+
 async function loadWasmModule() {
     if (wasmModuleLoaded) return;
     const mod = await import(withCacheBust('./rumoca.js'));
@@ -107,11 +113,17 @@ async function initialize() {
         await loadWasmModule();
         await init({ module_or_path: withCacheBust('./rumoca_bg.wasm') });
 
-        console.log('[Worker] Initializing thread pool...');
-        const numThreads = navigator.hardwareConcurrency || 4;
+        const requestedThreads = navigator.hardwareConcurrency || 4;
+        const numThreads = canUseSharedWasmThreads() ? requestedThreads : 0;
+        if (numThreads > 0) {
+            console.log('[Worker] Initializing thread pool...');
+        } else {
+            console.warn('[Worker] Shared WASM threads unavailable; using single-thread mode.');
+        }
         await wasm_init(numThreads);
-
-        console.log(`[Worker] Thread pool initialized with ${numThreads} threads`);
+        if (numThreads > 0) {
+            console.log(`[Worker] Thread pool initialized with ${numThreads} threads`);
+        }
         initialized = true;
         return true;
     } catch (e) {

--- a/editors/wasm/tests/node_rayon_shim.mjs
+++ b/editors/wasm/tests/node_rayon_shim.mjs
@@ -1,0 +1,30 @@
+export function ensureNodeSelfForWasmBindgenRayon() {
+  if (typeof globalThis.self === "undefined") {
+    globalThis.self = globalThis;
+  }
+
+  const target = globalThis.self;
+  if (typeof target.addEventListener === "function" && typeof target.removeEventListener === "function") {
+    return;
+  }
+
+  const messageListeners = new Set();
+  target.addEventListener = (type, listener) => {
+    if (type === "message" && typeof listener === "function") {
+      messageListeners.add(listener);
+    }
+  };
+  target.removeEventListener = (type, listener) => {
+    if (type === "message" && typeof listener === "function") {
+      messageListeners.delete(listener);
+    }
+  };
+
+  if (typeof target.postMessage !== "function") {
+    target.postMessage = (data) => {
+      for (const listener of messageListeners) {
+        listener({ data });
+      }
+    };
+  }
+}

--- a/editors/wasm/tests/simulate_smoke.mjs
+++ b/editors/wasm/tests/simulate_smoke.mjs
@@ -1,5 +1,4 @@
 import { readFile } from "node:fs/promises";
-import init, { simulate_model } from "../../../pkg/rumoca.js";
 
 const SOURCE = `
 model WasmSmoke
@@ -22,6 +21,8 @@ equation
   end when;
 end BallWasmSmoke;
 `;
+
+let simulate_model_fn = null;
 
 const ROOT_CROSS_SOURCE = `
 model RootCrossWasmSmoke
@@ -73,7 +74,7 @@ function seriesByName(parsed, name) {
 }
 
 function runLinearSmoke() {
-  const raw = simulate_model(SOURCE, "WasmSmoke", 0.2, 0.05, "auto");
+  const raw = simulate_model_fn(SOURCE, "WasmSmoke", 0.2, 0.05, "auto");
   const parsed = parseSimulationJson(raw);
 
   assert(parsed.times.length >= 2, "simulate_model: expected at least 2 time samples");
@@ -84,7 +85,7 @@ function runLinearSmoke() {
 }
 
 function runBouncingBallSmoke() {
-  const raw = simulate_model(BALL_SOURCE, "BallWasmSmoke", 1.5, 0.01, "auto");
+  const raw = simulate_model_fn(BALL_SOURCE, "BallWasmSmoke", 1.5, 0.01, "auto");
   const parsed = parseSimulationJson(raw);
   assert(
     parsed.times.length >= 20,
@@ -116,7 +117,7 @@ function runBouncingBallSmoke() {
 }
 
 function runRootCrossingSmoke() {
-  const raw = simulate_model(ROOT_CROSS_SOURCE, "RootCrossWasmSmoke", 1.0, 0.05, "auto");
+  const raw = simulate_model_fn(ROOT_CROSS_SOURCE, "RootCrossWasmSmoke", 1.0, 0.05, "auto");
   const parsed = parseSimulationJson(raw);
   const x = seriesByName(parsed, "x");
   const s = seriesByName(parsed, "s");
@@ -137,6 +138,13 @@ function runRootCrossingSmoke() {
 }
 
 async function run() {
+  if (typeof globalThis.self === "undefined") {
+    // wasm-bindgen-rayon helper modules expect `self` to exist at import time.
+    globalThis.self = new EventTarget();
+  }
+  const wasmModule = await import("../../../pkg/rumoca.js");
+  const init = wasmModule.default;
+  simulate_model_fn = wasmModule.simulate_model;
   const wasmBytes = await readFile(new URL("../../../pkg/rumoca_bg.wasm", import.meta.url));
   await init({ module_or_path: wasmBytes });
   runLinearSmoke();

--- a/editors/wasm/tests/simulate_smoke.mjs
+++ b/editors/wasm/tests/simulate_smoke.mjs
@@ -140,7 +140,8 @@ function runRootCrossingSmoke() {
 async function run() {
   if (typeof globalThis.self === "undefined") {
     // wasm-bindgen-rayon helper modules expect `self` to exist at import time.
-    globalThis.self = new EventTarget();
+    // In Node, alias it to the global object so APIs like Math stay available.
+    globalThis.self = globalThis;
   }
   const wasmModule = await import("../../../pkg/rumoca.js");
   const init = wasmModule.default;

--- a/editors/wasm/tests/simulate_smoke.mjs
+++ b/editors/wasm/tests/simulate_smoke.mjs
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { ensureNodeSelfForWasmBindgenRayon } from "./node_rayon_shim.mjs";
 
 const SOURCE = `
 model WasmSmoke
@@ -138,11 +139,7 @@ function runRootCrossingSmoke() {
 }
 
 async function run() {
-  if (typeof globalThis.self === "undefined") {
-    // wasm-bindgen-rayon helper modules expect `self` to exist at import time.
-    // In Node, alias it to the global object so APIs like Math stay available.
-    globalThis.self = globalThis;
-  }
+  ensureNodeSelfForWasmBindgenRayon();
   const wasmModule = await import("../../../pkg/rumoca.js");
   const init = wasmModule.default;
   simulate_model_fn = wasmModule.simulate_model;

--- a/editors/wasm/tests/source_root_smoke.mjs
+++ b/editors/wasm/tests/source_root_smoke.mjs
@@ -1,16 +1,17 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import init, {
-  clear_source_root_cache,
-  compile,
-  compile_with_source_roots,
-  get_source_root_document_count,
-  lsp_completion,
-  lsp_definition,
-  lsp_diagnostics,
-  lsp_hover,
-  load_source_roots,
-} from "../../../pkg/rumoca.js";
+import { ensureNodeSelfForWasmBindgenRayon } from "./node_rayon_shim.mjs";
+
+let initWasm = null;
+let clear_source_root_cache = null;
+let compile = null;
+let compile_with_source_roots = null;
+let get_source_root_document_count = null;
+let lsp_completion = null;
+let lsp_definition = null;
+let lsp_diagnostics = null;
+let lsp_hover = null;
+let load_source_roots = null;
 
 const MINI_MODELICA_SOURCE_ROOT = `
 within ;
@@ -189,8 +190,21 @@ async function runRealMslSliceSmoke() {
 }
 
 async function run() {
+  ensureNodeSelfForWasmBindgenRayon();
+  const wasmModule = await import("../../../pkg/rumoca.js");
+  initWasm = wasmModule.default;
+  clear_source_root_cache = wasmModule.clear_source_root_cache;
+  compile = wasmModule.compile;
+  compile_with_source_roots = wasmModule.compile_with_source_roots;
+  get_source_root_document_count = wasmModule.get_source_root_document_count;
+  lsp_completion = wasmModule.lsp_completion;
+  lsp_definition = wasmModule.lsp_definition;
+  lsp_diagnostics = wasmModule.lsp_diagnostics;
+  lsp_hover = wasmModule.lsp_hover;
+  load_source_roots = wasmModule.load_source_roots;
+
   const wasmBytes = await readFile(new URL("../../../pkg/rumoca_bg.wasm", import.meta.url));
-  await init({ module_or_path: wasmBytes });
+  await initWasm({ module_or_path: wasmBytes });
   runLoadSourceRootsSmoke();
   runCompileWithSourceRootsSmoke();
   runLspSmoke();

--- a/examples/templates/javascript.jinja
+++ b/examples/templates/javascript.jinja
@@ -19,9 +19,17 @@
 {%- set m_map = dae.m if dae.m is defined else {} -%}
 {%- set x_dot_alias_map = dae.x_dot_alias if dae.x_dot_alias is defined else {} -%}
 {%- set eqs = dae.f_x if dae.f_x is defined else (dae.fx if dae.fx is defined else []) -%}
-{%- set cond_eqs = dae.f_c if dae.f_c is defined else [] -%}
+{%- set relation_eqs = dae.relation if dae.relation is defined else [] -%}
+{%- set synthetic_root_conditions = dae.synthetic_root_conditions if dae.synthetic_root_conditions is defined else [] -%}
+{%- if dae.f_c is defined and dae.f_c|length > 0 -%}
+{%- set cond_eqs = dae.f_c -%}
+{%- elif relation_eqs|length > 0 -%}
+{%- set cond_eqs = relation_eqs -%}
+{%- else -%}
+{%- set cond_eqs = synthetic_root_conditions -%}
+{%- endif -%}
 {%- set when_clauses = dae.when_clauses if dae.when_clauses is defined else [] -%}
-{%- set reset_eqs = dae.f_z if dae.f_z is defined else [] -%}
+{%- set reset_eqs = (dae.f_z if dae.f_z is defined else []) + (dae.f_m if dae.f_m is defined else []) -%}
 
 {%- macro render_cref(cr) -%}
 {%- if cr.parts is defined -%}
@@ -413,6 +421,14 @@
 {%- endif -%}
 {%- endmacro -%}
 
+{%- macro condition_rhs_expr(ce) -%}
+{%- if ce is mapping and ce.rhs is defined -%}
+  {{ render_expr(ce.rhs) }}
+{%- else -%}
+  {{ render_expr(ce) }}
+{%- endif -%}
+{%- endmacro -%}
+
 function Model() {
   const __rumocaHasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 
@@ -721,7 +737,7 @@ function Model() {
 
     return [
     {%- for ce in cond_eqs %}
-      {{ render_expr(ce.rhs) }}{% if not loop.last %},{% endif %}
+      {{ condition_rhs_expr(ce) }}{% if not loop.last %},{% endif %}
     {%- endfor %}
     ];
   }
@@ -760,7 +776,7 @@ function Model() {
 
     return [
     {%- for ce in cond_eqs %}
-      {{ event_indicator_expr(ce.rhs) }}{% if not loop.last %},{% endif %}
+      {{ event_indicator_expr(ce.rhs if ce is mapping and ce.rhs is defined else ce) }}{% if not loop.last %},{% endif %}
     {%- endfor %}
     ];
   }

--- a/examples/templates/standalone_html.jinja
+++ b/examples/templates/standalone_html.jinja
@@ -309,9 +309,17 @@ return [];</textarea
 {%- set m_map = dae.m if dae.m is defined else {} -%}
 {%- set x_dot_alias_map = dae.x_dot_alias if dae.x_dot_alias is defined else {} -%}
 {%- set eqs = dae.f_x if dae.f_x is defined else (dae.fx if dae.fx is defined else []) -%}
-{%- set cond_eqs = dae.f_c if dae.f_c is defined else [] -%}
+{%- set relation_eqs = dae.relation if dae.relation is defined else [] -%}
+{%- set synthetic_root_conditions = dae.synthetic_root_conditions if dae.synthetic_root_conditions is defined else [] -%}
+{%- if dae.f_c is defined and dae.f_c|length > 0 -%}
+{%- set cond_eqs = dae.f_c -%}
+{%- elif relation_eqs|length > 0 -%}
+{%- set cond_eqs = relation_eqs -%}
+{%- else -%}
+{%- set cond_eqs = synthetic_root_conditions -%}
+{%- endif -%}
 {%- set when_clauses = dae.when_clauses if dae.when_clauses is defined else [] -%}
-{%- set reset_eqs = dae.f_z if dae.f_z is defined else [] -%}
+{%- set reset_eqs = (dae.f_z if dae.f_z is defined else []) + (dae.f_m if dae.f_m is defined else []) -%}
 
 {%- macro render_cref(cr) -%}
 {%- if cr.parts is defined -%}
@@ -703,6 +711,14 @@ return [];</textarea
 {%- endif -%}
 {%- endmacro -%}
 
+{%- macro condition_rhs_expr(ce) -%}
+{%- if ce is mapping and ce.rhs is defined -%}
+  {{ render_expr(ce.rhs) }}
+{%- else -%}
+  {{ render_expr(ce) }}
+{%- endif -%}
+{%- endmacro -%}
+
 function Model() {
   const __rumocaHasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 
@@ -1011,7 +1027,7 @@ function Model() {
 
     return [
     {%- for ce in cond_eqs %}
-      {{ render_expr(ce.rhs) }}{% if not loop.last %},{% endif %}
+      {{ condition_rhs_expr(ce) }}{% if not loop.last %},{% endif %}
     {%- endfor %}
     ];
   }
@@ -1050,7 +1066,7 @@ function Model() {
 
     return [
     {%- for ce in cond_eqs %}
-      {{ event_indicator_expr(ce.rhs) }}{% if not loop.last %},{% endif %}
+      {{ event_indicator_expr(ce.rhs if ce is mapping and ce.rhs is defined else ce) }}{% if not loop.last %},{% endif %}
     {%- endfor %}
     ];
   }


### PR DESCRIPTION
- a0670b5: Added richer symbolic DAE JSON metadata (for solver form
    selection), expanded regression coverage, and updated wasm bindgen/
    template outputs (javascript.jinja, standalone_html.jinja) plus related
    sim/dev/LSP wiring.
- d433d94: Refactored wasm + dev tooling for test/lint stability,
    including extraction into simulation_api.rs and static_server.rs, with
    corresponding test command updates.
- bd10a07: Continued test-fix refactor by moving stepper logic from
    lib.rs into stepper_api.rs, and updated wasm worker/smoke test
    behavior.
- 3f05503: Small follow-up correctness fixes in wasm bindings, verify
    command handling, and smoke tests.
- 1ad9338: Fixed wasm test/runtime issues caused by enabling Rayon by
    adding a Node Rayon shim and adjusting wasm smoke/source-root tests.
