### PR TITLE
fix(sim/prepare): demote orphan states after post-structure elimination

### DIFF
--- a/crates/rumoca-sim/src/with_diffsol/prepare.rs
+++ b/crates/rumoca-sim/src/with_diffsol/prepare.rs
@@ -1101,6 +1101,67 @@ fn normalize_runtime_aliases_and_update_elim(
     }
 }
 
+// Final orphan-state cleanup. `normalize_runtime_aliases` and the
+// post-structure trivial-elim pass can both *remove equations* that
+// earlier demote phases (phase1h2, phase1h3, phase1h5 inside
+// `run_prepare_structure_passes`) depended on to keep a state live.
+//
+// Concrete repro: `Modelica.Mechanics.Rotational.Components.Damper`
+// declares both `phi_rel` and `w_rel` as preferred states
+// (`stateSelect=prefer`), with `w_rel = der(phi_rel)` and
+// `a_rel = der(w_rel)`. `a_rel` is unused at the leaf model, so
+// post-structure elimination drops `a_rel = der(w_rel)`. That leaves
+// `w_rel` in `dae.states` with zero equations containing `der(w_rel)`
+// → reorder fails with `MissingStateEquation("damper.w_rel")` and
+// every `Modelica.Mechanics.Rotational.*` example fails to compile.
+//
+// The cheap fix: re-run the same two demotion helpers that
+// `phase1h2`/`phase1h3` already use, but AFTER the post-structure
+// elimination, so anything whose derivative-row was just removed
+// gets demoted to algebraic before reorder sees it.
+fn run_final_orphan_state_cleanup(
+    dae: &mut Dae,
+    budget: &TimeoutBudget,
+    trace: bool,
+) -> Result<(), SimError> {
+    let mut n_final_no_der = 0usize;
+    run_logged_phase(
+        trace,
+        "demote_states_without_derivative_refs(phase1j-final)",
+        || {
+            run_timeout_step(budget, || {
+                n_final_no_der = demote_states_without_derivative_refs(dae);
+            })
+        },
+    )?;
+    if n_final_no_der > 0 {
+        eprintln!(
+            "[prepare_dae] final pass: demoted {} states whose derivative rows \
+             were removed by post-structure elimination",
+            n_final_no_der
+        );
+    }
+
+    let mut n_final_unassignable = 0usize;
+    run_logged_phase(
+        trace,
+        "demote_states_without_assignable_derivative_rows(phase1k-final)",
+        || {
+            run_timeout_step(budget, || {
+                n_final_unassignable = demote_states_without_assignable_derivative_rows(dae);
+            })
+        },
+    )?;
+    if n_final_unassignable > 0 {
+        eprintln!(
+            "[prepare_dae] final pass: re-demoted {} states without assignable \
+             derivative rows after post-structure elimination",
+            n_final_unassignable
+        );
+    }
+    Ok(())
+}
+
 /// Core DAE preparation pipeline shared by both simulation and template codegen.
 ///
 /// Runs all structural passes (elimination, scalarization, equation reordering,
@@ -1178,61 +1239,7 @@ fn prepare_dae_core(
     run_post_structure_elimination_phase(&mut dae, trace, disable_trivial_elim, &mut elim);
     budget.check()?;
 
-    // Final orphan-state cleanup. `normalize_runtime_aliases` and the
-    // post-structure trivial-elim pass above can both *remove
-    // equations* that earlier demote phases (phase1h2, phase1h3,
-    // phase1h5 inside `run_prepare_structure_passes`) depended on to
-    // keep a state live.
-    //
-    // Concrete repro: `Modelica.Mechanics.Rotational.Components.Damper`
-    // declares both `phi_rel` and `w_rel` as preferred states
-    // (`stateSelect=prefer`), with `w_rel = der(phi_rel)` and
-    // `a_rel = der(w_rel)`. `a_rel` is unused at the leaf model, so
-    // post-structure elimination drops `a_rel = der(w_rel)`. That
-    // leaves `w_rel` in `dae.states` with zero equations containing
-    // `der(w_rel)` → reorder fails with
-    // `MissingStateEquation("damper.w_rel")` and every
-    // `Modelica.Mechanics.Rotational.*` example fails to compile.
-    //
-    // The cheap fix: re-run the same two demotion helpers that
-    // `phase1h2`/`phase1h3` already use, but AFTER the post-structure
-    // elimination, so anything whose derivative-row was just removed
-    // gets demoted to algebraic before reorder sees it.
-    let mut n_final_no_der = 0usize;
-    run_logged_phase(
-        trace,
-        "demote_states_without_derivative_refs(phase1j-final)",
-        || {
-            run_timeout_step(budget, || {
-                n_final_no_der = demote_states_without_derivative_refs(&mut dae);
-            })
-        },
-    )?;
-    if n_final_no_der > 0 {
-        eprintln!(
-            "[prepare_dae] final pass: demoted {} states whose derivative rows \
-             were removed by post-structure elimination",
-            n_final_no_der
-        );
-    }
-
-    let mut n_final_unassignable = 0usize;
-    run_logged_phase(
-        trace,
-        "demote_states_without_assignable_derivative_rows(phase1k-final)",
-        || {
-            run_timeout_step(budget, || {
-                n_final_unassignable = demote_states_without_assignable_derivative_rows(&mut dae);
-            })
-        },
-    )?;
-    if n_final_unassignable > 0 {
-        eprintln!(
-            "[prepare_dae] final pass: re-demoted {} states without assignable \
-             derivative rows after post-structure elimination",
-            n_final_unassignable
-        );
-    }
+    run_final_orphan_state_cleanup(&mut dae, budget, trace)?;
 
     debug_print_prepare_counts(&dae);
     let has_dummy = dae.states.values().map(|v| v.size()).sum::<usize>() == 0;

--- a/crates/rumoca-sim/src/with_diffsol/prepare.rs
+++ b/crates/rumoca-sim/src/with_diffsol/prepare.rs
@@ -1222,8 +1222,7 @@ fn prepare_dae_core(
         "demote_states_without_assignable_derivative_rows(phase1k-final)",
         || {
             run_timeout_step(budget, || {
-                n_final_unassignable =
-                    demote_states_without_assignable_derivative_rows(&mut dae);
+                n_final_unassignable = demote_states_without_assignable_derivative_rows(&mut dae);
             })
         },
     )?;

--- a/crates/rumoca-sim/src/with_diffsol/prepare.rs
+++ b/crates/rumoca-sim/src/with_diffsol/prepare.rs
@@ -1178,6 +1178,63 @@ fn prepare_dae_core(
     run_post_structure_elimination_phase(&mut dae, trace, disable_trivial_elim, &mut elim);
     budget.check()?;
 
+    // Final orphan-state cleanup. `normalize_runtime_aliases` and the
+    // post-structure trivial-elim pass above can both *remove
+    // equations* that earlier demote phases (phase1h2, phase1h3,
+    // phase1h5 inside `run_prepare_structure_passes`) depended on to
+    // keep a state live.
+    //
+    // Concrete repro: `Modelica.Mechanics.Rotational.Components.Damper`
+    // declares both `phi_rel` and `w_rel` as preferred states
+    // (`stateSelect=prefer`), with `w_rel = der(phi_rel)` and
+    // `a_rel = der(w_rel)`. `a_rel` is unused at the leaf model, so
+    // post-structure elimination drops `a_rel = der(w_rel)`. That
+    // leaves `w_rel` in `dae.states` with zero equations containing
+    // `der(w_rel)` → reorder fails with
+    // `MissingStateEquation("damper.w_rel")` and every
+    // `Modelica.Mechanics.Rotational.*` example fails to compile.
+    //
+    // The cheap fix: re-run the same two demotion helpers that
+    // `phase1h2`/`phase1h3` already use, but AFTER the post-structure
+    // elimination, so anything whose derivative-row was just removed
+    // gets demoted to algebraic before reorder sees it.
+    let mut n_final_no_der = 0usize;
+    run_logged_phase(
+        trace,
+        "demote_states_without_derivative_refs(phase1j-final)",
+        || {
+            run_timeout_step(budget, || {
+                n_final_no_der = demote_states_without_derivative_refs(&mut dae);
+            })
+        },
+    )?;
+    if n_final_no_der > 0 {
+        eprintln!(
+            "[prepare_dae] final pass: demoted {} states whose derivative rows \
+             were removed by post-structure elimination",
+            n_final_no_der
+        );
+    }
+
+    let mut n_final_unassignable = 0usize;
+    run_logged_phase(
+        trace,
+        "demote_states_without_assignable_derivative_rows(phase1k-final)",
+        || {
+            run_timeout_step(budget, || {
+                n_final_unassignable =
+                    demote_states_without_assignable_derivative_rows(&mut dae);
+            })
+        },
+    )?;
+    if n_final_unassignable > 0 {
+        eprintln!(
+            "[prepare_dae] final pass: re-demoted {} states without assignable \
+             derivative rows after post-structure elimination",
+            n_final_unassignable
+        );
+    }
+
     debug_print_prepare_counts(&dae);
     let has_dummy = dae.states.values().map(|v| v.size()).sum::<usize>() == 0;
     if has_dummy {


### PR DESCRIPTION
`run_prepare_structure_passes` demotes states whose derivative rows are missing (phase1h2/1h3/1h5), but then `normalize_runtime_aliases` and `run_post_structure_elimination_phase` can still remove equations that earlier demotion depended on. Nothing re-ran demotion after that, so orphan states slipped through to `reorder_equations_for_solver`, which raised `MissingStateEquation`.

Concrete repro: `Modelica.Mechanics.Rotational.Components.Damper` declares both `phi_rel` and `w_rel` as preferred states (`stateSelect=prefer`) via `PartialCompliantWithRelativeStates`, with `w_rel = der(phi_rel)` and `a_rel = der(w_rel)`. `a_rel` is unused at the leaf model, so post-structure elimination drops `a_rel = der(w_rel)`. That leaves `w_rel` in `dae.states` with zero equations containing `der(w_rel)`, and reorder fails with `MissingStateEquation("damper.w_rel")`. Every
`Modelica.Mechanics.Rotational.*` example — `First`, `PID_Controller`, etc. — fails to compile because of this.

Fix: re-run the two existing demotion helpers
(`demote_states_without_derivative_refs` and
`demote_states_without_assignable_derivative_rows`) as a final pass immediately before reorder. Anything whose derivative row was just removed by post-structure elimination gets demoted to algebraic before reorder sees it.

Verified against `Modelica.Mechanics.Rotational.Examples.First`: the final pass reports `demoted 1 states whose derivative rows were removed by post-structure elimination` and the stepper now builds.

# Rumoca PR Review Template

## Summary

- PID_Controller Example was not compiling before the commit. After - compiles.

## Code Size Budget (required)

- production_lines_added: 57
- production_lines_deleted: 0
- test_lines_added: 
- test_lines_deleted:
- public_items_added:
- public_items_removed:
- files_touched: 1
- net_added_lines: 57

If `net_added_lines` is positive, add:

- To make Modelica Examples work. 

## Design Notes

- Why each new abstraction was necessary.
- Why this was not solved by editing an existing module directly.
- What duplicate/legacy paths were deleted.

## Testing

File for test:

`// Repro for rumoca bug: 'MissingStateEquation("damper.w_rel")'.
//
// The MSL 'PartialCompliantWithRelativeStates' (used by every
// Rotational.Components.Spring / Damper / SpringDamper) declares both
// 'phi_rel' and 'w_rel' as preferred states with equations:
//
//     w_rel = der(phi_rel);
//     a_rel = der(w_rel);    // a_rel typically unused
//
// When 'a_rel' has no downstream consumer, rumoca's post-structure
// trivial-elim pass removes that equation. State 'w_rel' is left in
// 'dae.states' with zero equations defining 'der(w_rel)', so
// 'reorder_equations_for_solver' raises 'MissingStateEquation'.
//
// Every 'Modelica.Mechanics.Rotational.*' example (First,
// PID_Controller, …) hits this.
//


model SpringDamperReproCopy "Drive train exercising the compliant-states DAE path"
  parameter Real amplitude = 10 "Driving torque amplitude";
  parameter Real f = 5 "Driving torque frequency";
  parameter Real Jmotor = 0.1 "Motor inertia";
  parameter Real Jload = 2 "Load inertia";
  parameter Real damping = 10 "Bearing damping (triggers damper.w_rel state)";

  Modelica.Mechanics.Rotational.Components.Fixed fixed annotation(Placement(transformation(extent={{60,-20},{80,0}})));
  Modelica.Mechanics.Rotational.Sources.Torque torque(useSupport = true) annotation(Placement(transformation(extent={{150,-80},{170,-60}})));
  Modelica.Mechanics.Rotational.Components.Inertia inertia1(J = Jmotor) annotation(Placement(transformation(extent={{115,-15},{135,5}})));
  Modelica.Mechanics.Rotational.Components.Inertia inertia2(
    J = Jload,
    phi(fixed = true, start = 0),
    w(fixed = true, start = 0)) annotation(Placement(transformation(extent={{180,-20},{200,0}})));
  Modelica.Mechanics.Rotational.Components.Spring spring(
    c = 1.0e4,
    phi_rel(fixed = true)) annotation(Placement(transformation(extent={{90,-80},{110,-60}})));
  Modelica.Mechanics.Rotational.Components.Damper damper(d = damping) annotation(Placement(transformation(extent={{0,-20},{20,0}})));
  Modelica.Blocks.Sources.Sine sine(amplitude = amplitude, f = f) annotation(Placement(transformation(extent={{30,-80},{50,-60}})));
equation
  connect(sine.y, torque.tau);
  connect(torque.support, fixed.flange);
  connect(torque.flange, inertia1.flange_a);
  connect(inertia1.flange_b, spring.flange_a);
  connect(spring.flange_b, inertia2.flange_a);
  connect(damper.flange_a, inertia1.flange_b);
  connect(damper.flange_b, fixed.flange);
  annotation(experiment(StopTime = 1.0, Interval = 0.001));
end SpringDamperReproCopy;`

## Reviewer Checklist

- [ ] Size budget section completed.
- [ ] Positive net diff has explicit compression justification.
- [ ] New APIs are required and minimal.
- [ ] Old/new parallel paths were removed unless explicitly migrating.
