### PR TITLE
fix(typecheck,compile): allow deferred parameter [:] dims and speed u…

### DIFF
--- a/crates/rumoca-bind-wasm/src/lib.rs
+++ b/crates/rumoca-bind-wasm/src/lib.rs
@@ -29,7 +29,8 @@ use rumoca_compile::Session;
 use rumoca_compile::codegen::render_dae_template_with_json;
 use rumoca_compile::codegen::templates as runtime_templates;
 use rumoca_compile::compile::{
-    CompilationMode, CompilationResult, FailedPhase, PhaseResult, session_cache_stats,
+    CompilationMode, CompilationResult, CompilePhaseTimingSnapshot, FailedPhase, PhaseResult,
+    compile_phase_timing_stats, reset_compile_phase_timing_stats, session_cache_stats,
 };
 use rumoca_compile::parsing::ir_core as rumoca_ir_core;
 use rumoca_compile::parsing::{
@@ -83,22 +84,22 @@ type WTimingStart = f64;
 type WTimingStart = std::time::Instant;
 
 #[cfg(target_arch = "wasm32")]
-fn wasm_timing_start() -> WTimingStart {
+pub(crate) fn wasm_timing_start() -> WTimingStart {
     Date::now()
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn wasm_timing_start() -> WTimingStart {
+pub(crate) fn wasm_timing_start() -> WTimingStart {
     std::time::Instant::now()
 }
 
 #[cfg(target_arch = "wasm32")]
-fn wasm_elapsed_ms(start: WTimingStart) -> u64 {
+pub(crate) fn wasm_elapsed_ms(start: WTimingStart) -> u64 {
     (Date::now() - start).max(0.0).round() as u64
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn wasm_elapsed_ms(start: WTimingStart) -> u64 {
+pub(crate) fn wasm_elapsed_ms(start: WTimingStart) -> u64 {
     start.elapsed().as_millis() as u64
 }
 
@@ -432,7 +433,26 @@ fn attach_build_metadata(payload: &mut Value) {
 }
 
 /// Build a rich compile response with DAE, balance info, and pretty output.
-fn build_compile_response(result: &CompilationResult) -> Result<String, JsValue> {
+fn compile_timing_snapshot_to_json(snapshot: CompilePhaseTimingSnapshot) -> Value {
+    let stat = |calls: u64, total_nanos: u64| {
+        serde_json::json!({
+            "calls": calls,
+            "total_nanos": total_nanos,
+            "total_ms": (total_nanos as f64) / 1_000_000.0,
+        })
+    };
+    serde_json::json!({
+        "instantiate": stat(snapshot.instantiate.calls, snapshot.instantiate.total_nanos),
+        "typecheck": stat(snapshot.typecheck.calls, snapshot.typecheck.total_nanos),
+        "flatten": stat(snapshot.flatten.calls, snapshot.flatten.total_nanos),
+        "todae": stat(snapshot.todae.calls, snapshot.todae.total_nanos),
+    })
+}
+
+fn build_compile_response(
+    result: &CompilationResult,
+    compile_phase_timing: CompilePhaseTimingSnapshot,
+) -> Result<String, JsValue> {
     let dae = &result.dae;
     let mut dae_native_json =
         serde_json::to_value(dae).map_err(|e| JsValue::from_str(&format!("JSON error: {}", e)))?;
@@ -458,6 +478,7 @@ fn build_compile_response(result: &CompilationResult) -> Result<String, JsValue>
         "dae_native": dae_native_json,
         "balance": balance,
         "pretty": pretty,
+        "__compile_phase_timing": compile_timing_snapshot_to_json(compile_phase_timing),
     });
 
     serde_json::to_string(&response).map_err(|e| JsValue::from_str(&format!("JSON error: {}", e)))
@@ -542,10 +563,12 @@ fn compile_source_in_session(
     source: &str,
     model_name: &str,
 ) -> Result<String, JsValue> {
+    reset_compile_phase_timing_stats();
     session.update_document("input.mo", source);
     let requested_model = qualify_input_model_name(session, model_name);
     let result = compile_requested_model(session, &requested_model)?;
-    build_compile_response(&result)
+    let timing = compile_phase_timing_stats();
+    build_compile_response(&result, timing)
 }
 
 /// Compile Modelica source code to DAE JSON.

--- a/crates/rumoca-bind-wasm/src/source_root_api.rs
+++ b/crates/rumoca-bind-wasm/src/source_root_api.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use wasm_bindgen::prelude::*;
 
 use rumoca_compile::Session;
-use rumoca_compile::compile::SourceRootKind;
+use rumoca_compile::compile::{
+    SourceRootKind, compile_phase_timing_stats, reset_compile_phase_timing_stats,
+};
 use rumoca_compile::parsing::{StoredDefinition, parse_source_to_ast};
 #[cfg(not(target_arch = "wasm32"))]
 use rumoca_compile::source_roots::resolve_source_root_cache_dir;
@@ -12,7 +14,7 @@ use rumoca_compile::source_roots::resolve_source_root_cache_dir;
 use super::{
     BUNDLED_SOURCE_ROOT_CACHE_BYTES, BUNDLED_SOURCE_ROOT_MANIFEST_JSON, BundledSourceRootManifest,
     SESSION, WASM_BUNDLED_SOURCE_ROOT_SET_ID, WASM_PROJECT_SOURCE_SET_ID,
-    compile_source_in_session,
+    compile_source_in_session, wasm_elapsed_ms, wasm_timing_start,
 };
 
 #[derive(Default)]
@@ -255,15 +257,70 @@ pub fn compile_check_with_source_roots(
     source_roots_json: &str,
 ) -> Result<String, JsValue> {
     super::with_singleton_session(|session| {
+        let total_started = wasm_timing_start();
+
+        let load_started = wasm_timing_start();
         load_source_root_sources_in_session(session, source_roots_json)?;
+        let load_ms = wasm_elapsed_ms(load_started);
+
+        reset_compile_phase_timing_stats();
+
+        let update_started = wasm_timing_start();
         session.update_document("input.mo", source);
+        let update_ms = wasm_elapsed_ms(update_started);
+
+        let qualify_started = wasm_timing_start();
         let requested_model = super::qualify_input_model_name(session, model_name);
-        session
-            .check_model_strict_requested_only(&requested_model)
+        let qualify_ms = wasm_elapsed_ms(qualify_started);
+
+        let check_started = wasm_timing_start();
+        let strict_timing = session
+            .check_model_strict_requested_only_with_timing(&requested_model)
             .map_err(|message| JsValue::from_str(&message))?;
+        let check_ms = wasm_elapsed_ms(check_started);
+        let total_ms = wasm_elapsed_ms(total_started);
+
+        let timing = compile_phase_timing_stats();
         Ok(serde_json::json!({
             "status": "compiled",
             "model_name": requested_model,
+            "__compile_check_timing": {
+                "load_source_roots_ms": load_ms,
+                "update_document_ms": update_ms,
+                "qualify_model_ms": qualify_ms,
+                "check_model_ms": check_ms,
+                "total_ms": total_ms,
+                "strict": {
+                    "build_resolved_ms": strict_timing.build_resolved_ms,
+                    "reachable_closure_ms": strict_timing.reachable_closure_ms,
+                    "collect_parse_failures_ms": strict_timing.collect_parse_failures_ms,
+                    "collect_resolve_failures_ms": strict_timing.collect_resolve_failures_ms,
+                    "dae_phase_query_ms": strict_timing.dae_phase_query_ms,
+                    "total_ms": strict_timing.total_ms,
+                }
+            },
+            "__compile_phase_timing": {
+                "instantiate": {
+                    "calls": timing.instantiate.calls,
+                    "total_nanos": timing.instantiate.total_nanos,
+                    "total_ms": (timing.instantiate.total_nanos as f64) / 1_000_000.0,
+                },
+                "typecheck": {
+                    "calls": timing.typecheck.calls,
+                    "total_nanos": timing.typecheck.total_nanos,
+                    "total_ms": (timing.typecheck.total_nanos as f64) / 1_000_000.0,
+                },
+                "flatten": {
+                    "calls": timing.flatten.calls,
+                    "total_nanos": timing.flatten.total_nanos,
+                    "total_ms": (timing.flatten.total_nanos as f64) / 1_000_000.0,
+                },
+                "todae": {
+                    "calls": timing.todae.calls,
+                    "total_nanos": timing.todae.total_nanos,
+                    "total_ms": (timing.todae.total_nanos as f64) / 1_000_000.0,
+                },
+            }
         })
         .to_string())
     })

--- a/crates/rumoca-bind-wasm/src/tests.rs
+++ b/crates/rumoca-bind-wasm/src/tests.rs
@@ -458,10 +458,20 @@ fn test_compile_to_json_matches_compile_wrapper_output() {
 
     let compiled = compile(source, "Ball").expect("compile should succeed");
     let compiled_to_json = compile_to_json(source, "Ball").expect("compile_to_json should succeed");
-    let compiled_value: serde_json::Value =
+    let mut compiled_value: serde_json::Value =
         serde_json::from_str(&compiled).expect("compile should return valid JSON");
-    let compiled_to_json_value: serde_json::Value =
+    let mut compiled_to_json_value: serde_json::Value =
         serde_json::from_str(&compiled_to_json).expect("compile_to_json should return valid JSON");
+
+    // Timing metadata is intentionally non-semantic and can vary by call path.
+    // Keep strict alias comparison for all other fields.
+    for value in [&mut compiled_value, &mut compiled_to_json_value] {
+        if let Some(object) = value.as_object_mut() {
+            object.remove("__compile_phase_timing");
+            object.remove("__compile_check_timing");
+        }
+    }
+
     assert_eq!(
         compiled_value, compiled_to_json_value,
         "compile_to_json should remain an exact alias of compile"

--- a/crates/rumoca-compile/src/lib.rs
+++ b/crates/rumoca-compile/src/lib.rs
@@ -139,9 +139,9 @@ pub mod compile {
         ParsedSourceRootLoad, PhaseResult, SemanticDiagnosticsMode, Session, SessionChange,
         SessionConfig, SessionSnapshot, SourceRootActivityKind, SourceRootActivityPhase,
         SourceRootActivitySnapshot, SourceRootDurability, SourceRootKind, SourceRootLoadMode,
-        SourceRootLoadReport, SourceRootStatusSnapshot, StrictCompileReport, WorkspaceSymbol,
-        WorkspaceSymbolKind, WorkspaceSymbolSnapshotTiming, compile_phase_timing_stats,
-        reset_compile_phase_timing_stats,
+        SourceRootLoadReport, SourceRootStatusSnapshot, StrictCheckTiming, StrictCompileReport,
+        WorkspaceSymbol, WorkspaceSymbolKind, WorkspaceSymbolSnapshotTiming,
+        compile_phase_timing_stats, reset_compile_phase_timing_stats,
     };
 }
 

--- a/crates/rumoca-compile/src/session.rs
+++ b/crates/rumoca-compile/src/session.rs
@@ -1635,6 +1635,17 @@ pub struct StrictCompileReport {
     pub source_map: Option<SourceMap>,
 }
 
+/// Coarse timing breakdown for strict requested-only model checks.
+#[derive(Debug, Clone, Default)]
+pub struct StrictCheckTiming {
+    pub build_resolved_ms: u64,
+    pub reachable_closure_ms: u64,
+    pub collect_parse_failures_ms: u64,
+    pub collect_resolve_failures_ms: u64,
+    pub dae_phase_query_ms: u64,
+    pub total_ms: u64,
+}
+
 impl StrictCompileReport {
     /// Returns true when strict compile succeeded for the requested closure.
     pub fn requested_succeeded(&self) -> bool {

--- a/crates/rumoca-compile/src/session/session_impl.rs
+++ b/crates/rumoca-compile/src/session/session_impl.rs
@@ -1029,6 +1029,19 @@ impl Session {
     /// This avoids expensive DAE/flat deep clones in memory-constrained wasm
     /// surfaces while preserving strict-recovery diagnostics.
     pub fn check_model_strict_requested_only(&mut self, model_name: &str) -> Result<(), String> {
+        self.check_model_strict_requested_only_with_timing(model_name)
+            .map(|_| ())
+    }
+
+    /// Same as `check_model_strict_requested_only`, but returns coarse timing
+    /// stats to help diagnose strict-check latency hotspots.
+    pub fn check_model_strict_requested_only_with_timing(
+        &mut self,
+        model_name: &str,
+    ) -> Result<StrictCheckTiming, String> {
+        let total_started = maybe_start_timer();
+
+        let build_resolved_started = maybe_start_timer();
         let (resolved, resolve_diags) = self
             .build_resolved_for_strict_compile_with_diagnostics()
             .map_err(|diags| {
@@ -1045,24 +1058,39 @@ impl Session {
             let requested = requested_missing_result_message(model_name, &failures);
             format_strict_failure_summary(model_name, requested, &failures, 8)
         })?;
+        let build_resolved_ms = maybe_elapsed_duration(build_resolved_started)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
 
         let tree = &resolved.0;
+        let closure_started = maybe_start_timer();
         let closure = self.reachable_model_closure_query(
             tree,
             ResolveBuildMode::StrictCompileRecovery,
             model_name,
         );
+        let reachable_closure_ms = maybe_elapsed_duration(closure_started)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
         let target_source_files = collect_target_source_files(tree, &closure.reachable_classes);
+        let parse_failures_started = maybe_start_timer();
         let mut failures = collect_parse_failures_for_files(
             &self.documents,
             &tree.source_map,
             &target_source_files,
         );
+        let collect_parse_failures_ms = maybe_elapsed_duration(parse_failures_started)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let resolve_failures_started = maybe_start_timer();
         let resolve_failures = collect_resolve_failures_for_files(
             &resolve_diags,
             &tree.source_map,
             &target_source_files,
         );
+        let collect_resolve_failures_ms = maybe_elapsed_duration(resolve_failures_started)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
         let target_has_resolve_failures = !resolve_failures.is_empty();
         failures.extend(resolve_failures);
         if target_has_resolve_failures {
@@ -1072,8 +1100,12 @@ impl Session {
             ));
         }
 
+        let dae_query_started = maybe_start_timer();
         let requested_result =
             self.dae_phase_result_query(tree, ResolveBuildMode::StrictCompileRecovery, model_name);
+        let dae_phase_query_ms = maybe_elapsed_duration(dae_query_started)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
         let requested = dae_phase_result_requested_message(model_name, &requested_result);
         if let Some(failure) = dae_phase_result_to_failure(tree, model_name, &requested_result) {
             failures.push(failure);
@@ -1084,7 +1116,17 @@ impl Session {
             ));
         }
 
-        Ok(())
+        let total_ms = maybe_elapsed_duration(total_started)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        Ok(StrictCheckTiming {
+            build_resolved_ms,
+            reachable_closure_ms,
+            collect_parse_failures_ms,
+            collect_resolve_failures_ms,
+            dae_phase_query_ms,
+            total_ms,
+        })
     }
 
     /// Compile the requested model using strict-reachable semantics with

--- a/crates/rumoca-compile/src/session/strict_compile_diagnostics.rs
+++ b/crates/rumoca-compile/src/session/strict_compile_diagnostics.rs
@@ -5,7 +5,10 @@ use rumoca_core::{
     SourceId, SourceMap, Span,
 };
 use rumoca_ir_ast as ast;
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::{Mutex, OnceLock};
 
 pub(super) fn phase_result_to_failure(
     tree: &ast::ClassTree,
@@ -329,8 +332,29 @@ fn leading_non_whitespace_span(source_id: SourceId, content: &str) -> Span {
 }
 
 pub(super) fn same_path(left: &str, right: &str) -> bool {
-    let left_key = std::fs::canonicalize(left).unwrap_or_else(|_| std::path::PathBuf::from(left));
-    let right_key =
-        std::fs::canonicalize(right).unwrap_or_else(|_| std::path::PathBuf::from(right));
+    if left == right {
+        return true;
+    }
+    let left_key = canonicalized_path_key(left);
+    let right_key = canonicalized_path_key(right);
     left_key == right_key
+}
+
+fn canonicalized_path_key(path: &str) -> PathBuf {
+    static CANON_CACHE: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
+    let cache = CANON_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Ok(guard) = cache.lock()
+        && let Some(cached) = guard.get(path)
+    {
+        return cached.clone();
+    }
+
+    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path));
+
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(path.to_string(), resolved.clone());
+    }
+
+    resolved
 }

--- a/crates/rumoca-phase-dae/src/runtime_precompute/clock.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/clock.rs
@@ -2,11 +2,32 @@ use super::ToDaeError;
 use super::{eval_scalar_const_expr, extract_time_event_instant};
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write as _;
 
 use rumoca_ir_dae as dae;
 use rumoca_ir_dae::{ExpressionVisitor, ImplicitSampleChecker, VarRefWithSubscriptsCollector};
 
-type SourceMap<'a> = HashMap<String, Vec<&'a dae::Expression>>;
+struct SourceMap<'a> {
+    forward: HashMap<String, Vec<&'a dae::Expression>>,
+    reverse_alias: HashMap<String, Vec<String>>,
+}
+
+impl<'a> SourceMap<'a> {
+    fn new(forward: HashMap<String, Vec<&'a dae::Expression>>) -> Self {
+        Self {
+            forward,
+            reverse_alias: HashMap::new(),
+        }
+    }
+
+    fn get(&self, key: &str) -> Option<&Vec<&'a dae::Expression>> {
+        self.forward.get(key)
+    }
+
+    fn reverse_targets_for(&self, key: &str) -> Option<&Vec<String>> {
+        self.reverse_alias.get(key)
+    }
+}
 type ClockRuntimeMetadata = (
     Vec<dae::Expression>,
     Vec<dae::ClockSchedule>,
@@ -604,14 +625,20 @@ pub(super) fn canonical_var_ref_key(
     let mut key = name.as_str().to_string();
     for subscript in subscripts {
         match subscript {
-            dae::Subscript::Index(index) => key.push_str(&format!("[{index}]")),
+            dae::Subscript::Index(index) => {
+                key.push('[');
+                let _ = write!(&mut key, "{index}");
+                key.push(']');
+            }
             dae::Subscript::Expr(expr) => {
                 let raw = eval_scalar_const_expr(expr, constants)?;
                 let rounded = raw.round();
                 if !rounded.is_finite() {
                     return None;
                 }
-                key.push_str(&format!("[{}]", rounded as i64));
+                key.push('[');
+                let _ = write!(&mut key, "{}", rounded as i64);
+                key.push(']');
             }
             dae::Subscript::Colon => return None,
         }
@@ -686,20 +713,51 @@ fn build_clock_source_map<'a>(
     dae_model: &'a dae::Dae,
     constants: &HashMap<String, f64>,
 ) -> SourceMap<'a> {
-    let mut sources = HashMap::new();
+    let mut forward = HashMap::new();
+    let mut assignment_sources = Vec::new();
     for eq in dae_model
         .f_z
         .iter()
         .chain(dae_model.f_m.iter())
         .chain(dae_model.f_x.iter())
     {
-        let mut assignment_sources = Vec::new();
+        assignment_sources.clear();
         collect_assignment_sources(eq, constants, &mut assignment_sources);
-        for (target, source) in assignment_sources {
-            sources.entry(target).or_insert_with(Vec::new).push(source);
+        for (target, source) in assignment_sources.iter() {
+            forward
+                .entry(target.clone())
+                .or_insert_with(Vec::new)
+                .push(*source);
         }
     }
+    let mut sources = SourceMap::new(forward);
+    sources.reverse_alias = build_reverse_alias_index(&sources.forward, constants);
     sources
+}
+
+fn build_reverse_alias_index(
+    forward: &HashMap<String, Vec<&dae::Expression>>,
+    constants: &HashMap<String, f64>,
+) -> HashMap<String, Vec<String>> {
+    let mut reverse = HashMap::new();
+    for (target, source_exprs) in forward {
+        if target.contains('[') {
+            continue;
+        }
+        for expr in source_exprs {
+            let dae::Expression::VarRef { name, subscripts } = expr else {
+                continue;
+            };
+            let Some(source_key) = canonical_var_ref_key(name, subscripts, constants) else {
+                continue;
+            };
+            let targets = reverse.entry(source_key).or_insert_with(Vec::new);
+            if !targets.iter().any(|existing| existing == target) {
+                targets.push(target.clone());
+            }
+        }
+    }
+    reverse
 }
 
 fn infer_clock_intervals_by_variable(
@@ -709,14 +767,12 @@ fn infer_clock_intervals_by_variable(
 ) -> IndexMap<String, f64> {
     let sources = build_clock_source_map(dae_model, constants);
     let mut intervals = IndexMap::new();
+    let mut visiting = HashSet::new();
 
     for name in clock_interval_candidate_names(dae_model) {
-        let expr = dae::Expression::VarRef {
-            name: name.clone(),
-            subscripts: Vec::new(),
-        };
+        visiting.clear();
         if let Some((period, _phase)) =
-            infer_clock_timing_from_expr(&expr, constants, &sources, 24, &mut HashSet::new())
+            infer_clock_timing_from_var_ref(name, &[], constants, &sources, 24, &mut visiting)
             && period.is_finite()
             && period > 0.0
         {
@@ -1109,20 +1165,7 @@ fn infer_clock_timing_from_reverse_alias_sources(
     remaining_depth: usize,
     visiting: &mut HashSet<String>,
 ) -> Option<(f64, f64)> {
-    sources.iter().find_map(|(target, source_exprs)| {
-        if target.contains('[') {
-            return None;
-        }
-        let alias_hit = source_exprs.iter().any(|expr| {
-            if let dae::Expression::VarRef { name, subscripts } = expr {
-                canonical_var_ref_key(name, subscripts, constants).as_deref() == Some(key)
-            } else {
-                false
-            }
-        });
-        if !alias_hit {
-            return None;
-        }
+    sources.reverse_targets_for(key)?.iter().find_map(|target| {
         infer_clock_timing_next(
             &dae::Expression::VarRef {
                 name: dae::VarName::new(target.as_str()),

--- a/crates/rumoca-phase-typecheck/src/tests.rs
+++ b/crates/rumoca-phase-typecheck/src/tests.rs
@@ -260,6 +260,32 @@ fn test_colon_dimension_inference() {
 }
 
 #[test]
+fn test_parameter_colon_dimension_without_binding_is_allowed() {
+    // Parameter `[:]` may remain unresolved until instantiation binds it.
+    let source = r#"
+        model Test
+            parameter Real p[:];
+        end Test;
+    "#;
+
+    let parsed = parse(source);
+    let resolved = resolve(parsed).expect("resolve should succeed");
+    let typed = typecheck(resolved).expect("typecheck should succeed");
+
+    let tree = typed.into_inner();
+    let test_class = tree
+        .definitions
+        .classes
+        .get("Test")
+        .expect("Test class should exist");
+    let p = test_class.components.get("p").expect("p should exist");
+    assert!(
+        p.shape.is_empty(),
+        "unbound parameter colon dimensions should remain unresolved"
+    );
+}
+
+#[test]
 fn test_import_constant_prefixes_include_alias_and_full_path() {
     let import = ScopeImport::Renamed {
         alias: "Medium".to_string(),

--- a/crates/rumoca-phase-typecheck/src/typechecker/late_methods.rs
+++ b/crates/rumoca-phase-typecheck/src/typechecker/late_methods.rs
@@ -440,6 +440,7 @@ impl TypeChecker {
     /// - Non-input variables must have evaluable dimensions at translation time
     pub(crate) fn validate_dimensions(&mut self, overlay: &InstanceOverlay) {
         use rumoca_ir_ast as ast;
+        use rumoca_ir_core::Variability;
 
         for (_def_id, instance_data) in &overlay.components {
             // Only check primitives with dimension expressions
@@ -459,6 +460,18 @@ impl TypeChecker {
                 .any(|s| matches!(s, ast::Subscript::Range { .. }));
             let is_input = matches!(instance_data.causality, rumoca_ir_core::Causality::Input(_));
             if is_input && has_colon_dim {
+                continue;
+            }
+
+            // MLS §10.1 allows `[:]` dimensions to remain unspecified until a
+            // binding (or enclosing configuration) determines concrete size.
+            // For parameters/constants this often happens at instantiation time
+            // through record constructor modifications.
+            let is_structural_parameter_like = matches!(
+                instance_data.variability,
+                Variability::Parameter(_) | Variability::Constant(_)
+            );
+            if has_colon_dim && is_structural_parameter_like {
                 continue;
             }
 

--- a/scripts/profile_rumoca_model.sh
+++ b/scripts/profile_rumoca_model.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Profiles a Rumoca model compile/check path and emits:
+# 1) flamegraph SVG (for humans)
+# 2) perf script + folded stacks (for AI/automation)
+#
+# Why this script uses perf+inferno directly:
+# - More robust than cargo flamegraph in some environments where addr2line
+#   post-processing can spam/fail.
+# - AI-friendly outputs come from `perf script` and folded stacks.
+
+usage() {
+  cat <<'EOF'
+Usage:
+  profile_rumoca_model.sh [options]
+
+Options:
+  --workspace-root <path>   Workspace root override (default: auto-detect from repo layout)
+  --model <qualified.name>  Model to profile
+                            (default: WindPowerPlants.Components.GenericVariableSpeedGeneratorElectrical)
+  --windpower-root <path>   WindPower source-root directory
+                            (default: <workspace>/.tmp/windpower/WindPowerPlants-2.0.0)
+  --msl-root <path>         MSL source-root directory
+                            (default: auto-detect under packages/rumoca/target/msl/ModelicaStandardLibrary-*)
+  --mode <mode>             profiling mode: flamegraph | ai-data | all (default: all)
+  --freq <n>                perf sampling frequency (default: 99)
+  --sudo                    run perf/flamegraph with sudo (default: true)
+  --no-sudo                 run perf/flamegraph without sudo
+  --help                    show this help
+
+Outputs:
+  <workspace>/packages/rumoca/target/profile/<timestamp>/
+    - flamegraph.svg
+    - perf.data
+    - perf.script.txt
+    - perf.folded.txt
+    - run.meta.txt
+EOF
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+RUMOCA_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_ROOT="$(cd -- "$RUMOCA_DIR/../.." && pwd)"
+MODEL_NAME="WindPowerPlants.Components.GenericVariableSpeedGeneratorElectrical"
+MODE="all"
+FREQ="99"
+USE_SUDO="1"
+WINDPOWER_ROOT=""
+MSL_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workspace-root)
+      WORKSPACE_ROOT="${2:?missing value for --workspace-root}"
+      shift 2
+      ;;
+    --model)
+      MODEL_NAME="${2:?missing value for --model}"
+      shift 2
+      ;;
+    --windpower-root)
+      WINDPOWER_ROOT="${2:?missing value for --windpower-root}"
+      shift 2
+      ;;
+    --msl-root)
+      MSL_ROOT="${2:?missing value for --msl-root}"
+      shift 2
+      ;;
+    --mode)
+      MODE="${2:?missing value for --mode}"
+      shift 2
+      ;;
+    --freq)
+      FREQ="${2:?missing value for --freq}"
+      shift 2
+      ;;
+    --sudo)
+      USE_SUDO="1"
+      shift
+      ;;
+    --no-sudo)
+      USE_SUDO="0"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$MODE" != "flamegraph" && "$MODE" != "ai-data" && "$MODE" != "all" ]]; then
+  echo "Invalid --mode: $MODE (expected: flamegraph | ai-data | all)" >&2
+  exit 2
+fi
+
+if [[ -z "$WINDPOWER_ROOT" ]]; then
+  WINDPOWER_ROOT="$WORKSPACE_ROOT/.tmp/windpower/WindPowerPlants-2.0.0"
+fi
+if [[ -z "$MSL_ROOT" ]]; then
+  MSL_ROOT="$(find "$WORKSPACE_ROOT/packages/rumoca/target/msl" -maxdepth 1 -type d -name 'ModelicaStandardLibrary-*' | head -n 1 || true)"
+fi
+
+if [[ ! -d "$RUMOCA_DIR" ]]; then
+  echo "Rumoca directory not found: $RUMOCA_DIR" >&2
+  exit 1
+fi
+if [[ ! -d "$WINDPOWER_ROOT" ]]; then
+  echo "WindPower root not found: $WINDPOWER_ROOT" >&2
+  exit 1
+fi
+if [[ -z "$MSL_ROOT" || ! -d "$MSL_ROOT" ]]; then
+  echo "MSL root not found/detected: $MSL_ROOT" >&2
+  exit 1
+fi
+if ! command -v perf >/dev/null 2>&1; then
+  echo "perf is not available on PATH." >&2
+  exit 1
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo is not available on PATH." >&2
+  exit 1
+fi
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_DIR="$WORKSPACE_ROOT/packages/rumoca/target/profile/$TS"
+mkdir -p "$OUT_DIR"
+
+CHECK_FILE="$WINDPOWER_ROOT/WindPowerPlants/package.mo"
+if [[ ! -f "$CHECK_FILE" ]]; then
+  echo "Modelica package file not found: $CHECK_FILE" >&2
+  exit 1
+fi
+
+SUDO_CMD=""
+if [[ "$USE_SUDO" == "1" ]]; then
+  SUDO_CMD="sudo"
+fi
+
+{
+  echo "timestamp_utc=$TS"
+  echo "workspace_root=$WORKSPACE_ROOT"
+  echo "rumoca_dir=$RUMOCA_DIR"
+  echo "check_file=$CHECK_FILE"
+  echo "model_name=$MODEL_NAME"
+  echo "msl_root=$MSL_ROOT"
+  echo "windpower_root=$WINDPOWER_ROOT"
+  echo "mode=$MODE"
+  echo "freq=$FREQ"
+  echo "sudo=$USE_SUDO"
+} > "$OUT_DIR/run.meta.txt"
+
+echo "Output dir: $OUT_DIR"
+echo "Model: $MODEL_NAME"
+
+cd "$RUMOCA_DIR"
+
+echo "Recording perf data..."
+$SUDO_CMD perf record -F "$FREQ" -g --call-graph fp -o "$OUT_DIR/perf.data" -- \
+  target/release/rumoca check "$CHECK_FILE" \
+  --model "$MODEL_NAME" \
+  --source-root "$MSL_ROOT" \
+  --source-root "$WINDPOWER_ROOT"
+
+echo "Exporting perf script..."
+$SUDO_CMD perf script -i "$OUT_DIR/perf.data" --no-inline > "$OUT_DIR/perf.script.txt"
+
+if command -v inferno-collapse-perf >/dev/null 2>&1; then
+  echo "Exporting folded stacks via inferno-collapse-perf..."
+  inferno-collapse-perf < "$OUT_DIR/perf.script.txt" > "$OUT_DIR/perf.folded.txt"
+elif command -v stackcollapse-perf.pl >/dev/null 2>&1; then
+  echo "Exporting folded stacks via stackcollapse-perf.pl..."
+  stackcollapse-perf.pl "$OUT_DIR/perf.script.txt" > "$OUT_DIR/perf.folded.txt"
+else
+  echo "No stack collapse tool found. Install inferno: cargo install inferno" >&2
+fi
+
+if [[ "$MODE" == "flamegraph" || "$MODE" == "all" ]]; then
+  if command -v inferno-flamegraph >/dev/null 2>&1; then
+    echo "Generating flamegraph.svg via inferno-flamegraph..."
+    inferno-flamegraph < "$OUT_DIR/perf.folded.txt" > "$OUT_DIR/flamegraph.svg"
+  elif command -v flamegraph.pl >/dev/null 2>&1; then
+    echo "Generating flamegraph.svg via flamegraph.pl..."
+    flamegraph.pl "$OUT_DIR/perf.folded.txt" > "$OUT_DIR/flamegraph.svg"
+  else
+    echo "No flamegraph renderer found. Install inferno: cargo install inferno" >&2
+  fi
+fi
+
+echo "Done."
+echo "Artifacts:"
+ls -lh "$OUT_DIR"


### PR DESCRIPTION
  ## Summary

  - Fixes a compile correctness gap: parameter/constant [:] dimensions can now remain
    unresolved until later binding/instantiation (MLS-aligned), instead of failing early in
    typecheck.
  - Speeds up compile-heavy flows by optimizing clock timing precompute and strict path
    matching.
  - Adds compile/check timing metadata in source-root/WASM compile APIs for better
    diagnostics.
  - Adds a profiling utility script for reproducible perf/flamegraph and AI-readable profiling
    artifacts.
  - Measured impact on the target model
    WindPowerPlants.Components.GenericVariableSpeedGeneratorElectrical: compile-check wall
    time reduced from ~1m42s to ~12.7s (~8x faster).


  ## Code Size Budget (required)

  - production_lines_added: 455
  - production_lines_deleted: 44
  - test_lines_added: 26
  - test_lines_deleted: 0
  - public_items_added: 12
  - public_items_removed: 0
  - files_touched: 10
  - net_added_lines: 437

  If net_added_lines is positive, add:

  - Why this net growth is required.
      - The growth is primarily from two necessary additions: (1) timing instrumentation
        surfaces in compile APIs and (2) a reusable profiling script (scripts/
        profile_rumoca_model.sh). The performance fixes in clock precompute also require new
        indexing/data-structure code to avoid repeated scans.
  - Which code was removed/merged as part of the first compression pass.
      - Replaced repeated reverse-alias full scans with a precomputed reverse index in clock
        precompute.
      - Reused allocation/scratch paths instead of repeated per-iteration structures in hot
        code.
      - Replaced repeated path canonicalization calls with cached canonicalized keys in strict
        diagnostics.
  - Follow-up cleanup ticket/commit for remaining growth (if any).
      - Follow-up: collapse duplicated timing JSON construction between bind-wasm entry points
        into shared helpers and tighten script option parsing utilities (planned as a cleanup
        commit after merge).

  ## Design Notes

  - Why each new abstraction was necessary.
      - StrictCheckTiming: needed to expose strict-check phase latency without mixing concerns
        into error payload formatting.
      - SourceMap reverse-alias index in clock precompute: needed to remove O(N) scans per
        lookup in hot inference loops.
      - Path canonicalization cache: needed to avoid repeated filesystem canonicalize calls in
        strict failure collection.
  - Why this was not solved by editing an existing module directly.
      - The bottlenecks crossed module boundaries: typecheck validation, DAE clock precompute,
        compile session strict-check path, and wasm/source-root API serialization. A single-
        module tweak would not address end-to-end compile latency and observability.
  - What duplicate/legacy paths were deleted.
      - Legacy repeated reverse-alias lookup behavior in clock inference was effectively
        replaced by indexed lookup.
      - Repeated ad-hoc canonicalization in strict path equality was replaced by centralized
        cached resolution.

  ## Testing

  - Key command(s) run.
      - cargo fmt --all
      - cargo check -p rumoca-phase-dae -p rumoca-compile
      - ./target/release/rumoca check ... --model
        WindPowerPlants.Components.GenericVariableSpeedGeneratorElectrical ... (before/after
        timing comparison)
      - Workspace integration run (compile-only):
          - yarn modelica:compare run --compile-only --compile-debug --library-zip public/
            modelica-libraries/WindPowerPlants.zip --targets-prefix WindPowerPlants --target-
            class-types model,block --json
  - Files changed covered by tests.
      - crates/rumoca-phase-typecheck/src/typechecker/late_methods.rs is covered by new
        regression test in crates/rumoca-phase-typecheck/src/tests.rs
        (test_parameter_colon_dimension_without_binding_is_allowed).
      - Performance-related paths were validated by compile-only integration runs and direct
        model compile checks.
  - Updated a brittle WASM alias test to ignore only non-semantic timing metadata fields
    (__compile_phase_timing, __compile_check_timing) before comparing compile vs compile_to_json,
    while keeping strict equality for the full semantic payload.

  ## Reviewer Checklist

  - [ ] Size budget section completed.
  - [ ] Positive net diff has explicit compression justification.
  - [ ] New APIs are required and minimal.
  - [ ] Old/new parallel paths were removed unless explicitly migrating.
