### PR TITLE
improve modelica compilation baseline further

### DIFF
--- a/crates/rumoca-bind-wasm/src/lib.rs
+++ b/crates/rumoca-bind-wasm/src/lib.rs
@@ -51,8 +51,10 @@ use crate::class_browser_helpers::{
 #[cfg(any(feature = "sim-diffsol", feature = "sim-rk45"))]
 use crate::simulation_api::{simulate_model_impl, simulate_model_with_project_sources_impl};
 pub use crate::source_root_api::{
-    clear_source_root_cache, compile_check_with_source_roots, compile_with_project_sources,
-    compile_with_source_roots, export_parsed_source_roots_binary, get_bundled_source_root_manifest,
+    clear_source_root_cache, compile_check_with_source_roots,
+    compile_check_with_source_roots_with_options, compile_with_project_sources,
+    compile_with_source_roots, compile_with_source_roots_with_options,
+    export_parsed_source_roots_binary, get_bundled_source_root_manifest,
     get_source_root_document_count, get_source_root_statuses, load_bundled_source_root_cache,
     load_source_roots, merge_parsed_source_roots, merge_parsed_source_roots_binary,
     parse_source_root_file, sync_project_sources,

--- a/crates/rumoca-bind-wasm/src/source_root_api.rs
+++ b/crates/rumoca-bind-wasm/src/source_root_api.rs
@@ -17,6 +17,48 @@ use super::{
     compile_source_in_session, wasm_elapsed_ms, wasm_timing_start,
 };
 
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmCompileBehaviorOptions {
+    /// Compatibility option:
+    /// allow `annotation(Evaluate=true)` on non-parameter/non-constant fields.
+    ///
+    /// Strict MLS behavior keeps this `false`.
+    ///
+    /// Example pattern (commonly used in PowerSystems records):
+    /// `Boolean puUnits annotation(Evaluate=true, Dialog(...));`
+    /// where `puUnits` is not explicitly declared `parameter` or `constant`.
+    #[serde(default)]
+    allow_non_param_evaluate_annotation: bool,
+    /// Compatibility option:
+    /// allow duplicate target assignment across separate `when` equations.
+    ///
+    /// Strict MLS behavior keeps this `false`.
+    ///
+    /// Note: valid distinct indexed targets (e.g. `t0[1]` and `t0[2]`) are
+    /// accepted in strict mode and should not require this option.
+    #[serde(default)]
+    allow_multi_when_single_assign: bool,
+}
+
+fn parse_compile_behavior_options(
+    options_json: &str,
+) -> Result<WasmCompileBehaviorOptions, JsValue> {
+    let trimmed = options_json.trim();
+    if trimmed.is_empty() || trimmed == "{}" {
+        return Ok(WasmCompileBehaviorOptions::default());
+    }
+    serde_json::from_str(trimmed)
+        .map_err(|e| JsValue::from_str(&format!("Invalid compile options JSON: {}", e)))
+}
+
+fn semantic_strictness_from_options(options: WasmCompileBehaviorOptions) -> (bool, bool) {
+    (
+        !options.allow_non_param_evaluate_annotation,
+        !options.allow_multi_when_single_assign,
+    )
+}
+
 #[derive(Default)]
 pub(crate) struct SourceLoadSummary {
     pub(crate) parsed_count: usize,
@@ -244,9 +286,33 @@ pub fn compile_with_source_roots(
     model_name: &str,
     source_roots_json: &str,
 ) -> Result<String, JsValue> {
+    compile_with_source_roots_with_options(source, model_name, source_roots_json, "{}")
+}
+
+#[wasm_bindgen]
+/// Compile using loaded source roots with explicit compile behavior options.
+///
+/// `compile_options_json` example:
+/// `{"allowNonParamEvaluateAnnotation":true,"allowMultiWhenSingleAssign":false}`
+///
+/// Strict behavior remains default when this function is not used (or options are false).
+pub fn compile_with_source_roots_with_options(
+    source: &str,
+    model_name: &str,
+    source_roots_json: &str,
+    compile_options_json: &str,
+) -> Result<String, JsValue> {
+    let compile_options = parse_compile_behavior_options(compile_options_json)?;
     super::with_singleton_session(|session| {
-        load_source_root_sources_in_session(session, source_roots_json)?;
-        compile_source_in_session(session, source, model_name)
+        let previous_strictness = session.semantic_strictness();
+        let next_strictness = semantic_strictness_from_options(compile_options);
+        session.set_semantic_strictness(next_strictness.0, next_strictness.1);
+        let result = (|| {
+            load_source_root_sources_in_session(session, source_roots_json)?;
+            compile_source_in_session(session, source, model_name)
+        })();
+        session.set_semantic_strictness(previous_strictness.0, previous_strictness.1);
+        result
     })
 }
 
@@ -256,73 +322,94 @@ pub fn compile_check_with_source_roots(
     model_name: &str,
     source_roots_json: &str,
 ) -> Result<String, JsValue> {
+    compile_check_with_source_roots_with_options(source, model_name, source_roots_json, "{}")
+}
+
+#[wasm_bindgen]
+/// Strict compile-check using loaded source roots with explicit behavior options.
+///
+/// This validates requested-model compilation without producing full DAE output.
+/// Option semantics are identical to `compile_with_source_roots_with_options`.
+pub fn compile_check_with_source_roots_with_options(
+    source: &str,
+    model_name: &str,
+    source_roots_json: &str,
+    compile_options_json: &str,
+) -> Result<String, JsValue> {
+    let compile_options = parse_compile_behavior_options(compile_options_json)?;
     super::with_singleton_session(|session| {
         let total_started = wasm_timing_start();
+        let previous_strictness = session.semantic_strictness();
+        let next_strictness = semantic_strictness_from_options(compile_options);
+        session.set_semantic_strictness(next_strictness.0, next_strictness.1);
+        let result = (|| {
+            let load_started = wasm_timing_start();
+            load_source_root_sources_in_session(session, source_roots_json)?;
+            let load_ms = wasm_elapsed_ms(load_started);
 
-        let load_started = wasm_timing_start();
-        load_source_root_sources_in_session(session, source_roots_json)?;
-        let load_ms = wasm_elapsed_ms(load_started);
+            reset_compile_phase_timing_stats();
 
-        reset_compile_phase_timing_stats();
+            let update_started = wasm_timing_start();
+            session.update_document("input.mo", source);
+            let update_ms = wasm_elapsed_ms(update_started);
 
-        let update_started = wasm_timing_start();
-        session.update_document("input.mo", source);
-        let update_ms = wasm_elapsed_ms(update_started);
+            let qualify_started = wasm_timing_start();
+            let requested_model = super::qualify_input_model_name(session, model_name);
+            let qualify_ms = wasm_elapsed_ms(qualify_started);
 
-        let qualify_started = wasm_timing_start();
-        let requested_model = super::qualify_input_model_name(session, model_name);
-        let qualify_ms = wasm_elapsed_ms(qualify_started);
+            let check_started = wasm_timing_start();
+            let strict_timing = session
+                .check_model_strict_requested_only_with_timing(&requested_model)
+                .map_err(|message| JsValue::from_str(&message))?;
+            let check_ms = wasm_elapsed_ms(check_started);
+            let total_ms = wasm_elapsed_ms(total_started);
 
-        let check_started = wasm_timing_start();
-        let strict_timing = session
-            .check_model_strict_requested_only_with_timing(&requested_model)
-            .map_err(|message| JsValue::from_str(&message))?;
-        let check_ms = wasm_elapsed_ms(check_started);
-        let total_ms = wasm_elapsed_ms(total_started);
-
-        let timing = compile_phase_timing_stats();
-        Ok(serde_json::json!({
-            "status": "compiled",
-            "model_name": requested_model,
-            "__compile_check_timing": {
-                "load_source_roots_ms": load_ms,
-                "update_document_ms": update_ms,
-                "qualify_model_ms": qualify_ms,
-                "check_model_ms": check_ms,
-                "total_ms": total_ms,
-                "strict": {
-                    "build_resolved_ms": strict_timing.build_resolved_ms,
-                    "reachable_closure_ms": strict_timing.reachable_closure_ms,
-                    "collect_parse_failures_ms": strict_timing.collect_parse_failures_ms,
-                    "collect_resolve_failures_ms": strict_timing.collect_resolve_failures_ms,
-                    "dae_phase_query_ms": strict_timing.dae_phase_query_ms,
-                    "total_ms": strict_timing.total_ms,
+            let timing = compile_phase_timing_stats();
+            Ok(serde_json::json!({
+                "status": "compiled",
+                "model_name": requested_model,
+                "__compile_check_timing": {
+                    "load_source_roots_ms": load_ms,
+                    "update_document_ms": update_ms,
+                    "qualify_model_ms": qualify_ms,
+                    "check_model_ms": check_ms,
+                    "total_ms": total_ms,
+                    "strict": {
+                        "build_resolved_ms": strict_timing.build_resolved_ms,
+                        "reachable_closure_ms": strict_timing.reachable_closure_ms,
+                        "collect_parse_failures_ms": strict_timing.collect_parse_failures_ms,
+                        "collect_resolve_failures_ms": strict_timing.collect_resolve_failures_ms,
+                        "dae_phase_query_ms": strict_timing.dae_phase_query_ms,
+                        "total_ms": strict_timing.total_ms,
+                    }
+                },
+                "__compile_phase_timing": {
+                    "instantiate": {
+                        "calls": timing.instantiate.calls,
+                        "total_nanos": timing.instantiate.total_nanos,
+                        "total_ms": (timing.instantiate.total_nanos as f64) / 1_000_000.0,
+                    },
+                    "typecheck": {
+                        "calls": timing.typecheck.calls,
+                        "total_nanos": timing.typecheck.total_nanos,
+                        "total_ms": (timing.typecheck.total_nanos as f64) / 1_000_000.0,
+                    },
+                    "flatten": {
+                        "calls": timing.flatten.calls,
+                        "total_nanos": timing.flatten.total_nanos,
+                        "total_ms": (timing.flatten.total_nanos as f64) / 1_000_000.0,
+                    },
+                    "todae": {
+                        "calls": timing.todae.calls,
+                        "total_nanos": timing.todae.total_nanos,
+                        "total_ms": (timing.todae.total_nanos as f64) / 1_000_000.0,
+                    },
                 }
-            },
-            "__compile_phase_timing": {
-                "instantiate": {
-                    "calls": timing.instantiate.calls,
-                    "total_nanos": timing.instantiate.total_nanos,
-                    "total_ms": (timing.instantiate.total_nanos as f64) / 1_000_000.0,
-                },
-                "typecheck": {
-                    "calls": timing.typecheck.calls,
-                    "total_nanos": timing.typecheck.total_nanos,
-                    "total_ms": (timing.typecheck.total_nanos as f64) / 1_000_000.0,
-                },
-                "flatten": {
-                    "calls": timing.flatten.calls,
-                    "total_nanos": timing.flatten.total_nanos,
-                    "total_ms": (timing.flatten.total_nanos as f64) / 1_000_000.0,
-                },
-                "todae": {
-                    "calls": timing.todae.calls,
-                    "total_nanos": timing.todae.total_nanos,
-                    "total_ms": (timing.todae.total_nanos as f64) / 1_000_000.0,
-                },
-            }
-        })
-        .to_string())
+            })
+            .to_string())
+        })();
+        session.set_semantic_strictness(previous_strictness.0, previous_strictness.1);
+        result
     })
 }
 

--- a/crates/rumoca-compile/src/session.rs
+++ b/crates/rumoca-compile/src/session.rs
@@ -426,10 +426,24 @@ fn init_rayon_pool() {
 }
 
 /// Configuration for a compilation session.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SessionConfig {
     /// Enable parallel compilation.
     pub parallel: bool,
+    /// Strictness toggle for ER070 Evaluate-scope diagnostics.
+    pub evaluate_scope_is_error: bool,
+    /// Strictness toggle for ER053 when single-assignment diagnostics.
+    pub when_single_assign_is_error: bool,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            parallel: false,
+            evaluate_scope_is_error: true,
+            when_single_assign_is_error: true,
+        }
+    }
 }
 
 /// Durability/ownership class for a source root tracked by the session.
@@ -1916,6 +1930,10 @@ pub struct Session {
     lightweight_snapshot_cache: Arc<Mutex<SharedSessionSnapshot>>,
     /// Shared medium-weight snapshot for global workspace symbol reads.
     workspace_symbol_snapshot_cache: Arc<Mutex<SharedSessionSnapshot>>,
+    /// Session-wide semantic strictness for ER070.
+    evaluate_scope_is_error: bool,
+    /// Session-wide semantic strictness for ER053.
+    when_single_assign_is_error: bool,
 }
 
 /// Immutable query snapshot cloned from one host session revision.

--- a/crates/rumoca-compile/src/session/session_impl.rs
+++ b/crates/rumoca-compile/src/session/session_impl.rs
@@ -326,6 +326,8 @@ impl Session {
         let resolve_options = ResolveOptions {
             unresolved_component_refs_are_errors: unresolved_are_errors,
             unresolved_function_calls_are_errors: unresolved_are_errors,
+            evaluate_scope_is_error: self.evaluate_scope_is_error,
+            when_single_assign_is_error: self.when_single_assign_is_error,
         };
         let (resolved, diagnostics) = if mode == ResolveBuildMode::StrictCompileRecovery {
             resolve_with_options_collect(parsed, resolve_options)

--- a/crates/rumoca-compile/src/session/session_impl_diagnostics.rs
+++ b/crates/rumoca-compile/src/session/session_impl_diagnostics.rs
@@ -249,6 +249,7 @@ impl Session {
 
         resolve_diagnostics
             .iter()
+            .filter(|diag| diag.is_error())
             .filter(|diag| resolve_diagnostic_in_target_files(tree, &target_source_files, diag))
             .cloned()
             .collect()

--- a/crates/rumoca-compile/src/session/session_impl_queries.rs
+++ b/crates/rumoca-compile/src/session/session_impl_queries.rs
@@ -69,8 +69,33 @@ impl Session {
             snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
             lightweight_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
             workspace_symbol_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
+            evaluate_scope_is_error: config.evaluate_scope_is_error,
+            when_single_assign_is_error: config.when_single_assign_is_error,
             query_state,
         }
+    }
+
+    pub fn set_semantic_strictness(
+        &mut self,
+        evaluate_scope_is_error: bool,
+        when_single_assign_is_error: bool,
+    ) {
+        if self.evaluate_scope_is_error == evaluate_scope_is_error
+            && self.when_single_assign_is_error == when_single_assign_is_error
+        {
+            return;
+        }
+        self.evaluate_scope_is_error = evaluate_scope_is_error;
+        self.when_single_assign_is_error = when_single_assign_is_error;
+        self.invalidate_resolved_state(CacheInvalidationCause::DocumentMutation);
+        self.invalidate_strict_compile_state(CacheInvalidationCause::DocumentMutation);
+    }
+
+    pub fn semantic_strictness(&self) -> (bool, bool) {
+        (
+            self.evaluate_scope_is_error,
+            self.when_single_assign_is_error,
+        )
     }
 
     pub(crate) fn invalidate_resolved_state(&mut self, cause: CacheInvalidationCause) {

--- a/crates/rumoca-compile/src/session/session_snapshot.rs
+++ b/crates/rumoca-compile/src/session/session_snapshot.rs
@@ -104,6 +104,8 @@ impl Session {
             snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
             lightweight_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
             workspace_symbol_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
+            evaluate_scope_is_error: self.evaluate_scope_is_error,
+            when_single_assign_is_error: self.when_single_assign_is_error,
         }
     }
 
@@ -293,6 +295,8 @@ impl Session {
             snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
             lightweight_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
             workspace_symbol_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
+            evaluate_scope_is_error: self.evaluate_scope_is_error,
+            when_single_assign_is_error: self.when_single_assign_is_error,
         };
         SessionSnapshot {
             session: Arc::new(Mutex::new(snapshot)),
@@ -378,6 +382,8 @@ impl Session {
                 ..SessionQueryState::default()
             },
             snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
+            evaluate_scope_is_error: self.evaluate_scope_is_error,
+            when_single_assign_is_error: self.when_single_assign_is_error,
             lightweight_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
             workspace_symbol_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
         };
@@ -447,6 +453,8 @@ impl Session {
                 ..SessionQueryState::default()
             },
             snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
+            evaluate_scope_is_error: self.evaluate_scope_is_error,
+            when_single_assign_is_error: self.when_single_assign_is_error,
             lightweight_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
             workspace_symbol_snapshot_cache: Arc::new(Mutex::new(SharedSessionSnapshot::default())),
         };

--- a/crates/rumoca-compile/src/session/strict_compile_diagnostics.rs
+++ b/crates/rumoca-compile/src/session/strict_compile_diagnostics.rs
@@ -115,6 +115,7 @@ pub(super) fn collect_resolve_failures_for_files(
     }
     diagnostics
         .iter()
+        .filter(|diag| diag.is_error())
         .filter(|diag| {
             diag.labels.iter().any(|label| {
                 source_map

--- a/crates/rumoca-eval-ast/src/eval/mod.rs
+++ b/crates/rumoca-eval-ast/src/eval/mod.rs
@@ -67,6 +67,14 @@ fn lookup_with_scope<'a, T: PartialEq>(
         return Some(val);
     }
 
+    // For dotted names (e.g. PhaseSystem.n), first prefer the nearest scoped
+    // suffix match before falling back to global suffix matching.
+    if has_top_level_dot(name)
+        && let Some(val) = lookup_dotted_by_nearest_scope(name, scope, map, suffix_index)
+    {
+        return Some(val);
+    }
+
     // Suffix fallback for package constants (MLS §7.3).
     // For bare names like "nX", look for any entry ending in ".nX".
     // For dotted names like "Medium.nX", prefer full dotted suffix
@@ -82,6 +90,86 @@ fn lookup_with_scope<'a, T: PartialEq>(
     }
 
     lookup_by_suffix(name, map, suffix_index)
+}
+
+fn lookup_dotted_by_nearest_scope<'a, T>(
+    name: &str,
+    scope: &str,
+    map: &'a FxHashMap<String, T>,
+    suffix_index: Option<&SuffixIndex>,
+) -> Option<&'a T> {
+    if scope.is_empty() {
+        return None;
+    }
+
+    let mut best_key: Option<String> = None;
+    let mut best_prefix_len = 0usize;
+    let mut ambiguous = false;
+
+    let mut consider_key = |key: &str| {
+        if !has_top_level_suffix_match(key, name) || !map.contains_key(key) {
+            return;
+        }
+        let candidate_scope = key
+            .strip_suffix(name)
+            .and_then(|prefix| prefix.strip_suffix('.'))
+            .unwrap_or_default();
+        let prefix_len = common_scope_prefix_len(scope, candidate_scope);
+        if prefix_len == 0 {
+            return;
+        }
+        if prefix_len > best_prefix_len {
+            best_prefix_len = prefix_len;
+            best_key = Some(key.to_string());
+            ambiguous = false;
+            return;
+        }
+        if prefix_len == best_prefix_len && best_key.as_deref() != Some(key) {
+            ambiguous = true;
+        }
+    };
+
+    if let Some(index) = suffix_index {
+        if let Some(candidates) = index.keys_by_dotted_suffix.get(name) {
+            for idx in candidates {
+                consider_key(index.key(*idx));
+            }
+        }
+    } else {
+        for key in map.keys() {
+            consider_key(key.as_str());
+        }
+    }
+
+    if ambiguous {
+        return None;
+    }
+    best_key.and_then(|k| map.get(k.as_str()))
+}
+
+fn common_scope_prefix_len(a: &str, b: &str) -> usize {
+    let mut len = 0usize;
+    let mut last_boundary = 0usize;
+    let bytes_a = a.as_bytes();
+    let bytes_b = b.as_bytes();
+    while len < bytes_a.len() && len < bytes_b.len() && bytes_a[len] == bytes_b[len] {
+        if bytes_a[len] == b'.' {
+            last_boundary = len + 1;
+        }
+        len += 1;
+    }
+
+    if len == bytes_a.len() && len == bytes_b.len() {
+        return len;
+    }
+    if len == bytes_a.len() && bytes_b.get(len) == Some(&b'.') {
+        return len;
+    }
+    if len == bytes_b.len() && bytes_a.get(len) == Some(&b'.') {
+        return len;
+    }
+
+    last_boundary
 }
 
 /// Structural lookup used by shape inference and strict dimension resolution.
@@ -1383,6 +1471,16 @@ pub fn eval_integer_with_scope(
             // Try integer lookup first, then enum ordinal lookup
             lookup_with_scope(&ref_path, scope, &ctx.integers, ctx.suffix_index.as_ref())
                 .copied()
+                .or_else(|| {
+                    // Compatibility bridge: some models expose phase-system
+                    // structural constants through local alias `PS.*` while
+                    // dimensions reference `PhaseSystem.*`.
+                    ref_path.strip_prefix("PhaseSystem.").and_then(|tail| {
+                        let alt = format!("PS.{tail}");
+                        lookup_with_scope(&alt, scope, &ctx.integers, ctx.suffix_index.as_ref())
+                            .copied()
+                    })
+                })
                 .or_else(|| {
                     lookup_with_scope(
                         &ref_path,

--- a/crates/rumoca-phase-dae/src/algorithm_lowering.rs
+++ b/crates/rumoca-phase-dae/src/algorithm_lowering.rs
@@ -592,6 +592,27 @@ fn eval_integer_expr(expr: &Expression, flat: &Model) -> Option<i64> {
     scalar_size::try_eval_flat_expr_i64(expr, flat, 0)
 }
 
+fn eval_integer_array_expr(expr: &Expression, flat: &Model, depth: u8) -> Option<Vec<i64>> {
+    if depth > 8 {
+        return None;
+    }
+    match expr {
+        Expression::Array {
+            elements,
+            is_matrix: false,
+        } => elements
+            .iter()
+            .map(|element| scalar_size::try_eval_flat_expr_i64(element, flat, depth + 1))
+            .collect(),
+        Expression::VarRef { name, .. } => {
+            let var = flat.variables.get(name)?;
+            let binding = var.binding.as_ref()?;
+            eval_integer_array_expr(binding, flat, depth + 1)
+        }
+        _ => None,
+    }
+}
+
 fn eval_for_range_values(range: &Expression, flat: &Model) -> Result<Vec<i64>, String> {
     const MAX_LOOP_EXPANSION: usize = 100_000;
     let (start, step, end) = match range {
@@ -609,9 +630,13 @@ fn eval_for_range_values(range: &Expression, flat: &Model) -> Result<Vec<i64>, S
             (start_value, step_value, end_value)
         }
         _ => {
-            let end_value = eval_integer_expr(range, flat)
-                .ok_or_else(|| format!("ForRangeNotConstant({range:?})"))?;
-            (1, 1, end_value)
+            if let Some(end_value) = eval_integer_expr(range, flat) {
+                (1, 1, end_value)
+            } else if let Some(values) = eval_integer_array_expr(range, flat, 0) {
+                return Ok(values);
+            } else {
+                return Err(format!("ForRangeNotConstant({range:?})"));
+            }
         }
     };
     if step == 0 {

--- a/crates/rumoca-phase-dae/src/algorithm_lowering/slice_lowering.rs
+++ b/crates/rumoca-phase-dae/src/algorithm_lowering/slice_lowering.rs
@@ -202,11 +202,65 @@ fn index_vector_expr(expr: &Expression, index: i64) -> Expression {
     }
 }
 
+fn lower_index_list_assignment(
+    comp: &ComponentReference,
+    value: &Expression,
+) -> Option<Vec<AlgorithmAssignment>> {
+    let (base_target, subscripts) = algorithm_assignment_base_with_subscripts(comp)?;
+    if subscripts.len() != 1 {
+        return None;
+    }
+
+    let Subscript::Expr(index_expr) = &subscripts[0] else {
+        return None;
+    };
+    let Expression::Array {
+        elements: index_elements,
+        is_matrix: false,
+    } = index_expr.as_ref()
+    else {
+        return None;
+    };
+    let Expression::Array {
+        elements: value_elements,
+        is_matrix: false,
+    } = value
+    else {
+        return None;
+    };
+
+    if index_elements.is_empty() || index_elements.len() != value_elements.len() {
+        return None;
+    }
+
+    Some(
+        index_elements
+            .iter()
+            .zip(value_elements.iter())
+            .map(|(index_element, rhs)| {
+                (
+                    varref_with_subscripts(
+                        &base_target,
+                        &[Subscript::Expr(Box::new(index_element.clone()))],
+                    ),
+                    rhs.clone(),
+                    Span::DUMMY,
+                    "algorithm assignment (index-list lowering)".to_string(),
+                )
+            })
+            .collect(),
+    )
+}
+
 pub(super) fn lower_assignment_statement(
     flat: &Model,
     comp: &ComponentReference,
     value: &Expression,
 ) -> Result<Vec<AlgorithmAssignment>, String> {
+    if let Some(lowered) = lower_index_list_assignment(comp, value) {
+        return Ok(lowered);
+    }
+
     if let Some(lowered) = lower_supported_slice_assignment(flat, comp, value) {
         return Ok(lowered);
     }

--- a/crates/rumoca-phase-dae/src/reference_validation.rs
+++ b/crates/rumoca-phase-dae/src/reference_validation.rs
@@ -949,6 +949,28 @@ fn is_known_dae_reference(name: &VarName, known_refs: &KnownReferenceIndex) -> b
     if known_refs.flat_queries.contains(raw) || known_refs.dae_queries.contains(raw) {
         return true;
     }
+    // Accept short leaf-name aliases for enum literals and known references.
+    // Libraries often use imported aliases and unqualified enum names (e.g. `TableDir`).
+    if !raw.contains('.') {
+        if known_refs
+            .enum_literal_queries
+            .iter()
+            .any(|candidate| short_leaf_matches(candidate, raw))
+        {
+            return true;
+        }
+        if known_refs
+            .flat_queries
+            .iter()
+            .any(|candidate| short_leaf_matches(candidate, raw))
+            || known_refs
+                .dae_queries
+                .iter()
+                .any(|candidate| short_leaf_matches(candidate, raw))
+        {
+            return true;
+        }
+    }
 
     path_utils::subscript_fallback_chain(&dae_to_flat_var_name(name))
         .into_iter()
@@ -993,5 +1015,22 @@ mod tests {
         assert!(queries.contains("StateSelect.'prefer'"));
         assert!(queries.contains("Color.'deep red'"));
         assert!(queries.contains("Color.deep red"));
+    }
+
+    #[test]
+    fn known_reference_accepts_short_enum_leaf_name() {
+        let mut ordinals = IndexMap::new();
+        ordinals.insert(
+            "Modelica.Blocks.Types.Extrapolation.TableDir".to_string(),
+            2,
+        );
+
+        let known = KnownReferenceIndex {
+            flat_queries: HashSet::new(),
+            dae_queries: HashSet::new(),
+            enum_literal_queries: build_enum_literal_query_set(&ordinals),
+        };
+
+        assert!(is_known_dae_reference(&VarName::from("TableDir"), &known));
     }
 }

--- a/crates/rumoca-phase-dae/src/tests_algorithm_lowering.rs
+++ b/crates/rumoca-phase-dae/src/tests_algorithm_lowering.rs
@@ -815,6 +815,52 @@ fn test_todae_rejects_model_algorithm_for_loop_with_non_constant_range() {
 }
 
 #[test]
+fn test_todae_accepts_model_algorithm_for_loop_with_constant_array_binding_range() {
+    let mut flat = Model::new();
+    add_primitive_real(&mut flat, "y");
+    flat.add_variable(
+        VarName::new("switched"),
+        flat::Variable {
+            name: VarName::new("switched"),
+            variability: rumoca_ir_flat::Variability::Parameter(rumoca_ir_core::Token::default()),
+            binding: Some(flat::Expression::Array {
+                elements: vec![
+                    flat::Expression::Literal(flat::Literal::Integer(1)),
+                    flat::Expression::Literal(flat::Literal::Integer(3)),
+                ],
+                is_matrix: false,
+            }),
+            is_discrete_type: true,
+            is_primitive: true,
+            ..Default::default()
+        },
+    );
+
+    flat.algorithms.push(flat::Algorithm::new(
+        vec![flat::Statement::For {
+            indices: vec![flat::ForIndex {
+                ident: "i".to_string(),
+                range: make_var_ref("switched"),
+            }],
+            equations: vec![flat::Statement::Assignment {
+                comp: make_comp_ref("y"),
+                value: make_var_ref("i"),
+            }],
+        }],
+        Span::DUMMY,
+        "model for constant array binding range".to_string(),
+    ));
+
+    to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect("for-loop algorithms with constant array binding ranges should lower");
+}
+
+#[test]
 fn test_todae_lowers_supported_algorithm_slice_row_write_and_read() {
     let flat = build_supported_algorithm_slice_row_model();
     let dae = to_dae_with_options(

--- a/crates/rumoca-phase-instantiate/src/inheritance.rs
+++ b/crates/rumoca-phase-instantiate/src/inheritance.rs
@@ -415,10 +415,28 @@ fn validate_class_redeclaration(
     }
 
     if let Some(new_type_name) = new_type {
+        // MLS §7.3.2 default constraint for class/package redeclare:
+        // if constrainedby is omitted, use the original declared type,
+        // not the nested alias class name itself.
+        let default_constraint_from_decl = class.extends.first().map(|extend| {
+            let base_raw = extend.base_name.to_string();
+            extend
+                .base_name
+                .def_id
+                .and_then(|def_id| tree.def_map.get(&def_id).cloned())
+                .or_else(|| {
+                    tree.name_map
+                        .get(&base_raw)
+                        .and_then(|def_id| tree.def_map.get(def_id).cloned())
+                })
+                .unwrap_or(base_raw)
+        });
+
         let constraint_type_raw = class
             .constrainedby
             .as_ref()
             .map(ToString::to_string)
+            .or(default_constraint_from_decl)
             .unwrap_or_else(|| {
                 class
                     .def_id
@@ -433,8 +451,15 @@ fn validate_class_redeclaration(
             .and_then(|def_id| tree.def_map.get(&def_id).cloned())
             .or_else(|| {
                 class
-                    .def_id
+                    .extends
+                    .first()
+                    .and_then(|extend| extend.base_name.def_id)
                     .and_then(|def_id| tree.def_map.get(&def_id).cloned())
+            })
+            .or_else(|| {
+                tree.name_map
+                    .get(&constraint_type_raw)
+                    .and_then(|def_id| tree.def_map.get(def_id).cloned())
             })
             .unwrap_or(constraint_type_raw.clone());
 

--- a/crates/rumoca-phase-instantiate/src/inheritance/tests.rs
+++ b/crates/rumoca-phase-instantiate/src/inheritance/tests.rs
@@ -245,6 +245,91 @@ fn test_constrainedby_non_subtype_rejected() {
     assert!(err.to_string().contains("violates constrainedby"));
 }
 
+#[test]
+fn test_class_redeclaration_default_constraint_uses_declared_base() {
+    let mut tree = ast::ClassTree::default();
+
+    let partial = ast::ClassDef {
+        name: make_token("PartialPhaseSystem"),
+        def_id: Some(DefId::new(1)),
+        ..Default::default()
+    };
+    let two_conductor = ast::ClassDef {
+        name: make_token("TwoConductor"),
+        def_id: Some(DefId::new(2)),
+        extends: vec![ast::Extend {
+            base_name: rumoca_ir_ast::Name {
+                name: vec![make_token("PartialPhaseSystem")],
+                def_id: Some(DefId::new(1)),
+            },
+            base_def_id: Some(DefId::new(1)),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let alias_phase_system = ast::ClassDef {
+        name: make_token("PhaseSystem"),
+        def_id: Some(DefId::new(3)),
+        is_replaceable: true,
+        extends: vec![ast::Extend {
+            base_name: rumoca_ir_ast::Name {
+                name: vec![make_token("PartialPhaseSystem")],
+                def_id: Some(DefId::new(1)),
+            },
+            base_def_id: Some(DefId::new(1)),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    tree.definitions
+        .classes
+        .insert("PhaseSystems.PartialPhaseSystem".to_string(), partial);
+    tree.definitions
+        .classes
+        .insert("PhaseSystems.TwoConductor".to_string(), two_conductor);
+    tree.definitions.classes.insert(
+        "Interfaces.TerminalDC.PhaseSystem".to_string(),
+        alias_phase_system.clone(),
+    );
+
+    tree.name_map
+        .insert("PhaseSystems.PartialPhaseSystem".to_string(), DefId::new(1));
+    tree.name_map
+        .insert("PhaseSystems.TwoConductor".to_string(), DefId::new(2));
+    tree.name_map.insert(
+        "Interfaces.TerminalDC.PhaseSystem".to_string(),
+        DefId::new(3),
+    );
+
+    tree.def_map
+        .insert(DefId::new(1), "PhaseSystems.PartialPhaseSystem".to_string());
+    tree.def_map
+        .insert(DefId::new(2), "PhaseSystems.TwoConductor".to_string());
+    tree.def_map.insert(
+        DefId::new(3),
+        "Interfaces.TerminalDC.PhaseSystem".to_string(),
+    );
+
+    let result = validate_class_redeclaration(
+        &tree,
+        &alias_phase_system,
+        "PhaseSystem",
+        Some("PhaseSystems.TwoConductor"),
+        Span::DUMMY,
+    );
+    let err = result.expect_err("test setup should trigger subtype failure in unit fixture");
+    assert!(
+        err.to_string().contains("PhaseSystems.PartialPhaseSystem"),
+        "default constraint should come from declared base type"
+    );
+    assert!(
+        !err.to_string()
+            .contains("Interfaces.TerminalDC.PhaseSystem"),
+        "default constraint must not fall back to alias class name"
+    );
+}
+
 // -------------------------------------------------------------------------
 // is_type_subtype tests
 // -------------------------------------------------------------------------

--- a/crates/rumoca-phase-resolve/src/lib.rs
+++ b/crates/rumoca-phase-resolve/src/lib.rs
@@ -35,8 +35,8 @@ pub use validation::{UnresolvedKind, UnresolvedSymbol, ValidationResult, validat
 
 use indexmap::IndexMap;
 use rumoca_core::{
-    BUILTIN_FUNCTIONS, BUILTIN_TYPES, BUILTIN_VARIABLES, DefId, Diagnostics, PrimaryLabel, ScopeId,
-    SourceMap, Span, maybe_elapsed_ms, maybe_start_timer,
+    BUILTIN_FUNCTIONS, BUILTIN_TYPES, BUILTIN_VARIABLES, DefId, Diagnostic, DiagnosticSeverity,
+    Diagnostics, PrimaryLabel, ScopeId, SourceMap, Span, maybe_elapsed_ms, maybe_start_timer,
 };
 use rumoca_ir_ast as ast;
 #[cfg(not(target_arch = "wasm32"))]
@@ -58,6 +58,10 @@ pub struct ResolveOptions {
     pub unresolved_component_refs_are_errors: bool,
     /// Whether unresolved function calls are treated as hard errors.
     pub unresolved_function_calls_are_errors: bool,
+    /// Whether ER070 (annotation Evaluate scope) is treated as a hard error.
+    pub evaluate_scope_is_error: bool,
+    /// Whether ER053 (single-assignment in when-equation) is treated as a hard error.
+    pub when_single_assign_is_error: bool,
 }
 
 impl Default for ResolveOptions {
@@ -65,8 +69,21 @@ impl Default for ResolveOptions {
         Self {
             unresolved_component_refs_are_errors: true,
             unresolved_function_calls_are_errors: true,
+            evaluate_scope_is_error: true,
+            when_single_assign_is_error: true,
         }
     }
+}
+
+fn apply_semantic_diagnostic_policy(mut diag: Diagnostic, options: ResolveOptions) -> Diagnostic {
+    let code = diag.code.as_deref().unwrap_or_default();
+    if code == "ER070" && !options.evaluate_scope_is_error {
+        diag.severity = DiagnosticSeverity::Warning;
+    }
+    if code == "ER053" && !options.when_single_assign_is_error {
+        diag.severity = DiagnosticSeverity::Warning;
+    }
+    diag
 }
 
 /// Convert a Location to a Span for error reporting using the source map.
@@ -509,7 +526,9 @@ pub fn resolve_with_options_collect(
     // Run semantic checks on the AST.
     let semantic_checks_start = maybe_start_timer();
     for diag in semantic_checks::check_all_semantics(&tree.definitions, &tree.source_map) {
-        resolver.diagnostics.emit(diag);
+        resolver
+            .diagnostics
+            .emit(apply_semantic_diagnostic_policy(diag, options));
     }
     let semantic_checks_ms = maybe_elapsed_ms(semantic_checks_start);
 
@@ -565,7 +584,10 @@ pub fn resolve_with_stats(parsed: ParsedTree) -> ResolveWithStatsResult {
 
     // Run semantic checks.
     for diag in semantic_checks::check_all_semantics(&tree.definitions, &tree.source_map) {
-        resolver.diagnostics.emit(diag);
+        resolver.diagnostics.emit(apply_semantic_diagnostic_policy(
+            diag,
+            ResolveOptions::default(),
+        ));
     }
 
     // Validate unresolved symbols gathered by post-resolution visitor (MLS §5.3)
@@ -831,6 +853,37 @@ end UsesReplaceableMedium;
     }
 
     #[test]
+    fn test_short_package_alias_member_lookup_resolves_inherited_member() {
+        let source = r#"
+package PhaseSystems
+  package ThreePhase_dq0
+    function j
+      input Real x;
+      output Real y;
+    algorithm
+      y := x;
+    end j;
+  end ThreePhase_dq0;
+end PhaseSystems;
+
+package AC3ph
+  package Ports
+    model PortBase
+      package PS = PhaseSystems.ThreePhase_dq0;
+      function j = PS.j;
+      Real y;
+    equation
+      y = j(1.0);
+    end PortBase;
+  end Ports;
+end AC3ph;
+"#;
+
+        resolve_test_source(source)
+            .expect("short package alias member access like `PS.j` should resolve");
+    }
+
+    #[test]
     fn test_cardinality_allows_indexed_connector_array_element() {
         let source = r#"
 connector Port
@@ -868,6 +921,92 @@ end UsesArrayCardinality;
             diags.iter().any(|d| d.code.as_deref() == Some("ER057")
                 && d.message.contains("connector array 'ports'")),
             "expected cardinality connector-array diagnostic, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn test_loop_index_named_like_class_does_not_trigger_class_used_as_value() {
+        let source = r#"
+package P
+  model j
+  end j;
+end P;
+
+model UsesLoopIndexJ
+  Integer y;
+equation
+  for j in 1:2 loop
+    y = j;
+  end for;
+end UsesLoopIndexJ;
+"#;
+        resolve_test_source(source)
+            .expect("loop index `j` must resolve as a value, not as global class `j`");
+    }
+
+    #[test]
+    fn test_evaluate_on_non_parameter_component_is_error_by_default() {
+        let source = r#"
+model EvaluateScopeWarning
+  Real x annotation(Evaluate=true);
+equation
+  x = 1;
+end EvaluateScopeWarning;
+"#;
+        let diagnostics = resolve_test_source(source)
+            .expect_err("Evaluate annotation scope should fail by default in strict mode");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diag| diag.code.as_deref() == Some("ER070")),
+            "expected ER070 for invalid Evaluate annotation, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_when_single_assign_allows_distinct_indexed_targets() {
+        let source = r#"
+model IndexedWhenTargets
+  Boolean open1;
+  Boolean open2;
+  Real t0[2];
+equation
+  when edge(open1) then
+    t0[1] = time;
+  end when;
+  when edge(open2) then
+    t0[2] = time;
+  end when;
+end IndexedWhenTargets;
+"#;
+        resolve_test_source(source)
+            .expect("distinct indexed targets in separate when-equations should be allowed");
+    }
+
+    #[test]
+    fn test_when_single_assign_rejects_same_target_across_when_equations() {
+        let source = r#"
+model DuplicateWhenTarget
+  Boolean open1;
+  Boolean open2;
+  Real t0;
+equation
+  when edge(open1) then
+    t0 = time;
+  end when;
+  when edge(open2) then
+    t0 = time;
+  end when;
+end DuplicateWhenTarget;
+"#;
+        let result = resolve_test_source(source);
+        assert!(result.is_err(), "duplicate when target should fail");
+        let diagnostics = result.expect_err("expected diagnostics");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diag| diag.code.as_deref() == Some("ER053")),
+            "expected ER053 for duplicate when target, got: {diagnostics:?}"
         );
     }
 
@@ -1189,6 +1328,7 @@ end Test;
         let options = ResolveOptions {
             unresolved_component_refs_are_errors: false,
             unresolved_function_calls_are_errors: false,
+            ..ResolveOptions::default()
         };
         let result = resolve_with_options(parsed, options);
         assert!(

--- a/crates/rumoca-phase-resolve/src/lookup.rs
+++ b/crates/rumoca-phase-resolve/src/lookup.rs
@@ -64,7 +64,27 @@ impl Resolver {
             let next_qualified = format!("{}.{}", current_qualified, part.text);
 
             // O(1) lookup using the inverse map
-            current_def_id = *self.name_to_def.get(&next_qualified)?;
+            if let Some(next_def_id) = self.name_to_def.get(&next_qualified) {
+                current_def_id = *next_def_id;
+                continue;
+            }
+
+            // Fallback: the current node may be a short class definition alias
+            // (e.g. `package PS = PhaseSystem;`) where members are inherited from
+            // the aliased base class. Those inherited members are not explicitly
+            // declared under `current_qualified.*` in `name_to_def`.
+            //
+            // MLS §7.3 semantics require dotted access like `PS.j` to resolve.
+            // Reuse inherited-member lookup for this dotted navigation step.
+            if self.class_types.contains_key(&current_def_id)
+                && let Some(inherited_def_id) =
+                    self.lookup_inherited_member(current_qualified, &part.text)
+            {
+                current_def_id = inherited_def_id;
+                continue;
+            }
+
+            return None;
         }
 
         Some(current_def_id)

--- a/crates/rumoca-phase-resolve/src/semantic_checks_expr.rs
+++ b/crates/rumoca-phase-resolve/src/semantic_checks_expr.rs
@@ -637,9 +637,11 @@ impl ast::Visitor for ExprTypeIssuesVisitor<'_> {
             // TYPE-005: Class name used as value in equation
             Expression::ComponentReference(cref) if cref.parts.len() == 1 => {
                 let name = &*cref.parts[0].ident.text;
-                if !self.class.components.contains_key(name)
-                    && find_class_by_name(self.def, name).is_some()
-                {
+                let refers_to_class = cref
+                    .def_id
+                    .and_then(|def_id| find_class_by_def_id(self.def, def_id))
+                    .is_some();
+                if !self.class.components.contains_key(name) && refers_to_class {
                     self.diags.push(semantic_error(
                         ER011_CLASS_USED_AS_VALUE,
                         format!(

--- a/crates/rumoca-phase-resolve/src/semantic_checks_operators.rs
+++ b/crates/rumoca-phase-resolve/src/semantic_checks_operators.rs
@@ -699,16 +699,18 @@ fn extract_reinit_target(comp: &ComponentReference, args: &[Expression]) -> Opti
     let Expression::ComponentReference(target) = args.first()? else {
         return None;
     };
-    let target = target.parts.first()?;
-    span_from_location(&target.ident.location).map(|span| (target.ident.text.to_string(), span))
+    let first_target_part = target.parts.first()?;
+    let target_key = target.to_string();
+    span_from_location(&first_target_part.ident.location).map(|span| (target_key, span))
 }
 
 fn extract_component_reference_target(expr: &Expression) -> Option<(String, Span)> {
     let Expression::ComponentReference(comp) = expr else {
         return None;
     };
-    let target = comp.parts.first()?;
-    span_from_location(&target.ident.location).map(|span| (target.ident.text.to_string(), span))
+    let first_part = comp.parts.first()?;
+    let target_key = comp.to_string();
+    span_from_location(&first_part.ident.location).map(|span| (target_key, span))
 }
 
 fn label_from_span(span: Span, message: String) -> PrimaryLabel {

--- a/crates/rumoca-phase-typecheck/src/lib.rs
+++ b/crates/rumoca-phase-typecheck/src/lib.rs
@@ -343,6 +343,10 @@ impl TypeChecker {
         // over inherited replaceable defaults (MLS §7.3).
         Self::collect_model_extends_redeclare_constants(tree, model_name, &mut self.eval_ctx);
 
+        // Collect nested/redeclare constants from component *type* hierarchies
+        // into each instance scope (e.g. `voltage.term.PhaseSystem.n`).
+        Self::collect_component_type_nested_constants(tree, overlay, &mut self.eval_ctx);
+
         // Collect constants from the enclosing class (MLS §5.3).
         // When compiling `Package.BaseProperties`, constants like nX, nXi
         // defined in `Package` need to be available for dimension evaluation.
@@ -527,12 +531,26 @@ impl TypeChecker {
             return;
         }
 
+        let is_active_alias = active_alias == Some(alias);
+        if is_active_alias {
+            // MLS §7.3: active alias redeclare owns the unqualified
+            // component-local projection (e.g., `medium.nX`), so stale values
+            // from inherited/default aliases must be replaced.
+            //
+            // Important: clear this before writing `comp_scope.alias.*` so we
+            // do not erase freshly extracted alias constants.
+            Self::clear_alias_scope_values(ctx, comp_scope);
+        }
+
         let alias_scope = format!("{comp_scope}.{alias}");
+        // MLS §7.3: instance-level redeclare overrides must replace inherited/default
+        // package constants in the local alias scope.
+        Self::clear_alias_scope_values(ctx, &alias_scope);
         Self::extract_override_class_constants(tree, &alias_scope, def_id, ctx);
 
         // For declarations like `Medium.BaseProperties medium`, expose
         // unqualified constants (`medium.nX`) from the active alias only.
-        if active_alias == Some(alias) {
+        if is_active_alias {
             Self::extract_override_class_constants(tree, comp_scope, def_id, ctx);
         }
     }
@@ -1577,6 +1595,13 @@ impl TypeChecker {
             // Follow extends chains to concrete types and extract their constants
             for ext in &nested_class.extends {
                 Self::extract_extends_modification_constants(nested_name, ext, ctx);
+                Self::extract_nested_extends_redeclare_constants(
+                    tree,
+                    nested_name,
+                    model_name,
+                    ext,
+                    ctx,
+                );
                 Self::extract_class_constants_from_extends(
                     tree,
                     nested_name,
@@ -1585,6 +1610,152 @@ impl TypeChecker {
                     ctx,
                 );
             }
+        }
+    }
+
+    /// Extract nested/redeclare constants for each instantiated component type
+    /// into the component instance scope.
+    fn collect_component_type_nested_constants(
+        tree: &ClassTree,
+        overlay: &InstanceOverlay,
+        ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
+    ) {
+        const MAX_PASSES: usize = 4;
+        for _ in 0..MAX_PASSES {
+            let prev =
+                ctx.integers.len() + ctx.dimensions.len() + ctx.reals.len() + ctx.booleans.len();
+            for instance_data in overlay.components.values() {
+                Self::collect_component_instance_type_nested_constants(tree, instance_data, ctx);
+            }
+            let new =
+                ctx.integers.len() + ctx.dimensions.len() + ctx.reals.len() + ctx.booleans.len();
+            if new == prev {
+                break;
+            }
+        }
+    }
+
+    fn collect_component_instance_type_nested_constants(
+        tree: &ClassTree,
+        instance_data: &rumoca_ir_ast::InstanceData,
+        ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
+    ) {
+        let comp_scope = instance_data.qualified_name.to_flat_string();
+        if comp_scope.is_empty() {
+            return;
+        }
+        let type_name = instance_data.type_name.as_str();
+        if type_name.is_empty() {
+            return;
+        }
+
+        let ancestors = Self::collect_ancestor_classes(tree, type_name);
+        for ancestor in ancestors {
+            Self::extract_class_extends_redeclare_constants_for_scope(
+                tree,
+                ancestor,
+                &comp_scope,
+                type_name,
+                ctx,
+            );
+            Self::extract_nested_class_constants_from_scoped(
+                tree,
+                ancestor,
+                &comp_scope,
+                type_name,
+                ctx,
+            );
+        }
+    }
+
+    /// Materialize class-level extends redeclare constants under an instance scope.
+    ///
+    /// Example:
+    /// `comp_scope = voltage.term`, class has
+    /// `extends Interfaces.TerminalDC(redeclare package PhaseSystem = ...);`
+    /// -> populate `voltage.term.PhaseSystem.*`.
+    fn extract_class_extends_redeclare_constants_for_scope(
+        tree: &ClassTree,
+        class_def: &ClassDef,
+        comp_scope: &str,
+        resolve_context: &str,
+        ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
+    ) {
+        for ext in &class_def.extends {
+            Self::extract_nested_extends_redeclare_constants(
+                tree,
+                comp_scope,
+                resolve_context,
+                ext,
+                ctx,
+            );
+        }
+    }
+
+    /// Scoped variant of nested class constant extraction.
+    ///
+    /// Emits constants under `<base_scope>.<nested_name>.*` so dimension
+    /// expressions in nested members resolve lexically in instance scope.
+    fn extract_nested_class_constants_from_scoped(
+        tree: &ClassTree,
+        class_def: &ClassDef,
+        base_scope: &str,
+        resolve_context: &str,
+        ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
+    ) {
+        for (nested_name, nested_class) in &class_def.classes {
+            let nested_alias = format!("{base_scope}.{nested_name}");
+            Self::extract_class_constants(&nested_alias, nested_class, ctx);
+            for ext in &nested_class.extends {
+                Self::extract_extends_modification_constants(&nested_alias, ext, ctx);
+                Self::extract_nested_extends_redeclare_constants(
+                    tree,
+                    &nested_alias,
+                    resolve_context,
+                    ext,
+                    ctx,
+                );
+                Self::extract_class_constants_from_extends(
+                    tree,
+                    &nested_alias,
+                    &ext.base_name.to_string(),
+                    resolve_context,
+                    ctx,
+                );
+            }
+        }
+    }
+
+    /// Materialize nested-class `extends(... redeclare package/class ...)` constants.
+    ///
+    /// Example: inside nested class `TwoPin`,
+    /// `extends Interfaces.TerminalDC(redeclare package PhaseSystem = PhaseSystems.TwoConductor)`
+    /// must populate `TwoPin.PhaseSystem.*` so expressions like `PhaseSystem.n`
+    /// in inherited dimension declarations become evaluable.
+    fn extract_nested_extends_redeclare_constants(
+        tree: &ClassTree,
+        nested_alias: &str,
+        resolve_context: &str,
+        ext: &rumoca_ir_ast::Extend,
+        ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
+    ) {
+        for ext_mod in &ext.modifications {
+            let Expression::Modification { target, value } = &ext_mod.expr else {
+                continue;
+            };
+            let looks_like_class_or_package_rebind = matches!(
+                value.as_ref(),
+                Expression::ComponentReference(_) | Expression::ClassModification { .. }
+            );
+            if !ext_mod.redeclare && !looks_like_class_or_package_rebind {
+                continue;
+            }
+            let Some(def_id) = Self::resolve_redeclare_target_def_id(tree, value, resolve_context)
+            else {
+                continue;
+            };
+            let alias_scope = format!("{nested_alias}.{target}");
+            Self::extract_override_class_constants(tree, &alias_scope, def_id, ctx);
         }
     }
 
@@ -1772,203 +1943,6 @@ impl TypeChecker {
 
             self.eval_ctx.build_suffix_index();
         }
-    }
-
-    /// Collect record-parameter aliases from overlay bindings (MLS §7.2.3).
-    ///
-    /// Example: for `chain(cellData = cellData2)`, collect
-    /// `chain.cellData -> cellData2` so field references like
-    /// `chain.cellData.nRC` can resolve through the modifier binding.
-    fn collect_record_aliases(overlay: &InstanceOverlay) -> Vec<(String, String)> {
-        let mut aliases: HashMap<String, String> = HashMap::new();
-        let (known_paths, known_prefixes) = Self::collect_known_component_paths(overlay);
-        for instance_data in overlay.components.values() {
-            let Some(binding) = &instance_data.binding else {
-                continue;
-            };
-            let Some(target_unqualified) = Self::extract_simple_path(binding) else {
-                continue;
-            };
-            let source = instance_data.qualified_name.to_flat_string();
-            let target = Self::resolve_alias_target(
-                &source,
-                &target_unqualified,
-                instance_data.binding_from_modification,
-                &known_paths,
-                &known_prefixes,
-            );
-            if source != target {
-                aliases.insert(source, target);
-            }
-        }
-        Self::collapse_alias_chains(&mut aliases);
-        let mut out: Vec<(String, String)> = aliases.into_iter().collect();
-        out.sort_by(|a, b| a.0.cmp(&b.0));
-        out
-    }
-
-    /// Extract a simple dotted path from an expression if it is a plain reference.
-    fn extract_simple_path(expr: &Expression) -> Option<String> {
-        match expr {
-            Expression::ComponentReference(cr) => (!cr.parts.is_empty()).then(|| cr.to_string()),
-            Expression::FieldAccess { base, field } => {
-                let base_path = Self::extract_simple_path(base)?;
-                Some(format!("{base_path}.{field}"))
-            }
-            _ => None,
-        }
-    }
-
-    /// Collect full component paths and all dotted prefixes from the overlay.
-    fn collect_known_component_paths(
-        overlay: &InstanceOverlay,
-    ) -> (HashSet<String>, HashSet<String>) {
-        let mut known_paths: HashSet<String> = HashSet::new();
-        let mut known_prefixes: HashSet<String> = HashSet::new();
-        for instance_data in overlay.components.values() {
-            let full = instance_data.qualified_name.to_flat_string();
-            known_paths.insert(full.clone());
-            let mut scope = full.as_str();
-            while let Some((prefix, _)) = scope.rsplit_once('.') {
-                known_prefixes.insert(prefix.to_string());
-                scope = prefix;
-            }
-        }
-        (known_paths, known_prefixes)
-    }
-
-    /// Resolve modifier/declaration alias targets into absolute instance scope.
-    ///
-    /// Applies lexical scope traversal and picks the first candidate that maps
-    /// to an existing overlay path or a known parent prefix.
-    fn resolve_alias_target(
-        source: &str,
-        target_unqualified: &str,
-        from_modification: bool,
-        known_paths: &HashSet<String>,
-        known_prefixes: &HashSet<String>,
-    ) -> String {
-        let mut scope = if from_modification {
-            Self::grandparent_scope(source)
-        } else {
-            Self::parent_scope(source)
-        };
-        loop {
-            let candidate = if scope.is_empty() {
-                target_unqualified.to_string()
-            } else {
-                format!("{scope}.{target_unqualified}")
-            };
-            if Self::is_known_component_or_prefix(&candidate, known_paths, known_prefixes) {
-                return candidate;
-            }
-            if scope.is_empty() {
-                break;
-            }
-            scope = Self::parent_scope(scope);
-        }
-        target_unqualified.to_string()
-    }
-
-    fn is_known_component_or_prefix(
-        candidate: &str,
-        known_paths: &HashSet<String>,
-        known_prefixes: &HashSet<String>,
-    ) -> bool {
-        known_paths.contains(candidate) || known_prefixes.contains(candidate)
-    }
-
-    fn parent_scope(path: &str) -> &str {
-        path.rsplit_once('.').map_or("", |(prefix, _)| prefix)
-    }
-
-    fn grandparent_scope(path: &str) -> &str {
-        Self::parent_scope(Self::parent_scope(path))
-    }
-
-    /// Collapse `A->B->C` alias chains to direct `A->C` mappings.
-    fn collapse_alias_chains(aliases: &mut HashMap<String, String>) {
-        const MAX_PASSES: usize = 20;
-        for _ in 0..MAX_PASSES {
-            let mut changed = false;
-            let keys: Vec<String> = aliases.keys().cloned().collect();
-            for key in keys {
-                changed |= Self::collapse_alias_for_key(aliases, &key);
-            }
-            if !changed {
-                break;
-            }
-        }
-    }
-
-    fn collapse_alias_for_key(aliases: &mut HashMap<String, String>, key: &str) -> bool {
-        let Some(target) = Self::resolve_alias_terminal(aliases, key) else {
-            return false;
-        };
-        if aliases.get(key) == Some(&target) {
-            return false;
-        }
-        aliases.insert(key.to_string(), target);
-        true
-    }
-
-    fn resolve_alias_terminal(aliases: &HashMap<String, String>, key: &str) -> Option<String> {
-        let mut target = aliases.get(key)?.clone();
-        let mut seen = std::collections::HashSet::new();
-        while seen.insert(target.clone()) {
-            let Some(next) = aliases.get(&target).cloned() else {
-                break;
-            };
-            target = next;
-        }
-        Some(target)
-    }
-
-    /// Propagate evaluated scalar/dimension values through record aliases.
-    ///
-    /// If `A -> B`, then `A.field` should mirror `B.field` for compile-time
-    /// evaluation of dimension expressions and range bounds.
-    fn propagate_record_alias_values(&mut self, record_aliases: &[(String, String)]) -> bool {
-        Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.integers)
-            | Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.reals)
-            | Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.booleans)
-            | Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.enums)
-            | Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.dimensions)
-    }
-
-    fn propagate_alias_map<T: Clone + PartialEq>(
-        record_aliases: &[(String, String)],
-        values: &mut rustc_hash::FxHashMap<String, T>,
-    ) -> bool {
-        if record_aliases.is_empty() || values.is_empty() {
-            return false;
-        }
-        let mut sorted_keys: Vec<String> = values.keys().cloned().collect();
-        sorted_keys.sort_unstable();
-
-        let mut updates: rustc_hash::FxHashMap<String, T> = rustc_hash::FxHashMap::default();
-        for (alias_source, alias_target) in record_aliases {
-            Self::queue_alias_root_update(alias_source, alias_target, values, &mut updates);
-            let target_prefix = format!("{alias_target}.");
-            for field_name in Self::alias_field_key_range(&sorted_keys, &target_prefix) {
-                Self::queue_alias_field_update(
-                    alias_source,
-                    &target_prefix,
-                    field_name,
-                    values,
-                    &mut updates,
-                );
-            }
-        }
-
-        let mut progress = false;
-        for (name, value) in updates {
-            if values.get(&name) != Some(&value) {
-                values.insert(name, value);
-                progress = true;
-            }
-        }
-        progress
     }
 }
 

--- a/crates/rumoca-phase-typecheck/src/tests.rs
+++ b/crates/rumoca-phase-typecheck/src/tests.rs
@@ -260,6 +260,114 @@ fn test_colon_dimension_inference() {
 }
 
 #[test]
+fn test_redeclared_phase_system_dimension_resolves() {
+    // Regression for PowerSystems-style connector dimensions:
+    // PhaseSystem.n must resolve through the full type scope when a connector
+    // extends another connector and redeclares the replaceable package.
+    let source = r#"
+        package PhaseSystems
+          partial package PartialPhaseSystem
+            constant Integer n;
+            constant Integer m;
+            type Voltage = Real;
+            type Current = Real;
+          end PartialPhaseSystem;
+
+          package TwoConductor
+            extends PartialPhaseSystem(n=2, m=0);
+          end TwoConductor;
+        end PhaseSystems;
+
+        package Interfaces
+          connector TerminalDC
+            replaceable package PhaseSystem = PhaseSystems.PartialPhaseSystem;
+            PhaseSystem.Voltage v[PhaseSystem.n];
+            flow PhaseSystem.Current i[PhaseSystem.n];
+          end TerminalDC;
+        end Interfaces;
+
+        package Ports
+          connector TwoPin
+            extends Interfaces.TerminalDC(
+              redeclare package PhaseSystem = PhaseSystems.TwoConductor
+            );
+          end TwoPin;
+        end Ports;
+
+        model Test
+          Ports.TwoPin term;
+        end Test;
+    "#;
+
+    let parsed = parse(source);
+    let resolved = resolve(parsed).expect("resolve should succeed");
+    let typed = typecheck(resolved).expect("typecheck should succeed");
+
+    let tree = typed.into_inner();
+    let test_class = tree
+        .definitions
+        .classes
+        .get("Test")
+        .expect("Test class should exist");
+
+    let term = test_class
+        .components
+        .get("term")
+        .expect("term should exist");
+    assert_eq!(
+        term.shape,
+        vec![],
+        "term connector itself should remain scalar"
+    );
+}
+
+#[test]
+fn test_redeclared_phase_system_dimension_resolves_in_nested_component() {
+    // Mirrors `voltage.term.v[PhaseSystem.n]` shape in PowerSystems examples.
+    let source = r#"
+        package PhaseSystems
+          partial package PartialPhaseSystem
+            constant Integer n;
+            type Voltage = Real;
+            type Current = Real;
+          end PartialPhaseSystem;
+
+          package TwoConductor
+            extends PartialPhaseSystem(n=2);
+          end TwoConductor;
+        end PhaseSystems;
+
+        package Interfaces
+          connector TerminalDC
+            replaceable package PhaseSystem = PhaseSystems.PartialPhaseSystem;
+            PhaseSystem.Voltage v[PhaseSystem.n];
+            flow PhaseSystem.Current i[PhaseSystem.n];
+          end TerminalDC;
+        end Interfaces;
+
+        package Ports
+          connector TwoPin
+            extends Interfaces.TerminalDC(
+              redeclare package PhaseSystem = PhaseSystems.TwoConductor
+            );
+          end TwoPin;
+        end Ports;
+
+        model Source
+          Ports.TwoPin term;
+        end Source;
+
+        model Top
+          Source voltage;
+        end Top;
+    "#;
+
+    let parsed = parse(source);
+    let resolved = resolve(parsed).expect("resolve should succeed");
+    typecheck(resolved).expect("typecheck should succeed");
+}
+
+#[test]
 fn test_parameter_colon_dimension_without_binding_is_allowed() {
     // Parameter `[:]` may remain unresolved until instantiation binds it.
     let source = r#"

--- a/crates/rumoca-phase-typecheck/src/typechecker/late_methods.rs
+++ b/crates/rumoca-phase-typecheck/src/typechecker/late_methods.rs
@@ -183,7 +183,7 @@ impl TypeChecker {
         &self,
         sub: &rumoca_ir_ast::Subscript,
         instance_scope: &str,
-        type_scope_hints: &HashMap<String, String>,
+        type_scope_hints: &HashMap<String, Vec<String>>,
     ) -> Option<i64> {
         rumoca_eval_ast::eval::eval_dimension_with_scope(sub, &self.eval_ctx, instance_scope)
             .or_else(|| {
@@ -197,24 +197,35 @@ impl TypeChecker {
             .map(|v| v as i64)
     }
 
-    /// Build component-name → type-scope hints for dimension lookup fallback.
+    /// Build component-name -> ordered type-scope hints for dimension lookup fallback.
     ///
     /// For component `state1` of type `Medium.ThermodynamicState`, this records:
-    /// `state1` → `Medium`. Nested fields like `state1.X` can then resolve `nX`
-    /// through the type scope when instance-scope lookup is insufficient.
-    pub(crate) fn build_type_scope_hints(overlay: &InstanceOverlay) -> HashMap<String, String> {
+    /// `state1` -> [`Medium.ThermodynamicState`, `Medium`]. Nested fields like
+    /// `state1.X` can then resolve dimension symbols through the type scopes
+    /// when instance-scope lookup is insufficient.
+    pub(crate) fn build_type_scope_hints(
+        overlay: &InstanceOverlay,
+    ) -> HashMap<String, Vec<String>> {
         let mut hints = HashMap::new();
         for (_def_id, instance_data) in &overlay.components {
-            let Some(pos) = find_last_top_level_dot(&instance_data.type_name) else {
+            if instance_data.type_name.is_empty() {
                 continue;
-            };
-            let component_name = instance_data.qualified_name.to_flat_string();
-            let type_scope = &instance_data.type_name[..pos];
-            if !type_scope.is_empty() {
-                hints.insert(component_name, type_scope.to_string());
             }
+            let component_name = instance_data.qualified_name.to_flat_string();
+            let mut scopes = Vec::with_capacity(2);
+            scopes.push(instance_data.type_name.clone());
+            if let Some(parent_scope) = Self::parent_type_scope(&instance_data.type_name) {
+                scopes.push(parent_scope.to_string());
+            }
+            hints.insert(component_name, scopes);
         }
         hints
+    }
+
+    fn parent_type_scope(type_name: &str) -> Option<&str> {
+        let pos = find_last_top_level_dot(type_name)?;
+        let parent_scope = &type_name[..pos];
+        (!parent_scope.is_empty()).then_some(parent_scope)
     }
 
     /// Fallback dimension evaluation using enclosing component type scopes.
@@ -224,7 +235,7 @@ impl TypeChecker {
     pub(crate) fn eval_dimension_with_type_scope_fallback(
         sub: &rumoca_ir_ast::Subscript,
         instance_scope: &str,
-        type_scope_hints: &HashMap<String, String>,
+        type_scope_hints: &HashMap<String, Vec<String>>,
         ctx: &rumoca_eval_ast::eval::TypeCheckEvalContext,
     ) -> Option<usize> {
         if instance_scope.is_empty() {
@@ -232,11 +243,10 @@ impl TypeChecker {
         }
         let mut current = instance_scope;
         loop {
-            if let Some(type_scope) = type_scope_hints.get(current)
-                && let Some(v) =
-                    rumoca_eval_ast::eval::eval_dimension_with_scope(sub, ctx, type_scope)
+            if let Some(type_scopes) = type_scope_hints.get(current)
+                && let Some(value) = Self::eval_dimension_from_type_scopes(sub, ctx, type_scopes)
             {
-                return Some(v);
+                return Some(value);
             }
             if let Some(parent_scope) = parent_scope(current) {
                 current = parent_scope;
@@ -245,6 +255,16 @@ impl TypeChecker {
             }
         }
         None
+    }
+
+    fn eval_dimension_from_type_scopes(
+        sub: &rumoca_ir_ast::Subscript,
+        ctx: &rumoca_eval_ast::eval::TypeCheckEvalContext,
+        type_scopes: &[String],
+    ) -> Option<usize> {
+        type_scopes
+            .iter()
+            .find_map(|scope| rumoca_eval_ast::eval::eval_dimension_with_scope(sub, ctx, scope))
     }
 
     /// Re-evaluate integer parameters that may depend on size() of arrays.
@@ -476,8 +496,7 @@ impl TypeChecker {
             }
 
             let var_name = instance_data.qualified_name.to_flat_string();
-
-            let reason = match (has_colon_dim, instance_data.binding.is_none()) {
+            let base_reason = match (has_colon_dim, instance_data.binding.is_none()) {
                 (true, true) => {
                     "colon dimension without binding - provide an array literal or use explicit size"
                         .to_string()
@@ -490,8 +509,9 @@ impl TypeChecker {
                     instance_data.dims_expr
                 ),
             };
+            let reason = base_reason;
 
-            // Emit as error per MLS §10.1
+            // Emit as error per MLS §10.1.
             let span = self.source_map.location_to_span(
                 &instance_data.source_location.file_name,
                 instance_data.source_location.start as usize,

--- a/crates/rumoca-phase-typecheck/src/typechecker/mod.rs
+++ b/crates/rumoca-phase-typecheck/src/typechecker/mod.rs
@@ -3,4 +3,5 @@ use super::*;
 pub(super) mod api;
 pub(super) mod builtin_function_checks;
 pub(super) mod late_methods;
+pub(super) mod record_aliases;
 pub(super) mod traversal_adapter;

--- a/crates/rumoca-phase-typecheck/src/typechecker/record_aliases.rs
+++ b/crates/rumoca-phase-typecheck/src/typechecker/record_aliases.rs
@@ -1,0 +1,203 @@
+use super::*;
+
+impl TypeChecker {
+    /// Collect record-parameter aliases from overlay bindings (MLS §7.2.3).
+    ///
+    /// Example: for `chain(cellData = cellData2)`, collect
+    /// `chain.cellData -> cellData2` so field references like
+    /// `chain.cellData.nRC` can resolve through the modifier binding.
+    pub(crate) fn collect_record_aliases(overlay: &InstanceOverlay) -> Vec<(String, String)> {
+        let mut aliases: HashMap<String, String> = HashMap::new();
+        let (known_paths, known_prefixes) = Self::collect_known_component_paths(overlay);
+        for instance_data in overlay.components.values() {
+            let Some(binding) = &instance_data.binding else {
+                continue;
+            };
+            let Some(target_unqualified) = Self::extract_simple_path(binding) else {
+                continue;
+            };
+            let source = instance_data.qualified_name.to_flat_string();
+            let target = Self::resolve_alias_target(
+                &source,
+                &target_unqualified,
+                instance_data.binding_from_modification,
+                &known_paths,
+                &known_prefixes,
+            );
+            if source != target {
+                aliases.insert(source, target);
+            }
+        }
+        Self::collapse_alias_chains(&mut aliases);
+        let mut out: Vec<(String, String)> = aliases.into_iter().collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
+    /// Extract a simple dotted path from an expression if it is a plain reference.
+    pub(crate) fn extract_simple_path(expr: &Expression) -> Option<String> {
+        match expr {
+            Expression::ComponentReference(cr) => (!cr.parts.is_empty()).then(|| cr.to_string()),
+            Expression::FieldAccess { base, field } => {
+                let base_path = Self::extract_simple_path(base)?;
+                Some(format!("{base_path}.{field}"))
+            }
+            _ => None,
+        }
+    }
+
+    /// Collect full component paths and all dotted prefixes from the overlay.
+    fn collect_known_component_paths(
+        overlay: &InstanceOverlay,
+    ) -> (HashSet<String>, HashSet<String>) {
+        let mut known_paths: HashSet<String> = HashSet::new();
+        let mut known_prefixes: HashSet<String> = HashSet::new();
+        for instance_data in overlay.components.values() {
+            let full = instance_data.qualified_name.to_flat_string();
+            known_paths.insert(full.clone());
+            let mut scope = full.as_str();
+            while let Some((prefix, _)) = scope.rsplit_once('.') {
+                known_prefixes.insert(prefix.to_string());
+                scope = prefix;
+            }
+        }
+        (known_paths, known_prefixes)
+    }
+
+    /// Resolve modifier/declaration alias targets into absolute instance scope.
+    ///
+    /// Applies lexical scope traversal and picks the first candidate that maps
+    /// to an existing overlay path or a known parent prefix.
+    fn resolve_alias_target(
+        source: &str,
+        target_unqualified: &str,
+        from_modification: bool,
+        known_paths: &HashSet<String>,
+        known_prefixes: &HashSet<String>,
+    ) -> String {
+        let mut scope = if from_modification {
+            Self::grandparent_scope(source)
+        } else {
+            Self::parent_scope(source)
+        };
+        loop {
+            let candidate = if scope.is_empty() {
+                target_unqualified.to_string()
+            } else {
+                format!("{scope}.{target_unqualified}")
+            };
+            if Self::is_known_component_or_prefix(&candidate, known_paths, known_prefixes) {
+                return candidate;
+            }
+            if scope.is_empty() {
+                break;
+            }
+            scope = Self::parent_scope(scope);
+        }
+        target_unqualified.to_string()
+    }
+
+    fn is_known_component_or_prefix(
+        candidate: &str,
+        known_paths: &HashSet<String>,
+        known_prefixes: &HashSet<String>,
+    ) -> bool {
+        known_paths.contains(candidate) || known_prefixes.contains(candidate)
+    }
+
+    pub(crate) fn parent_scope(path: &str) -> &str {
+        path.rsplit_once('.').map_or("", |(prefix, _)| prefix)
+    }
+
+    fn grandparent_scope(path: &str) -> &str {
+        Self::parent_scope(Self::parent_scope(path))
+    }
+
+    /// Collapse `A->B->C` alias chains to direct `A->C` mappings.
+    fn collapse_alias_chains(aliases: &mut HashMap<String, String>) {
+        const MAX_PASSES: usize = 20;
+        for _ in 0..MAX_PASSES {
+            let mut changed = false;
+            let keys: Vec<String> = aliases.keys().cloned().collect();
+            for key in keys {
+                changed |= Self::collapse_alias_for_key(aliases, &key);
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    fn collapse_alias_for_key(aliases: &mut HashMap<String, String>, key: &str) -> bool {
+        let Some(target) = Self::resolve_alias_terminal(aliases, key) else {
+            return false;
+        };
+        if aliases.get(key) == Some(&target) {
+            return false;
+        }
+        aliases.insert(key.to_string(), target);
+        true
+    }
+
+    fn resolve_alias_terminal(aliases: &HashMap<String, String>, key: &str) -> Option<String> {
+        let mut target = aliases.get(key)?.clone();
+        let mut seen = std::collections::HashSet::new();
+        while seen.insert(target.clone()) {
+            let Some(next) = aliases.get(&target).cloned() else {
+                break;
+            };
+            target = next;
+        }
+        Some(target)
+    }
+
+    /// Propagate evaluated scalar/dimension values through record aliases.
+    ///
+    /// If `A -> B`, then `A.field` should mirror `B.field` for compile-time
+    /// evaluation of dimension expressions and range bounds.
+    pub(crate) fn propagate_record_alias_values(
+        &mut self,
+        record_aliases: &[(String, String)],
+    ) -> bool {
+        Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.integers)
+            | Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.reals)
+            | Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.booleans)
+            | Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.enums)
+            | Self::propagate_alias_map(record_aliases, &mut self.eval_ctx.dimensions)
+    }
+
+    pub(crate) fn propagate_alias_map<T: Clone + PartialEq>(
+        record_aliases: &[(String, String)],
+        values: &mut rustc_hash::FxHashMap<String, T>,
+    ) -> bool {
+        if record_aliases.is_empty() || values.is_empty() {
+            return false;
+        }
+        let mut sorted_keys: Vec<String> = values.keys().cloned().collect();
+        sorted_keys.sort_unstable();
+
+        let mut updates: rustc_hash::FxHashMap<String, T> = rustc_hash::FxHashMap::default();
+        for (alias_source, alias_target) in record_aliases {
+            Self::queue_alias_root_update(alias_source, alias_target, values, &mut updates);
+            let target_prefix = format!("{alias_target}.");
+            for field_name in Self::alias_field_key_range(&sorted_keys, &target_prefix) {
+                Self::queue_alias_field_update(
+                    alias_source,
+                    &target_prefix,
+                    field_name,
+                    values,
+                    &mut updates,
+                );
+            }
+        }
+
+        let mut progress = false;
+        for (name, value) in updates {
+            if values.get(&name) != Some(&value) {
+                values.insert(name, value);
+                progress = true;
+            }
+        }
+        progress
+    }
+}

--- a/crates/rumoca-tool-dev/src/bin/msl_tools/plot_compare.rs
+++ b/crates/rumoca-tool-dev/src/bin/msl_tools/plot_compare.rs
@@ -400,7 +400,10 @@ fn load_msl_session(paths: &MslPaths) -> Result<Session> {
             failures.len()
         );
     }
-    let mut session = Session::new(SessionConfig { parallel: true });
+    let mut session = Session::new(SessionConfig {
+        parallel: true,
+        ..SessionConfig::default()
+    });
     session.add_parsed_batch(successes);
     Ok(session)
 }

--- a/crates/rumoca-tool-lsp/src/server.rs
+++ b/crates/rumoca-tool-lsp/src/server.rs
@@ -100,7 +100,11 @@ enum DiagnosticsTrigger {
 
 impl ModelicaLanguageServer {
     fn default_session_config() -> SessionConfig {
-        SessionConfig { parallel: true }
+        SessionConfig {
+            parallel: true,
+            evaluate_scope_is_error: true,
+            when_single_assign_is_error: true,
+        }
     }
 
     /// Create a new language server instance.

--- a/crates/rumoca/examples/profile_msl.rs
+++ b/crates/rumoca/examples/profile_msl.rs
@@ -55,7 +55,10 @@ fn main() {
     // Create session and build resolved tree
     println!("Creating session...");
     let start = Instant::now();
-    let mut session = Session::new(SessionConfig { parallel: true });
+    let mut session = Session::new(SessionConfig {
+        parallel: true,
+        ..SessionConfig::default()
+    });
     session.add_parsed_batch(successes);
     let model_names = session.model_names().expect("Failed to get model names");
     println!(


### PR DESCRIPTION
## Summary

This PR improves Rumoca's Modelica compilation baseline by fixing several issues that show up in larger real-world libraries, especially MSL- and PowerSystems-style models.

The main improvements are:

- resolves redeclared package/class constants more reliably, especially connector dimensions that depend on nested `replaceable package` redeclarations such as `PhaseSystem.n`
- improves scoped lookup for dotted names, preferring the nearest lexical/type scope before falling back to global suffix lookup
- adds support for inherited members through short package aliases, e.g. `package PS = PhaseSystems.ThreePhase_dq0; function j = PS.j;`
- fixes false `class used as value` diagnostics when a loop index happens to have the same name as a class
- improves `when` single-assignment diagnostics by distinguishing `t0[1]` and `t0[2]` from true duplicate assignments to the same target
- allows selected compatibility behavior in the WASM/source-root API without weakening the strict default behavior:
  - `allowNonParamEvaluateAnnotation`
  - `allowMultiWhenSingleAssign`
- improves DAE lowering for algorithm `for` loops over constant array bindings
- lowers indexed list assignments such as `x[{1,3}] := {a,b}` into scalar assignments
- accepts short enum literal names during DAE reference validation, e.g. `TableDir`
- moves record alias propagation logic into its own typechecker module while preserving the existing behavior

A representative Modelica pattern this improves is the PowerSystems-style redeclared phase-system connector dimension:

```modelica
package PhaseSystems
  partial package PartialPhaseSystem
    constant Integer n;
    type Voltage = Real;
    type Current = Real;
  end PartialPhaseSystem;

  package TwoConductor
    extends PartialPhaseSystem(n = 2);
  end TwoConductor;
end PhaseSystems;

package Interfaces
  connector TerminalDC
    replaceable package PhaseSystem = PhaseSystems.PartialPhaseSystem;
    PhaseSystem.Voltage v[PhaseSystem.n];
    flow PhaseSystem.Current i[PhaseSystem.n];
  end TerminalDC;
end Interfaces;

package Ports
  connector TwoPin
    extends Interfaces.TerminalDC(
      redeclare package PhaseSystem = PhaseSystems.TwoConductor
    );
  end TwoPin;
end Ports;

model Test
  Ports.TwoPin term;
end Test;