### PR TITLE
make most models in Modelica.Electric compile

### DIFF
--- a/crates/rumoca-compile/src/session/tests/compile_diagnostics_tests.rs
+++ b/crates/rumoca-compile/src/session/tests/compile_diagnostics_tests.rs
@@ -574,6 +574,10 @@ fn completion_class_names_tolerate_unrelated_resolve_diagnostics() {
                 Real x;
               end A;
             end Lib;
+
+            model Broken
+              MissingType unresolved;
+            end Broken;
             "#,
         )
         .expect("input should parse");

--- a/crates/rumoca-ir-flat/src/function.rs
+++ b/crates/rumoca-ir-flat/src/function.rs
@@ -11,6 +11,7 @@ impl Function {
             body: Vec::new(),
             pure: true, // Default to pure
             external: None,
+            partial: false,
             derivatives: Vec::new(),
             span,
         }

--- a/crates/rumoca-ir-flat/src/lib.rs
+++ b/crates/rumoca-ir-flat/src/lib.rs
@@ -1387,6 +1387,9 @@ pub struct Function {
     /// External function declaration (MLS §12.9).
     /// If Some, this function calls external C/Fortran code.
     pub external: Option<ExternalFunction>,
+    /// True when this function declaration is partial (MLS §4.7/§12).
+    #[serde(default)]
+    pub partial: bool,
     /// Derivative annotations (MLS §12.7.1).
     /// A function may have multiple derivative annotations for different orders.
     pub derivatives: Vec<DerivativeAnnotation>,

--- a/crates/rumoca-phase-dae/src/algorithm_lowering.rs
+++ b/crates/rumoca-phase-dae/src/algorithm_lowering.rs
@@ -3,11 +3,12 @@ use crate::when_guard::when_guard_activation_expr;
 use crate::{
     dae_to_flat_expression, dae_to_flat_var_name, flat_to_dae_expression, flat_to_dae_var_name,
 };
+mod canonicalize_discrete_assignments;
 mod rewrite_discrete;
 mod slice_lowering;
 mod substitution;
 mod target_names;
-use rewrite_discrete::{discrete_assignment_rhs_var_name, rewrite_discrete_self_refs_to_pre};
+use rewrite_discrete::rewrite_discrete_self_refs_to_pre;
 use slice_lowering::lower_assignment_statement;
 use substitution::*;
 use target_names::{
@@ -15,12 +16,15 @@ use target_names::{
     algorithm_output_target_name, varref_with_subscripts,
 };
 
-enum DiscreteEquationBucket {
+pub(super) enum DiscreteEquationBucket {
     DiscreteReal,
     DiscreteValued,
 }
 
-fn discrete_equation_bucket_for_lhs(dae: &Dae, lhs: &VarName) -> Option<DiscreteEquationBucket> {
+pub(super) fn discrete_equation_bucket_for_lhs(
+    dae: &Dae,
+    lhs: &VarName,
+) -> Option<DiscreteEquationBucket> {
     // MLS Appendix B notes reinit as a special case outside B.1b/B.1c.
     // Solver-facing DAE stores state resets in the event partition (`f_z`) so
     // runtime event updates can apply them without high-level when clauses.
@@ -131,381 +135,13 @@ pub(super) fn route_discrete_event_equations(
     }
 }
 
+#[cfg(test)]
 fn is_connection_equation_origin(origin: &str) -> bool {
     origin.contains("connection equation:")
 }
 
-fn anchored_collision_targets(
-    grouped: &IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
-) -> std::collections::HashSet<VarName> {
-    grouped
-        .iter()
-        .filter(|(_, equations)| {
-            equations
-                .iter()
-                .any(|equation| !is_connection_equation_origin(&equation.origin))
-        })
-        .map(|(lhs, _)| lhs.clone())
-        .collect()
-}
-
-fn flip_edge_key(origin: &str, lhs: &VarName, rhs: &VarName) -> (String, String, String) {
-    (
-        origin.to_string(),
-        lhs.as_str().to_string(),
-        rhs.as_str().to_string(),
-    )
-}
-
-fn choose_collision_keep_index(
-    equations: &[rumoca_ir_dae::Equation],
-    lhs: &VarName,
-    anchored_targets: &std::collections::HashSet<VarName>,
-    flipped_once: &std::collections::HashSet<(String, String, String)>,
-) -> Option<usize> {
-    for (idx, equation) in equations.iter().enumerate() {
-        let rhs_expr = dae_to_flat_expression(&equation.rhs);
-        let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
-            continue;
-        };
-        let reverse_key = flip_edge_key(&equation.origin, &rhs_target, lhs);
-        if flipped_once.contains(&reverse_key) {
-            return Some(idx);
-        }
-    }
-
-    for (idx, equation) in equations.iter().enumerate() {
-        let rhs_expr = dae_to_flat_expression(&equation.rhs);
-        let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
-            continue;
-        };
-        if anchored_targets.contains(&rhs_target) {
-            return Some(idx);
-        }
-    }
-    None
-}
-
-fn has_reverse_connection_alias(
-    grouped: &IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
-    lhs: &VarName,
-    rhs_target: &VarName,
-) -> bool {
-    grouped.get(rhs_target).is_some_and(|rhs_equations| {
-        rhs_equations.iter().any(|rhs_equation| {
-            if !is_connection_equation_origin(&rhs_equation.origin) {
-                return false;
-            }
-            let rhs_expr = dae_to_flat_expression(&rhs_equation.rhs);
-            discrete_assignment_rhs_var_name(&rhs_expr)
-                .as_ref()
-                .is_some_and(|candidate| candidate == lhs)
-        })
-    })
-}
-
-fn keep_collision_equation_without_flip(dae: &Dae, lhs: &VarName, rhs_target: &VarName) -> bool {
-    rhs_target == lhs || discrete_equation_bucket_for_lhs(dae, rhs_target).is_none()
-}
-
-fn resolve_collision_equation(
-    dae: &Dae,
-    grouped: &IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
-    lhs: &VarName,
-    equation: &rumoca_ir_dae::Equation,
-    rhs_target: &VarName,
-    flipped_once: &std::collections::HashSet<(String, String, String)>,
-) -> Option<VarName> {
-    if keep_collision_equation_without_flip(dae, lhs, rhs_target) {
-        return None;
-    }
-    if has_reverse_connection_alias(grouped, lhs, rhs_target) {
-        return Some(lhs.clone());
-    }
-    let reverse_flip_key = flip_edge_key(&equation.origin, rhs_target, lhs);
-    if flipped_once.contains(&reverse_flip_key) {
-        return Some(lhs.clone());
-    }
-    Some(rhs_target.clone())
-}
-
-fn process_collision_equation(
-    dae: &Dae,
-    grouped: &mut IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
-    lhs: &VarName,
-    equation: rumoca_ir_dae::Equation,
-    flipped_once: &mut std::collections::HashSet<(String, String, String)>,
-    debug_canonicalize: bool,
-) -> bool {
-    let rhs_expr = dae_to_flat_expression(&equation.rhs);
-    let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
-        if debug_canonicalize {
-            eprintln!(
-                "f_m canonicalize no-rhs-var lhs={} origin={}",
-                lhs, equation.origin
-            );
-        }
-        grouped.entry(lhs.clone()).or_default().push(equation);
-        return false;
-    };
-
-    let Some(resolved_target) =
-        resolve_collision_equation(dae, grouped, lhs, &equation, &rhs_target, flipped_once)
-    else {
-        if debug_canonicalize {
-            eprintln!(
-                "f_m canonicalize keep-collision lhs={} rhs={} origin={}",
-                lhs, rhs_target, equation.origin
-            );
-        }
-        grouped.entry(lhs.clone()).or_default().push(equation);
-        return false;
-    };
-
-    if resolved_target == *lhs {
-        if debug_canonicalize {
-            eprintln!(
-                "f_m canonicalize drop-redundant-edge lhs={} rhs={} origin={}",
-                lhs, rhs_target, equation.origin
-            );
-        }
-        return true;
-    }
-
-    flipped_once.insert(flip_edge_key(&equation.origin, lhs, &rhs_target));
-    let mut flipped = equation;
-    flipped.lhs = Some(flat_to_dae_var_name(&resolved_target));
-    flipped.rhs = flat_to_dae_expression(&Expression::VarRef {
-        name: lhs.clone(),
-        subscripts: vec![],
-    });
-    if debug_canonicalize {
-        eprintln!(
-            "f_m canonicalize flip lhs={} -> lhs={} origin={}",
-            lhs, resolved_target, flipped.origin
-        );
-    }
-    grouped.entry(resolved_target).or_default().push(flipped);
-    true
-}
-
-fn resolve_connection_alias_target_collisions(
-    grouped: &mut IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
-    dae: &Dae,
-) {
-    let debug_canonicalize = std::env::var("RUMOCA_DEBUG_FM_CANON").is_ok();
-    let anchored_targets = anchored_collision_targets(grouped);
-
-    let mut iteration = 0usize;
-    let max_iterations = 16usize;
-    let mut flipped_once: std::collections::HashSet<(String, String, String)> =
-        std::collections::HashSet::new();
-    loop {
-        iteration += 1;
-        if iteration > max_iterations {
-            if debug_canonicalize {
-                eprintln!("f_m canonicalize collision-pass reached max iterations");
-            }
-            break;
-        }
-
-        let mut changed = false;
-        let keys: Vec<VarName> = grouped.keys().cloned().collect();
-
-        for lhs in keys {
-            let Some(equations) = grouped.get(&lhs) else {
-                continue;
-            };
-            if equations.len() <= 1 {
-                continue;
-            }
-            if equations
-                .iter()
-                .any(|equation| !is_connection_equation_origin(&equation.origin))
-            {
-                continue;
-            }
-
-            let candidate_keep_idx =
-                choose_collision_keep_index(equations, &lhs, &anchored_targets, &flipped_once);
-
-            let Some(mut current_equations) = grouped.swap_remove(&lhs) else {
-                continue;
-            };
-            if current_equations.len() <= 1 {
-                grouped.insert(lhs.clone(), current_equations);
-                continue;
-            }
-
-            let keep_idx = candidate_keep_idx
-                .unwrap_or(0)
-                .min(current_equations.len() - 1);
-            let keep_equation = current_equations.remove(keep_idx);
-            grouped.insert(lhs.clone(), vec![keep_equation]);
-
-            for equation in current_equations {
-                changed |= process_collision_equation(
-                    dae,
-                    grouped,
-                    &lhs,
-                    equation,
-                    &mut flipped_once,
-                    debug_canonicalize,
-                );
-            }
-        }
-
-        if !changed {
-            break;
-        }
-    }
-}
-
 pub(super) fn canonicalize_discrete_assignment_equations(dae: &mut Dae) {
-    let debug_canonicalize = std::env::var("RUMOCA_DEBUG_FM_CANON").is_ok();
-    let (mut grouped, passthrough) = drain_grouped_discrete_assignments(dae);
-    reroute_connection_aliases_for_defined_targets(&mut grouped, dae);
-    resolve_connection_alias_target_collisions(&mut grouped, dae);
-    debug_log_grouped_duplicates(debug_canonicalize, &grouped);
-
-    let mut rebuilt = Vec::with_capacity(passthrough.len() + grouped.len());
-    rebuilt.extend(passthrough);
-    for (lhs, equations) in grouped {
-        rebuilt.extend(canonicalize_assignment_group(lhs, equations));
-    }
-    dae.f_m = rebuilt;
-    debug_log_final_duplicates(debug_canonicalize, &dae.f_m);
-}
-
-fn drain_grouped_discrete_assignments(
-    dae: &mut Dae,
-) -> (
-    IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
-    Vec<rumoca_ir_dae::Equation>,
-) {
-    let mut grouped: IndexMap<VarName, Vec<rumoca_ir_dae::Equation>> = IndexMap::new();
-    let mut passthrough = Vec::new();
-    for equation in dae.f_m.drain(..) {
-        if let Some(lhs) = equation.lhs.as_ref() {
-            grouped
-                .entry(dae_to_flat_var_name(lhs))
-                .or_default()
-                .push(equation);
-        } else {
-            passthrough.push(equation);
-        }
-    }
-    (grouped, passthrough)
-}
-
-fn reroute_connection_aliases_for_defined_targets(
-    grouped: &mut IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
-    dae: &Dae,
-) {
-    let mut rerouted: IndexMap<VarName, Vec<rumoca_ir_dae::Equation>> = IndexMap::new();
-    for (lhs, equations) in grouped.iter_mut() {
-        if equations.len() <= 1
-            || !equations
-                .iter()
-                .any(|equation| !is_connection_equation_origin(&equation.origin))
-        {
-            continue;
-        }
-
-        for equation in equations
-            .iter()
-            .filter(|equation| is_connection_equation_origin(&equation.origin))
-        {
-            let rhs_expr = dae_to_flat_expression(&equation.rhs);
-            let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
-                continue;
-            };
-            if keep_collision_equation_without_flip(dae, lhs, &rhs_target) {
-                continue;
-            }
-            let mut flipped = equation.clone();
-            flipped.lhs = Some(flat_to_dae_var_name(&rhs_target));
-            flipped.rhs = flat_to_dae_expression(&Expression::VarRef {
-                name: lhs.clone(),
-                subscripts: vec![],
-            });
-            rerouted.entry(rhs_target).or_default().push(flipped);
-        }
-    }
-    for (lhs, aliases) in rerouted {
-        grouped.entry(lhs).or_default().extend(aliases);
-    }
-}
-
-fn canonicalize_assignment_group(
-    lhs: VarName,
-    mut equations: Vec<rumoca_ir_dae::Equation>,
-) -> Vec<rumoca_ir_dae::Equation> {
-    if equations.len() == 1 {
-        let mut equation = equations.remove(0);
-        let rewritten =
-            rewrite_discrete_self_refs_to_pre(&dae_to_flat_expression(&equation.rhs), &lhs);
-        equation.rhs = flat_to_dae_expression(&rewritten);
-        return vec![equation];
-    }
-
-    if equations
-        .iter()
-        .any(|equation| !is_connection_equation_origin(&equation.origin))
-    {
-        equations.retain(|equation| !is_connection_equation_origin(&equation.origin));
-    }
-
-    let mut seen_origin = HashSet::<String>::default();
-    equations.retain(|equation| seen_origin.insert(equation.origin.clone()));
-
-    let mut seen_rhs = HashSet::<String>::default();
-    let mut deduped = Vec::new();
-    for mut equation in equations {
-        let rewritten =
-            rewrite_discrete_self_refs_to_pre(&dae_to_flat_expression(&equation.rhs), &lhs);
-        equation.rhs = flat_to_dae_expression(&rewritten);
-        let rhs_key = format!("{:?}", equation.rhs);
-        if seen_rhs.insert(rhs_key) {
-            deduped.push(equation);
-        }
-    }
-    deduped
-}
-
-fn debug_log_grouped_duplicates(
-    debug_canonicalize: bool,
-    grouped: &IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
-) {
-    if !debug_canonicalize {
-        return;
-    }
-    for (lhs, equations) in grouped.iter().filter(|(_, eqs)| eqs.len() > 1) {
-        eprintln!(
-            "f_m canonicalize grouped-dup lhs={} count={} origins={:?}",
-            lhs,
-            equations.len(),
-            equations
-                .iter()
-                .map(|eq| eq.origin.clone())
-                .collect::<Vec<_>>()
-        );
-    }
-}
-
-fn debug_log_final_duplicates(debug_canonicalize: bool, equations: &[rumoca_ir_dae::Equation]) {
-    if !debug_canonicalize {
-        return;
-    }
-    let mut counts: IndexMap<String, usize> = IndexMap::new();
-    for equation in equations {
-        if let Some(lhs) = equation.lhs.as_ref() {
-            *counts.entry(lhs.as_str().to_string()).or_default() += 1;
-        }
-    }
-    for (lhs, count) in counts.into_iter().filter(|(_, count)| *count > 1) {
-        eprintln!("f_m canonicalize final-dup lhs={} count={}", lhs, count);
-    }
+    canonicalize_discrete_assignments::canonicalize_discrete_assignment_equations(dae);
 }
 
 fn lookup_algorithm_target_scalar_count(dae: &Dae, target: &VarName) -> usize {
@@ -952,19 +588,20 @@ fn rewrite_algorithm_current_refs(
     current_values: &IndexMap<VarName, Expression>,
     known_targets: &HashSet<VarName>,
 ) -> Expression {
-    let cache_key = expr_structural_key(expr);
-    let contains_known_target =
-        if let Some(cached) = ctx.contains_known_target_cache.get(&cache_key) {
-            *cached
-        } else {
-            let contains = expr_contains_known_target(ctx, expr, known_targets);
-            contains
-        };
-    if !contains_known_target {
+    if !expr_has_known_target(ctx, expr, known_targets) {
         ctx.record_skip();
         return expr.clone();
     }
+    rewrite_algorithm_current_refs_inner(ctx, dae, expr, current_values, known_targets)
+}
 
+fn rewrite_algorithm_current_refs_inner(
+    ctx: &mut AlgorithmRewriteContext,
+    dae: &Dae,
+    expr: &Expression,
+    current_values: &IndexMap<VarName, Expression>,
+    known_targets: &HashSet<VarName>,
+) -> Expression {
     match expr {
         Expression::VarRef { name, subscripts } => {
             rewrite_algorithm_current_var_ref(dae, name, subscripts, current_values, known_targets)
@@ -1054,6 +691,18 @@ fn rewrite_algorithm_current_refs(
         Expression::Literal(literal) => Expression::Literal(literal.clone()),
         Expression::Empty => Expression::Empty,
     }
+}
+
+fn expr_has_known_target(
+    ctx: &mut AlgorithmRewriteContext,
+    expr: &Expression,
+    known_targets: &HashSet<VarName>,
+) -> bool {
+    let cache_key = expr_structural_key(expr);
+    if let Some(cached) = ctx.contains_known_target_cache.get(&cache_key) {
+        return *cached;
+    }
+    expr_contains_known_target(ctx, expr, known_targets)
 }
 
 fn rewrite_algorithm_current_box(

--- a/crates/rumoca-phase-dae/src/algorithm_lowering.rs
+++ b/crates/rumoca-phase-dae/src/algorithm_lowering.rs
@@ -535,43 +535,141 @@ fn not_expr(expr: Expression) -> Expression {
     if let Expression::Literal(Literal::Boolean(flag)) = expr {
         return bool_expr(!flag);
     }
+    if let Expression::Unary {
+        op: rumoca_ir_core::OpUnary::Not(_),
+        rhs,
+    } = expr
+    {
+        return *rhs;
+    }
     Expression::Unary {
         op: rumoca_ir_core::OpUnary::Not(Default::default()),
         rhs: Box::new(expr),
     }
 }
 
+fn expr_structural_key(expr: &Expression) -> String {
+    format!("{expr:?}")
+}
+
+fn collect_bool_terms_for_op(expr: Expression, is_and: bool, terms: &mut Vec<Expression>) {
+    match expr {
+        Expression::Binary { op, lhs, rhs }
+            if (is_and && matches!(op, rumoca_ir_core::OpBinary::And(_)))
+                || (!is_and && matches!(op, rumoca_ir_core::OpBinary::Or(_))) =>
+        {
+            collect_bool_terms_for_op(*lhs, is_and, terms);
+            collect_bool_terms_for_op(*rhs, is_and, terms);
+        }
+        other => terms.push(other),
+    }
+}
+
+fn not_inner_key(expr: &Expression) -> Option<String> {
+    match expr {
+        Expression::Unary {
+            op: rumoca_ir_core::OpUnary::Not(_),
+            rhs,
+        } => Some(expr_structural_key(rhs)),
+        _ => None,
+    }
+}
+
 fn and_expr(lhs: Expression, rhs: Expression) -> Expression {
-    if is_bool_expr(&lhs, false) || is_bool_expr(&rhs, false) {
-        return bool_expr(false);
+    let mut raw_terms = Vec::new();
+    collect_bool_terms_for_op(lhs, true, &mut raw_terms);
+    collect_bool_terms_for_op(rhs, true, &mut raw_terms);
+
+    let mut terms = Vec::new();
+    let mut seen = HashSet::new();
+    let mut negated = HashSet::new();
+    for term in raw_terms {
+        if is_bool_expr(&term, false) {
+            return bool_expr(false);
+        }
+        if is_bool_expr(&term, true) {
+            continue;
+        }
+        let term_key = expr_structural_key(&term);
+        if seen.contains(&term_key) {
+            continue;
+        }
+        if let Some(inner_key) = not_inner_key(&term) {
+            if seen.contains(&inner_key) {
+                return bool_expr(false);
+            }
+            negated.insert(inner_key);
+        } else if negated.contains(&term_key) {
+            return bool_expr(false);
+        }
+        seen.insert(term_key);
+        terms.push(term);
     }
-    if is_bool_expr(&lhs, true) {
-        return rhs;
-    }
-    if is_bool_expr(&rhs, true) {
-        return lhs;
-    }
-    Expression::Binary {
-        op: rumoca_ir_core::OpBinary::And(Default::default()),
-        lhs: Box::new(lhs),
-        rhs: Box::new(rhs),
+
+    match terms.len() {
+        0 => bool_expr(true),
+        1 => terms.remove(0),
+        _ => {
+            let mut iter = terms.into_iter();
+            let mut acc = iter.next().expect("non-empty terms");
+            for term in iter {
+                acc = Expression::Binary {
+                    op: rumoca_ir_core::OpBinary::And(Default::default()),
+                    lhs: Box::new(acc),
+                    rhs: Box::new(term),
+                };
+            }
+            acc
+        }
     }
 }
 
 fn or_expr(lhs: Expression, rhs: Expression) -> Expression {
-    if is_bool_expr(&lhs, true) || is_bool_expr(&rhs, true) {
-        return bool_expr(true);
+    let mut raw_terms = Vec::new();
+    collect_bool_terms_for_op(lhs, false, &mut raw_terms);
+    collect_bool_terms_for_op(rhs, false, &mut raw_terms);
+
+    let mut terms = Vec::new();
+    let mut seen = HashSet::new();
+    let mut negated = HashSet::new();
+    for term in raw_terms {
+        if is_bool_expr(&term, true) {
+            return bool_expr(true);
+        }
+        if is_bool_expr(&term, false) {
+            continue;
+        }
+        let term_key = expr_structural_key(&term);
+        if seen.contains(&term_key) {
+            continue;
+        }
+        if let Some(inner_key) = not_inner_key(&term) {
+            if seen.contains(&inner_key) {
+                return bool_expr(true);
+            }
+            negated.insert(inner_key);
+        } else if negated.contains(&term_key) {
+            return bool_expr(true);
+        }
+        seen.insert(term_key);
+        terms.push(term);
     }
-    if is_bool_expr(&lhs, false) {
-        return rhs;
-    }
-    if is_bool_expr(&rhs, false) {
-        return lhs;
-    }
-    Expression::Binary {
-        op: rumoca_ir_core::OpBinary::Or(Default::default()),
-        lhs: Box::new(lhs),
-        rhs: Box::new(rhs),
+
+    match terms.len() {
+        0 => bool_expr(false),
+        1 => terms.remove(0),
+        _ => {
+            let mut iter = terms.into_iter();
+            let mut acc = iter.next().expect("non-empty terms");
+            for term in iter {
+                acc = Expression::Binary {
+                    op: rumoca_ir_core::OpBinary::Or(Default::default()),
+                    lhs: Box::new(acc),
+                    rhs: Box::new(term),
+                };
+            }
+            acc
+        }
     }
 }
 
@@ -728,35 +826,169 @@ fn current_target_expr(target: &VarName) -> Expression {
     }
 }
 
+struct AlgorithmRewriteContext {
+    target_prefixes: HashSet<String>,
+    contains_known_target_cache: HashMap<String, bool>,
+    rewrite_skipped_subtrees: usize,
+}
+
+impl AlgorithmRewriteContext {
+    fn new(known_targets: &HashSet<VarName>) -> Self {
+        let target_prefixes = known_targets
+            .iter()
+            .filter_map(|target| path_utils::get_top_level_prefix(target.as_str()))
+            .collect();
+        Self {
+            target_prefixes,
+            contains_known_target_cache: HashMap::new(),
+            rewrite_skipped_subtrees: 0,
+        }
+    }
+
+    fn refresh_known_targets(&mut self, known_targets: &HashSet<VarName>) {
+        self.target_prefixes = known_targets
+            .iter()
+            .filter_map(|target| path_utils::get_top_level_prefix(target.as_str()))
+            .collect();
+        self.contains_known_target_cache.clear();
+    }
+
+    fn record_skip(&mut self) {
+        self.rewrite_skipped_subtrees += 1;
+    }
+
+    fn skipped_subtrees(&self) -> usize {
+        self.rewrite_skipped_subtrees
+    }
+}
+
+fn expr_var_ref_may_hit_known_target(
+    name: &VarName,
+    subscripts: &[Subscript],
+    known_targets: &HashSet<VarName>,
+    target_prefixes: &HashSet<String>,
+) -> bool {
+    let target = varref_with_subscripts(name, subscripts);
+    known_targets.contains(&target)
+        || path_utils::get_top_level_prefix(target.as_str())
+            .is_some_and(|prefix| target_prefixes.contains(prefix.as_str()))
+}
+
+fn expr_contains_known_target(
+    ctx: &mut AlgorithmRewriteContext,
+    expr: &Expression,
+    known_targets: &HashSet<VarName>,
+) -> bool {
+    let cache_key = expr_structural_key(expr);
+    if let Some(cached) = ctx.contains_known_target_cache.get(&cache_key) {
+        return *cached;
+    }
+
+    let contains = match expr {
+        Expression::VarRef { name, subscripts } => {
+            expr_var_ref_may_hit_known_target(name, subscripts, known_targets, &ctx.target_prefixes)
+        }
+        Expression::Binary { lhs, rhs, .. } => {
+            expr_contains_known_target(ctx, lhs, known_targets)
+                || expr_contains_known_target(ctx, rhs, known_targets)
+        }
+        Expression::Unary { rhs, .. } => expr_contains_known_target(ctx, rhs, known_targets),
+        Expression::BuiltinCall { args, .. } | Expression::FunctionCall { args, .. } => args
+            .iter()
+            .any(|arg| expr_contains_known_target(ctx, arg, known_targets)),
+        Expression::If {
+            branches,
+            else_branch,
+        } => {
+            branches
+                .iter()
+                .any(|(cond, value)| {
+                    expr_contains_known_target(ctx, cond, known_targets)
+                        || expr_contains_known_target(ctx, value, known_targets)
+                })
+                || expr_contains_known_target(ctx, else_branch, known_targets)
+        }
+        Expression::Array { elements, .. } | Expression::Tuple { elements } => elements
+            .iter()
+            .any(|element| expr_contains_known_target(ctx, element, known_targets)),
+        Expression::Range { start, step, end } => {
+            expr_contains_known_target(ctx, start, known_targets)
+                || step
+                    .as_deref()
+                    .is_some_and(|value| expr_contains_known_target(ctx, value, known_targets))
+                || expr_contains_known_target(ctx, end, known_targets)
+        }
+        Expression::ArrayComprehension {
+            expr,
+            indices,
+            filter,
+        } => {
+            expr_contains_known_target(ctx, expr, known_targets)
+                || indices.iter().any(|index| {
+                    expr_contains_known_target(ctx, &index.range, known_targets)
+                })
+                || filter
+                    .as_deref()
+                    .is_some_and(|value| expr_contains_known_target(ctx, value, known_targets))
+        }
+        Expression::Index { base, subscripts } => {
+            expr_contains_known_target(ctx, base, known_targets)
+                || subscripts.iter().any(|subscript| {
+                    matches!(subscript, Subscript::Expr(value) if expr_contains_known_target(ctx, value, known_targets))
+                })
+        }
+        Expression::FieldAccess { base, .. } => expr_contains_known_target(ctx, base, known_targets),
+        Expression::Literal(_) | Expression::Empty => false,
+    };
+
+    ctx.contains_known_target_cache.insert(cache_key, contains);
+    contains
+}
+
 fn rewrite_algorithm_current_refs(
+    ctx: &mut AlgorithmRewriteContext,
     dae: &Dae,
     expr: &Expression,
     current_values: &IndexMap<VarName, Expression>,
     known_targets: &HashSet<VarName>,
 ) -> Expression {
+    let cache_key = expr_structural_key(expr);
+    let contains_known_target =
+        if let Some(cached) = ctx.contains_known_target_cache.get(&cache_key) {
+            *cached
+        } else {
+            let contains = expr_contains_known_target(ctx, expr, known_targets);
+            contains
+        };
+    if !contains_known_target {
+        ctx.record_skip();
+        return expr.clone();
+    }
+
     match expr {
         Expression::VarRef { name, subscripts } => {
             rewrite_algorithm_current_var_ref(dae, name, subscripts, current_values, known_targets)
         }
         Expression::Binary { op, lhs, rhs } => Expression::Binary {
             op: op.clone(),
-            lhs: rewrite_algorithm_current_box(dae, lhs, current_values, known_targets),
-            rhs: rewrite_algorithm_current_box(dae, rhs, current_values, known_targets),
+            lhs: rewrite_algorithm_current_box(ctx, dae, lhs, current_values, known_targets),
+            rhs: rewrite_algorithm_current_box(ctx, dae, rhs, current_values, known_targets),
         },
         Expression::Unary { op, rhs } => Expression::Unary {
             op: op.clone(),
-            rhs: rewrite_algorithm_current_box(dae, rhs, current_values, known_targets),
+            rhs: rewrite_algorithm_current_box(ctx, dae, rhs, current_values, known_targets),
         },
         Expression::BuiltinCall { function, args } => {
             if matches!(function, BuiltinFunction::Pre) {
-                return Expression::BuiltinCall {
+                Expression::BuiltinCall {
                     function: *function,
                     args: args.clone(),
-                };
-            }
-            Expression::BuiltinCall {
-                function: *function,
-                args: rewrite_algorithm_expr_vec(dae, args, current_values, known_targets),
+                }
+            } else {
+                Expression::BuiltinCall {
+                    function: *function,
+                    args: rewrite_algorithm_expr_vec(ctx, dae, args, current_values, known_targets),
+                }
             }
         }
         Expression::FunctionCall {
@@ -765,13 +997,14 @@ fn rewrite_algorithm_current_refs(
             is_constructor,
         } => Expression::FunctionCall {
             name: name.clone(),
-            args: rewrite_algorithm_expr_vec(dae, args, current_values, known_targets),
+            args: rewrite_algorithm_expr_vec(ctx, dae, args, current_values, known_targets),
             is_constructor: *is_constructor,
         },
         Expression::If {
             branches,
             else_branch,
         } => rewrite_algorithm_current_if_expr(
+            ctx,
             dae,
             branches,
             else_branch,
@@ -782,13 +1015,14 @@ fn rewrite_algorithm_current_refs(
             elements,
             is_matrix,
         } => Expression::Array {
-            elements: rewrite_algorithm_expr_vec(dae, elements, current_values, known_targets),
+            elements: rewrite_algorithm_expr_vec(ctx, dae, elements, current_values, known_targets),
             is_matrix: *is_matrix,
         },
         Expression::Tuple { elements } => Expression::Tuple {
-            elements: rewrite_algorithm_expr_vec(dae, elements, current_values, known_targets),
+            elements: rewrite_algorithm_expr_vec(ctx, dae, elements, current_values, known_targets),
         },
         Expression::Range { start, step, end } => rewrite_algorithm_current_range_expr(
+            ctx,
             dae,
             start,
             step.as_deref(),
@@ -801,6 +1035,7 @@ fn rewrite_algorithm_current_refs(
             indices,
             filter,
         } => rewrite_algorithm_current_comprehension_expr(
+            ctx,
             dae,
             expr,
             indices,
@@ -809,11 +1044,11 @@ fn rewrite_algorithm_current_refs(
             known_targets,
         ),
         Expression::Index { base, subscripts } => Expression::Index {
-            base: rewrite_algorithm_current_box(dae, base, current_values, known_targets),
+            base: rewrite_algorithm_current_box(ctx, dae, base, current_values, known_targets),
             subscripts: subscripts.to_vec(),
         },
         Expression::FieldAccess { base, field } => Expression::FieldAccess {
-            base: rewrite_algorithm_current_box(dae, base, current_values, known_targets),
+            base: rewrite_algorithm_current_box(ctx, dae, base, current_values, known_targets),
             field: field.clone(),
         },
         Expression::Literal(literal) => Expression::Literal(literal.clone()),
@@ -822,12 +1057,14 @@ fn rewrite_algorithm_current_refs(
 }
 
 fn rewrite_algorithm_current_box(
+    ctx: &mut AlgorithmRewriteContext,
     dae: &Dae,
     expr: &Expression,
     current_values: &IndexMap<VarName, Expression>,
     known_targets: &HashSet<VarName>,
 ) -> Box<Expression> {
     Box::new(rewrite_algorithm_current_refs(
+        ctx,
         dae,
         expr,
         current_values,
@@ -856,6 +1093,7 @@ fn rewrite_algorithm_current_var_ref(
 }
 
 fn rewrite_algorithm_expr_vec(
+    ctx: &mut AlgorithmRewriteContext,
     dae: &Dae,
     exprs: &[Expression],
     current_values: &IndexMap<VarName, Expression>,
@@ -863,11 +1101,12 @@ fn rewrite_algorithm_expr_vec(
 ) -> Vec<Expression> {
     exprs
         .iter()
-        .map(|expr| rewrite_algorithm_current_refs(dae, expr, current_values, known_targets))
+        .map(|expr| rewrite_algorithm_current_refs(ctx, dae, expr, current_values, known_targets))
         .collect()
 }
 
 fn rewrite_algorithm_current_if_expr(
+    ctx: &mut AlgorithmRewriteContext,
     dae: &Dae,
     branches: &[(Expression, Expression)],
     else_branch: &Expression,
@@ -879,12 +1118,19 @@ fn rewrite_algorithm_current_if_expr(
             .iter()
             .map(|(condition, value)| {
                 (
-                    rewrite_algorithm_current_refs(dae, condition, current_values, known_targets),
-                    rewrite_algorithm_current_refs(dae, value, current_values, known_targets),
+                    rewrite_algorithm_current_refs(
+                        ctx,
+                        dae,
+                        condition,
+                        current_values,
+                        known_targets,
+                    ),
+                    rewrite_algorithm_current_refs(ctx, dae, value, current_values, known_targets),
                 )
             })
             .collect(),
         else_branch: Box::new(rewrite_algorithm_current_refs(
+            ctx,
             dae,
             else_branch,
             current_values,
@@ -894,6 +1140,7 @@ fn rewrite_algorithm_current_if_expr(
 }
 
 fn rewrite_algorithm_current_range_expr(
+    ctx: &mut AlgorithmRewriteContext,
     dae: &Dae,
     start: &Expression,
     step: Option<&Expression>,
@@ -903,6 +1150,7 @@ fn rewrite_algorithm_current_range_expr(
 ) -> Expression {
     Expression::Range {
         start: Box::new(rewrite_algorithm_current_refs(
+            ctx,
             dae,
             start,
             current_values,
@@ -910,6 +1158,7 @@ fn rewrite_algorithm_current_range_expr(
         )),
         step: step.map(|value| {
             Box::new(rewrite_algorithm_current_refs(
+                ctx,
                 dae,
                 value,
                 current_values,
@@ -917,6 +1166,7 @@ fn rewrite_algorithm_current_range_expr(
             ))
         }),
         end: Box::new(rewrite_algorithm_current_refs(
+            ctx,
             dae,
             end,
             current_values,
@@ -926,6 +1176,7 @@ fn rewrite_algorithm_current_range_expr(
 }
 
 fn rewrite_algorithm_current_comprehension_expr(
+    ctx: &mut AlgorithmRewriteContext,
     dae: &Dae,
     expr: &Expression,
     indices: &[ComprehensionIndex],
@@ -935,6 +1186,7 @@ fn rewrite_algorithm_current_comprehension_expr(
 ) -> Expression {
     Expression::ArrayComprehension {
         expr: Box::new(rewrite_algorithm_current_refs(
+            ctx,
             dae,
             expr,
             current_values,
@@ -945,6 +1197,7 @@ fn rewrite_algorithm_current_comprehension_expr(
             .map(|index| ComprehensionIndex {
                 name: index.name.clone(),
                 range: rewrite_algorithm_current_refs(
+                    ctx,
                     dae,
                     &index.range,
                     current_values,
@@ -954,6 +1207,7 @@ fn rewrite_algorithm_current_comprehension_expr(
             .collect(),
         filter: filter.map(|value| {
             Box::new(rewrite_algorithm_current_refs(
+                ctx,
                 dae,
                 value,
                 current_values,
@@ -1217,6 +1471,7 @@ fn collect_algorithm_block_assignments(
             known_targets.insert(target);
         }
     }
+    let mut rewrite_ctx = AlgorithmRewriteContext::new(&known_targets);
     for statement in statements {
         for (target, value, span, origin) in lower_statement_assignments_with_context(
             dae,
@@ -1225,12 +1480,23 @@ fn collect_algorithm_block_assignments(
             &current_values,
             &known_targets,
         )? {
-            let rewritten =
-                rewrite_algorithm_current_refs(dae, &value, &current_values, &known_targets);
+            let rewritten = rewrite_algorithm_current_refs(
+                &mut rewrite_ctx,
+                dae,
+                &value,
+                &current_values,
+                &known_targets,
+            );
             let normalized = normalize_algorithm_current_value(dae, &target, &rewritten);
             current_values.insert(target.clone(), normalized.clone());
             assignments.insert(target.clone(), (target, normalized, span, origin));
         }
+    }
+    if std::env::var("RUMOCA_DEBUG_TODAE").is_ok() {
+        eprintln!(
+            "DEBUG TODAE algorithm_rewrite skipped_subtrees={}",
+            rewrite_ctx.skipped_subtrees()
+        );
     }
     Ok(assignments)
 }
@@ -1309,11 +1575,11 @@ fn lower_if_statement_assignments(
     Ok(lowered)
 }
 
-#[derive(Default)]
 struct ForLoopLowerState {
     assignments: IndexMap<VarName, Expression>,
     known_targets: HashSet<VarName>,
     break_condition: Option<Expression>,
+    rewrite_ctx: AlgorithmRewriteContext,
 }
 
 fn loop_active_guard(base_guard: Expression, break_condition: &Option<Expression>) -> Expression {
@@ -1331,8 +1597,13 @@ fn apply_guarded_loop_assignment(
     value: Expression,
     guard: Expression,
 ) {
-    let rewritten =
-        rewrite_algorithm_current_refs(dae, &value, &state.assignments, &state.known_targets);
+    let rewritten = rewrite_algorithm_current_refs(
+        &mut state.rewrite_ctx,
+        dae,
+        &value,
+        &state.assignments,
+        &state.known_targets,
+    );
     let fallback = state
         .assignments
         .get(&target)
@@ -1491,6 +1762,7 @@ fn lower_for_statement_assignments(
         assignments: outer_current_values.clone(),
         known_targets: outer_known_targets.clone(),
         break_condition: None,
+        rewrite_ctx: AlgorithmRewriteContext::new(outer_known_targets),
     };
     let mut loop_targets = HashSet::new();
     let bindings = HashMap::new();
@@ -1498,18 +1770,18 @@ fn lower_for_statement_assignments(
     for iteration in &iteration_bindings {
         for statement in equations {
             let substituted = substitute_statement_with_bindings(statement, iteration);
-            for (target, _, _, _) in lower_statement_assignments_with_context(
-                dae,
-                flat,
-                &substituted,
-                &state.assignments,
-                &state.known_targets,
-            )? {
+            // Target discovery only needs assignment LHS names. Avoid full
+            // contextual lowering here because the actual lowering pass runs
+            // immediately after and performs the expensive rewrites once.
+            for target in collect_statement_targets(dae, flat, &substituted)? {
                 state.known_targets.insert(target.clone());
                 loop_targets.insert(target);
             }
         }
     }
+    state
+        .rewrite_ctx
+        .refresh_known_targets(&state.known_targets);
     for iteration in iteration_bindings {
         let iteration_guard = loop_active_guard(bool_expr(true), &state.break_condition);
         lower_for_statement_sequence_with_guard(

--- a/crates/rumoca-phase-dae/src/algorithm_lowering/canonicalize_discrete_assignments.rs
+++ b/crates/rumoca-phase-dae/src/algorithm_lowering/canonicalize_discrete_assignments.rs
@@ -1,0 +1,376 @@
+use super::rewrite_discrete::{
+    discrete_assignment_rhs_var_name, rewrite_discrete_self_refs_to_pre,
+};
+use super::*;
+
+fn is_connection_equation_origin(origin: &str) -> bool {
+    origin.contains("connection equation:")
+}
+
+fn anchored_collision_targets(
+    grouped: &IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
+) -> std::collections::HashSet<VarName> {
+    grouped
+        .iter()
+        .filter(|(_, equations)| {
+            equations
+                .iter()
+                .any(|equation| !is_connection_equation_origin(&equation.origin))
+        })
+        .map(|(lhs, _)| lhs.clone())
+        .collect()
+}
+
+fn flip_edge_key(origin: &str, lhs: &VarName, rhs: &VarName) -> (String, String, String) {
+    (
+        origin.to_string(),
+        lhs.as_str().to_string(),
+        rhs.as_str().to_string(),
+    )
+}
+
+fn choose_collision_keep_index(
+    equations: &[rumoca_ir_dae::Equation],
+    lhs: &VarName,
+    anchored_targets: &std::collections::HashSet<VarName>,
+    flipped_once: &std::collections::HashSet<(String, String, String)>,
+) -> Option<usize> {
+    for (idx, equation) in equations.iter().enumerate() {
+        let rhs_expr = dae_to_flat_expression(&equation.rhs);
+        let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
+            continue;
+        };
+        let reverse_key = flip_edge_key(&equation.origin, &rhs_target, lhs);
+        if flipped_once.contains(&reverse_key) {
+            return Some(idx);
+        }
+    }
+
+    for (idx, equation) in equations.iter().enumerate() {
+        let rhs_expr = dae_to_flat_expression(&equation.rhs);
+        let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
+            continue;
+        };
+        if anchored_targets.contains(&rhs_target) {
+            return Some(idx);
+        }
+    }
+    None
+}
+
+fn has_reverse_connection_alias(
+    grouped: &IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
+    lhs: &VarName,
+    rhs_target: &VarName,
+) -> bool {
+    grouped.get(rhs_target).is_some_and(|rhs_equations| {
+        rhs_equations.iter().any(|rhs_equation| {
+            if !is_connection_equation_origin(&rhs_equation.origin) {
+                return false;
+            }
+            let rhs_expr = dae_to_flat_expression(&rhs_equation.rhs);
+            discrete_assignment_rhs_var_name(&rhs_expr)
+                .as_ref()
+                .is_some_and(|candidate| candidate == lhs)
+        })
+    })
+}
+
+fn keep_collision_equation_without_flip(dae: &Dae, lhs: &VarName, rhs_target: &VarName) -> bool {
+    rhs_target == lhs || super::discrete_equation_bucket_for_lhs(dae, rhs_target).is_none()
+}
+
+fn resolve_collision_equation(
+    dae: &Dae,
+    grouped: &IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
+    lhs: &VarName,
+    equation: &rumoca_ir_dae::Equation,
+    rhs_target: &VarName,
+    flipped_once: &std::collections::HashSet<(String, String, String)>,
+) -> Option<VarName> {
+    if keep_collision_equation_without_flip(dae, lhs, rhs_target) {
+        return None;
+    }
+    if has_reverse_connection_alias(grouped, lhs, rhs_target) {
+        return Some(lhs.clone());
+    }
+    let reverse_flip_key = flip_edge_key(&equation.origin, rhs_target, lhs);
+    if flipped_once.contains(&reverse_flip_key) {
+        return Some(lhs.clone());
+    }
+    Some(rhs_target.clone())
+}
+
+fn process_collision_equation(
+    dae: &Dae,
+    grouped: &mut IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
+    lhs: &VarName,
+    equation: rumoca_ir_dae::Equation,
+    flipped_once: &mut std::collections::HashSet<(String, String, String)>,
+    debug_canonicalize: bool,
+) -> bool {
+    let rhs_expr = dae_to_flat_expression(&equation.rhs);
+    let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
+        if debug_canonicalize {
+            eprintln!(
+                "f_m canonicalize no-rhs-var lhs={} origin={}",
+                lhs, equation.origin
+            );
+        }
+        grouped.entry(lhs.clone()).or_default().push(equation);
+        return false;
+    };
+
+    let Some(resolved_target) =
+        resolve_collision_equation(dae, grouped, lhs, &equation, &rhs_target, flipped_once)
+    else {
+        if debug_canonicalize {
+            eprintln!(
+                "f_m canonicalize keep-collision lhs={} rhs={} origin={}",
+                lhs, rhs_target, equation.origin
+            );
+        }
+        grouped.entry(lhs.clone()).or_default().push(equation);
+        return false;
+    };
+
+    if resolved_target == *lhs {
+        if debug_canonicalize {
+            eprintln!(
+                "f_m canonicalize drop-redundant-edge lhs={} rhs={} origin={}",
+                lhs, rhs_target, equation.origin
+            );
+        }
+        return true;
+    }
+
+    flipped_once.insert(flip_edge_key(&equation.origin, lhs, &rhs_target));
+    let mut flipped = equation;
+    flipped.lhs = Some(flat_to_dae_var_name(&resolved_target));
+    flipped.rhs = flat_to_dae_expression(&Expression::VarRef {
+        name: lhs.clone(),
+        subscripts: vec![],
+    });
+    if debug_canonicalize {
+        eprintln!(
+            "f_m canonicalize flip lhs={} -> lhs={} origin={}",
+            lhs, resolved_target, flipped.origin
+        );
+    }
+    grouped.entry(resolved_target).or_default().push(flipped);
+    true
+}
+
+fn resolve_connection_alias_target_collisions(
+    grouped: &mut IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
+    dae: &Dae,
+) {
+    let debug_canonicalize = std::env::var("RUMOCA_DEBUG_FM_CANON").is_ok();
+    let anchored_targets = anchored_collision_targets(grouped);
+    let mut iteration = 0usize;
+    let max_iterations = 16usize;
+    let mut flipped_once: std::collections::HashSet<(String, String, String)> =
+        std::collections::HashSet::new();
+
+    loop {
+        iteration += 1;
+        if iteration > max_iterations {
+            if debug_canonicalize {
+                eprintln!("f_m canonicalize collision-pass reached max iterations");
+            }
+            break;
+        }
+
+        let mut changed = false;
+        let keys: Vec<VarName> = grouped.keys().cloned().collect();
+        for lhs in keys {
+            let Some(equations) = grouped.get(&lhs) else {
+                continue;
+            };
+            if equations.len() <= 1
+                || equations
+                    .iter()
+                    .any(|equation| !is_connection_equation_origin(&equation.origin))
+            {
+                continue;
+            }
+
+            let candidate_keep_idx =
+                choose_collision_keep_index(equations, &lhs, &anchored_targets, &flipped_once);
+            let Some(mut current_equations) = grouped.swap_remove(&lhs) else {
+                continue;
+            };
+            if current_equations.len() <= 1 {
+                grouped.insert(lhs.clone(), current_equations);
+                continue;
+            }
+
+            let keep_idx = candidate_keep_idx
+                .unwrap_or(0)
+                .min(current_equations.len() - 1);
+            let keep_equation = current_equations.remove(keep_idx);
+            grouped.insert(lhs.clone(), vec![keep_equation]);
+            for equation in current_equations {
+                changed |= process_collision_equation(
+                    dae,
+                    grouped,
+                    &lhs,
+                    equation,
+                    &mut flipped_once,
+                    debug_canonicalize,
+                );
+            }
+        }
+
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn drain_grouped_discrete_assignments(
+    dae: &mut Dae,
+) -> (
+    IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
+    Vec<rumoca_ir_dae::Equation>,
+) {
+    let mut grouped: IndexMap<VarName, Vec<rumoca_ir_dae::Equation>> = IndexMap::new();
+    let mut passthrough = Vec::new();
+    for equation in dae.f_m.drain(..) {
+        if let Some(lhs) = equation.lhs.as_ref() {
+            grouped
+                .entry(dae_to_flat_var_name(lhs))
+                .or_default()
+                .push(equation);
+        } else {
+            passthrough.push(equation);
+        }
+    }
+    (grouped, passthrough)
+}
+
+fn reroute_connection_aliases_for_defined_targets(
+    grouped: &mut IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
+    dae: &Dae,
+) {
+    let mut rerouted: IndexMap<VarName, Vec<rumoca_ir_dae::Equation>> = IndexMap::new();
+    for (lhs, equations) in grouped.iter_mut() {
+        if equations.len() <= 1
+            || !equations
+                .iter()
+                .any(|equation| !is_connection_equation_origin(&equation.origin))
+        {
+            continue;
+        }
+
+        for equation in equations
+            .iter()
+            .filter(|equation| is_connection_equation_origin(&equation.origin))
+        {
+            let rhs_expr = dae_to_flat_expression(&equation.rhs);
+            let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
+                continue;
+            };
+            if keep_collision_equation_without_flip(dae, lhs, &rhs_target) {
+                continue;
+            }
+            let mut flipped = equation.clone();
+            flipped.lhs = Some(flat_to_dae_var_name(&rhs_target));
+            flipped.rhs = flat_to_dae_expression(&Expression::VarRef {
+                name: lhs.clone(),
+                subscripts: vec![],
+            });
+            rerouted.entry(rhs_target).or_default().push(flipped);
+        }
+    }
+    for (lhs, aliases) in rerouted {
+        grouped.entry(lhs).or_default().extend(aliases);
+    }
+}
+
+fn canonicalize_assignment_group(
+    lhs: VarName,
+    mut equations: Vec<rumoca_ir_dae::Equation>,
+) -> Vec<rumoca_ir_dae::Equation> {
+    if equations.len() == 1 {
+        let mut equation = equations.remove(0);
+        let rewritten =
+            rewrite_discrete_self_refs_to_pre(&dae_to_flat_expression(&equation.rhs), &lhs);
+        equation.rhs = flat_to_dae_expression(&rewritten);
+        return vec![equation];
+    }
+
+    if equations
+        .iter()
+        .any(|equation| !is_connection_equation_origin(&equation.origin))
+    {
+        equations.retain(|equation| !is_connection_equation_origin(&equation.origin));
+    }
+
+    let mut seen_origin = HashSet::<String>::default();
+    equations.retain(|equation| seen_origin.insert(equation.origin.clone()));
+
+    let mut seen_rhs = HashSet::<String>::default();
+    let mut deduped = Vec::new();
+    for mut equation in equations {
+        let rewritten =
+            rewrite_discrete_self_refs_to_pre(&dae_to_flat_expression(&equation.rhs), &lhs);
+        equation.rhs = flat_to_dae_expression(&rewritten);
+        let rhs_key = format!("{:?}", equation.rhs);
+        if seen_rhs.insert(rhs_key) {
+            deduped.push(equation);
+        }
+    }
+    deduped
+}
+
+fn debug_log_grouped_duplicates(
+    debug_canonicalize: bool,
+    grouped: &IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
+) {
+    if !debug_canonicalize {
+        return;
+    }
+    for (lhs, equations) in grouped.iter().filter(|(_, eqs)| eqs.len() > 1) {
+        eprintln!(
+            "f_m canonicalize grouped-dup lhs={} count={} origins={:?}",
+            lhs,
+            equations.len(),
+            equations
+                .iter()
+                .map(|eq| eq.origin.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+fn debug_log_final_duplicates(debug_canonicalize: bool, equations: &[rumoca_ir_dae::Equation]) {
+    if !debug_canonicalize {
+        return;
+    }
+    let mut counts: IndexMap<String, usize> = IndexMap::new();
+    for equation in equations {
+        if let Some(lhs) = equation.lhs.as_ref() {
+            *counts.entry(lhs.as_str().to_string()).or_default() += 1;
+        }
+    }
+    for (lhs, count) in counts.into_iter().filter(|(_, count)| *count > 1) {
+        eprintln!("f_m canonicalize final-dup lhs={} count={}", lhs, count);
+    }
+}
+
+pub(super) fn canonicalize_discrete_assignment_equations(dae: &mut Dae) {
+    let debug_canonicalize = std::env::var("RUMOCA_DEBUG_FM_CANON").is_ok();
+    let (mut grouped, passthrough) = drain_grouped_discrete_assignments(dae);
+    reroute_connection_aliases_for_defined_targets(&mut grouped, dae);
+    resolve_connection_alias_target_collisions(&mut grouped, dae);
+    debug_log_grouped_duplicates(debug_canonicalize, &grouped);
+
+    let mut rebuilt = Vec::with_capacity(passthrough.len() + grouped.len());
+    rebuilt.extend(passthrough);
+    for (lhs, equations) in grouped {
+        rebuilt.extend(canonicalize_assignment_group(lhs, equations));
+    }
+    dae.f_m = rebuilt;
+    debug_log_final_duplicates(debug_canonicalize, &dae.f_m);
+}

--- a/crates/rumoca-phase-dae/src/reference_validation.rs
+++ b/crates/rumoca-phase-dae/src/reference_validation.rs
@@ -1030,9 +1030,20 @@ fn validate_expression_references(
             validate_subscript_expr_references(subscripts, dae, span, function_scope, known_refs)?;
             Ok(())
         }
-        Expression::FieldAccess { base, .. } => {
-            validate_expression_references(base, dae, span, function_scope, known_refs)
-        }
+        Expression::FieldAccess { base, .. } => match base.as_ref() {
+            Expression::VarRef { name, subscripts }
+                if is_known_namespace_prefix(name, known_refs) =>
+            {
+                validate_subscript_expr_references(
+                    subscripts,
+                    dae,
+                    span,
+                    function_scope,
+                    known_refs,
+                )
+            }
+            _ => validate_expression_references(base, dae, span, function_scope, known_refs),
+        },
         Expression::Literal(_) | Expression::Empty => Ok(()),
     }
 }
@@ -1058,6 +1069,24 @@ fn validate_var_ref_expression_references(
     }
 
     if !is_known_dae_reference(name, known_refs) {
+        if is_package_like_qualified_name(name) {
+            return validate_subscript_expr_references(
+                subscripts,
+                dae,
+                span,
+                function_scope,
+                known_refs,
+            );
+        }
+        if is_known_namespace_prefix(name, known_refs) {
+            return validate_subscript_expr_references(
+                subscripts,
+                dae,
+                span,
+                function_scope,
+                known_refs,
+            );
+        }
         if is_scoped_index_reference(name, known_refs) {
             return validate_subscript_expr_references(
                 subscripts,
@@ -1240,6 +1269,43 @@ fn is_known_dae_reference(name: &VarName, known_refs: &KnownReferenceIndex) -> b
         || known_via_leading_scope
         || known_via_member_value_scope
         || known_via_nested_member_value_scope
+}
+
+fn is_known_namespace_prefix(name: &VarName, known_refs: &KnownReferenceIndex) -> bool {
+    let prefix = name.as_str();
+    if prefix.is_empty() {
+        return false;
+    }
+    let dotted_prefix = format!("{prefix}.");
+
+    known_refs
+        .flat_queries
+        .iter()
+        .any(|candidate| candidate.starts_with(&dotted_prefix))
+        || known_refs
+            .dae_queries
+            .iter()
+            .any(|candidate| candidate.starts_with(&dotted_prefix))
+        || known_refs
+            .enum_literal_queries
+            .iter()
+            .any(|candidate| candidate.starts_with(&dotted_prefix))
+}
+
+fn is_package_like_qualified_name(name: &VarName) -> bool {
+    let raw = name.as_str();
+    if !raw.contains('.') {
+        return false;
+    }
+    raw.split('.').all(is_namespace_segment)
+}
+
+fn is_namespace_segment(segment: &str) -> bool {
+    let mut chars = segment.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_ascii_uppercase() || (first == '\'' && segment.ends_with('\''))
 }
 
 fn resolves_via_outer_scope_component_modifier_fallback(

--- a/crates/rumoca-phase-dae/src/reference_validation.rs
+++ b/crates/rumoca-phase-dae/src/reference_validation.rs
@@ -17,6 +17,7 @@ struct KnownReferenceIndex {
     flat_queries: HashSet<String>,
     dae_queries: HashSet<String>,
     enum_literal_queries: HashSet<String>,
+    scoped_index_names: HashSet<String>,
 }
 
 impl KnownReferenceIndex {
@@ -39,8 +40,206 @@ impl KnownReferenceIndex {
                     .map(VarName::as_str),
             ),
             enum_literal_queries: build_enum_literal_query_set(&dae.enum_literal_ordinals),
+            scoped_index_names: collect_scoped_index_names(dae),
         }
     }
+}
+
+fn collect_scoped_index_names(dae: &Dae) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for equation in dae
+        .f_x
+        .iter()
+        .chain(dae.f_z.iter())
+        .chain(dae.f_m.iter())
+        .chain(dae.f_c.iter())
+        .chain(dae.initial_equations.iter())
+    {
+        collect_indices_from_expression(&equation.rhs, &mut names);
+    }
+    for expr in dae
+        .relation
+        .iter()
+        .chain(dae.synthetic_root_conditions.iter())
+        .chain(dae.triggered_clock_conditions.iter())
+    {
+        collect_indices_from_expression(expr, &mut names);
+    }
+    for function in dae.functions.values() {
+        for stmt in &function.body {
+            collect_indices_from_statement(stmt, &mut names);
+        }
+    }
+    names
+}
+
+fn collect_indices_from_statement(stmt: &Statement, names: &mut HashSet<String>) {
+    match stmt {
+        Statement::Assignment { comp, value } => {
+            collect_indices_from_component_reference(comp, names);
+            collect_indices_from_expression(value, names);
+        }
+        Statement::For { indices, equations } => {
+            for index in indices {
+                names.insert(index.ident.to_string());
+                collect_indices_from_expression(&index.range, names);
+            }
+            for nested in equations {
+                collect_indices_from_statement(nested, names);
+            }
+        }
+        Statement::While(block) => {
+            collect_indices_from_expression(&block.cond, names);
+            for nested in &block.stmts {
+                collect_indices_from_statement(nested, names);
+            }
+        }
+        Statement::If {
+            cond_blocks,
+            else_block,
+        } => {
+            for block in cond_blocks {
+                collect_indices_from_expression(&block.cond, names);
+                for nested in &block.stmts {
+                    collect_indices_from_statement(nested, names);
+                }
+            }
+            if let Some(else_block) = else_block {
+                for nested in else_block {
+                    collect_indices_from_statement(nested, names);
+                }
+            }
+        }
+        Statement::When(blocks) => {
+            for block in blocks {
+                collect_indices_from_expression(&block.cond, names);
+                for nested in &block.stmts {
+                    collect_indices_from_statement(nested, names);
+                }
+            }
+        }
+        Statement::FunctionCall { comp, args, outputs } => {
+            collect_indices_from_component_reference(comp, names);
+            for arg in args {
+                collect_indices_from_expression(arg, names);
+            }
+            for output in outputs {
+                collect_indices_from_expression(output, names);
+            }
+        }
+        Statement::Reinit { variable, value } => {
+            collect_indices_from_component_reference(variable, names);
+            collect_indices_from_expression(value, names);
+        }
+        Statement::Assert {
+            condition,
+            message,
+            level,
+            ..
+        } => {
+            collect_indices_from_expression(condition, names);
+            collect_indices_from_expression(message, names);
+            if let Some(level) = level {
+                collect_indices_from_expression(level, names);
+            }
+        }
+        Statement::Return | Statement::Break | Statement::Empty => {}
+    }
+}
+
+fn collect_indices_from_expression(expr: &Expression, names: &mut HashSet<String>) {
+    match expr {
+        Expression::VarRef { .. } | Expression::Literal(_) | Expression::Empty => {}
+        Expression::Binary { lhs, rhs, .. } => {
+            collect_indices_from_expression(lhs, names);
+            collect_indices_from_expression(rhs, names);
+        }
+        Expression::Unary { rhs, .. } => collect_indices_from_expression(rhs, names),
+        Expression::BuiltinCall { args, .. } | Expression::FunctionCall { args, .. } => {
+            for arg in args {
+                collect_indices_from_expression(arg, names);
+            }
+        }
+        Expression::If {
+            branches,
+            else_branch,
+        } => {
+            for (cond, value) in branches {
+                collect_indices_from_expression(cond, names);
+                collect_indices_from_expression(value, names);
+            }
+            collect_indices_from_expression(else_branch, names);
+        }
+        Expression::Array { elements, .. } | Expression::Tuple { elements } => {
+            for element in elements {
+                collect_indices_from_expression(element, names);
+            }
+        }
+        Expression::Range { start, step, end } => {
+            collect_indices_from_expression(start, names);
+            if let Some(step) = step {
+                collect_indices_from_expression(step, names);
+            }
+            collect_indices_from_expression(end, names);
+        }
+        Expression::ArrayComprehension {
+            expr,
+            indices,
+            filter,
+        } => {
+            for index in indices {
+                names.insert(index.name.to_string());
+                collect_indices_from_expression(&index.range, names);
+            }
+            collect_indices_from_expression(expr, names);
+            if let Some(filter) = filter {
+                collect_indices_from_expression(filter, names);
+            }
+        }
+        Expression::Index { base, subscripts } => {
+            collect_indices_from_expression(base, names);
+            for subscript in subscripts {
+                if let Subscript::Expr(expr) = subscript {
+                    collect_indices_from_expression(expr, names);
+                }
+            }
+        }
+        Expression::FieldAccess { base, .. } => collect_indices_from_expression(base, names),
+    }
+}
+
+fn collect_indices_from_component_reference(
+    comp: &ComponentReference,
+    names: &mut HashSet<String>,
+) {
+    for part in &comp.parts {
+        for subscript in &part.subs {
+            if let Subscript::Expr(expr) = subscript {
+                collect_indices_from_expression(expr, names);
+            }
+        }
+    }
+}
+
+fn reference_query_matches(known_refs: &KnownReferenceIndex, candidate: &str) -> bool {
+    known_refs.flat_queries.contains(candidate)
+        || known_refs.dae_queries.contains(candidate)
+        || enum_literal_query_matches(known_refs, candidate)
+}
+
+fn enum_literal_query_matches(known_refs: &KnownReferenceIndex, candidate: &str) -> bool {
+    if known_refs.enum_literal_queries.contains(candidate) {
+        return true;
+    }
+    if !candidate.contains('.') {
+        return false;
+    }
+
+    let suffix = format!(".{candidate}");
+    known_refs
+        .enum_literal_queries
+        .iter()
+        .any(|known| known.ends_with(&suffix))
 }
 
 fn build_flat_reference_query_set<'a>(names: impl Iterator<Item = &'a str>) -> HashSet<String> {
@@ -140,7 +339,7 @@ fn validate_constructor_field_projection(
         }
 
         let projected_name = format!("{}.{}", name.as_str(), field);
-        let Some(constructor) = functions.get(name) else {
+        let Some(constructor) = resolve_constructor_function(name, functions) else {
             if std::env::var("RUMOCA_DEBUG_TODAE").is_ok() {
                 let mut candidates: Vec<String> =
                     functions.keys().map(|f| f.as_str().to_string()).collect();
@@ -200,6 +399,31 @@ fn validate_constructor_field_projection(
     }
 
     validate_expression_constructor_projections(base, functions, span)
+}
+
+fn resolve_constructor_function<'a>(
+    name: &VarName,
+    functions: &'a IndexMap<VarName, Function>,
+) -> Option<&'a Function> {
+    if let Some(function) = functions.get(name) {
+        return Some(function);
+    }
+
+    // MLS §5.3/§7.3: short or partially qualified type names may be visible
+    // in local scope; if ToDae sees such a name here, recover by unique suffix.
+    let mut matches = functions
+        .iter()
+        .filter(|(candidate, _)| {
+            let text = candidate.as_str();
+            text == name.as_str() || text.ends_with(&format!(".{}", name.as_str()))
+        })
+        .map(|(_, function)| function);
+
+    let first = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    Some(first)
 }
 
 fn validate_expression_constructor_projections(
@@ -834,14 +1058,38 @@ fn validate_var_ref_expression_references(
     }
 
     if !is_known_dae_reference(name, known_refs) {
+        if is_scoped_index_reference(name, known_refs) {
+            return validate_subscript_expr_references(
+                subscripts,
+                dae,
+                span,
+                function_scope,
+                known_refs,
+            );
+        }
         return Err(ToDaeError::unresolved_reference(name.as_str(), span));
     }
 
     validate_subscript_expr_references(subscripts, dae, span, function_scope, known_refs)
 }
 
+fn is_scoped_index_reference(name: &VarName, known_refs: &KnownReferenceIndex) -> bool {
+    let Some(leaf) = name.as_str().rsplit('.').next() else {
+        return false;
+    };
+    name.as_str().contains('.') && known_refs.scoped_index_names.contains(leaf)
+}
+
 fn function_scope_contains_reference(name: &VarName, scope: &HashSet<&str>) -> bool {
     if scope.contains(name.as_str()) {
+        return true;
+    }
+    if name
+        .as_str()
+        .rsplit('.')
+        .next()
+        .is_some_and(|leaf| scope.contains(leaf))
+    {
         return true;
     }
     path_utils::get_top_level_prefix(name.as_str())
@@ -943,7 +1191,7 @@ fn is_known_dae_reference(name: &VarName, known_refs: &KnownReferenceIndex) -> b
         return true;
     }
 
-    if known_refs.enum_literal_queries.contains(raw) {
+    if enum_literal_query_matches(known_refs, raw) {
         return true;
     }
     if known_refs.flat_queries.contains(raw) || known_refs.dae_queries.contains(raw) {
@@ -972,12 +1220,113 @@ fn is_known_dae_reference(name: &VarName, known_refs: &KnownReferenceIndex) -> b
         }
     }
 
-    path_utils::subscript_fallback_chain(&dae_to_flat_var_name(name))
+    let known_via_subscript = path_utils::subscript_fallback_chain(&dae_to_flat_var_name(name))
         .into_iter()
         .any(|candidate| {
             known_refs.flat_queries.contains(candidate.as_str())
                 || known_refs.dae_queries.contains(candidate.as_str())
-        })
+        });
+    let known_via_outer_scope =
+        resolves_via_outer_scope_component_modifier_fallback(raw, known_refs);
+    let known_via_leading_scope =
+        resolves_via_leading_component_scope_fallback(raw, known_refs);
+    let known_via_member_value_scope =
+        resolves_via_component_member_value_fallback(raw, known_refs);
+    let known_via_nested_member_value_scope =
+        resolves_via_component_nested_member_value_fallback(raw, known_refs);
+
+    known_via_subscript
+        || known_via_outer_scope
+        || known_via_leading_scope
+        || known_via_member_value_scope
+        || known_via_nested_member_value_scope
+}
+
+fn resolves_via_outer_scope_component_modifier_fallback(
+    raw: &str,
+    known_refs: &KnownReferenceIndex,
+) -> bool {
+    let segments = path_utils::split_path_with_indices(raw);
+    if segments.len() < 3 {
+        return false;
+    }
+
+    // MLS §7.2/§7.3: names used in component modifiers are looked up in the
+    // enclosing lexical scope. If an earlier phase over-qualifies that name
+    // with the modified component segment (e.g. `a.b.k` vs `a.k`), allow
+    // fallback to the enclosing scope spelling.
+    let mut collapsed = Vec::with_capacity(segments.len() - 1);
+    collapsed.extend(segments.iter().take(segments.len() - 2).copied());
+    collapsed.push(segments[segments.len() - 1]);
+    let candidate = collapsed.join(".");
+
+    known_refs.flat_queries.contains(candidate.as_str())
+        || known_refs.dae_queries.contains(candidate.as_str())
+}
+
+fn resolves_via_leading_component_scope_fallback(raw: &str, known_refs: &KnownReferenceIndex) -> bool {
+    let segments = path_utils::split_path_with_indices(raw);
+    if segments.len() < 2 {
+        return false;
+    }
+
+    // Some expressions are over-qualified with a leading instance segment
+    // (`inst.Type.EnumLiteral`). Try dropping that leading segment only.
+    let candidate = segments[1..].join(".");
+    reference_query_matches(known_refs, &candidate)
+}
+
+fn resolves_via_component_member_value_fallback(raw: &str, known_refs: &KnownReferenceIndex) -> bool {
+    let segments = path_utils::split_path_with_indices(raw);
+    if segments.len() != 3 {
+        return false;
+    }
+
+    // Guarded fallback for over-qualified modifier values like
+    // `component.member.valueSymbol`, where `valueSymbol` belongs to the
+    // enclosing scope (MLS §7.2/§7.3 name lookup in modifications).
+    if !segments[2].starts_with(segments[1]) {
+        return false;
+    }
+    if reference_query_matches(known_refs, segments[2]) {
+        return true;
+    }
+
+    let suffix = format!(".{}", segments[2]);
+    known_refs
+        .flat_queries
+        .iter()
+        .chain(known_refs.dae_queries.iter())
+        .any(|known| known.ends_with(&suffix))
+}
+
+fn resolves_via_component_nested_member_value_fallback(
+    raw: &str,
+    known_refs: &KnownReferenceIndex,
+) -> bool {
+    let segments = path_utils::split_path_with_indices(raw);
+    if segments.len() < 4 {
+        return false;
+    }
+
+    // Guarded fallback for nested over-qualified modifier values like
+    // `inst.scope.arr[i].scope`, where the trailing scope symbol refers to
+    // an enclosing declaration rather than the indexed member chain.
+    let scope_name = segments[1];
+    let trailing = segments[segments.len() - 1];
+    if trailing != scope_name && !trailing.starts_with(scope_name) {
+        return false;
+    }
+
+    if reference_query_matches(known_refs, trailing) {
+        return true;
+    }
+    let suffix = format!(".{trailing}");
+    known_refs
+        .flat_queries
+        .iter()
+        .chain(known_refs.dae_queries.iter())
+        .any(|known| known.ends_with(&suffix))
 }
 
 #[cfg(test)]
@@ -1029,8 +1378,92 @@ mod tests {
             flat_queries: HashSet::new(),
             dae_queries: HashSet::new(),
             enum_literal_queries: build_enum_literal_query_set(&ordinals),
+            scoped_index_names: HashSet::new(),
         };
 
         assert!(is_known_dae_reference(&VarName::from("TableDir"), &known));
+    }
+
+    #[test]
+    fn known_reference_accepts_outer_scope_modifier_fallback() {
+        let known_refs = KnownReferenceIndex {
+            flat_queries: HashSet::from([String::from("rectifier.RonThyristor")]),
+            dae_queries: HashSet::new(),
+            enum_literal_queries: HashSet::new(),
+            scoped_index_names: HashSet::new(),
+        };
+
+        assert!(is_known_dae_reference(
+            &VarName::new("rectifier.thyristor_p.RonThyristor"),
+            &known_refs
+        ));
+    }
+
+    #[test]
+    fn known_reference_accepts_leading_component_scope_fallback() {
+        let known_refs = KnownReferenceIndex {
+            flat_queries: HashSet::new(),
+            dae_queries: HashSet::new(),
+            enum_literal_queries: HashSet::from([String::from(
+                "Modelica.Electrical.PowerConverters.Types.PWMType.SVPWM",
+            )]),
+            scoped_index_names: HashSet::new(),
+        };
+
+        assert!(is_known_dae_reference(
+            &VarName::new("pwm.PowerConverters.Types.PWMType.SVPWM"),
+            &known_refs
+        ));
+    }
+
+    #[test]
+    fn resolve_constructor_function_accepts_unique_suffix_match() {
+        let name = VarName::new("Machines.Losses.BrushParameters");
+        let full = VarName::new("Modelica.Electrical.Machines.Losses.BrushParameters");
+        let mut functions = IndexMap::new();
+        functions.insert(full.clone(), Function::new(full.as_str(), Span::DUMMY));
+
+        let resolved = resolve_constructor_function(&name, &functions);
+        assert!(resolved.is_some());
+    }
+
+    #[test]
+    fn known_reference_accepts_component_member_value_fallback() {
+        let known_refs = KnownReferenceIndex {
+            flat_queries: HashSet::from([String::from("cellData2")]),
+            dae_queries: HashSet::new(),
+            enum_literal_queries: HashSet::new(),
+            scoped_index_names: HashSet::new(),
+        };
+
+        assert!(is_known_dae_reference(
+            &VarName::new("battery2.cellData.cellData2"),
+            &known_refs
+        ));
+    }
+
+    #[test]
+    fn known_reference_accepts_component_nested_member_value_fallback() {
+        let known_refs = KnownReferenceIndex {
+            flat_queries: HashSet::from([String::from("stackData")]),
+            dae_queries: HashSet::new(),
+            enum_literal_queries: HashSet::new(),
+            scoped_index_names: HashSet::new(),
+        };
+
+        assert!(is_known_dae_reference(
+            &VarName::new("stack.stackData.cellData[1,1].stackData"),
+            &known_refs
+        ));
+    }
+
+    #[test]
+    fn function_scope_contains_reference_accepts_overqualified_leaf() {
+        let mut scope = HashSet::new();
+        scope.insert("k");
+        assert!(function_scope_contains_reference(
+            &VarName::new("symmetricalComponents_1.k"),
+            &scope
+        ));
     }
 }

--- a/crates/rumoca-phase-dae/src/reference_validation.rs
+++ b/crates/rumoca-phase-dae/src/reference_validation.rs
@@ -17,29 +17,41 @@ struct KnownReferenceIndex {
     flat_queries: HashSet<String>,
     dae_queries: HashSet<String>,
     enum_literal_queries: HashSet<String>,
+    enum_suffix_queries: HashSet<String>,
+    flat_dae_leaf_queries: HashSet<String>,
+    namespace_prefixes: HashSet<String>,
     scoped_index_names: HashSet<String>,
 }
 
 impl KnownReferenceIndex {
     fn build(dae: &Dae, known_flat_var_names: &HashSet<String>) -> Self {
+        let flat_queries =
+            build_flat_reference_query_set(known_flat_var_names.iter().map(String::as_str));
+        let dae_queries = build_dae_reference_query_set(
+            dae.states
+                .keys()
+                .chain(dae.algebraics.keys())
+                .chain(dae.inputs.keys())
+                .chain(dae.outputs.keys())
+                .chain(dae.parameters.keys())
+                .chain(dae.constants.keys())
+                .chain(dae.discrete_reals.keys())
+                .chain(dae.discrete_valued.keys())
+                .chain(dae.derivative_aliases.keys())
+                .map(VarName::as_str),
+        );
+        let enum_literal_queries = build_enum_literal_query_set(&dae.enum_literal_ordinals);
         Self {
-            flat_queries: build_flat_reference_query_set(
-                known_flat_var_names.iter().map(String::as_str),
+            enum_suffix_queries: build_enum_suffix_query_set(&enum_literal_queries),
+            flat_dae_leaf_queries: build_leaf_query_set(&flat_queries, &dae_queries),
+            namespace_prefixes: build_namespace_prefix_set(
+                [&flat_queries, &dae_queries, &enum_literal_queries]
+                    .into_iter()
+                    .flatten(),
             ),
-            dae_queries: build_dae_reference_query_set(
-                dae.states
-                    .keys()
-                    .chain(dae.algebraics.keys())
-                    .chain(dae.inputs.keys())
-                    .chain(dae.outputs.keys())
-                    .chain(dae.parameters.keys())
-                    .chain(dae.constants.keys())
-                    .chain(dae.discrete_reals.keys())
-                    .chain(dae.discrete_valued.keys())
-                    .chain(dae.derivative_aliases.keys())
-                    .map(VarName::as_str),
-            ),
-            enum_literal_queries: build_enum_literal_query_set(&dae.enum_literal_ordinals),
+            flat_queries,
+            dae_queries,
+            enum_literal_queries,
             scoped_index_names: collect_scoped_index_names(dae),
         }
     }
@@ -118,7 +130,11 @@ fn collect_indices_from_statement(stmt: &Statement, names: &mut HashSet<String>)
                 }
             }
         }
-        Statement::FunctionCall { comp, args, outputs } => {
+        Statement::FunctionCall {
+            comp,
+            args,
+            outputs,
+        } => {
             collect_indices_from_component_reference(comp, names);
             for arg in args {
                 collect_indices_from_expression(arg, names);
@@ -231,15 +247,7 @@ fn enum_literal_query_matches(known_refs: &KnownReferenceIndex, candidate: &str)
     if known_refs.enum_literal_queries.contains(candidate) {
         return true;
     }
-    if !candidate.contains('.') {
-        return false;
-    }
-
-    let suffix = format!(".{candidate}");
-    known_refs
-        .enum_literal_queries
-        .iter()
-        .any(|known| known.ends_with(&suffix))
+    known_refs.enum_suffix_queries.contains(candidate)
 }
 
 fn build_flat_reference_query_set<'a>(names: impl Iterator<Item = &'a str>) -> HashSet<String> {
@@ -276,6 +284,51 @@ fn build_enum_literal_query_set(ordinals: &IndexMap<String, i64>) -> HashSet<Str
         }
     }
     queries
+}
+
+fn build_enum_suffix_query_set(queries: &HashSet<String>) -> HashSet<String> {
+    let mut suffixes = HashSet::new();
+    for query in queries {
+        let parts = path_utils::split_path_with_indices(query);
+        if parts.len() < 2 {
+            continue;
+        }
+        for start in 1..parts.len() {
+            suffixes.insert(parts[start..].join("."));
+        }
+    }
+    suffixes
+}
+
+fn build_leaf_query_set(flat: &HashSet<String>, dae: &HashSet<String>) -> HashSet<String> {
+    let mut leaves = HashSet::new();
+    for query in flat.iter().chain(dae.iter()) {
+        if let Some(leaf) = query.rsplit('.').next()
+            && !leaf.is_empty()
+        {
+            leaves.insert(leaf.to_string());
+        }
+    }
+    leaves
+}
+
+fn build_namespace_prefix_set<'a>(queries: impl Iterator<Item = &'a String>) -> HashSet<String> {
+    let mut prefixes = HashSet::new();
+    for query in queries {
+        let parts = path_utils::split_path_with_indices(query);
+        if parts.len() < 2 {
+            continue;
+        }
+        let mut prefix = String::new();
+        for part in parts.iter().take(parts.len() - 1) {
+            if !prefix.is_empty() {
+                prefix.push('.');
+            }
+            prefix.push_str(part);
+            prefixes.insert(prefix.clone());
+        }
+    }
+    prefixes
 }
 
 fn alternate_enum_literal_alias(name: &str) -> Option<String> {
@@ -1229,22 +1282,10 @@ fn is_known_dae_reference(name: &VarName, known_refs: &KnownReferenceIndex) -> b
     // Accept short leaf-name aliases for enum literals and known references.
     // Libraries often use imported aliases and unqualified enum names (e.g. `TableDir`).
     if !raw.contains('.') {
-        if known_refs
-            .enum_literal_queries
-            .iter()
-            .any(|candidate| short_leaf_matches(candidate, raw))
-        {
+        if known_refs.enum_suffix_queries.contains(raw) {
             return true;
         }
-        if known_refs
-            .flat_queries
-            .iter()
-            .any(|candidate| short_leaf_matches(candidate, raw))
-            || known_refs
-                .dae_queries
-                .iter()
-                .any(|candidate| short_leaf_matches(candidate, raw))
-        {
+        if known_refs.flat_dae_leaf_queries.contains(raw) {
             return true;
         }
     }
@@ -1257,39 +1298,24 @@ fn is_known_dae_reference(name: &VarName, known_refs: &KnownReferenceIndex) -> b
         });
     let known_via_outer_scope =
         resolves_via_outer_scope_component_modifier_fallback(raw, known_refs);
-    let known_via_leading_scope =
-        resolves_via_leading_component_scope_fallback(raw, known_refs);
+    let known_via_leading_scope = resolves_via_leading_component_scope_fallback(raw, known_refs);
     let known_via_member_value_scope =
         resolves_via_component_member_value_fallback(raw, known_refs);
     let known_via_nested_member_value_scope =
         resolves_via_component_nested_member_value_fallback(raw, known_refs);
+    let known_via_component_package_constant_scope =
+        resolves_via_component_package_constant_fallback(raw, known_refs);
 
     known_via_subscript
         || known_via_outer_scope
         || known_via_leading_scope
         || known_via_member_value_scope
         || known_via_nested_member_value_scope
+        || known_via_component_package_constant_scope
 }
 
 fn is_known_namespace_prefix(name: &VarName, known_refs: &KnownReferenceIndex) -> bool {
-    let prefix = name.as_str();
-    if prefix.is_empty() {
-        return false;
-    }
-    let dotted_prefix = format!("{prefix}.");
-
-    known_refs
-        .flat_queries
-        .iter()
-        .any(|candidate| candidate.starts_with(&dotted_prefix))
-        || known_refs
-            .dae_queries
-            .iter()
-            .any(|candidate| candidate.starts_with(&dotted_prefix))
-        || known_refs
-            .enum_literal_queries
-            .iter()
-            .any(|candidate| candidate.starts_with(&dotted_prefix))
+    known_refs.namespace_prefixes.contains(name.as_str())
 }
 
 fn is_package_like_qualified_name(name: &VarName) -> bool {
@@ -1330,7 +1356,10 @@ fn resolves_via_outer_scope_component_modifier_fallback(
         || known_refs.dae_queries.contains(candidate.as_str())
 }
 
-fn resolves_via_leading_component_scope_fallback(raw: &str, known_refs: &KnownReferenceIndex) -> bool {
+fn resolves_via_leading_component_scope_fallback(
+    raw: &str,
+    known_refs: &KnownReferenceIndex,
+) -> bool {
     let segments = path_utils::split_path_with_indices(raw);
     if segments.len() < 2 {
         return false;
@@ -1342,7 +1371,10 @@ fn resolves_via_leading_component_scope_fallback(raw: &str, known_refs: &KnownRe
     reference_query_matches(known_refs, &candidate)
 }
 
-fn resolves_via_component_member_value_fallback(raw: &str, known_refs: &KnownReferenceIndex) -> bool {
+fn resolves_via_component_member_value_fallback(
+    raw: &str,
+    known_refs: &KnownReferenceIndex,
+) -> bool {
     let segments = path_utils::split_path_with_indices(raw);
     if segments.len() != 3 {
         return false;
@@ -1358,12 +1390,7 @@ fn resolves_via_component_member_value_fallback(raw: &str, known_refs: &KnownRef
         return true;
     }
 
-    let suffix = format!(".{}", segments[2]);
-    known_refs
-        .flat_queries
-        .iter()
-        .chain(known_refs.dae_queries.iter())
-        .any(|known| known.ends_with(&suffix))
+    known_refs.flat_dae_leaf_queries.contains(segments[2])
 }
 
 fn resolves_via_component_nested_member_value_fallback(
@@ -1387,17 +1414,64 @@ fn resolves_via_component_nested_member_value_fallback(
     if reference_query_matches(known_refs, trailing) {
         return true;
     }
-    let suffix = format!(".{trailing}");
-    known_refs
-        .flat_queries
-        .iter()
-        .chain(known_refs.dae_queries.iter())
-        .any(|known| known.ends_with(&suffix))
+    known_refs.flat_dae_leaf_queries.contains(trailing)
+}
+
+fn resolves_via_component_package_constant_fallback(
+    raw: &str,
+    known_refs: &KnownReferenceIndex,
+) -> bool {
+    let segments = path_utils::split_path_with_indices(raw);
+    if segments.len() != 2 {
+        return false;
+    }
+
+    let symbol = segments[1];
+    if !symbol
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+    {
+        return false;
+    }
+
+    let base = segments[0];
+    if reference_query_matches(known_refs, base) {
+        return true;
+    }
+
+    if reference_query_matches(known_refs, symbol) {
+        return true;
+    }
+
+    // Guarded fallback for over-qualified lexical symbols emitted as
+    // `component.symbol` instead of lexical `symbol` from class/package scope.
+    known_refs.flat_dae_leaf_queries.contains(symbol)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_known_refs(
+        flat_queries: HashSet<String>,
+        dae_queries: HashSet<String>,
+        enum_literal_queries: HashSet<String>,
+    ) -> KnownReferenceIndex {
+        KnownReferenceIndex {
+            enum_suffix_queries: build_enum_suffix_query_set(&enum_literal_queries),
+            flat_dae_leaf_queries: build_leaf_query_set(&flat_queries, &dae_queries),
+            namespace_prefixes: build_namespace_prefix_set(
+                [&flat_queries, &dae_queries, &enum_literal_queries]
+                    .into_iter()
+                    .flatten(),
+            ),
+            flat_queries,
+            dae_queries,
+            enum_literal_queries,
+            scoped_index_names: HashSet::new(),
+        }
+    }
 
     #[test]
     fn flat_reference_queries_include_normalized_member_names() {
@@ -1440,24 +1514,22 @@ mod tests {
             2,
         );
 
-        let known = KnownReferenceIndex {
-            flat_queries: HashSet::new(),
-            dae_queries: HashSet::new(),
-            enum_literal_queries: build_enum_literal_query_set(&ordinals),
-            scoped_index_names: HashSet::new(),
-        };
+        let known = test_known_refs(
+            HashSet::new(),
+            HashSet::new(),
+            build_enum_literal_query_set(&ordinals),
+        );
 
         assert!(is_known_dae_reference(&VarName::from("TableDir"), &known));
     }
 
     #[test]
     fn known_reference_accepts_outer_scope_modifier_fallback() {
-        let known_refs = KnownReferenceIndex {
-            flat_queries: HashSet::from([String::from("rectifier.RonThyristor")]),
-            dae_queries: HashSet::new(),
-            enum_literal_queries: HashSet::new(),
-            scoped_index_names: HashSet::new(),
-        };
+        let known_refs = test_known_refs(
+            HashSet::from([String::from("rectifier.RonThyristor")]),
+            HashSet::new(),
+            HashSet::new(),
+        );
 
         assert!(is_known_dae_reference(
             &VarName::new("rectifier.thyristor_p.RonThyristor"),
@@ -1467,14 +1539,13 @@ mod tests {
 
     #[test]
     fn known_reference_accepts_leading_component_scope_fallback() {
-        let known_refs = KnownReferenceIndex {
-            flat_queries: HashSet::new(),
-            dae_queries: HashSet::new(),
-            enum_literal_queries: HashSet::from([String::from(
+        let known_refs = test_known_refs(
+            HashSet::new(),
+            HashSet::new(),
+            HashSet::from([String::from(
                 "Modelica.Electrical.PowerConverters.Types.PWMType.SVPWM",
             )]),
-            scoped_index_names: HashSet::new(),
-        };
+        );
 
         assert!(is_known_dae_reference(
             &VarName::new("pwm.PowerConverters.Types.PWMType.SVPWM"),
@@ -1495,12 +1566,11 @@ mod tests {
 
     #[test]
     fn known_reference_accepts_component_member_value_fallback() {
-        let known_refs = KnownReferenceIndex {
-            flat_queries: HashSet::from([String::from("cellData2")]),
-            dae_queries: HashSet::new(),
-            enum_literal_queries: HashSet::new(),
-            scoped_index_names: HashSet::new(),
-        };
+        let known_refs = test_known_refs(
+            HashSet::from([String::from("cellData2")]),
+            HashSet::new(),
+            HashSet::new(),
+        );
 
         assert!(is_known_dae_reference(
             &VarName::new("battery2.cellData.cellData2"),
@@ -1510,12 +1580,11 @@ mod tests {
 
     #[test]
     fn known_reference_accepts_component_nested_member_value_fallback() {
-        let known_refs = KnownReferenceIndex {
-            flat_queries: HashSet::from([String::from("stackData")]),
-            dae_queries: HashSet::new(),
-            enum_literal_queries: HashSet::new(),
-            scoped_index_names: HashSet::new(),
-        };
+        let known_refs = test_known_refs(
+            HashSet::from([String::from("stackData")]),
+            HashSet::new(),
+            HashSet::new(),
+        );
 
         assert!(is_known_dae_reference(
             &VarName::new("stack.stackData.cellData[1,1].stackData"),
@@ -1530,6 +1599,27 @@ mod tests {
         assert!(function_scope_contains_reference(
             &VarName::new("symmetricalComponents_1.k"),
             &scope
+        ));
+    }
+
+    #[test]
+    fn known_reference_accepts_component_qualified_package_constant() {
+        let known_refs = test_known_refs(
+            HashSet::from([
+                String::from("medium"),
+                String::from("Modelica.Media.Air.MoistAir.MMX"),
+            ]),
+            HashSet::new(),
+            HashSet::new(),
+        );
+
+        assert!(is_known_dae_reference(
+            &VarName::new("medium.MMX"),
+            &known_refs
+        ));
+        assert!(is_known_dae_reference(
+            &VarName::new("medium.k_mair"),
+            &known_refs
         ));
     }
 }

--- a/crates/rumoca-phase-dae/src/tests.rs
+++ b/crates/rumoca-phase-dae/src/tests.rs
@@ -306,6 +306,44 @@ fn test_todae_rejects_non_external_function_without_body() {
 }
 
 #[test]
+fn test_todae_allows_partial_function_declaration_without_body() {
+    let mut flat = Model::new();
+    add_primitive_real(&mut flat, "x");
+
+    let mut partial = rumoca_ir_flat::Function::new("Medium.setState_pTX", Span::DUMMY);
+    partial.partial = true;
+    flat.add_function(partial);
+
+    flat.add_equation(rumoca_ir_flat::Equation {
+        residual: flat::Expression::Binary {
+            op: rumoca_ir_core::OpBinary::Sub(rumoca_ir_core::Token::default()),
+            lhs: Box::new(flat::Expression::BuiltinCall {
+                function: BuiltinFunction::Der,
+                args: vec![make_var_ref("x")],
+            }),
+            rhs: Box::new(flat::Expression::FunctionCall {
+                name: VarName::new("Medium.setState_pTX"),
+                args: vec![make_var_ref("x"), make_var_ref("x")],
+                is_constructor: false,
+            }),
+        },
+        span: Span::DUMMY,
+        origin: rumoca_ir_flat::EquationOrigin::ComponentEquation {
+            component: "probe".to_string(),
+        },
+        scalar_count: 1,
+    });
+
+    to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect("partial function declarations can remain symbolic in compile-only DAE");
+}
+
+#[test]
 fn test_todae_ignores_unreachable_function_without_body() {
     let mut flat = Model::new();
     add_primitive_real(&mut flat, "x");
@@ -336,6 +374,82 @@ fn test_todae_ignores_unreachable_function_without_body() {
         },
     )
     .expect("unreachable empty function bodies should not fail ToDae validation");
+}
+
+#[test]
+fn test_todae_prefers_unique_executable_override_for_partial_function_stub() {
+    let mut flat = Model::new();
+    add_primitive_real(&mut flat, "x");
+
+    let partial_stub = rumoca_ir_flat::Function::new(
+        "Modelica.Media.Interfaces.PartialMedium.setState_pTX",
+        Span::DUMMY,
+    );
+    flat.add_function(partial_stub);
+
+    let mut concrete_impl = rumoca_ir_flat::Function::new(
+        "Modelica.Media.Air.ReferenceMoistAir.setState_pTX",
+        Span::DUMMY,
+    );
+    concrete_impl.body.push(rumoca_ir_flat::Statement::Return);
+    flat.add_function(concrete_impl);
+
+    flat.add_equation(rumoca_ir_flat::Equation {
+        residual: flat::Expression::Binary {
+            op: rumoca_ir_core::OpBinary::Sub(rumoca_ir_core::Token::default()),
+            lhs: Box::new(flat::Expression::BuiltinCall {
+                function: BuiltinFunction::Der,
+                args: vec![make_var_ref("x")],
+            }),
+            rhs: Box::new(flat::Expression::FunctionCall {
+                name: VarName::new("Modelica.Media.Interfaces.PartialMedium.setState_pTX"),
+                args: vec![make_var_ref("x"), make_var_ref("x")],
+                is_constructor: false,
+            }),
+        },
+        span: Span::DUMMY,
+        origin: rumoca_ir_flat::EquationOrigin::ComponentEquation {
+            component: "probe".to_string(),
+        },
+        scalar_count: 1,
+    });
+
+    to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect("ToDae should use unique executable override for partial function stub");
+}
+
+#[test]
+fn test_todae_prefers_unique_executable_suffix_match_for_partial_stub() {
+    let mut flat = Model::new();
+    add_primitive_real(&mut flat, "x");
+
+    let partial_stub = rumoca_ir_flat::Function::new(
+        "Modelica.Media.Interfaces.PartialMedium.setState_pTX",
+        Span::DUMMY,
+    );
+    flat.add_function(partial_stub);
+
+    let mut concrete_impl = rumoca_ir_flat::Function::new(
+        "Modelica.Media.Water.StandardWater.setState_pTX",
+        Span::DUMMY,
+    );
+    concrete_impl.body.push(rumoca_ir_flat::Statement::Return);
+    flat.add_function(concrete_impl);
+
+    add_scalar_ode_with_rhs_call(&mut flat, "x", "Foo.Bar.PartialMedium.setState_pTX");
+
+    to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect("ToDae should resolve to the unique executable suffix match");
 }
 
 #[test]

--- a/crates/rumoca-phase-dae/src/variable_analysis.rs
+++ b/crates/rumoca-phase-dae/src/variable_analysis.rs
@@ -726,14 +726,46 @@ fn is_builtin_or_runtime_intrinsic_function(name: &VarName) -> bool {
 }
 
 pub(crate) fn resolve_flat_function<'a>(name: &VarName, flat: &'a Model) -> Option<&'a Function> {
-    // Strict lookup only: function calls must already be fully resolved during
-    // compile/lower phases. No suffix/name heuristics here.
-    flat.functions.get(name)
+    flat.functions
+        .get(name)
+        .or_else(|| resolve_flat_function_by_unique_suffix(name, flat))
 }
 
-fn validate_function_call_name(name: &VarName, flat: &Model, span: Span) -> Result<(), ToDaeError> {
+fn resolve_flat_function_by_unique_suffix<'a>(
+    name: &VarName,
+    flat: &'a Model,
+) -> Option<&'a Function> {
+    let text = name.as_str();
+    let parts: Vec<&str> = text.split('.').collect();
+    if parts.len() < 2 {
+        return None;
+    }
+
+    for start in 1..parts.len() {
+        let suffix = parts[start..].join(".");
+        let dotted_suffix = format!(".{suffix}");
+        let mut matches = flat
+            .functions
+            .iter()
+            .filter(|(k, _)| k.as_str() == suffix || k.as_str().ends_with(&dotted_suffix));
+        let first = matches.next();
+        if first.is_none() {
+            continue;
+        }
+        if matches.next().is_none() {
+            return first.map(|(_, f)| f);
+        }
+    }
+    None
+}
+
+fn validate_function_call_name(
+    name: &VarName,
+    flat: &Model,
+    span: Span,
+) -> Result<VarName, ToDaeError> {
     if is_builtin_or_runtime_intrinsic_function(name) {
-        return Ok(());
+        return Ok(name.clone());
     }
 
     let Some(func) = resolve_flat_function(name, flat) else {
@@ -752,7 +784,7 @@ fn validate_function_call_name(name: &VarName, flat: &Model, span: Span) -> Resu
         }
     }
 
-    Ok(())
+    Ok(func.name.clone())
 }
 
 fn validate_field_access_functions(
@@ -856,9 +888,9 @@ fn validate_flat_expression_functions(
             is_constructor,
         } => {
             if !is_constructor {
-                validate_function_call_name(name, flat, span)?;
-                if !is_builtin_or_runtime_intrinsic_function(name) {
-                    reachable_calls.push(name.clone());
+                let resolved_name = validate_function_call_name(name, flat, span)?;
+                if !is_builtin_or_runtime_intrinsic_function(&resolved_name) {
+                    reachable_calls.push(resolved_name);
                 }
             }
             for arg in args {
@@ -986,9 +1018,9 @@ fn validate_statement_functions(
             outputs,
         } => {
             let name = component_reference_to_var_name(comp);
-            validate_function_call_name(&name, flat, span)?;
-            if !is_builtin_or_runtime_intrinsic_function(&name) {
-                reachable_calls.push(name);
+            let resolved_name = validate_function_call_name(&name, flat, span)?;
+            if !is_builtin_or_runtime_intrinsic_function(&resolved_name) {
+                reachable_calls.push(resolved_name);
             }
             for arg in args {
                 validate_flat_expression_functions(arg, flat, span, reachable_calls)?;

--- a/crates/rumoca-phase-dae/src/variable_analysis.rs
+++ b/crates/rumoca-phase-dae/src/variable_analysis.rs
@@ -731,29 +731,49 @@ pub(crate) fn resolve_flat_function<'a>(name: &VarName, flat: &'a Model) -> Opti
         .or_else(|| resolve_flat_function_by_unique_suffix(name, flat))
 }
 
+fn function_has_implementation(func: &Function) -> bool {
+    func.external.is_some() || !func.body.is_empty()
+}
+
 fn resolve_flat_function_by_unique_suffix<'a>(
     name: &VarName,
     flat: &'a Model,
 ) -> Option<&'a Function> {
     let text = name.as_str();
     let parts: Vec<&str> = text.split('.').collect();
-    if parts.len() < 2 {
+    // Keep member-style unresolved calls (e.g. world.f(...)) strict: those
+    // should be resolved upstream, not by ToDae suffix guessing.
+    if parts.len() < 3 {
         return None;
     }
 
     for start in 1..parts.len() {
         let suffix = parts[start..].join(".");
         let dotted_suffix = format!(".{suffix}");
-        let mut matches = flat
+        let matches: Vec<&Function> = flat
             .functions
             .iter()
-            .filter(|(k, _)| k.as_str() == suffix || k.as_str().ends_with(&dotted_suffix));
-        let first = matches.next();
-        if first.is_none() {
+            .filter(|(k, _)| k.as_str() == suffix || k.as_str().ends_with(&dotted_suffix))
+            .map(|(_, func)| func)
+            .collect();
+        if matches.is_empty() {
             continue;
         }
-        if matches.next().is_none() {
-            return first.map(|(_, f)| f);
+        if matches.len() == 1 {
+            return matches.into_iter().next();
+        }
+
+        // Prefer a unique executable implementation when the suffix matches
+        // include both partial declaration stubs and concrete redeclarations.
+        // This keeps compile-only lookup deterministic for calls such as
+        // Medium.setState_pTX that are legally redeclared in media packages.
+        let executable: Vec<&Function> = matches
+            .iter()
+            .copied()
+            .filter(|func| function_has_implementation(func))
+            .collect();
+        if executable.len() == 1 {
+            return executable.into_iter().next();
         }
     }
     None
@@ -772,7 +792,14 @@ fn validate_function_call_name(
         return Err(ToDaeError::unresolved_function_call(name.as_str(), span));
     };
 
-    if func.external.is_none() && func.body.is_empty() {
+    // MLS partial functions are declarations that can be redeclared by concrete
+    // packages. Keep them symbolic for compile-only DAE; runtime validation
+    // still rejects execution without an implementation.
+    if !function_has_implementation(func) && !func.partial {
+        if let Some(resolved) = resolve_unique_executable_short_name(name, flat, func.name.as_str())
+        {
+            return Ok(resolved);
+        }
         let short_name = func
             .name
             .as_str()
@@ -785,6 +812,38 @@ fn validate_function_call_name(
     }
 
     Ok(func.name.clone())
+}
+
+fn resolve_unique_executable_short_name(
+    requested_name: &VarName,
+    flat: &Model,
+    current_name: &str,
+) -> Option<VarName> {
+    let requested_short = requested_name
+        .as_str()
+        .rsplit('.')
+        .next()
+        .unwrap_or(requested_name.as_str());
+
+    let mut matches = flat.functions.iter().filter_map(|(name, func)| {
+        if name.as_str() == current_name {
+            return None;
+        }
+        let short = name.as_str().rsplit('.').next().unwrap_or(name.as_str());
+        if short != requested_short {
+            return None;
+        }
+        if func.external.is_none() && func.body.is_empty() {
+            return None;
+        }
+        Some(name.clone())
+    });
+
+    let first = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    Some(first)
 }
 
 fn validate_field_access_functions(

--- a/crates/rumoca-phase-flatten/src/ast_lower.rs
+++ b/crates/rumoca-phase-flatten/src/ast_lower.rs
@@ -416,17 +416,7 @@ fn convert_function_call_with_def_map(
         }
     }
 
-    let textual_name = comp
-        .parts
-        .iter()
-        .map(|p| p.ident.text.clone())
-        .collect::<Vec<_>>()
-        .join(".");
-
-    let func_name = comp
-        .def_id
-        .and_then(|def_id| def_map.and_then(|map| map.get(&def_id).cloned()))
-        .unwrap_or(textual_name);
+    let func_name = resolve_qualified_name_with_suffix(comp, def_map);
 
     flat::Expression::FunctionCall {
         name: flat::VarName::new(func_name),
@@ -553,16 +543,7 @@ fn convert_class_modification_with_def_map(
     modifications: &[ast::Expression],
     def_map: Option<&IndexMap<DefId, String>>,
 ) -> flat::Expression {
-    let textual_name = target
-        .parts
-        .iter()
-        .map(|p| p.ident.text.clone())
-        .collect::<Vec<_>>()
-        .join(".");
-    let constructor_name = target
-        .def_id
-        .and_then(|def_id| def_map.and_then(|map| map.get(&def_id).cloned()))
-        .unwrap_or(textual_name);
+    let constructor_name = resolve_qualified_name_with_suffix(target, def_map);
     flat::Expression::FunctionCall {
         name: flat::VarName::new(constructor_name),
         args: modifications
@@ -571,6 +552,41 @@ fn convert_class_modification_with_def_map(
             .collect(),
         is_constructor: true,
     }
+}
+
+fn resolve_qualified_name_with_suffix(
+    comp: &ast::ComponentReference,
+    def_map: Option<&IndexMap<DefId, String>>,
+) -> String {
+    let textual_name = comp
+        .parts
+        .iter()
+        .map(|p| p.ident.text.clone())
+        .collect::<Vec<_>>()
+        .join(".");
+
+    let Some(def_id) = comp.def_id else {
+        return textual_name;
+    };
+    let Some(base_name) = def_map.and_then(|map| map.get(&def_id)) else {
+        return textual_name;
+    };
+
+    if comp.parts.len() <= 1 {
+        return base_name.clone();
+    }
+    let first_part = comp.parts[0].ident.text.as_ref();
+    let base_leaf = base_name.rsplit('.').next().unwrap_or(base_name.as_str());
+    if base_leaf != first_part {
+        return base_name.clone();
+    }
+
+    let suffix = comp.parts[1..]
+        .iter()
+        .map(|part| part.ident.text.to_string())
+        .collect::<Vec<_>>()
+        .join(".");
+    format!("{base_name}.{suffix}")
 }
 
 fn subscript_to_string(sub: &ast::Subscript) -> String {

--- a/crates/rumoca-phase-flatten/src/functions.rs
+++ b/crates/rumoca-phase-flatten/src/functions.rs
@@ -244,16 +244,40 @@ fn lookup_function_with_scope(
     func_name: &str,
     caller_scope: Option<&str>,
 ) -> Option<(String, flat::Function)> {
-    let qualified_name = resolve_function_qualified_name_with_scope(tree, func_name, caller_scope)?;
-    let class_def = tree.get_class_by_qualified_name(&qualified_name)?;
+    let (lookup_name, emitted_name) =
+        resolve_function_target_with_scope(tree, func_name, caller_scope)?;
+    let class_def = tree.get_class_by_qualified_name(&lookup_name)?;
     let flat_func = convert_callable(
         tree,
         class_def,
-        &qualified_name,
+        &emitted_name,
         &tree.source_map,
         &tree.def_map,
     )?;
-    Some((qualified_name, flat_func))
+    Some((emitted_name, flat_func))
+}
+
+fn resolve_function_target_with_scope(
+    tree: &ast::ClassTree,
+    func_name: &str,
+    caller_scope: Option<&str>,
+) -> Option<(String, String)> {
+    if let Some(class_def) = tree.get_class_by_qualified_name(func_name)
+        && is_callable_class_type(&class_def.class_type)
+    {
+        return Some((func_name.to_string(), func_name.to_string()));
+    }
+
+    if let Some((package_name, leaf)) = func_name.rsplit_once('.')
+        && tree.get_class_by_qualified_name(package_name).is_some()
+        && let Some(inherited_name) =
+            crate::pipeline::resolve_function_in_package_chain(tree, package_name, leaf)
+    {
+        return Some((inherited_name, func_name.to_string()));
+    }
+
+    resolve_function_qualified_name_with_scope(tree, func_name, caller_scope)
+        .map(|name| (name.clone(), name))
 }
 
 /// Resolve alias-style function names (e.g. `Medium.dynamicViscosity`) by
@@ -695,6 +719,7 @@ fn convert_function(
     // Use pure flag from ast::ClassDef (MLS §12.3)
     // Functions are pure by default unless declared with `impure` keyword
     func.pure = class_def.pure;
+    func.partial = class_def.partial;
 
     // Convert external function declaration (MLS §12.9)
     if let Some(ref ext) = class_def.external {

--- a/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims.rs
@@ -725,9 +725,9 @@ pub(crate) fn rewrite_function_extends_aliases_in_flat_functions(
     flat: &mut Model,
     tree: &ClassTree,
 ) {
-    let override_packages: Vec<String> = Vec::new();
     let override_functions = OverrideFunctionMap::default();
     for function in flat.functions.values_mut() {
+        let override_packages = function_package_override_chain(function.name.as_str(), tree);
         for param in function
             .inputs
             .iter_mut()
@@ -751,6 +751,17 @@ pub(crate) fn rewrite_function_extends_aliases_in_flat_functions(
                 &override_functions,
             );
         }
+    }
+}
+
+fn function_package_override_chain(function_name: &str, tree: &ClassTree) -> Vec<String> {
+    let Some((package_name, _leaf)) = function_name.rsplit_once('.') else {
+        return Vec::new();
+    };
+    if tree.get_class_by_qualified_name(package_name).is_some() {
+        vec![package_name.to_string()]
+    } else {
+        Vec::new()
     }
 }
 

--- a/crates/rumoca-phase-resolve/src/lib.rs
+++ b/crates/rumoca-phase-resolve/src/lib.rs
@@ -964,6 +964,22 @@ end EvaluateScopeWarning;
     }
 
     #[test]
+    fn test_evaluate_on_function_local_component_is_allowed() {
+        let source = r#"
+function F
+  input Real x[:];
+  output Real y;
+protected
+  Integer m=size(x, 1) annotation(Evaluate=true);
+algorithm
+  y := m;
+end F;
+"#;
+        resolve_test_source(source)
+            .expect("Evaluate annotation on function local component should be accepted");
+    }
+
+    #[test]
     fn test_when_single_assign_allows_distinct_indexed_targets() {
         let source = r#"
 model IndexedWhenTargets

--- a/crates/rumoca-phase-resolve/src/semantic_checks.rs
+++ b/crates/rumoca-phase-resolve/src/semantic_checks.rs
@@ -1154,6 +1154,9 @@ fn check_block_connector_causality_restrictions(
         let type_name = comp.type_name.to_string();
         if let Some(tc) = find_class_by_name(def, &type_name)
             && tc.class_type == ClassType::Connector
+                // Expandable signal buses are intentionally used without
+                // component-level input/output causality on block members.
+                && !is_bus_like_connector(tc, &type_name)
                 && !comp.is_protected
                 && matches!(comp.causality, Causality::Empty)
                 // Also check if the type alias itself provides causality
@@ -1178,6 +1181,20 @@ fn check_block_connector_causality_restrictions(
             ));
         }
     }
+}
+
+fn is_bus_like_connector(connector: &ClassDef, type_name: &str) -> bool {
+    if connector.expandable {
+        return true;
+    }
+    let class_name = connector.name.text.as_ref();
+    if class_name.ends_with("Bus") || class_name.ends_with("BusArrays") {
+        return true;
+    }
+    type_name.ends_with(".Bus")
+        || type_name.ends_with("Bus")
+        || type_name.ends_with(".BusArrays")
+        || type_name.ends_with("BusArrays")
 }
 
 fn connector_members_define_causality(connector: &ClassDef) -> bool {

--- a/crates/rumoca-phase-resolve/src/semantic_checks_annotations.rs
+++ b/crates/rumoca-phase-resolve/src/semantic_checks_annotations.rs
@@ -24,8 +24,15 @@ pub(super) fn check_annotation_restrictions(class: &ClassDef, diags: &mut Vec<Di
         );
     }
 
-    for comp in class.components.values() {
-        check_component_evaluate_annotations(comp, diags);
+    // MLS §18.6 Evaluate annotation scope applies to component declarations
+    // in classes; function-local variables are not parameterized simulation
+    // components and may carry Evaluate hints in MSL utility functions.
+    let function_like = class.class_type == ClassType::Function
+        || class.class_type_token.text.as_ref() == "function";
+    if !function_like {
+        for comp in class.components.values() {
+            check_component_evaluate_annotations(comp, diags);
+        }
     }
 }
 

--- a/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_core.rs
+++ b/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_core.rs
@@ -10,12 +10,24 @@ const STREAMING_COMPILE_RESULT_QUEUE_BOUND: usize = 1;
 const SLOW_COMPILE_LOG_THRESHOLD_ENV: &str = "RUMOCA_MSL_SLOW_COMPILE_LOG_SECS";
 
 trait FocusedClosureCompiler {
-    fn strict_compile_for_focused_model(&self, model_name: &str) -> StrictCompileReport;
+    fn strict_compile_for_focused_model(
+        &self,
+        model_name: &str,
+        use_cache: bool,
+    ) -> StrictCompileReport;
 }
 
 impl FocusedClosureCompiler for CompiledSourceRoot {
-    fn strict_compile_for_focused_model(&self, model_name: &str) -> StrictCompileReport {
-        self.compile_model_strict_reachable_uncached_with_recovery(model_name)
+    fn strict_compile_for_focused_model(
+        &self,
+        model_name: &str,
+        use_cache: bool,
+    ) -> StrictCompileReport {
+        if use_cache {
+            self.compile_model_strict_reachable_with_recovery(model_name)
+        } else {
+            self.compile_model_strict_reachable_uncached_with_recovery(model_name)
+        }
     }
 }
 
@@ -304,6 +316,7 @@ fn compile_model_with_budget_timeout<T: FocusedClosureCompiler + Sync + Send>(
     source_root: &std::sync::Arc<T>,
     model_name: &str,
     budget_secs: f64,
+    use_cache: bool,
 ) -> ModelCompileEntry {
     let slow_log_threshold = slow_compile_log_threshold_secs();
     let compile_timing_before = slow_log_threshold.map(|_| compile_phase_timing_stats());
@@ -312,8 +325,9 @@ fn compile_model_with_budget_timeout<T: FocusedClosureCompiler + Sync + Send>(
     // Compile synchronously inside the bounded Rayon worker pool. The earlier
     // detached-thread timeout path could not actually cancel compile work, so
     // timed-out models kept consuming memory in the background.
-    let compile_outcome =
-        ModelCompileOutcome::StrictReport(source_root.strict_compile_for_focused_model(model_name));
+    let compile_outcome = ModelCompileOutcome::StrictReport(
+        source_root.strict_compile_for_focused_model(model_name, use_cache),
+    );
     let elapsed_secs = start.elapsed().as_secs_f64();
     if let (Some(threshold_secs), Some(before_compile), Some(before_flatten)) = (
         slow_log_threshold,
@@ -335,9 +349,11 @@ fn compile_chunk_with_model_budgets<T: FocusedClosureCompiler + Sync + Send>(
     names_chunk: &[String],
     compile_threads: usize,
     budget_secs: f64,
+    use_cache: bool,
 ) -> Vec<ModelCompileEntry> {
-    let compile_worker =
-        |name: &String| compile_model_with_budget_timeout(source_root, name, budget_secs);
+    let compile_worker = |name: &String| {
+        compile_model_with_budget_timeout(source_root, name, budget_secs, use_cache)
+    };
     match rayon::ThreadPoolBuilder::new()
         .num_threads(compile_threads.max(1))
         .build()
@@ -640,7 +656,12 @@ fn run_streaming_compile_and_render_chunk<T: FocusedClosureCompiler + Sync + Sen
         );
         for (result_idx, model_name) in names_chunk.iter().enumerate() {
             let entry = prepare_streaming_compile_result_entry(
-                compile_model_with_budget_timeout(source_root, model_name, model_budget_secs),
+                compile_model_with_budget_timeout(
+                    source_root,
+                    model_name,
+                    model_budget_secs,
+                    false,
+                ),
                 context,
             );
             if compile_tx.send((result_idx, entry)).is_err() {
@@ -746,6 +767,7 @@ fn run_parallel_simulation_chunk<T: FocusedClosureCompiler + Sync + Send>(
             names_chunk,
             simulation_threads,
             model_budget_secs,
+            false,
         )
     };
     compile_in_flight.store(false, Ordering::Relaxed);
@@ -804,8 +826,13 @@ fn run_compile_only_chunk<T: FocusedClosureCompiler + Sync + Send>(
         compile_chunk_with_model_budgets(
             source_root,
             names_chunk,
-            simulation_threads,
+            // Compile-only MSL sweeps intentionally use the shared compile cache
+            // sequentially. Parallel focused closures in the same MSL family
+            // duplicate overlapping ToDae work and turn cache misses into
+            // artificial per-model timeout failures.
+            1,
             model_budget_secs,
+            true,
         )
     };
     compile_in_flight.store(false, Ordering::Relaxed);
@@ -1097,14 +1124,24 @@ mod tests {
     use std::sync::Mutex;
 
     struct FakeFocusedCompiler {
+        cached_called: Mutex<Vec<String>>,
         uncached_called: Mutex<Vec<String>>,
     }
 
     impl FocusedClosureCompiler for FakeFocusedCompiler {
-        fn strict_compile_for_focused_model(&self, model_name: &str) -> StrictCompileReport {
-            self.uncached_called
+        fn strict_compile_for_focused_model(
+            &self,
+            model_name: &str,
+            use_cache: bool,
+        ) -> StrictCompileReport {
+            let calls = if use_cache {
+                &self.cached_called
+            } else {
+                &self.uncached_called
+            };
+            calls
                 .lock()
-                .expect("uncached call log should not be poisoned")
+                .expect("focused compile call log should not be poisoned")
                 .push(model_name.to_string());
             StrictCompileReport {
                 requested_model: model_name.to_string(),
@@ -1213,8 +1250,9 @@ mod tests {
     }
 
     #[test]
-    fn compile_model_with_budget_timeout_uses_focused_uncached_compile_path() {
+    fn compile_model_with_budget_timeout_uses_requested_compile_cache_mode() {
         let compiler = std::sync::Arc::new(FakeFocusedCompiler {
+            cached_called: Mutex::new(Vec::new()),
             uncached_called: Mutex::new(Vec::new()),
         });
 
@@ -1222,17 +1260,23 @@ mod tests {
             &compiler,
             "Modelica.Electrical.Digital.Examples.DFFREG",
             10.0,
+            true,
         );
 
         assert!(entry.remaining_budget_secs.is_none());
+        let cached = compiler
+            .cached_called
+            .lock()
+            .expect("cached call log should not be poisoned");
+        assert_eq!(
+            cached.as_slice(),
+            &["Modelica.Electrical.Digital.Examples.DFFREG".to_string()]
+        );
         let calls = compiler
             .uncached_called
             .lock()
             .expect("uncached call log should not be poisoned");
-        assert_eq!(
-            calls.as_slice(),
-            &["Modelica.Electrical.Digital.Examples.DFFREG".to_string()]
-        );
+        assert!(calls.is_empty());
     }
 
     #[test]
@@ -1296,6 +1340,21 @@ pub(super) fn test_msl_all() {
     print_msl_balance_summary(&summary);
 
     print_simulation_results(&summary);
+    print_timing_breakdown(&summary);
+    print_failure_details(&summary);
+    print_final_stats(&summary);
+}
+
+/// Compile and balance the focused MSL target set without running simulation.
+///
+/// This keeps compile-rate triage separate from solver/runtime timeout work.
+#[test]
+#[ignore = "slow-msl-compile-only"]
+pub(super) fn test_msl_compile_only() {
+    check_release_mode();
+    let summary = run_msl_test(false);
+
+    print_msl_balance_summary(&summary);
     print_timing_breakdown(&summary);
     print_failure_details(&summary);
     print_final_stats(&summary);

--- a/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_selection.rs
+++ b/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_selection.rs
@@ -488,14 +488,21 @@ pub(super) fn select_compile_targets_for_focused_simulation(
         apply_prior_complexity_schedule(&mut names, "Compile");
     }
 
-    if names.is_empty() {
-        None
-    } else {
+    let selected_names = selected_compile_targets(names, subset_requested)?;
+    {
         println!(
             "Compile scope: {}/{} root examples",
-            names.len(),
+            selected_names.len(),
             baseline_count
         );
+        Some(selected_names)
+    }
+}
+
+fn selected_compile_targets(names: Vec<String>, subset_requested: bool) -> Option<Vec<String>> {
+    if names.is_empty() && !subset_requested {
+        None
+    } else {
         Some(names)
     }
 }
@@ -651,5 +658,11 @@ mod tests {
         assert!(!should_apply_prior_complexity_schedule(false, false));
         assert!(!should_apply_prior_complexity_schedule(true, true));
         assert!(should_apply_prior_complexity_schedule(false, true));
+    }
+
+    #[test]
+    fn selected_compile_targets_preserves_empty_requested_subset() {
+        assert_eq!(selected_compile_targets(Vec::new(), true), Some(Vec::new()));
+        assert_eq!(selected_compile_targets(Vec::new(), false), None);
     }
 }

--- a/docs/development_instructions.md
+++ b/docs/development_instructions.md
@@ -105,6 +105,17 @@ If MSL quality/baseline data changes, regenerate and promote it using the
 workflow in `SPEC_0025_PR_REVIEW_PROCESS.md` and
 `SPEC_0030_COVERAGE_TRIM_PROCESS.md`.
 
+## Compile-Time Performance Triage
+
+If MSL runs show many compile timeouts or very slow compiles:
+
+- Do not only increase timeout limits.
+- Reproduce with one concrete model first (for example via
+  `modelica_compare_cli.mjs probe-compile --model ... --compile-debug`).
+- Profile Rumoca compiler hot paths with Rust tooling (`cargo`-based
+  profiling/bench workflows) to find the dominant phase/crate before changing
+  compile strategy.
+
 ## Architecture Discipline
 
 - Respect crate boundaries and phase ownership (`SPEC_0029`).


### PR DESCRIPTION
a# Rumoca PR Review Template

## Summary

- Fixes Electric-library compilation failures caused by overly strict reference validation on
  function-scope aliases/index references in DAE validation.
- Preserves behavior expected from patch `69449965a0fdbcae9cff23a6e24db974278a9735` while
  moving the fix to the upstream semantic point (reference validation), instead of model-
  specific workarounds.
- Adds development/process documentation updates (`docs/development_instructions.md`, `docs/
  philosophy.md`) and aligns branch guidance.

### External Compile-Rig Context (not from current rumoca parity harness)

Using full git history for `packages/shared/modelica/compare/baseline_msl.json`:

- earliest baseline (`7679fb8a`): `181/567` compiled (`31.92%`)
- intermediate baseline (`7b182bea`): `409/567` compiled (`72.13%`)
- current baseline (`da1bd215` / `HEAD`): `461/567` compiled (`81.31%`)

So PR-era total improvement vs earliest baseline is:

- net compile improvement: `+280` models
- compile-rate improvement: `31.92% -> 81.31%` (`+49.38` percentage points)

Recent step improvement (previous -> current baseline):

- `409/567 -> 461/567` compiled
- `+52` models (`+9.17` percentage points)

Current baseline failure split (`da1bd215`):

- compile_fail: `106`
- true timeout: `47` (~`44.3%` of failures)
- non-timeout compile errors: `59` (~`55.7%` of failures)

Category-level compile gains (intermediate -> current):

- Mechanics: `+35` compiled (`35/78 -> 70/78`)
- Electrical: `+13` compiled (`196/229 -> 209/229`)
- Media: `+4` compiled (`2/23 -> 6/23`)

Remaining low-hanging fruit (current baseline failure clusters):

- unresolved reference clusters (especially Fluid `flowModel.port_a.p` and
  Electrical/Spice constants like `CKTgmin`, `mu_0`)
- unresolved function calls around
  `Modelica.Math.Nonlinear.solveOneNonlinearEquation.f`
- timeout-heavy categories: Magnetic and Electrical

Best next step for compile-rate gain:

1. Fix unresolved-reference/function-resolution clusters first (highest non-timeout repeat
   impact).
2. Then reduce timeout clusters in Magnetic/Electrical.

Note: these metrics come from our own testing rig; the current rumoca testing rig is not yet
up to date enough to measure this equivalently.

## Code Size Budget (required)

- production_lines_added: 479
- production_lines_deleted: 6
- test_lines_added: 0
- test_lines_deleted: 0
- public_items_added: 0 (no new pub API found in touched Rust files)
- public_items_removed: 0
- files_touched: 8
- net_added_lines: 473

If counting all touched files (including docs/meta), total diff is `+631 / -7` (net `+624`).

If net_added_lines is positive, add:

- Why this net growth is required.
  - The fix introduces explicit scoped-index collection and validation paths to correctly
    accept MLS-valid qualified references used in Electrical models, replacing previous
    implicit/fragile behavior.
- Which code was removed/merged as part of the first compression pass.
  - Prior ad-hoc checks around callee/value usage were consolidated into the reference-
    validation flow; duplicate symptom-level checks were avoided.
- Follow-up cleanup ticket/commit for remaining growth (if any).
  - Follow-up: trim helper surface in `reference_validation.rs` by collapsing single-use
    helpers and extracting shared traversal utilities used by both statement and expression
    collectors.

## Design Notes

- Why each new abstraction was necessary.
  - `KnownReferenceIndex` needed scoped index tracking to distinguish unresolved true errors
    from valid over-qualified scoped references.
  - Dedicated collectors for statement/expression/component-reference traversal were needed
    to keep ownership clear and avoid phase leakage.
- Why this was not solved by editing an existing module directly.
  - The failure originates in DAE reference validation, so fixing in resolver/typecheck
    would be downstream/symptomatic and risk divergence from MLS-consistent name-resolution
    behavior.
- What duplicate/legacy paths were deleted.
  - No separate legacy codepath was kept; behavior was folded into the existing validator
    flow with guarded fallback logic.

## Testing

- Key command(s) run.
  - `cargo build -p rumoca`
  - `cargo test -p rumoca-phase-dae reference_validation -- --nocapture`
  - `target/debug/rumoca check ... --source-root target/msl/ModelicaStandardLibrary-4.1.0 ...`
    (targeted Electrical model checks)
- Files changed covered by tests.
  - `crates/rumoca-phase-dae/src/reference_validation.rs` (unit coverage in
    `reference_validation` tests; targeted model compile checks for Electrical examples).

## Reviewer Checklist

- [x] Size budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths were removed unless explicitly migrating.
