### PR TITLE
Remove timeouts

### DIFF
--- a/crates/rumoca-ir-ast/src/instance.rs
+++ b/crates/rumoca-ir-ast/src/instance.rs
@@ -472,6 +472,8 @@ pub struct InstanceData {
 pub struct ClassInstanceData {
     /// Unique identifier for this class instance.
     pub instance_id: InstanceId,
+    /// DefId of the class definition this instance was instantiated from.
+    pub class_def_id: Option<DefId>,
     /// Fully qualified name in the instance tree.
     pub qualified_name: QualifiedName,
     /// Equations from this instance (not inherited).

--- a/crates/rumoca-phase-dae/src/binding_conversion.rs
+++ b/crates/rumoca-phase-dae/src/binding_conversion.rs
@@ -313,7 +313,7 @@ fn build_duplicate_binding_set(flat: &Model) -> HashSet<VarName> {
             continue;
         }
 
-        // Extract LHS name and RHS expression from residual: lhs - rhs = 0.
+        // Extract canonical assignment from residual: target - expr = 0.
         let Expression::Binary { op, lhs, rhs } = &eq.residual else {
             continue;
         };
@@ -323,7 +323,6 @@ fn build_duplicate_binding_set(flat: &Model) -> HashSet<VarName> {
         let Expression::VarRef { name, .. } = lhs.as_ref() else {
             continue;
         };
-
         let is_dup = flat
             .variables
             .get(name)

--- a/crates/rumoca-phase-dae/src/reference_validation.rs
+++ b/crates/rumoca-phase-dae/src/reference_validation.rs
@@ -1305,7 +1305,6 @@ fn is_known_dae_reference(name: &VarName, known_refs: &KnownReferenceIndex) -> b
         resolves_via_component_nested_member_value_fallback(raw, known_refs);
     let known_via_component_package_constant_scope =
         resolves_via_component_package_constant_fallback(raw, known_refs);
-
     known_via_subscript
         || known_via_outer_scope
         || known_via_leading_scope

--- a/crates/rumoca-phase-dae/src/runtime_precompute/clock.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/clock.rs
@@ -1,6 +1,7 @@
 use super::ToDaeError;
 use super::{eval_scalar_const_expr, extract_time_event_instant};
 use indexmap::IndexMap;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
@@ -10,6 +11,8 @@ use rumoca_ir_dae::{ExpressionVisitor, ImplicitSampleChecker, VarRefWithSubscrip
 struct SourceMap<'a> {
     forward: HashMap<String, Vec<&'a dae::Expression>>,
     reverse_alias: HashMap<String, Vec<String>>,
+    timing_cache: RefCell<HashMap<String, Option<(f64, f64)>>>,
+    scalar_cache: RefCell<HashMap<String, Option<f64>>>,
 }
 
 impl<'a> SourceMap<'a> {
@@ -17,6 +20,8 @@ impl<'a> SourceMap<'a> {
         Self {
             forward,
             reverse_alias: HashMap::new(),
+            timing_cache: RefCell::new(HashMap::new()),
+            scalar_cache: RefCell::new(HashMap::new()),
         }
     }
 
@@ -518,6 +523,9 @@ fn eval_clock_scalar_from_var_ref(
     visiting: &mut HashSet<String>,
 ) -> Option<f64> {
     let key = canonical_var_ref_key(name, subscripts, constants)?;
+    if let Some(cached) = sources.scalar_cache.borrow().get(&key).cloned() {
+        return cached;
+    }
     let visit_key = format!("scalar::{key}");
     if !visiting.insert(visit_key.clone()) {
         return None;
@@ -528,6 +536,7 @@ fn eval_clock_scalar_from_var_ref(
         })
     });
     visiting.remove(&visit_key);
+    sources.scalar_cache.borrow_mut().insert(key, inferred);
     inferred
 }
 
@@ -1110,6 +1119,9 @@ fn infer_clock_timing_from_var_ref(
     visiting: &mut HashSet<String>,
 ) -> Option<(f64, f64)> {
     let key = canonical_var_ref_key(name, subscripts, constants)?;
+    if let Some(cached) = sources.timing_cache.borrow().get(&key).cloned() {
+        return cached;
+    }
     if !visiting.insert(key.clone()) {
         return None;
     }
@@ -1141,6 +1153,7 @@ fn infer_clock_timing_from_var_ref(
         )
     });
     visiting.remove(&key);
+    sources.timing_cache.borrow_mut().insert(key, inferred);
     inferred
 }
 

--- a/crates/rumoca-phase-dae/src/runtime_precompute/mod.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/mod.rs
@@ -10,7 +10,14 @@ mod clock;
 
 pub(crate) fn populate_runtime_precompute(dae_model: &mut dae::Dae) -> Result<(), ToDaeError> {
     let profile = std::env::var("RUMOCA_TODAE_PROFILE").is_ok();
+    let scalar_collection_start = maybe_start_timer_if(profile);
     let compile_time_scalars = collect_compile_time_scalars(dae_model);
+    if scalar_collection_start.is_some() {
+        eprintln!(
+            "ToDae runtime_precompute compile_time_scalars: {:.3}s",
+            maybe_elapsed_seconds(scalar_collection_start)
+        );
+    }
 
     let synthetic_root_start = maybe_start_timer_if(profile);
     let mut synthetic_roots = Vec::new();
@@ -121,7 +128,9 @@ fn insert_compile_time_scalar(values: &mut HashMap<String, f64>, name: &str, val
         values.insert(name.to_string(), value);
         changed = true;
     }
-    if let Some(base) = dae::component_base_name(name)
+    let is_indexed_name = name.contains('[');
+    if !is_indexed_name
+        && let Some(base) = dae::component_base_name(name)
         && values
             .get(base.as_str())
             .is_none_or(|existing| (existing - value).abs() > 1.0e-12)
@@ -202,20 +211,26 @@ fn collect_array_scalar_entries(
 }
 
 fn collect_compile_time_scalars(dae_model: &dae::Dae) -> HashMap<String, f64> {
+    let profile = std::env::var("RUMOCA_TODAE_PROFILE").is_ok();
+    let collect_start = maybe_start_timer_if(profile);
     let mut values = HashMap::new();
     for (literal, ordinal) in &dae_model.enum_literal_ordinals {
         values.insert(literal.clone(), *ordinal as f64);
     }
+    // Compile-time scalar propagation only includes true compile-time entities.
+    // Inputs are externally driven at runtime and their `start` values are not
+    // compile-time constants for static event/clock extraction.
     let bindings: Vec<(&dae::VarName, &dae::Expression)> = dae_model
         .parameters
         .iter()
         .chain(dae_model.constants.iter())
-        .chain(dae_model.inputs.iter())
         .filter_map(|(name, variable)| variable.start.as_ref().map(|start| (name, start)))
         .collect();
 
     let max_passes = (bindings.len().max(1)).saturating_mul(2);
+    let mut passes_run = 0usize;
     for _ in 0..max_passes {
+        passes_run += 1;
         let mut changed = false;
         for (name, start) in &bindings {
             if let Some(value) = eval_scalar_const_expr(start, &values) {
@@ -229,6 +244,14 @@ fn collect_compile_time_scalars(dae_model: &dae::Dae) -> HashMap<String, f64> {
         if !changed {
             break;
         }
+    }
+    if collect_start.is_some() {
+        eprintln!(
+            "ToDae runtime_precompute compile_time_scalars stats: bindings={} passes={} values={}",
+            bindings.len(),
+            passes_run,
+            values.len()
+        );
     }
 
     values

--- a/crates/rumoca-phase-dae/src/tests.rs
+++ b/crates/rumoca-phase-dae/src/tests.rs
@@ -1969,5 +1969,6 @@ fn test_model_description_propagation() {
 
 mod tests_embedded_range;
 mod tests_flow_sum;
+mod tests_function_param_calls;
 mod tests_regressions;
 mod tests_scalar_shape;

--- a/crates/rumoca-phase-dae/src/tests/tests_function_param_calls.rs
+++ b/crates/rumoca-phase-dae/src/tests/tests_function_param_calls.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+#[test]
+fn test_todae_accepts_function_typed_parameter_calls_in_function_body() {
+    let mut flat = Model::new();
+    add_primitive_real(&mut flat, "x");
+
+    let mut partial =
+        rumoca_ir_flat::Function::new("Modelica.Math.Nonlinear.partialScalarFunction", Span::DUMMY);
+    partial.partial = true;
+    flat.add_function(partial);
+
+    let mut nonlinear = rumoca_ir_flat::Function::new(
+        "Modelica.Math.Nonlinear.solveOneNonlinearEquation",
+        Span::DUMMY,
+    );
+    nonlinear.inputs.push(rumoca_ir_flat::FunctionParam {
+        name: "f".to_string(),
+        type_name: "Modelica.Math.Nonlinear.partialScalarFunction".to_string(),
+        dims: vec![],
+        default: None,
+        description: None,
+    });
+    nonlinear.inputs.push(rumoca_ir_flat::FunctionParam {
+        name: "u".to_string(),
+        type_name: "Real".to_string(),
+        dims: vec![],
+        default: None,
+        description: None,
+    });
+    nonlinear.outputs.push(rumoca_ir_flat::FunctionParam {
+        name: "y".to_string(),
+        type_name: "Real".to_string(),
+        dims: vec![],
+        default: None,
+        description: None,
+    });
+    nonlinear.body.push(rumoca_ir_flat::Statement::Assignment {
+        comp: make_comp_ref("y"),
+        value: flat::Expression::FunctionCall {
+            name: VarName::new("Modelica.Math.Nonlinear.solveOneNonlinearEquation.f"),
+            args: vec![make_var_ref("u")],
+            is_constructor: false,
+        },
+    });
+    flat.add_function(nonlinear);
+
+    add_scalar_ode_with_rhs_call(
+        &mut flat,
+        "x",
+        "Modelica.Math.Nonlinear.solveOneNonlinearEquation",
+    );
+
+    to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect("function-typed function parameters should be callable in function bodies");
+}

--- a/crates/rumoca-phase-dae/src/variable_analysis.rs
+++ b/crates/rumoca-phase-dae/src/variable_analysis.rs
@@ -783,7 +783,15 @@ fn validate_function_call_name(
     name: &VarName,
     flat: &Model,
     span: Span,
+    function_scope: Option<&HashSet<String>>,
 ) -> Result<VarName, ToDaeError> {
+    if is_function_typed_member_call(name, flat) {
+        return Ok(name.clone());
+    }
+
+    if function_scope.is_some_and(|scope| function_scope_contains_function_call(name, scope)) {
+        return Ok(name.clone());
+    }
     if is_builtin_or_runtime_intrinsic_function(name) {
         return Ok(name.clone());
     }
@@ -814,6 +822,69 @@ fn validate_function_call_name(
     Ok(func.name.clone())
 }
 
+fn function_scope_contains_function_call(name: &VarName, scope: &HashSet<String>) -> bool {
+    if scope.contains(name.as_str()) {
+        return true;
+    }
+    name.as_str()
+        .rsplit('.')
+        .next()
+        .is_some_and(|leaf| scope.contains(leaf))
+}
+
+fn function_param_is_function_typed(param: &flat::FunctionParam, flat: &Model) -> bool {
+    if param.type_name.is_empty() {
+        return false;
+    }
+    // MLS §12 allows function-typed formal parameters. Recognize them by
+    // resolving the declared type name to a function declaration in flat IR.
+    if resolve_flat_function(&VarName::new(&param.type_name), flat).is_some() {
+        return true;
+    }
+    !matches!(
+        param.type_name.as_str(),
+        "Real"
+            | "Integer"
+            | "Boolean"
+            | "String"
+            | "Clock"
+            | "Complex"
+            | "Modelica.ComplexMath.Complex"
+    )
+}
+
+fn is_function_typed_member_call(name: &VarName, flat: &Model) -> bool {
+    let raw = name.as_str();
+    let Some((owner, member)) = raw.rsplit_once('.') else {
+        return false;
+    };
+    let owner_name = VarName::new(owner);
+    let Some(function) = resolve_flat_function(&owner_name, flat) else {
+        return false;
+    };
+    function
+        .inputs
+        .iter()
+        .chain(function.outputs.iter())
+        .chain(function.locals.iter())
+        .any(|param| param.name == member && function_param_is_function_typed(param, flat))
+}
+
+fn function_callable_scope(function: &Function, flat: &Model) -> HashSet<String> {
+    function
+        .inputs
+        .iter()
+        .chain(function.outputs.iter())
+        .chain(function.locals.iter())
+        .filter(|param| function_param_is_function_typed(param, flat))
+        .flat_map(|param| {
+            [
+                param.name.clone(),
+                format!("{}.{}", function.name.as_str(), param.name),
+            ]
+        })
+        .collect()
+}
 fn resolve_unique_executable_short_name(
     requested_name: &VarName,
     flat: &Model,
@@ -852,6 +923,7 @@ fn validate_field_access_functions(
     flat: &Model,
     span: Span,
     reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
 ) -> Result<(), ToDaeError> {
     if let Expression::FunctionCall {
         name,
@@ -860,7 +932,7 @@ fn validate_field_access_functions(
     } = base
     {
         for arg in args {
-            validate_flat_expression_functions(arg, flat, span, reachable_calls)?;
+            validate_flat_expression_functions(arg, flat, span, reachable_calls, function_scope)?;
         }
 
         // Complex constructors commonly project `.re`/`.im` without explicit
@@ -931,7 +1003,7 @@ fn validate_field_access_functions(
         return Ok(());
     }
 
-    validate_flat_expression_functions(base, flat, span, reachable_calls)
+    validate_flat_expression_functions(base, flat, span, reachable_calls, function_scope)
 }
 
 fn validate_flat_expression_functions(
@@ -939,82 +1011,206 @@ fn validate_flat_expression_functions(
     flat: &Model,
     span: Span,
     reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
 ) -> Result<(), ToDaeError> {
     match expr {
         Expression::FunctionCall {
             name,
             args,
             is_constructor,
-        } => {
-            if !is_constructor {
-                let resolved_name = validate_function_call_name(name, flat, span)?;
-                if !is_builtin_or_runtime_intrinsic_function(&resolved_name) {
-                    reachable_calls.push(resolved_name);
-                }
-            }
-            for arg in args {
-                validate_flat_expression_functions(arg, flat, span, reachable_calls)?;
-            }
-        }
+        } => validate_function_call_expr(
+            name,
+            args,
+            *is_constructor,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?,
         Expression::BuiltinCall { args, .. } => {
-            for arg in args {
-                validate_flat_expression_functions(arg, flat, span, reachable_calls)?;
-            }
+            validate_expr_list(args, flat, span, reachable_calls, function_scope)?
         }
         Expression::Binary { lhs, rhs, .. } => {
-            validate_flat_expression_functions(lhs, flat, span, reachable_calls)?;
-            validate_flat_expression_functions(rhs, flat, span, reachable_calls)?;
+            validate_flat_expression_functions(lhs, flat, span, reachable_calls, function_scope)?;
+            validate_flat_expression_functions(rhs, flat, span, reachable_calls, function_scope)?
         }
         Expression::Unary { rhs, .. } => {
-            validate_flat_expression_functions(rhs, flat, span, reachable_calls)?
+            validate_flat_expression_functions(rhs, flat, span, reachable_calls, function_scope)?
         }
         Expression::If {
             branches,
             else_branch,
-        } => {
-            for (cond, value) in branches {
-                validate_flat_expression_functions(cond, flat, span, reachable_calls)?;
-                validate_flat_expression_functions(value, flat, span, reachable_calls)?;
-            }
-            validate_flat_expression_functions(else_branch, flat, span, reachable_calls)?;
-        }
+        } => validate_if_expr(
+            branches,
+            else_branch,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?,
         Expression::Array { elements, .. } | Expression::Tuple { elements } => {
-            for element in elements {
-                validate_flat_expression_functions(element, flat, span, reachable_calls)?;
-            }
+            validate_expr_list(elements, flat, span, reachable_calls, function_scope)?
         }
-        Expression::Range { start, step, end } => {
-            validate_flat_expression_functions(start, flat, span, reachable_calls)?;
-            if let Some(step) = step {
-                validate_flat_expression_functions(step, flat, span, reachable_calls)?;
-            }
-            validate_flat_expression_functions(end, flat, span, reachable_calls)?;
-        }
-        Expression::Index { base, subscripts } => {
-            validate_flat_expression_functions(base, flat, span, reachable_calls)?;
-            for subscript in subscripts {
-                if let Subscript::Expr(expr) = subscript {
-                    validate_flat_expression_functions(expr, flat, span, reachable_calls)?;
-                }
-            }
-        }
+        Expression::Range { start, step, end } => validate_range_expr(
+            start,
+            step.as_deref(),
+            end,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?,
+        Expression::Index { base, subscripts } => validate_index_expr(
+            base,
+            subscripts,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?,
         Expression::FieldAccess { base, field } => {
-            validate_field_access_functions(base, field, flat, span, reachable_calls)?;
+            validate_field_access_functions(
+                base,
+                field,
+                flat,
+                span,
+                reachable_calls,
+                function_scope,
+            )?;
         }
         Expression::ArrayComprehension {
             expr,
             indices,
             filter,
-        } => {
-            validate_flat_expression_functions(expr, flat, span, reachable_calls)?;
-            for index in indices {
-                validate_flat_expression_functions(&index.range, flat, span, reachable_calls)?;
-            }
-            if let Some(filter_expr) = filter {
-                validate_flat_expression_functions(filter_expr, flat, span, reachable_calls)?;
-            }
-        }
+        } => validate_array_comprehension_expr(
+            expr,
+            indices,
+            filter.as_deref(),
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?,
         Expression::VarRef { .. } | Expression::Literal(_) | Expression::Empty => {}
+    }
+    Ok(())
+}
+
+fn validate_function_call_expr(
+    name: &VarName,
+    args: &[Expression],
+    is_constructor: bool,
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    if !is_constructor {
+        let resolved_name = validate_function_call_name(name, flat, span, function_scope)?;
+        maybe_enqueue_reachable_call(&resolved_name, flat, reachable_calls, function_scope);
+    }
+    validate_expr_list(args, flat, span, reachable_calls, function_scope)
+}
+
+fn maybe_enqueue_reachable_call(
+    resolved_name: &VarName,
+    flat: &Model,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) {
+    let scope_callable = function_scope
+        .is_some_and(|scope| function_scope_contains_function_call(resolved_name, scope));
+    let dynamic_member_call = is_function_typed_member_call(resolved_name, flat);
+    if !is_builtin_or_runtime_intrinsic_function(resolved_name)
+        && !scope_callable
+        && !dynamic_member_call
+    {
+        reachable_calls.push(resolved_name.clone());
+    }
+}
+
+fn validate_expr_list(
+    exprs: &[Expression],
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    for expr in exprs {
+        validate_flat_expression_functions(expr, flat, span, reachable_calls, function_scope)?;
+    }
+    Ok(())
+}
+
+fn validate_if_expr(
+    branches: &[(Expression, Expression)],
+    else_branch: &Expression,
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    for (cond, value) in branches {
+        validate_flat_expression_functions(cond, flat, span, reachable_calls, function_scope)?;
+        validate_flat_expression_functions(value, flat, span, reachable_calls, function_scope)?;
+    }
+    validate_flat_expression_functions(else_branch, flat, span, reachable_calls, function_scope)
+}
+
+fn validate_range_expr(
+    start: &Expression,
+    step: Option<&Expression>,
+    end: &Expression,
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    validate_flat_expression_functions(start, flat, span, reachable_calls, function_scope)?;
+    if let Some(step) = step {
+        validate_flat_expression_functions(step, flat, span, reachable_calls, function_scope)?;
+    }
+    validate_flat_expression_functions(end, flat, span, reachable_calls, function_scope)
+}
+
+fn validate_index_expr(
+    base: &Expression,
+    subscripts: &[Subscript],
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    validate_flat_expression_functions(base, flat, span, reachable_calls, function_scope)?;
+    for subscript in subscripts {
+        if let Subscript::Expr(expr) = subscript {
+            validate_flat_expression_functions(expr, flat, span, reachable_calls, function_scope)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_array_comprehension_expr(
+    expr: &Expression,
+    indices: &[rumoca_ir_flat::ComprehensionIndex],
+    filter: Option<&Expression>,
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    validate_flat_expression_functions(expr, flat, span, reachable_calls, function_scope)?;
+    for index in indices {
+        validate_flat_expression_functions(
+            &index.range,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?;
+    }
+    if let Some(filter) = filter {
+        validate_flat_expression_functions(filter, flat, span, reachable_calls, function_scope)?;
     }
     Ok(())
 }
@@ -1028,81 +1224,190 @@ fn validate_statement_functions(
     flat: &Model,
     span: Span,
     reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
 ) -> Result<(), ToDaeError> {
     match stmt {
         Statement::Assignment { value, .. } => {
-            validate_flat_expression_functions(value, flat, span, reachable_calls)?
+            validate_flat_expression_functions(value, flat, span, reachable_calls, function_scope)?
         }
-        Statement::For { indices, equations } => {
-            for index in indices {
-                validate_flat_expression_functions(&index.range, flat, span, reachable_calls)?;
-            }
-            for nested in equations {
-                validate_statement_functions(nested, flat, span, reachable_calls)?;
-            }
-        }
+        Statement::For { indices, equations } => validate_for_statement(
+            indices,
+            equations,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?,
         Statement::While(block) => {
-            validate_flat_expression_functions(&block.cond, flat, span, reachable_calls)?;
-            for nested in &block.stmts {
-                validate_statement_functions(nested, flat, span, reachable_calls)?;
-            }
+            validate_while_statement(block, flat, span, reachable_calls, function_scope)?
         }
         Statement::If {
             cond_blocks,
             else_block,
-        } => {
-            for block in cond_blocks {
-                validate_flat_expression_functions(&block.cond, flat, span, reachable_calls)?;
-                for nested in &block.stmts {
-                    validate_statement_functions(nested, flat, span, reachable_calls)?;
-                }
-            }
-            if let Some(else_block) = else_block {
-                for nested in else_block {
-                    validate_statement_functions(nested, flat, span, reachable_calls)?;
-                }
-            }
-        }
+        } => validate_if_statement(
+            cond_blocks,
+            else_block.as_deref(),
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?,
         Statement::When(blocks) => {
-            for block in blocks {
-                validate_flat_expression_functions(&block.cond, flat, span, reachable_calls)?;
-                for nested in &block.stmts {
-                    validate_statement_functions(nested, flat, span, reachable_calls)?;
-                }
-            }
+            validate_when_statement(blocks, flat, span, reachable_calls, function_scope)?
         }
         Statement::FunctionCall {
             comp,
             args,
             outputs,
-        } => {
-            let name = component_reference_to_var_name(comp);
-            let resolved_name = validate_function_call_name(&name, flat, span)?;
-            if !is_builtin_or_runtime_intrinsic_function(&resolved_name) {
-                reachable_calls.push(resolved_name);
-            }
-            for arg in args {
-                validate_flat_expression_functions(arg, flat, span, reachable_calls)?;
-            }
-            for output in outputs {
-                validate_flat_expression_functions(output, flat, span, reachable_calls)?;
-            }
-        }
+        } => validate_statement_function_call(
+            comp,
+            args,
+            outputs,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?,
         Statement::Reinit { value, .. } => {
-            validate_flat_expression_functions(value, flat, span, reachable_calls)?
+            validate_flat_expression_functions(value, flat, span, reachable_calls, function_scope)?
         }
         Statement::Assert {
             condition,
             message,
             level,
         } => {
-            validate_flat_expression_functions(condition, flat, span, reachable_calls)?;
-            validate_flat_expression_functions(message, flat, span, reachable_calls)?;
+            validate_flat_expression_functions(
+                condition,
+                flat,
+                span,
+                reachable_calls,
+                function_scope,
+            )?;
+            validate_flat_expression_functions(
+                message,
+                flat,
+                span,
+                reachable_calls,
+                function_scope,
+            )?;
             if let Some(level) = level {
-                validate_flat_expression_functions(level, flat, span, reachable_calls)?;
+                validate_flat_expression_functions(
+                    level,
+                    flat,
+                    span,
+                    reachable_calls,
+                    function_scope,
+                )?;
             }
         }
         Statement::Empty | Statement::Return | Statement::Break => {}
+    }
+    Ok(())
+}
+
+fn validate_for_statement(
+    indices: &[rumoca_ir_flat::ForIndex],
+    equations: &[Statement],
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    for index in indices {
+        validate_flat_expression_functions(
+            &index.range,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?;
+    }
+    for nested in equations {
+        validate_statement_functions(nested, flat, span, reachable_calls, function_scope)?;
+    }
+    Ok(())
+}
+
+fn validate_while_statement(
+    block: &rumoca_ir_flat::StatementBlock,
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    validate_flat_expression_functions(&block.cond, flat, span, reachable_calls, function_scope)?;
+    validate_statement_list(&block.stmts, flat, span, reachable_calls, function_scope)
+}
+
+fn validate_if_statement(
+    cond_blocks: &[rumoca_ir_flat::StatementBlock],
+    else_block: Option<&[Statement]>,
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    for block in cond_blocks {
+        validate_flat_expression_functions(
+            &block.cond,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?;
+        validate_statement_list(&block.stmts, flat, span, reachable_calls, function_scope)?;
+    }
+    if let Some(else_block) = else_block {
+        validate_statement_list(else_block, flat, span, reachable_calls, function_scope)?;
+    }
+    Ok(())
+}
+
+fn validate_when_statement(
+    blocks: &[rumoca_ir_flat::StatementBlock],
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    for block in blocks {
+        validate_flat_expression_functions(
+            &block.cond,
+            flat,
+            span,
+            reachable_calls,
+            function_scope,
+        )?;
+        validate_statement_list(&block.stmts, flat, span, reachable_calls, function_scope)?;
+    }
+    Ok(())
+}
+
+fn validate_statement_function_call(
+    comp: &ComponentReference,
+    args: &[Expression],
+    outputs: &[Expression],
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    let name = component_reference_to_var_name(comp);
+    let resolved_name = validate_function_call_name(&name, flat, span, function_scope)?;
+    maybe_enqueue_reachable_call(&resolved_name, flat, reachable_calls, function_scope);
+    validate_expr_list(args, flat, span, reachable_calls, function_scope)?;
+    validate_expr_list(outputs, flat, span, reachable_calls, function_scope)
+}
+
+fn validate_statement_list(
+    stmts: &[Statement],
+    flat: &Model,
+    span: Span,
+    reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
+) -> Result<(), ToDaeError> {
+    for stmt in stmts {
+        validate_statement_functions(stmt, flat, span, reachable_calls, function_scope)?;
     }
     Ok(())
 }
@@ -1111,17 +1416,24 @@ fn validate_when_equation_functions(
     equation: &rumoca_ir_flat::WhenEquation,
     flat: &Model,
     reachable_calls: &mut Vec<VarName>,
+    function_scope: Option<&HashSet<String>>,
 ) -> Result<(), ToDaeError> {
     match equation {
         rumoca_ir_flat::WhenEquation::Assign { value, span, .. } => {
-            validate_flat_expression_functions(value, flat, *span, reachable_calls)?
+            validate_flat_expression_functions(value, flat, *span, reachable_calls, function_scope)?
         }
         rumoca_ir_flat::WhenEquation::Reinit { value, span, .. } => {
-            validate_flat_expression_functions(value, flat, *span, reachable_calls)?
+            validate_flat_expression_functions(value, flat, *span, reachable_calls, function_scope)?
         }
         rumoca_ir_flat::WhenEquation::Assert {
             condition, span, ..
-        } => validate_flat_expression_functions(condition, flat, *span, reachable_calls)?,
+        } => validate_flat_expression_functions(
+            condition,
+            flat,
+            *span,
+            reachable_calls,
+            function_scope,
+        )?,
         rumoca_ir_flat::WhenEquation::Terminate { .. } => {}
         rumoca_ir_flat::WhenEquation::Conditional {
             branches,
@@ -1129,17 +1441,34 @@ fn validate_when_equation_functions(
             ..
         } => {
             for (condition, equations) in branches {
-                validate_flat_expression_functions(condition, flat, Span::DUMMY, reachable_calls)?;
+                validate_flat_expression_functions(
+                    condition,
+                    flat,
+                    Span::DUMMY,
+                    reachable_calls,
+                    function_scope,
+                )?;
                 for nested in equations {
-                    validate_when_equation_functions(nested, flat, reachable_calls)?;
+                    validate_when_equation_functions(
+                        nested,
+                        flat,
+                        reachable_calls,
+                        function_scope,
+                    )?;
                 }
             }
             for nested in else_branch {
-                validate_when_equation_functions(nested, flat, reachable_calls)?;
+                validate_when_equation_functions(nested, flat, reachable_calls, function_scope)?;
             }
         }
         rumoca_ir_flat::WhenEquation::FunctionCallOutputs { function, span, .. } => {
-            validate_flat_expression_functions(function, flat, *span, reachable_calls)?
+            validate_flat_expression_functions(
+                function,
+                flat,
+                *span,
+                reachable_calls,
+                function_scope,
+            )?
         }
     }
     Ok(())
@@ -1148,6 +1477,25 @@ fn validate_when_equation_functions(
 pub(crate) fn validate_flat_function_calls(flat: &Model) -> Result<(), ToDaeError> {
     let mut reachable_calls: Vec<VarName> = Vec::new();
 
+    collect_root_reachable_calls(flat, &mut reachable_calls)?;
+    validate_reachable_function_closure(flat, &mut reachable_calls)
+}
+
+fn collect_root_reachable_calls(
+    flat: &Model,
+    reachable_calls: &mut Vec<VarName>,
+) -> Result<(), ToDaeError> {
+    collect_variable_attr_calls(flat, reachable_calls)?;
+    collect_equation_calls(flat, reachable_calls)?;
+    collect_assertion_calls(flat, reachable_calls)?;
+    collect_when_calls(flat, reachable_calls)?;
+    collect_algorithm_calls(flat, reachable_calls)
+}
+
+fn collect_variable_attr_calls(
+    flat: &Model,
+    reachable_calls: &mut Vec<VarName>,
+) -> Result<(), ToDaeError> {
     for variable in flat.variables.values() {
         let is_param_or_const = matches!(
             variable.variability,
@@ -1156,7 +1504,6 @@ pub(crate) fn validate_flat_function_calls(flat: &Model) -> Result<(), ToDaeErro
         if is_param_or_const {
             continue;
         }
-
         for expr in [
             variable.start.as_ref(),
             variable.min.as_ref(),
@@ -1167,19 +1514,32 @@ pub(crate) fn validate_flat_function_calls(flat: &Model) -> Result<(), ToDaeErro
         .into_iter()
         .flatten()
         {
-            validate_flat_expression_functions(expr, flat, Span::DUMMY, &mut reachable_calls)?;
+            validate_flat_expression_functions(expr, flat, Span::DUMMY, reachable_calls, None)?;
         }
     }
+    Ok(())
+}
 
+fn collect_equation_calls(
+    flat: &Model,
+    reachable_calls: &mut Vec<VarName>,
+) -> Result<(), ToDaeError> {
     for equation in flat.equations.iter().chain(flat.initial_equations.iter()) {
         validate_flat_expression_functions(
             &equation.residual,
             flat,
             equation.span,
-            &mut reachable_calls,
+            reachable_calls,
+            None,
         )?;
     }
+    Ok(())
+}
 
+fn collect_assertion_calls(
+    flat: &Model,
+    reachable_calls: &mut Vec<VarName>,
+) -> Result<(), ToDaeError> {
     for assertion in flat
         .assert_equations
         .iter()
@@ -1189,32 +1549,59 @@ pub(crate) fn validate_flat_function_calls(flat: &Model) -> Result<(), ToDaeErro
             &assertion.condition,
             flat,
             assertion.span,
-            &mut reachable_calls,
+            reachable_calls,
+            None,
         )?;
         validate_flat_expression_functions(
             &assertion.message,
             flat,
             assertion.span,
-            &mut reachable_calls,
+            reachable_calls,
+            None,
         )?;
         if let Some(level) = &assertion.level {
-            validate_flat_expression_functions(level, flat, assertion.span, &mut reachable_calls)?;
+            validate_flat_expression_functions(level, flat, assertion.span, reachable_calls, None)?;
         }
     }
+    Ok(())
+}
 
+fn collect_when_calls(flat: &Model, reachable_calls: &mut Vec<VarName>) -> Result<(), ToDaeError> {
     for when in &flat.when_clauses {
-        validate_flat_expression_functions(&when.condition, flat, when.span, &mut reachable_calls)?;
+        validate_flat_expression_functions(
+            &when.condition,
+            flat,
+            when.span,
+            reachable_calls,
+            None,
+        )?;
         for equation in &when.equations {
-            validate_when_equation_functions(equation, flat, &mut reachable_calls)?;
+            validate_when_equation_functions(equation, flat, reachable_calls, None)?;
         }
     }
+    Ok(())
+}
 
+fn collect_algorithm_calls(
+    flat: &Model,
+    reachable_calls: &mut Vec<VarName>,
+) -> Result<(), ToDaeError> {
     for algorithm in flat.algorithms.iter().chain(flat.initial_algorithms.iter()) {
-        for statement in &algorithm.statements {
-            validate_statement_functions(statement, flat, algorithm.span, &mut reachable_calls)?;
-        }
+        validate_statement_list(
+            &algorithm.statements,
+            flat,
+            algorithm.span,
+            reachable_calls,
+            None,
+        )?;
     }
+    Ok(())
+}
 
+fn validate_reachable_function_closure(
+    flat: &Model,
+    reachable_calls: &mut Vec<VarName>,
+) -> Result<(), ToDaeError> {
     let mut visited: HashSet<VarName> = HashSet::default();
     while let Some(function_name) = reachable_calls.pop() {
         if !visited.insert(function_name.clone()) {
@@ -1226,26 +1613,40 @@ pub(crate) fn validate_flat_function_calls(flat: &Model) -> Result<(), ToDaeErro
                 Span::DUMMY,
             ));
         };
-        for param in function
-            .inputs
-            .iter()
-            .chain(function.outputs.iter())
-            .chain(function.locals.iter())
-        {
-            if let Some(default_expr) = &param.default {
-                validate_flat_expression_functions(
-                    default_expr,
-                    flat,
-                    function.span,
-                    &mut reachable_calls,
-                )?;
-            }
-        }
-        for statement in &function.body {
-            validate_statement_functions(statement, flat, function.span, &mut reachable_calls)?;
+        validate_function_defaults(function, flat, reachable_calls)?;
+        let callable_scope = function_callable_scope(function, flat);
+        validate_statement_list(
+            &function.body,
+            flat,
+            function.span,
+            reachable_calls,
+            Some(&callable_scope),
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_function_defaults(
+    function: &Function,
+    flat: &Model,
+    reachable_calls: &mut Vec<VarName>,
+) -> Result<(), ToDaeError> {
+    for param in function
+        .inputs
+        .iter()
+        .chain(function.outputs.iter())
+        .chain(function.locals.iter())
+    {
+        if let Some(default_expr) = &param.default {
+            validate_flat_expression_functions(
+                default_expr,
+                flat,
+                function.span,
+                reachable_calls,
+                None,
+            )?;
         }
     }
-
     Ok(())
 }
 

--- a/crates/rumoca-phase-flatten/src/equations/conditional_and_eval.rs
+++ b/crates/rumoca-phase-flatten/src/equations/conditional_and_eval.rs
@@ -103,6 +103,7 @@ pub(super) fn expand_nested_if_to_simple(
 
 /// Create a single conditional equation from pre-expanded simple equations.
 pub(super) struct ConditionalEquationContext<'a> {
+    pub(super) ctx: &'a Context,
     pub(super) prefix: &'a QualifiedName,
     pub(super) span: rumoca_core::Span,
     pub(super) origin: &'a rumoca_ir_flat::EquationOrigin,
@@ -121,11 +122,12 @@ pub(super) fn create_conditional_equation_from_simple(
     // This preserves MLS semantics even when branch equations do not share the same lhs.
     let conditional_residual =
         build_conditional_residual_from_simple(expanded_branches, else_simple_eqs, eq_idx)?;
-    let residual = qualify_expression_imports_with_def_map(
+    let residual = qualify_expression_imports_with_def_map_ctx(
         &conditional_residual,
         context.prefix,
         context.imports,
         context.def_map,
+        context.ctx,
     );
     Ok(flat::Equation::new(
         residual,
@@ -204,7 +206,7 @@ fn flatten_simple_in_list(
     let lhs = expand_array_comprehensions_in_expression(ctx, lhs, prefix, span)?;
     let rhs = expand_array_comprehensions_in_expression(ctx, rhs, prefix, span)?;
 
-    let residual = make_residual(&lhs, &rhs, prefix, &ctx.current_imports, def_map);
+    let residual = make_residual(ctx, &lhs, &rhs, prefix, &ctx.current_imports, def_map);
     let scalar_count = infer_simple_equation_scalar_count(&lhs, &rhs, prefix, ctx);
     if scalar_count == 0 {
         return Ok(vec![]);
@@ -261,10 +263,16 @@ pub(super) fn flatten_equations_list(
             } => {
                 let imports = &ctx.current_imports;
                 let assert_eq = AssertEquation::new(
-                    qualify_expression_imports_with_def_map(condition, prefix, imports, def_map),
-                    qualify_expression_imports_with_def_map(message, prefix, imports, def_map),
+                    qualify_expression_imports_with_def_map_ctx(
+                        condition, prefix, imports, def_map, ctx,
+                    ),
+                    qualify_expression_imports_with_def_map_ctx(
+                        message, prefix, imports, def_map, ctx,
+                    ),
                     level.as_ref().map(|expr| {
-                        qualify_expression_imports_with_def_map(expr, prefix, imports, def_map)
+                        qualify_expression_imports_with_def_map_ctx(
+                            expr, prefix, imports, def_map, ctx,
+                        )
                     }),
                     span,
                 );
@@ -282,6 +290,7 @@ pub(super) fn flatten_equations_list(
             }
             ast::Equation::FunctionCall { comp, args } => {
                 let flattened = flatten_function_call_equation(
+                    ctx,
                     comp,
                     args,
                     prefix,
@@ -1171,7 +1180,7 @@ fn try_eval_with_rumoca_eval_const(
     let fallback_start = crate::maybe_start_timer();
     // Convert AST expression to qualified ast::Expression
     let flat_expr =
-        qualify_expression_imports_with_def_map(expr, prefix, &ctx.current_imports, None);
+        qualify_expression_imports_with_def_map_ctx(expr, prefix, &ctx.current_imports, None, ctx);
 
     // Reuse the per-flatten base evaluation context to avoid rebuilding
     // parameter/function maps on every complex-expression fallback.

--- a/crates/rumoca-phase-flatten/src/equations/mod.rs
+++ b/crates/rumoca-phase-flatten/src/equations/mod.rs
@@ -16,7 +16,7 @@ use crate::boolean_eval::{
     is_structural_expression, try_eval_boolean_with_ctx_inner, try_eval_structural_boolean,
 };
 use crate::errors::FlattenError;
-use crate::{Context, qualify_expression_imports_with_def_map};
+use crate::{Context, qualify_expression_imports_with_def_map_ctx};
 
 mod conditional_and_eval;
 mod connections_graph;
@@ -507,7 +507,7 @@ pub(crate) fn flatten_equation_with_def_map(
 
             // Preserve simple equations as a single residual equation.
             // Array scalarization and counting are handled downstream.
-            let residual = make_residual(&lhs, &rhs, prefix, &ctx.current_imports, def_map);
+            let residual = make_residual(ctx, &lhs, &rhs, prefix, &ctx.current_imports, def_map);
             let scalar_count = infer_simple_equation_scalar_count(&lhs, &rhs, prefix, ctx);
             if scalar_count == 0 {
                 return Ok(FlattenedEquations::default());
@@ -554,9 +554,15 @@ pub(crate) fn flatten_equation_with_def_map(
             expand_if_equation(ctx, cond_blocks, else_block, prefix, span, &origin, def_map)
         }
 
-        ast::Equation::FunctionCall { comp, args } => {
-            flatten_function_call_equation(comp, args, prefix, span, &ctx.current_imports, def_map)
-        }
+        ast::Equation::FunctionCall { comp, args } => flatten_function_call_equation(
+            ctx,
+            comp,
+            args,
+            prefix,
+            span,
+            &ctx.current_imports,
+            def_map,
+        ),
 
         ast::Equation::Assert {
             condition,
@@ -567,10 +573,12 @@ pub(crate) fn flatten_equation_with_def_map(
             // They do not contribute to the DAE residual equation system.
             let imports = &ctx.current_imports;
             let assert_eq = flat::AssertEquation::new(
-                qualify_expression_imports_with_def_map(condition, prefix, imports, def_map),
-                qualify_expression_imports_with_def_map(message, prefix, imports, def_map),
+                qualify_expression_imports_with_def_map_ctx(
+                    condition, prefix, imports, def_map, ctx,
+                ),
+                qualify_expression_imports_with_def_map_ctx(message, prefix, imports, def_map, ctx),
                 level.as_ref().map(|expr| {
-                    qualify_expression_imports_with_def_map(expr, prefix, imports, def_map)
+                    qualify_expression_imports_with_def_map_ctx(expr, prefix, imports, def_map, ctx)
                 }),
                 span,
             );
@@ -588,6 +596,7 @@ pub(crate) fn flatten_equation_with_def_map(
 }
 
 fn flatten_function_call_equation(
+    ctx: &Context,
     comp: &ast::ComponentReference,
     args: &[ast::Expression],
     prefix: &ast::QualifiedName,
@@ -596,7 +605,7 @@ fn flatten_function_call_equation(
     def_map: Option<&crate::ResolveDefMap>,
 ) -> Result<FlattenedEquations, FlattenError> {
     if is_assert_function_call(comp) {
-        return flatten_assert_function_call(args, prefix, span, imports, def_map);
+        return flatten_assert_function_call(ctx, args, prefix, span, imports, def_map);
     }
     Ok(extract_vcg_data_from_function_call(comp, args, prefix))
 }
@@ -609,6 +618,7 @@ fn is_assert_function_call(comp: &ast::ComponentReference) -> bool {
 }
 
 fn flatten_assert_function_call(
+    ctx: &Context,
     args: &[ast::Expression],
     prefix: &ast::QualifiedName,
     span: rumoca_core::Span,
@@ -634,9 +644,11 @@ fn flatten_assert_function_call(
     };
 
     let assert_eq = flat::AssertEquation::new(
-        qualify_expression_imports_with_def_map(condition, prefix, imports, def_map),
-        qualify_expression_imports_with_def_map(message, prefix, imports, def_map),
-        level.map(|expr| qualify_expression_imports_with_def_map(expr, prefix, imports, def_map)),
+        qualify_expression_imports_with_def_map_ctx(condition, prefix, imports, def_map, ctx),
+        qualify_expression_imports_with_def_map_ctx(message, prefix, imports, def_map, ctx),
+        level.map(|expr| {
+            qualify_expression_imports_with_def_map_ctx(expr, prefix, imports, def_map, ctx)
+        }),
         span,
     );
 
@@ -668,6 +680,7 @@ fn named_call_arg<'a>(args: &'a [ast::Expression], name: &str) -> Option<&'a ast
 
 /// Create a residual expression: lhs - rhs
 fn make_residual(
+    ctx: &Context,
     lhs: &ast::Expression,
     rhs: &ast::Expression,
     prefix: &ast::QualifiedName,
@@ -681,7 +694,7 @@ fn make_residual(
         rhs: Arc::new(rhs.clone()),
     };
 
-    qualify_expression_imports_with_def_map(&residual, prefix, imports, def_map)
+    qualify_expression_imports_with_def_map_ctx(&residual, prefix, imports, def_map, ctx)
 }
 
 /// Expand array comprehensions in equation expressions when index ranges are structural.
@@ -1559,6 +1572,7 @@ fn expand_if_equation(
         // Fast path: position-based matching (original behavior)
         let mut result = FlattenedEquations::default();
         let eq_context = ConditionalEquationContext {
+            ctx,
             prefix,
             span,
             origin,

--- a/crates/rumoca-phase-flatten/src/functions.rs
+++ b/crates/rumoca-phase-flatten/src/functions.rs
@@ -719,6 +719,11 @@ fn build_static_function_binding(
         }
         let arg_expr = args.get(index).or(param.default.as_ref())?;
         let target = function_name_from_expr(arg_expr)?;
+        if !can_specialize_target_function(&target, function_index) {
+            // Keep canonical call names for non-specializable targets
+            // (notably external/runtime functions).
+            return None;
+        }
         binding_pairs.push((param.name.clone(), target));
     }
     if binding_pairs.is_empty() {
@@ -747,8 +752,25 @@ fn is_function_typed_param(
     if NON_FUNCTION_SCALAR_TYPES.contains(&param.type_name.as_str()) {
         return false;
     }
-    function_index.contains_key(&flat::VarName::new(param.type_name.as_str()))
+    // Treat as function-typed only when the declared type resolves to a partial
+    // function signature. Do not infer "function-typed" from arbitrary named
+    // types that happen to have constructor functions.
+    function_index
+        .get(&flat::VarName::new(param.type_name.as_str()))
+        .is_some_and(|sig| sig.partial)
         || param.type_name.contains("partial")
+}
+
+fn can_specialize_target_function(
+    target_name: &str,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+) -> bool {
+    let Some(target) = function_index.get(&flat::VarName::new(target_name)) else {
+        // Unknown targets must stay canonical.
+        return false;
+    };
+    // External/runtime-bound functions must keep canonical symbol names.
+    target.external.is_none()
 }
 
 fn function_name_from_expr(expr: &flat::Expression) -> Option<String> {

--- a/crates/rumoca-phase-flatten/src/functions.rs
+++ b/crates/rumoca-phase-flatten/src/functions.rs
@@ -11,8 +11,6 @@
 //! - An algorithm section (the function body)
 
 use indexmap::IndexMap;
-#[cfg(test)]
-use rumoca_core::Span;
 use rumoca_ir_ast as ast;
 use rumoca_ir_flat as flat;
 use std::collections::{HashMap, HashSet};
@@ -21,6 +19,20 @@ use crate::algorithms;
 use crate::ast_lower;
 use crate::errors::FlattenError;
 use crate::qualify;
+
+const NON_FUNCTION_SCALAR_TYPES: &[&str] = &[
+    "Real",
+    "Integer",
+    "Boolean",
+    "String",
+    "Clock",
+    "Complex",
+    "Modelica.ComplexMath.Complex",
+];
+type StaticBindingPairs = Vec<(String, String)>;
+type SpecializationKey = (String, StaticBindingPairs);
+type SpecializationCache = HashMap<SpecializationKey, flat::VarName>;
+type StaticBindingResult = (SpecializationKey, String);
 
 fn is_callable_class_type(class_type: &ast::ClassType) -> bool {
     !matches!(
@@ -221,6 +233,731 @@ pub(crate) fn collect_functions(
     }
 
     Ok(())
+}
+
+/// Specialize static function-typed parameters at flatten level.
+///
+/// For calls where a function-typed input has a concrete static binding
+/// (explicit argument or function default), clone the callee into a specialized
+/// function and rewrite local function-parameter calls to the concrete target.
+///
+/// MLS §12.4.1/§12.4.2: function formals are lexically scoped and call-time
+/// bound; this pass resolves static bindings early for compile-time overhead
+/// reduction while preserving semantics.
+pub(crate) fn specialize_static_function_params(flat: &mut flat::Model) {
+    let function_index = flat.functions.clone();
+    let mut cache: SpecializationCache = HashMap::new();
+    let mut pending_new_functions: Vec<flat::Function> = Vec::new();
+
+    specialize_equation_lists(
+        flat,
+        &function_index,
+        &mut cache,
+        &mut pending_new_functions,
+    );
+    specialize_variable_annotations(
+        flat,
+        &function_index,
+        &mut cache,
+        &mut pending_new_functions,
+    );
+    specialize_assertions(
+        flat,
+        &function_index,
+        &mut cache,
+        &mut pending_new_functions,
+    );
+    specialize_when_clauses(
+        flat,
+        &function_index,
+        &mut cache,
+        &mut pending_new_functions,
+    );
+    specialize_algorithms(
+        flat,
+        &function_index,
+        &mut cache,
+        &mut pending_new_functions,
+    );
+    specialize_functions(
+        flat,
+        &function_index,
+        &mut cache,
+        &mut pending_new_functions,
+    );
+
+    for func in pending_new_functions {
+        flat.functions.insert(func.name.clone(), func);
+    }
+}
+
+fn specialize_equation_lists(
+    flat: &mut flat::Model,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    for eq in &mut flat.equations {
+        specialize_in_expr(
+            &mut eq.residual,
+            function_index,
+            cache,
+            pending_new_functions,
+        );
+    }
+    for eq in &mut flat.initial_equations {
+        specialize_in_expr(
+            &mut eq.residual,
+            function_index,
+            cache,
+            pending_new_functions,
+        );
+    }
+}
+
+fn specialize_variable_annotations(
+    flat: &mut flat::Model,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    for var in flat.variables.values_mut() {
+        for expr in [
+            &mut var.binding,
+            &mut var.start,
+            &mut var.min,
+            &mut var.max,
+            &mut var.nominal,
+        ] {
+            rewrite_opt_expr(expr, function_index, cache, pending_new_functions);
+        }
+    }
+}
+
+fn specialize_assertions(
+    flat: &mut flat::Model,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    for assertion in &mut flat.assert_equations {
+        specialize_in_expr(
+            &mut assertion.condition,
+            function_index,
+            cache,
+            pending_new_functions,
+        );
+        specialize_in_expr(
+            &mut assertion.message,
+            function_index,
+            cache,
+            pending_new_functions,
+        );
+        rewrite_opt_expr(
+            &mut assertion.level,
+            function_index,
+            cache,
+            pending_new_functions,
+        );
+    }
+    for assertion in &mut flat.initial_assert_equations {
+        specialize_in_expr(
+            &mut assertion.condition,
+            function_index,
+            cache,
+            pending_new_functions,
+        );
+        specialize_in_expr(
+            &mut assertion.message,
+            function_index,
+            cache,
+            pending_new_functions,
+        );
+        rewrite_opt_expr(
+            &mut assertion.level,
+            function_index,
+            cache,
+            pending_new_functions,
+        );
+    }
+}
+
+fn specialize_when_clauses(
+    flat: &mut flat::Model,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    for when in &mut flat.when_clauses {
+        specialize_in_expr(
+            &mut when.condition,
+            function_index,
+            cache,
+            pending_new_functions,
+        );
+        for eq in &mut when.equations {
+            specialize_in_when_equation(eq, function_index, cache, pending_new_functions);
+        }
+    }
+}
+
+fn specialize_algorithms(
+    flat: &mut flat::Model,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    for alg in &mut flat.algorithms {
+        for stmt in &mut alg.statements {
+            specialize_in_statement(stmt, function_index, cache, pending_new_functions);
+        }
+    }
+    for alg in &mut flat.initial_algorithms {
+        for stmt in &mut alg.statements {
+            specialize_in_statement(stmt, function_index, cache, pending_new_functions);
+        }
+    }
+}
+
+fn specialize_functions(
+    flat: &mut flat::Model,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    for func in flat.functions.values_mut() {
+        for param in func
+            .inputs
+            .iter_mut()
+            .chain(func.outputs.iter_mut())
+            .chain(func.locals.iter_mut())
+        {
+            rewrite_opt_expr(
+                &mut param.default,
+                function_index,
+                cache,
+                pending_new_functions,
+            );
+        }
+        for stmt in &mut func.body {
+            specialize_in_statement(stmt, function_index, cache, pending_new_functions);
+        }
+    }
+}
+
+fn rewrite_opt_expr(
+    expr: &mut Option<flat::Expression>,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    if let Some(expr) = expr {
+        specialize_in_expr(expr, function_index, cache, pending_new_functions);
+    }
+}
+
+fn specialize_in_statement(
+    stmt: &mut flat::Statement,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    match stmt {
+        flat::Statement::Assignment { value, .. } => {
+            specialize_in_expr(value, function_index, cache, pending_new_functions);
+        }
+        flat::Statement::For { indices, equations } => {
+            for idx in indices {
+                specialize_in_expr(&mut idx.range, function_index, cache, pending_new_functions);
+            }
+            for nested in equations {
+                specialize_in_statement(nested, function_index, cache, pending_new_functions);
+            }
+        }
+        flat::Statement::While(block) => {
+            specialize_in_expr(
+                &mut block.cond,
+                function_index,
+                cache,
+                pending_new_functions,
+            );
+            for nested in &mut block.stmts {
+                specialize_in_statement(nested, function_index, cache, pending_new_functions);
+            }
+        }
+        flat::Statement::If {
+            cond_blocks,
+            else_block,
+        } => {
+            for block in cond_blocks {
+                specialize_in_expr(
+                    &mut block.cond,
+                    function_index,
+                    cache,
+                    pending_new_functions,
+                );
+                for nested in &mut block.stmts {
+                    specialize_in_statement(nested, function_index, cache, pending_new_functions);
+                }
+            }
+            if let Some(stmts) = else_block {
+                for nested in stmts {
+                    specialize_in_statement(nested, function_index, cache, pending_new_functions);
+                }
+            }
+        }
+        flat::Statement::When(blocks) => {
+            for block in blocks {
+                specialize_in_expr(
+                    &mut block.cond,
+                    function_index,
+                    cache,
+                    pending_new_functions,
+                );
+                for nested in &mut block.stmts {
+                    specialize_in_statement(nested, function_index, cache, pending_new_functions);
+                }
+            }
+        }
+        flat::Statement::FunctionCall { args, outputs, .. } => {
+            for arg in args {
+                specialize_in_expr(arg, function_index, cache, pending_new_functions);
+            }
+            for output in outputs {
+                specialize_in_expr(output, function_index, cache, pending_new_functions);
+            }
+        }
+        flat::Statement::Reinit { value, .. } => {
+            specialize_in_expr(value, function_index, cache, pending_new_functions);
+        }
+        flat::Statement::Assert {
+            condition,
+            message,
+            level,
+        } => {
+            specialize_in_expr(condition, function_index, cache, pending_new_functions);
+            specialize_in_expr(message, function_index, cache, pending_new_functions);
+            if let Some(level_expr) = level {
+                specialize_in_expr(level_expr, function_index, cache, pending_new_functions);
+            }
+        }
+        flat::Statement::Empty | flat::Statement::Return | flat::Statement::Break => {}
+    }
+}
+
+fn specialize_in_when_equation(
+    eq: &mut flat::WhenEquation,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    match eq {
+        flat::WhenEquation::Assign { value, .. } | flat::WhenEquation::Reinit { value, .. } => {
+            specialize_in_expr(value, function_index, cache, pending_new_functions);
+        }
+        flat::WhenEquation::Assert { condition, .. } => {
+            specialize_in_expr(condition, function_index, cache, pending_new_functions);
+        }
+        flat::WhenEquation::Conditional {
+            branches,
+            else_branch,
+            ..
+        } => {
+            for (condition, equations) in branches {
+                specialize_in_expr(condition, function_index, cache, pending_new_functions);
+                for nested in equations {
+                    specialize_in_when_equation(
+                        nested,
+                        function_index,
+                        cache,
+                        pending_new_functions,
+                    );
+                }
+            }
+            for nested in else_branch {
+                specialize_in_when_equation(nested, function_index, cache, pending_new_functions);
+            }
+        }
+        flat::WhenEquation::FunctionCallOutputs { function, .. } => {
+            specialize_in_expr(function, function_index, cache, pending_new_functions);
+        }
+        flat::WhenEquation::Terminate { .. } => {}
+    }
+}
+
+fn specialize_in_expr(
+    expr: &mut flat::Expression,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    match expr {
+        flat::Expression::Binary { lhs, rhs, .. } => {
+            specialize_in_expr(lhs, function_index, cache, pending_new_functions);
+            specialize_in_expr(rhs, function_index, cache, pending_new_functions);
+        }
+        flat::Expression::Unary { rhs, .. } => {
+            specialize_in_expr(rhs, function_index, cache, pending_new_functions);
+        }
+        flat::Expression::BuiltinCall { args, .. } => {
+            for arg in args {
+                specialize_in_expr(arg, function_index, cache, pending_new_functions);
+            }
+        }
+        flat::Expression::FunctionCall { name, args, .. } => {
+            for arg in args.iter_mut() {
+                specialize_in_expr(arg, function_index, cache, pending_new_functions);
+            }
+            rewrite_static_function_call(name, args, function_index, cache, pending_new_functions);
+        }
+        flat::Expression::If {
+            branches,
+            else_branch,
+        } => {
+            for (cond, then_expr) in branches {
+                specialize_in_expr(cond, function_index, cache, pending_new_functions);
+                specialize_in_expr(then_expr, function_index, cache, pending_new_functions);
+            }
+            specialize_in_expr(else_branch, function_index, cache, pending_new_functions);
+        }
+        flat::Expression::Array { elements, .. } | flat::Expression::Tuple { elements } => {
+            for elem in elements {
+                specialize_in_expr(elem, function_index, cache, pending_new_functions);
+            }
+        }
+        flat::Expression::Range { start, step, end } => {
+            specialize_in_expr(start, function_index, cache, pending_new_functions);
+            if let Some(step) = step {
+                specialize_in_expr(step, function_index, cache, pending_new_functions);
+            }
+            specialize_in_expr(end, function_index, cache, pending_new_functions);
+        }
+        flat::Expression::Index { base, subscripts } => {
+            specialize_in_expr(base, function_index, cache, pending_new_functions);
+            for sub in subscripts {
+                if let flat::Subscript::Expr(inner) = sub {
+                    specialize_in_expr(inner, function_index, cache, pending_new_functions);
+                }
+            }
+        }
+        flat::Expression::FieldAccess { base, .. } => {
+            specialize_in_expr(base, function_index, cache, pending_new_functions);
+        }
+        flat::Expression::ArrayComprehension {
+            expr,
+            indices,
+            filter,
+        } => {
+            specialize_in_expr(expr, function_index, cache, pending_new_functions);
+            for idx in indices {
+                specialize_in_expr(&mut idx.range, function_index, cache, pending_new_functions);
+            }
+            if let Some(filter) = filter {
+                specialize_in_expr(filter, function_index, cache, pending_new_functions);
+            }
+        }
+        flat::Expression::VarRef { .. }
+        | flat::Expression::Literal(_)
+        | flat::Expression::Empty => {}
+    }
+}
+
+fn rewrite_static_function_call(
+    name: &mut flat::VarName,
+    args: &mut [flat::Expression],
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) {
+    let Some((key, specialized_name)) =
+        build_static_function_binding(name.as_str(), args, function_index)
+    else {
+        return;
+    };
+    let Some(specialized) = resolve_specialized_name(
+        &key,
+        &specialized_name,
+        name.as_str(),
+        function_index,
+        cache,
+        pending_new_functions,
+    ) else {
+        return;
+    };
+    *name = specialized;
+}
+
+fn resolve_specialized_name(
+    key: &SpecializationKey,
+    specialized_name: &str,
+    original_name: &str,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    cache: &mut SpecializationCache,
+    pending_new_functions: &mut Vec<flat::Function>,
+) -> Option<flat::VarName> {
+    if let Some(existing) = cache.get(key) {
+        return Some(existing.clone());
+    }
+    let func =
+        create_specialized_function(function_index, original_name, specialized_name, &key.1)?;
+    let new_name = func.name.clone();
+    cache.insert(key.clone(), new_name.clone());
+    pending_new_functions.push(func);
+    Some(new_name)
+}
+
+fn build_static_function_binding(
+    function_name: &str,
+    args: &[flat::Expression],
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+) -> Option<StaticBindingResult> {
+    let function = function_index.get(&flat::VarName::new(function_name))?;
+    let mut binding_pairs = Vec::new();
+    for (index, param) in function.inputs.iter().enumerate() {
+        if !is_function_typed_param(param, function_index) {
+            continue;
+        }
+        let arg_expr = args.get(index).or(param.default.as_ref())?;
+        let target = function_name_from_expr(arg_expr)?;
+        binding_pairs.push((param.name.clone(), target));
+    }
+    if binding_pairs.is_empty() {
+        return None;
+    }
+    let suffix = binding_pairs
+        .iter()
+        .map(|(param, target)| format!("{param}={target}"))
+        .collect::<Vec<_>>()
+        .join(";");
+    let specialized_name = format!(
+        "{}$spec${}",
+        function.name.as_str(),
+        simple_hash_hex(&suffix)
+    );
+    Some((
+        (function.name.as_str().to_string(), binding_pairs),
+        specialized_name,
+    ))
+}
+
+fn is_function_typed_param(
+    param: &flat::FunctionParam,
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+) -> bool {
+    if NON_FUNCTION_SCALAR_TYPES.contains(&param.type_name.as_str()) {
+        return false;
+    }
+    function_index.contains_key(&flat::VarName::new(param.type_name.as_str()))
+        || param.type_name.contains("partial")
+}
+
+fn function_name_from_expr(expr: &flat::Expression) -> Option<String> {
+    match expr {
+        flat::Expression::VarRef { name, subscripts } if subscripts.is_empty() => {
+            Some(name.as_str().to_string())
+        }
+        flat::Expression::FunctionCall {
+            name,
+            args,
+            is_constructor: false,
+        } if args.is_empty() => Some(name.as_str().to_string()),
+        _ => None,
+    }
+}
+
+fn create_specialized_function(
+    function_index: &IndexMap<flat::VarName, flat::Function>,
+    original_name: &str,
+    specialized_name: &str,
+    bindings: &[(String, String)],
+) -> Option<flat::Function> {
+    let mut cloned = function_index
+        .get(&flat::VarName::new(original_name))?
+        .clone();
+    cloned.name = flat::VarName::new(specialized_name);
+    let binding_map: HashMap<&str, &str> = bindings
+        .iter()
+        .map(|(param, target)| (param.as_str(), target.as_str()))
+        .collect();
+    for stmt in &mut cloned.body {
+        rewrite_function_param_callees_in_statement(stmt, original_name, &binding_map);
+    }
+    Some(cloned)
+}
+
+fn rewrite_function_param_callees_in_statement(
+    stmt: &mut flat::Statement,
+    owner_name: &str,
+    bindings: &HashMap<&str, &str>,
+) {
+    match stmt {
+        flat::Statement::Assignment { value, .. } => {
+            rewrite_function_param_callees_in_expr(value, owner_name, bindings);
+        }
+        flat::Statement::For { indices, equations } => {
+            for idx in indices {
+                rewrite_function_param_callees_in_expr(&mut idx.range, owner_name, bindings);
+            }
+            for nested in equations {
+                rewrite_function_param_callees_in_statement(nested, owner_name, bindings);
+            }
+        }
+        flat::Statement::While(block) => {
+            rewrite_function_param_callees_in_expr(&mut block.cond, owner_name, bindings);
+            for nested in &mut block.stmts {
+                rewrite_function_param_callees_in_statement(nested, owner_name, bindings);
+            }
+        }
+        flat::Statement::If {
+            cond_blocks,
+            else_block,
+        } => {
+            for block in cond_blocks {
+                rewrite_function_param_callees_in_expr(&mut block.cond, owner_name, bindings);
+                for nested in &mut block.stmts {
+                    rewrite_function_param_callees_in_statement(nested, owner_name, bindings);
+                }
+            }
+            if let Some(stmts) = else_block {
+                for nested in stmts {
+                    rewrite_function_param_callees_in_statement(nested, owner_name, bindings);
+                }
+            }
+        }
+        flat::Statement::When(blocks) => {
+            for block in blocks {
+                rewrite_function_param_callees_in_expr(&mut block.cond, owner_name, bindings);
+                for nested in &mut block.stmts {
+                    rewrite_function_param_callees_in_statement(nested, owner_name, bindings);
+                }
+            }
+        }
+        flat::Statement::FunctionCall { args, outputs, .. } => {
+            for arg in args {
+                rewrite_function_param_callees_in_expr(arg, owner_name, bindings);
+            }
+            for output in outputs {
+                rewrite_function_param_callees_in_expr(output, owner_name, bindings);
+            }
+        }
+        flat::Statement::Reinit { value, .. } => {
+            rewrite_function_param_callees_in_expr(value, owner_name, bindings);
+        }
+        flat::Statement::Assert {
+            condition,
+            message,
+            level,
+        } => {
+            rewrite_function_param_callees_in_expr(condition, owner_name, bindings);
+            rewrite_function_param_callees_in_expr(message, owner_name, bindings);
+            if let Some(level_expr) = level {
+                rewrite_function_param_callees_in_expr(level_expr, owner_name, bindings);
+            }
+        }
+        flat::Statement::Empty | flat::Statement::Return | flat::Statement::Break => {}
+    }
+}
+
+fn rewrite_function_param_callees_in_expr(
+    expr: &mut flat::Expression,
+    owner_name: &str,
+    bindings: &HashMap<&str, &str>,
+) {
+    match expr {
+        flat::Expression::Binary { lhs, rhs, .. } => {
+            rewrite_function_param_callees_in_expr(lhs, owner_name, bindings);
+            rewrite_function_param_callees_in_expr(rhs, owner_name, bindings);
+        }
+        flat::Expression::Unary { rhs, .. } => {
+            rewrite_function_param_callees_in_expr(rhs, owner_name, bindings);
+        }
+        flat::Expression::BuiltinCall { args, .. } => {
+            for arg in args {
+                rewrite_function_param_callees_in_expr(arg, owner_name, bindings);
+            }
+        }
+        flat::Expression::FunctionCall { name, args, .. } => {
+            for arg in args {
+                rewrite_function_param_callees_in_expr(arg, owner_name, bindings);
+            }
+            if let Some(rewritten) = rewrite_callee_name(name.as_str(), owner_name, bindings) {
+                *name = flat::VarName::new(rewritten);
+            }
+        }
+        flat::Expression::If {
+            branches,
+            else_branch,
+        } => {
+            for (cond, then_expr) in branches {
+                rewrite_function_param_callees_in_expr(cond, owner_name, bindings);
+                rewrite_function_param_callees_in_expr(then_expr, owner_name, bindings);
+            }
+            rewrite_function_param_callees_in_expr(else_branch, owner_name, bindings);
+        }
+        flat::Expression::Array { elements, .. } | flat::Expression::Tuple { elements } => {
+            for elem in elements {
+                rewrite_function_param_callees_in_expr(elem, owner_name, bindings);
+            }
+        }
+        flat::Expression::Range { start, step, end } => {
+            rewrite_function_param_callees_in_expr(start, owner_name, bindings);
+            if let Some(step) = step {
+                rewrite_function_param_callees_in_expr(step, owner_name, bindings);
+            }
+            rewrite_function_param_callees_in_expr(end, owner_name, bindings);
+        }
+        flat::Expression::Index { base, subscripts } => {
+            rewrite_function_param_callees_in_expr(base, owner_name, bindings);
+            for sub in subscripts {
+                if let flat::Subscript::Expr(inner) = sub {
+                    rewrite_function_param_callees_in_expr(inner, owner_name, bindings);
+                }
+            }
+        }
+        flat::Expression::FieldAccess { base, .. } => {
+            rewrite_function_param_callees_in_expr(base, owner_name, bindings);
+        }
+        flat::Expression::ArrayComprehension {
+            expr,
+            indices,
+            filter,
+        } => {
+            rewrite_function_param_callees_in_expr(expr, owner_name, bindings);
+            for idx in indices {
+                rewrite_function_param_callees_in_expr(&mut idx.range, owner_name, bindings);
+            }
+            if let Some(filter) = filter {
+                rewrite_function_param_callees_in_expr(filter, owner_name, bindings);
+            }
+        }
+        flat::Expression::VarRef { .. }
+        | flat::Expression::Literal(_)
+        | flat::Expression::Empty => {}
+    }
+}
+
+fn rewrite_callee_name(
+    name: &str,
+    owner_name: &str,
+    bindings: &HashMap<&str, &str>,
+) -> Option<String> {
+    if let Some(target) = bindings.get(name) {
+        return Some((*target).to_string());
+    }
+    if let Some((owner, member)) = name.rsplit_once('.')
+        && owner == owner_name
+        && let Some(target) = bindings.get(member)
+    {
+        return Some((*target).to_string());
+    }
+    None
+}
+
+fn simple_hash_hex(input: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    input.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
 }
 
 /// Look up a function by name from the ast::ClassTree and convert to flat::Function.
@@ -1204,265 +1941,5 @@ fn qualify_function_expr(
 pub(crate) use crate::function_lowering::{insert_array_size_args, lower_record_function_params};
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_collect_no_function_calls() {
-        let flat = flat::Model::new();
-        let calls = collect_function_calls(&flat);
-        assert!(calls.is_empty());
-    }
-
-    #[test]
-    fn test_collect_function_call_in_equation() {
-        let mut flat = flat::Model::new();
-
-        // Create an equation with a function call: 0 = myFunc(x) - y
-        let func_call = flat::Expression::FunctionCall {
-            name: flat::VarName::new("MyPackage.myFunc"),
-            args: vec![flat::Expression::VarRef {
-                name: flat::VarName::new("x"),
-                subscripts: vec![],
-            }],
-            is_constructor: false,
-        };
-        let residual = flat::Expression::Binary {
-            op: rumoca_ir_flat::OpBinary::Sub(rumoca_ir_flat::Token::default()),
-            lhs: Box::new(func_call),
-            rhs: Box::new(flat::Expression::VarRef {
-                name: flat::VarName::new("y"),
-                subscripts: vec![],
-            }),
-        };
-        flat.add_equation(flat::Equation::new(
-            residual,
-            Span::DUMMY,
-            rumoca_ir_flat::EquationOrigin::ComponentEquation {
-                component: "test".to_string(),
-            },
-        ));
-
-        let calls = collect_function_calls(&flat);
-        assert!(calls.contains("MyPackage.myFunc"));
-        assert_eq!(calls.len(), 1);
-    }
-
-    #[test]
-    fn test_collect_nested_function_calls() {
-        let mut flat = flat::Model::new();
-
-        // Create: 0 = outer(inner(x)) - y
-        let inner_call = flat::Expression::FunctionCall {
-            name: flat::VarName::new("inner"),
-            args: vec![flat::Expression::VarRef {
-                name: flat::VarName::new("x"),
-                subscripts: vec![],
-            }],
-            is_constructor: false,
-        };
-        let outer_call = flat::Expression::FunctionCall {
-            name: flat::VarName::new("outer"),
-            args: vec![inner_call],
-            is_constructor: false,
-        };
-        let residual = flat::Expression::Binary {
-            op: rumoca_ir_flat::OpBinary::Sub(rumoca_ir_flat::Token::default()),
-            lhs: Box::new(outer_call),
-            rhs: Box::new(flat::Expression::VarRef {
-                name: flat::VarName::new("y"),
-                subscripts: vec![],
-            }),
-        };
-        flat.add_equation(flat::Equation::new(
-            residual,
-            Span::DUMMY,
-            rumoca_ir_flat::EquationOrigin::ComponentEquation {
-                component: "test".to_string(),
-            },
-        ));
-
-        let calls = collect_function_calls(&flat);
-        assert!(calls.contains("inner"));
-        assert!(calls.contains("outer"));
-        assert_eq!(calls.len(), 2);
-    }
-
-    #[test]
-    fn test_convert_component_to_param_prefers_binding_over_start_default() {
-        let component = ast::Component {
-            type_name: ast::Name::from_string("Real"),
-            has_explicit_binding: true,
-            start: ast::Expression::Terminal {
-                terminal_type: rumoca_ir_ast::TerminalType::UnsignedInteger,
-                token: rumoca_ir_core::Token {
-                    text: "0".into(),
-                    ..Default::default()
-                },
-            },
-            binding: Some(ast::Expression::Terminal {
-                terminal_type: rumoca_ir_ast::TerminalType::UnsignedInteger,
-                token: rumoca_ir_core::Token {
-                    text: "3".into(),
-                    ..Default::default()
-                },
-            }),
-            ..Default::default()
-        };
-
-        let def_map = indexmap::IndexMap::new();
-        let param = convert_component_to_param(
-            "m",
-            &component,
-            &def_map,
-            &qualify::ImportMap::default(),
-            &HashSet::new(),
-        );
-        assert!(matches!(
-            param.default,
-            Some(flat::Expression::Literal(flat::Literal::Integer(3)))
-        ));
-    }
-
-    #[test]
-    fn test_extract_derivative_annotation_simple() {
-        use rumoca_ir_ast::{ComponentRefPart, ComponentReference, Token};
-        use std::sync::Arc;
-
-        // Test: annotation(derivative = myFunc_der)
-        let annotations = vec![ast::Expression::NamedArgument {
-            name: Token {
-                text: Arc::from("derivative"),
-                ..Default::default()
-            },
-            value: Arc::new(ast::Expression::ComponentReference(ComponentReference {
-                local: false,
-                def_id: None,
-                parts: vec![ComponentRefPart {
-                    ident: Token {
-                        text: Arc::from("myFunc_der"),
-                        ..Default::default()
-                    },
-                    subs: None,
-                }],
-            })),
-        }];
-
-        let derivs = extract_derivative_annotations(&annotations);
-        assert_eq!(derivs.len(), 1);
-        assert_eq!(derivs[0].derivative_function, "myFunc_der");
-        assert_eq!(derivs[0].order, 1);
-        assert!(derivs[0].zero_derivative.is_empty());
-        assert!(derivs[0].no_derivative.is_empty());
-    }
-
-    #[test]
-    fn test_extract_derivative_annotation_with_modification() {
-        use rumoca_ir_ast::{ComponentRefPart, ComponentReference, Token};
-        use std::sync::Arc;
-
-        // Test: annotation(derivative(order=2) = myFunc_der2)
-        // This is represented as a Modification with target having subscripts
-        let annotations = vec![ast::Expression::Modification {
-            target: ComponentReference {
-                local: false,
-                def_id: None,
-                parts: vec![ComponentRefPart {
-                    ident: Token {
-                        text: Arc::from("derivative"),
-                        ..Default::default()
-                    },
-                    subs: Some(vec![ast::Subscript::Expression(
-                        ast::Expression::NamedArgument {
-                            name: Token {
-                                text: Arc::from("order"),
-                                ..Default::default()
-                            },
-                            value: Arc::new(ast::Expression::Terminal {
-                                terminal_type: rumoca_ir_ast::TerminalType::UnsignedInteger,
-                                token: Token {
-                                    text: Arc::from("2"),
-                                    ..Default::default()
-                                },
-                            }),
-                        },
-                    )]),
-                }],
-            },
-            value: Arc::new(ast::Expression::ComponentReference(ComponentReference {
-                local: false,
-                def_id: None,
-                parts: vec![ComponentRefPart {
-                    ident: Token {
-                        text: Arc::from("myFunc_der2"),
-                        ..Default::default()
-                    },
-                    subs: None,
-                }],
-            })),
-        }];
-
-        let derivs = extract_derivative_annotations(&annotations);
-        assert_eq!(derivs.len(), 1);
-        assert_eq!(derivs[0].derivative_function, "myFunc_der2");
-        assert_eq!(derivs[0].order, 2);
-    }
-
-    #[test]
-    fn test_extract_derivative_annotation_with_zero_derivative() {
-        use rumoca_ir_ast::{ComponentRefPart, ComponentReference, Token};
-        use std::sync::Arc;
-
-        // Test: annotation(derivative(zeroDerivative=k) = myFunc_der)
-        let annotations = vec![ast::Expression::Modification {
-            target: ComponentReference {
-                local: false,
-                def_id: None,
-                parts: vec![ComponentRefPart {
-                    ident: Token {
-                        text: Arc::from("derivative"),
-                        ..Default::default()
-                    },
-                    subs: Some(vec![ast::Subscript::Expression(
-                        ast::Expression::NamedArgument {
-                            name: Token {
-                                text: Arc::from("zeroDerivative"),
-                                ..Default::default()
-                            },
-                            value: Arc::new(ast::Expression::ComponentReference(
-                                ComponentReference {
-                                    local: false,
-                                    def_id: None,
-                                    parts: vec![ComponentRefPart {
-                                        ident: Token {
-                                            text: Arc::from("k"),
-                                            ..Default::default()
-                                        },
-                                        subs: None,
-                                    }],
-                                },
-                            )),
-                        },
-                    )]),
-                }],
-            },
-            value: Arc::new(ast::Expression::ComponentReference(ComponentReference {
-                local: false,
-                def_id: None,
-                parts: vec![ComponentRefPart {
-                    ident: Token {
-                        text: Arc::from("myFunc_der"),
-                        ..Default::default()
-                    },
-                    subs: None,
-                }],
-            })),
-        }];
-
-        let derivs = extract_derivative_annotations(&annotations);
-        assert_eq!(derivs.len(), 1);
-        assert_eq!(derivs[0].derivative_function, "myFunc_der");
-        assert_eq!(derivs[0].order, 1);
-        assert_eq!(derivs[0].zero_derivative, vec!["k"]);
-    }
-}
+#[path = "functions_tests.rs"]
+mod functions_tests;

--- a/crates/rumoca-phase-flatten/src/functions_tests.rs
+++ b/crates/rumoca-phase-flatten/src/functions_tests.rs
@@ -1,0 +1,398 @@
+use super::*;
+use rumoca_core::Span;
+
+#[test]
+fn test_collect_no_function_calls() {
+    let flat = flat::Model::new();
+    let calls = collect_function_calls(&flat);
+    assert!(calls.is_empty());
+}
+
+#[test]
+fn test_collect_function_call_in_equation() {
+    let mut flat = flat::Model::new();
+
+    let func_call = flat::Expression::FunctionCall {
+        name: flat::VarName::new("MyPackage.myFunc"),
+        args: vec![flat::Expression::VarRef {
+            name: flat::VarName::new("x"),
+            subscripts: vec![],
+        }],
+        is_constructor: false,
+    };
+    let residual = flat::Expression::Binary {
+        op: rumoca_ir_flat::OpBinary::Sub(rumoca_ir_flat::Token::default()),
+        lhs: Box::new(func_call),
+        rhs: Box::new(flat::Expression::VarRef {
+            name: flat::VarName::new("y"),
+            subscripts: vec![],
+        }),
+    };
+    flat.add_equation(flat::Equation::new(
+        residual,
+        Span::DUMMY,
+        rumoca_ir_flat::EquationOrigin::ComponentEquation {
+            component: "test".to_string(),
+        },
+    ));
+
+    let calls = collect_function_calls(&flat);
+    assert!(calls.contains("MyPackage.myFunc"));
+    assert_eq!(calls.len(), 1);
+}
+
+#[test]
+fn test_collect_nested_function_calls() {
+    let mut flat = flat::Model::new();
+
+    let inner_call = flat::Expression::FunctionCall {
+        name: flat::VarName::new("inner"),
+        args: vec![flat::Expression::VarRef {
+            name: flat::VarName::new("x"),
+            subscripts: vec![],
+        }],
+        is_constructor: false,
+    };
+    let outer_call = flat::Expression::FunctionCall {
+        name: flat::VarName::new("outer"),
+        args: vec![inner_call],
+        is_constructor: false,
+    };
+    let residual = flat::Expression::Binary {
+        op: rumoca_ir_flat::OpBinary::Sub(rumoca_ir_flat::Token::default()),
+        lhs: Box::new(outer_call),
+        rhs: Box::new(flat::Expression::VarRef {
+            name: flat::VarName::new("y"),
+            subscripts: vec![],
+        }),
+    };
+    flat.add_equation(flat::Equation::new(
+        residual,
+        Span::DUMMY,
+        rumoca_ir_flat::EquationOrigin::ComponentEquation {
+            component: "test".to_string(),
+        },
+    ));
+
+    let calls = collect_function_calls(&flat);
+    assert!(calls.contains("inner"));
+    assert!(calls.contains("outer"));
+    assert_eq!(calls.len(), 2);
+}
+
+#[test]
+fn test_convert_component_to_param_prefers_binding_over_start_default() {
+    let component = ast::Component {
+        type_name: ast::Name::from_string("Real"),
+        has_explicit_binding: true,
+        start: ast::Expression::Terminal {
+            terminal_type: rumoca_ir_ast::TerminalType::UnsignedInteger,
+            token: rumoca_ir_core::Token {
+                text: "0".into(),
+                ..Default::default()
+            },
+        },
+        binding: Some(ast::Expression::Terminal {
+            terminal_type: rumoca_ir_ast::TerminalType::UnsignedInteger,
+            token: rumoca_ir_core::Token {
+                text: "3".into(),
+                ..Default::default()
+            },
+        }),
+        ..Default::default()
+    };
+
+    let def_map = indexmap::IndexMap::new();
+    let param = convert_component_to_param(
+        "m",
+        &component,
+        &def_map,
+        &qualify::ImportMap::default(),
+        &HashSet::new(),
+    );
+    assert!(matches!(
+        param.default,
+        Some(flat::Expression::Literal(flat::Literal::Integer(3)))
+    ));
+}
+
+#[test]
+fn test_extract_derivative_annotation_simple() {
+    use rumoca_ir_ast::{ComponentRefPart, ComponentReference, Token};
+    use std::sync::Arc;
+
+    let annotations = vec![ast::Expression::NamedArgument {
+        name: Token {
+            text: Arc::from("derivative"),
+            ..Default::default()
+        },
+        value: Arc::new(ast::Expression::ComponentReference(ComponentReference {
+            local: false,
+            def_id: None,
+            parts: vec![ComponentRefPart {
+                ident: Token {
+                    text: Arc::from("myFunc_der"),
+                    ..Default::default()
+                },
+                subs: None,
+            }],
+        })),
+    }];
+
+    let derivs = extract_derivative_annotations(&annotations);
+    assert_eq!(derivs.len(), 1);
+    assert_eq!(derivs[0].derivative_function, "myFunc_der");
+    assert_eq!(derivs[0].order, 1);
+    assert!(derivs[0].zero_derivative.is_empty());
+    assert!(derivs[0].no_derivative.is_empty());
+}
+
+#[test]
+fn test_extract_derivative_annotation_with_modification() {
+    use rumoca_ir_ast::{ComponentRefPart, ComponentReference, Token};
+    use std::sync::Arc;
+
+    let annotations = vec![ast::Expression::Modification {
+        target: ComponentReference {
+            local: false,
+            def_id: None,
+            parts: vec![ComponentRefPart {
+                ident: Token {
+                    text: Arc::from("derivative"),
+                    ..Default::default()
+                },
+                subs: Some(vec![ast::Subscript::Expression(
+                    ast::Expression::NamedArgument {
+                        name: Token {
+                            text: Arc::from("order"),
+                            ..Default::default()
+                        },
+                        value: Arc::new(ast::Expression::Terminal {
+                            terminal_type: rumoca_ir_ast::TerminalType::UnsignedInteger,
+                            token: Token {
+                                text: Arc::from("2"),
+                                ..Default::default()
+                            },
+                        }),
+                    },
+                )]),
+            }],
+        },
+        value: Arc::new(ast::Expression::ComponentReference(ComponentReference {
+            local: false,
+            def_id: None,
+            parts: vec![ComponentRefPart {
+                ident: Token {
+                    text: Arc::from("myFunc_der2"),
+                    ..Default::default()
+                },
+                subs: None,
+            }],
+        })),
+    }];
+
+    let derivs = extract_derivative_annotations(&annotations);
+    assert_eq!(derivs.len(), 1);
+    assert_eq!(derivs[0].derivative_function, "myFunc_der2");
+    assert_eq!(derivs[0].order, 2);
+}
+
+#[test]
+fn test_extract_derivative_annotation_with_zero_derivative() {
+    use rumoca_ir_ast::{ComponentRefPart, ComponentReference, Token};
+    use std::sync::Arc;
+
+    let annotations = vec![ast::Expression::Modification {
+        target: ComponentReference {
+            local: false,
+            def_id: None,
+            parts: vec![ComponentRefPart {
+                ident: Token {
+                    text: Arc::from("derivative"),
+                    ..Default::default()
+                },
+                subs: Some(vec![ast::Subscript::Expression(
+                    ast::Expression::NamedArgument {
+                        name: Token {
+                            text: Arc::from("zeroDerivative"),
+                            ..Default::default()
+                        },
+                        value: Arc::new(ast::Expression::ComponentReference(ComponentReference {
+                            local: false,
+                            def_id: None,
+                            parts: vec![ComponentRefPart {
+                                ident: Token {
+                                    text: Arc::from("k"),
+                                    ..Default::default()
+                                },
+                                subs: None,
+                            }],
+                        })),
+                    },
+                )]),
+            }],
+        },
+        value: Arc::new(ast::Expression::ComponentReference(ComponentReference {
+            local: false,
+            def_id: None,
+            parts: vec![ComponentRefPart {
+                ident: Token {
+                    text: Arc::from("myFunc_der"),
+                    ..Default::default()
+                },
+                subs: None,
+            }],
+        })),
+    }];
+
+    let derivs = extract_derivative_annotations(&annotations);
+    assert_eq!(derivs.len(), 1);
+    assert_eq!(derivs[0].derivative_function, "myFunc_der");
+    assert_eq!(derivs[0].order, 1);
+    assert_eq!(derivs[0].zero_derivative, vec!["k"]);
+}
+
+#[test]
+fn test_specialize_static_function_param_from_explicit_call_arg() {
+    let mut flat = flat::Model::new();
+
+    let mut apply = flat::Function::new("Pkg.applyOp", Span::DUMMY);
+    apply
+        .inputs
+        .push(flat::FunctionParam::new("f", "Pkg.partialScalarFunction"));
+    apply.inputs.push(flat::FunctionParam::new("x", "Real"));
+    apply.outputs.push(flat::FunctionParam::new("y", "Real"));
+    apply.body.push(flat::Statement::Assignment {
+        comp: flat::ComponentReference {
+            local: false,
+            parts: vec![flat::ComponentRefPart {
+                ident: "y".to_string(),
+                subs: vec![],
+            }],
+            def_id: None,
+        },
+        value: flat::Expression::FunctionCall {
+            name: flat::VarName::new("Pkg.applyOp.f"),
+            args: vec![flat::Expression::VarRef {
+                name: flat::VarName::new("x"),
+                subscripts: vec![],
+            }],
+            is_constructor: false,
+        },
+    });
+    flat.add_function(apply);
+    flat.add_function(flat::Function::new(
+        "Pkg.partialScalarFunction",
+        Span::DUMMY,
+    ));
+    flat.add_function(flat::Function::new("Pkg.square", Span::DUMMY));
+
+    flat.add_equation(flat::Equation::new(
+        flat::Expression::FunctionCall {
+            name: flat::VarName::new("Pkg.applyOp"),
+            args: vec![
+                flat::Expression::VarRef {
+                    name: flat::VarName::new("Pkg.square"),
+                    subscripts: vec![],
+                },
+                flat::Expression::Literal(flat::Literal::Real(2.0)),
+            ],
+            is_constructor: false,
+        },
+        Span::DUMMY,
+        flat::EquationOrigin::ComponentEquation {
+            component: "probe".to_string(),
+        },
+    ));
+
+    specialize_static_function_params(&mut flat);
+
+    let flat::Expression::FunctionCall { name, .. } = &flat.equations[0].residual else {
+        panic!("expected function call equation");
+    };
+    assert_ne!(name.as_str(), "Pkg.applyOp");
+
+    let specialized = flat
+        .functions
+        .get(name)
+        .expect("specialized function must exist");
+    let flat::Statement::Assignment { value, .. } = &specialized.body[0] else {
+        panic!("expected assignment in specialized body");
+    };
+    let flat::Expression::FunctionCall { name, .. } = value else {
+        panic!("expected specialized call in body");
+    };
+    assert_eq!(name.as_str(), "Pkg.square");
+}
+
+#[test]
+fn test_specialize_static_function_param_from_default_arg() {
+    let mut flat = flat::Model::new();
+
+    let mut apply = flat::Function::new("Pkg.applyDefault", Span::DUMMY);
+    apply.inputs.push(flat::FunctionParam::new("x", "Real"));
+    apply.inputs.push(
+        flat::FunctionParam::new("f", "Pkg.partialScalarFunction").with_default(
+            flat::Expression::VarRef {
+                name: flat::VarName::new("Pkg.square"),
+                subscripts: vec![],
+            },
+        ),
+    );
+    apply.outputs.push(flat::FunctionParam::new("y", "Real"));
+    apply.body.push(flat::Statement::Assignment {
+        comp: flat::ComponentReference {
+            local: false,
+            parts: vec![flat::ComponentRefPart {
+                ident: "y".to_string(),
+                subs: vec![],
+            }],
+            def_id: None,
+        },
+        value: flat::Expression::FunctionCall {
+            name: flat::VarName::new("f"),
+            args: vec![flat::Expression::VarRef {
+                name: flat::VarName::new("x"),
+                subscripts: vec![],
+            }],
+            is_constructor: false,
+        },
+    });
+    flat.add_function(apply);
+    flat.add_function(flat::Function::new(
+        "Pkg.partialScalarFunction",
+        Span::DUMMY,
+    ));
+    flat.add_function(flat::Function::new("Pkg.square", Span::DUMMY));
+
+    flat.add_equation(flat::Equation::new(
+        flat::Expression::FunctionCall {
+            name: flat::VarName::new("Pkg.applyDefault"),
+            args: vec![flat::Expression::Literal(flat::Literal::Real(4.0))],
+            is_constructor: false,
+        },
+        Span::DUMMY,
+        flat::EquationOrigin::ComponentEquation {
+            component: "probe".to_string(),
+        },
+    ));
+
+    specialize_static_function_params(&mut flat);
+
+    let flat::Expression::FunctionCall { name, .. } = &flat.equations[0].residual else {
+        panic!("expected function call equation");
+    };
+    assert_ne!(name.as_str(), "Pkg.applyDefault");
+
+    let specialized = flat
+        .functions
+        .get(name)
+        .expect("specialized function must exist");
+    let flat::Statement::Assignment { value, .. } = &specialized.body[0] else {
+        panic!("expected assignment in specialized body");
+    };
+    let flat::Expression::FunctionCall { name, .. } = value else {
+        panic!("expected specialized call in body");
+    };
+    assert_eq!(name.as_str(), "Pkg.square");
+}

--- a/crates/rumoca-phase-flatten/src/lib.rs
+++ b/crates/rumoca-phase-flatten/src/lib.rs
@@ -268,6 +268,13 @@ pub fn flatten_ref_with_options(
     options: FlattenOptions,
 ) -> Result<flat::Model, FlattenError> {
     let mut ctx = Context::new();
+    ctx.class_def_ids = std::sync::Arc::new(
+        tree.def_map
+            .keys()
+            .filter(|def_id| tree.get_class_by_def_id(**def_id).is_some())
+            .copied()
+            .collect(),
+    );
     let mut flat = flat::Model::new();
     let global_imports = collect_global_imports(overlay);
     let component_override_map = build_component_override_map(overlay, tree);

--- a/crates/rumoca-phase-flatten/src/lib.rs
+++ b/crates/rumoca-phase-flatten/src/lib.rs
@@ -484,6 +484,12 @@ fn extract_simple_path(expr: &ast::Expression) -> Option<String> {
 /// of the component (MLS §7.2.4).
 fn extract_record_aliases(ctx: &mut Context, overlay: &ast::InstanceOverlay) {
     for (_def_id, instance_data) in &overlay.components {
+        // Record-alias canonicalization is only valid for non-primitive component
+        // containers (records/connectors/classes). Primitive scalar bindings like
+        // `output Real y = x` are value bindings, not prefix aliases.
+        if instance_data.is_primitive {
+            continue;
+        }
         // Check if this component has a binding that's a simple path
         let Some(binding) = &instance_data.binding else {
             continue;

--- a/crates/rumoca-phase-flatten/src/pipeline/component_alias_injection.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/component_alias_injection.rs
@@ -20,7 +20,10 @@ pub(crate) fn inject_component_instance_nested_class_constants(
     for _pass in 0..MAX_PASSES {
         let prev = ctx.parameter_values.len()
             + ctx.array_dimensions.len()
-            + ctx.boolean_parameter_values.len();
+            + ctx.boolean_parameter_values.len()
+            + ctx.real_parameter_values.len()
+            + ctx.enum_parameter_values.len()
+            + ctx.constant_values.len();
 
         for comp in overlay.components.values() {
             let comp_scope = comp.qualified_name.to_flat_string();
@@ -78,7 +81,10 @@ pub(crate) fn inject_component_instance_nested_class_constants(
 
         let new = ctx.parameter_values.len()
             + ctx.array_dimensions.len()
-            + ctx.boolean_parameter_values.len();
+            + ctx.boolean_parameter_values.len()
+            + ctx.real_parameter_values.len()
+            + ctx.enum_parameter_values.len()
+            + ctx.constant_values.len();
         if new == prev {
             break;
         }
@@ -93,6 +99,15 @@ pub(crate) fn inject_component_declared_class_overrides(
     ctx: &mut Context,
 ) {
     let active_alias = active_component_alias(&comp.type_name);
+    let lower_alias = |name: &str| {
+        let mut chars = name.chars();
+        let Some(first) = chars.next() else {
+            return String::new();
+        };
+        let mut lowered = first.to_lowercase().collect::<String>();
+        lowered.push_str(chars.as_str());
+        lowered
+    };
 
     for (alias_name, def_id) in &comp.class_overrides {
         let Some(alias_class) = tree.get_class_by_def_id(*def_id) else {
@@ -106,6 +121,20 @@ pub(crate) fn inject_component_declared_class_overrides(
 
         let alias_scope = format!("{comp_scope}.{alias_name}");
         extract_constants_from_class_with_prefix(&alias_scope, alias_class, ctx);
+        let lowered_alias_name = lower_alias(alias_name);
+        if lowered_alias_name != *alias_name {
+            let lowered_alias_scope = format!("{comp_scope}.{lowered_alias_name}");
+            extract_constants_from_class_with_prefix(&lowered_alias_scope, alias_class, ctx);
+            for ext in &alias_class.extends {
+                apply_extends_constants_for_scope(
+                    tree,
+                    &lowered_alias_scope,
+                    ext,
+                    alias_resolve_context,
+                    ctx,
+                );
+            }
+        }
         for ext in &alias_class.extends {
             apply_extends_constants_for_scope(tree, &alias_scope, ext, alias_resolve_context, ctx);
         }
@@ -147,7 +176,10 @@ pub(crate) fn inject_component_enclosing_class_constants(
     for _pass in 0..MAX_PASSES {
         let prev = ctx.parameter_values.len()
             + ctx.array_dimensions.len()
-            + ctx.boolean_parameter_values.len();
+            + ctx.boolean_parameter_values.len()
+            + ctx.real_parameter_values.len()
+            + ctx.enum_parameter_values.len()
+            + ctx.constant_values.len();
 
         for ancestor in &ancestors {
             let resolve_context = ancestor
@@ -162,7 +194,10 @@ pub(crate) fn inject_component_enclosing_class_constants(
 
         let new = ctx.parameter_values.len()
             + ctx.array_dimensions.len()
-            + ctx.boolean_parameter_values.len();
+            + ctx.boolean_parameter_values.len()
+            + ctx.real_parameter_values.len()
+            + ctx.enum_parameter_values.len()
+            + ctx.constant_values.len();
         if new == prev {
             break;
         }

--- a/crates/rumoca-phase-flatten/src/pipeline/constant_injection.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/constant_injection.rs
@@ -1591,6 +1591,9 @@ pub(crate) struct Context {
     /// Current import map for the class instance being processed (MLS §13.2).
     /// Set before processing each class instance's equations, cleared after.
     pub current_imports: crate::qualify::ImportMap,
+    /// Set of DefIds that correspond to class definitions in the current tree.
+    /// Used by qualification to distinguish class/type references from components.
+    pub class_def_ids: std::sync::Arc<rustc_hash::FxHashSet<rumoca_core::DefId>>,
 }
 
 #[cfg(test)]

--- a/crates/rumoca-phase-flatten/src/pipeline/constant_injection.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/constant_injection.rs
@@ -202,7 +202,10 @@ pub(crate) fn extract_ancestor_constants_multi_pass(
     for _pass in 0..MAX_PASSES {
         let prev = ctx.parameter_values.len()
             + ctx.array_dimensions.len()
-            + ctx.boolean_parameter_values.len();
+            + ctx.boolean_parameter_values.len()
+            + ctx.real_parameter_values.len()
+            + ctx.enum_parameter_values.len()
+            + ctx.constant_values.len();
         for ancestor in ancestors {
             for ext in &ancestor.extends {
                 extract_extends_modification_constants(tree, "", ext, resolve_context, ctx);
@@ -211,7 +214,10 @@ pub(crate) fn extract_ancestor_constants_multi_pass(
         }
         let new = ctx.parameter_values.len()
             + ctx.array_dimensions.len()
-            + ctx.boolean_parameter_values.len();
+            + ctx.boolean_parameter_values.len()
+            + ctx.real_parameter_values.len()
+            + ctx.enum_parameter_values.len()
+            + ctx.constant_values.len();
         if new == prev {
             break;
         }

--- a/crates/rumoca-phase-flatten/src/pipeline/constant_injection.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/constant_injection.rs
@@ -1594,6 +1594,9 @@ pub(crate) struct Context {
     /// Set of DefIds that correspond to class definitions in the current tree.
     /// Used by qualification to distinguish class/type references from components.
     pub class_def_ids: std::sync::Arc<rustc_hash::FxHashSet<rumoca_core::DefId>>,
+    /// Canonical class scope path for the class instance currently being flattened.
+    /// Derived from `def_map` via the owning class DefId.
+    pub current_class_scope_path: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
@@ -758,7 +758,7 @@ impl Context {
     /// - `stack.cell.stackData.cellData` -> `stack.stackData.cellData`
     ///
     /// Returns the original name if no alias applies.
-    fn resolve_alias(&self, name: &str) -> String {
+    pub(crate) fn resolve_alias(&self, name: &str) -> String {
         const MAX_DEPTH: usize = 10; // Prevent infinite loops
         let mut current = name.to_string();
         for _iteration in 0..MAX_DEPTH {

--- a/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
@@ -28,6 +28,7 @@ impl Context {
             cardinality_counts: rustc_hash::FxHashMap::default(),
             eval_fallback_context: std::cell::OnceCell::new(),
             current_imports: crate::qualify::ImportMap::default(),
+            class_def_ids: std::sync::Arc::new(rustc_hash::FxHashSet::default()),
         }
     }
 
@@ -49,7 +50,6 @@ impl Context {
         self.seed_flat_parameter_constant_keys(flat);
         let params = self.collect_parameters(flat);
 
-        self.supplement_record_aliases(&params);
         self.init_array_dimensions(flat);
 
         let var_bindings = Self::collect_var_bindings(flat);
@@ -133,22 +133,6 @@ impl Context {
                 expr.map(|b| (name.to_string(), b.clone()))
             })
             .collect()
-    }
-
-    /// Supplement record aliases from flat variable bindings (MLS §7.2.3).
-    fn supplement_record_aliases(&mut self, params: &[(String, Expression)]) {
-        for (name, binding) in params {
-            if let Expression::VarRef {
-                name: alias_target,
-                subscripts,
-            } = binding
-                && subscripts.is_empty()
-                && !self.record_aliases.contains_key(name)
-            {
-                self.record_aliases
-                    .insert(name.clone(), alias_target.to_string());
-            }
-        }
     }
 
     /// Initialize array dimensions from declared dims (MLS §10.1).
@@ -1268,4 +1252,97 @@ pub(crate) fn qualify_expression_imports_with_def_map(
     };
     let qualified = qualify::qualify_expression_with_imports(expr, prefix, opts, imports);
     crate::ast_lower::expression_from_ast_with_def_map(&qualified, def_map)
+}
+
+/// Like `qualify_expression_imports_with_def_map`, but uses flatten context
+/// semantic metadata (class DefIds) to keep class/type references lexical.
+pub(crate) fn qualify_expression_imports_with_def_map_ctx(
+    expr: &ast::Expression,
+    prefix: &QualifiedName,
+    imports: &qualify::ImportMap,
+    def_map: Option<&crate::ResolveDefMap>,
+    ctx: &Context,
+) -> rumoca_ir_flat::Expression {
+    let expr = canonicalize_class_reference_paths(expr, def_map, &ctx.class_def_ids);
+    let opts = qualify::QualifyOptions {
+        preserve_def_id: true,
+        ..qualify::QualifyOptions::default()
+    };
+    let qualified = qualify::qualify_expression_with_imports(&expr, prefix, opts, imports);
+    crate::ast_lower::expression_from_ast_with_def_map(&qualified, def_map)
+}
+
+fn canonicalize_class_reference_paths(
+    expr: &ast::Expression,
+    def_map: Option<&crate::ResolveDefMap>,
+    class_def_ids: &rustc_hash::FxHashSet<rumoca_core::DefId>,
+) -> ast::Expression {
+    match expr {
+        ast::Expression::ComponentReference(cr) => ast::Expression::ComponentReference(
+            canonicalize_class_component_ref(cr, def_map, class_def_ids),
+        ),
+        ast::Expression::Binary { op, lhs, rhs } => ast::Expression::Binary {
+            op: op.clone(),
+            lhs: std::sync::Arc::new(canonicalize_class_reference_paths(
+                lhs,
+                def_map,
+                class_def_ids,
+            )),
+            rhs: std::sync::Arc::new(canonicalize_class_reference_paths(
+                rhs,
+                def_map,
+                class_def_ids,
+            )),
+        },
+        ast::Expression::Unary { op, rhs } => ast::Expression::Unary {
+            op: op.clone(),
+            rhs: std::sync::Arc::new(canonicalize_class_reference_paths(
+                rhs,
+                def_map,
+                class_def_ids,
+            )),
+        },
+        ast::Expression::FunctionCall { comp, args } => ast::Expression::FunctionCall {
+            comp: canonicalize_class_component_ref(comp, def_map, class_def_ids),
+            args: args
+                .iter()
+                .map(|arg| canonicalize_class_reference_paths(arg, def_map, class_def_ids))
+                .collect(),
+        },
+        _ => expr.clone(),
+    }
+}
+
+fn canonicalize_class_component_ref(
+    cr: &ast::ComponentReference,
+    def_map: Option<&crate::ResolveDefMap>,
+    class_def_ids: &rustc_hash::FxHashSet<rumoca_core::DefId>,
+) -> ast::ComponentReference {
+    let Some(def_id) = cr.def_id else {
+        return cr.clone();
+    };
+    if !class_def_ids.contains(&def_id) {
+        return cr.clone();
+    }
+    let Some(path) = def_map.and_then(|map| map.get(&def_id)) else {
+        return cr.clone();
+    };
+    let mut parts: Vec<ast::ComponentRefPart> = path
+        .split('.')
+        .map(|segment| ast::ComponentRefPart {
+            ident: rumoca_ir_ast::Token {
+                text: std::sync::Arc::from(segment),
+                ..Default::default()
+            },
+            subs: None,
+        })
+        .collect();
+    if cr.parts.len() > 1 {
+        parts.extend(cr.parts.iter().skip(1).cloned());
+    }
+    ast::ComponentReference {
+        local: false,
+        parts,
+        def_id: Some(def_id),
+    }
 }

--- a/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
@@ -983,124 +983,179 @@ pub(crate) fn process_class_instance(
 ) -> Result<(), FlattenError> {
     let previous_class_scope = ctx.current_class_scope_path.clone();
     ctx.current_class_scope_path = class_def_id.and_then(|id| tree.def_map.get(&id).cloned());
+    let result = process_class_instance_body(ctx, flat, class_data, component_override_map, tree);
+    ctx.current_class_scope_path = previous_class_scope;
+    result
+}
 
+fn process_class_instance_body(
+    ctx: &mut Context,
+    flat: &mut Model,
+    class_data: &ClassInstanceData,
+    component_override_map: &ComponentOverrideMap,
+    tree: &ClassTree,
+) -> Result<(), FlattenError> {
     let prefix = &class_data.qualified_name;
     let def_map = Some(&tree.def_map);
-    let (override_packages, override_functions) = override_context_for_scope(
-        &class_data.qualified_name.to_flat_string(),
-        component_override_map,
+    let scope = class_data.qualified_name.to_flat_string();
+    let (override_packages, override_functions) =
+        override_context_for_scope(&scope, component_override_map, tree);
+    set_class_imports(ctx, class_data, tree);
+    let params = ClassFlattenParams {
+        prefix,
+        def_map,
         tree,
-    );
+        override_packages: &override_packages,
+        override_functions: &override_functions,
+    };
+    flatten_class_equations(ctx, flat, class_data, &params)?;
+    flatten_class_algorithms(flat, class_data, &ctx.current_imports, &params)
+}
 
-    // MLS §13.2: Set the import map for this class instance so that
-    // qualification resolves imported short names (e.g., `pi` → `Modelica.Constants.pi`)
-    // instead of incorrectly prefixing them with the component path.
+struct ClassFlattenParams<'a> {
+    prefix: &'a QualifiedName,
+    def_map: Option<&'a crate::ResolveDefMap>,
+    tree: &'a ClassTree,
+    override_packages: &'a [String],
+    override_functions: &'a rustc_hash::FxHashMap<String, String>,
+}
+
+fn set_class_imports(ctx: &mut Context, class_data: &ClassInstanceData, tree: &ClassTree) {
+    // MLS §13.2: Resolve imported short names instead of prefix-qualifying with component path.
     let mut imports: crate::qualify::ImportMap =
         class_data.resolved_imports.iter().cloned().collect();
     if let Some(class_name) = class_scope_name_for_instance(class_data) {
         crate::qualify::collect_lexical_package_aliases(tree, &class_name, &mut imports);
     }
     ctx.current_imports = imports;
+}
 
-    // Convert regular equations.
+fn flatten_class_equations(
+    ctx: &mut Context,
+    flat: &mut Model,
+    class_data: &ClassInstanceData,
+    params: &ClassFlattenParams<'_>,
+) -> Result<(), FlattenError> {
     for inst_eq in &class_data.equations {
-        // Handle when-equations separately (pass context for parameter evaluation).
-        let mut clauses = when_equations::flatten_when_equation(ctx, inst_eq, prefix, def_map)?;
-        for clause in &mut clauses {
-            rewrite_function_overrides_in_when_clause(
-                clause,
-                tree,
-                &override_packages,
-                &override_functions,
-            );
-        }
-        flat.when_clauses.extend(clauses);
-
-        // Handle other equations (including for-loops that may contain when-equations).
-        let mut flattened =
-            equations::flatten_equation_with_def_map(ctx, inst_eq, prefix, def_map)?;
-        rewrite_function_overrides_in_flattened(
-            &mut flattened,
-            tree,
-            &override_packages,
-            &override_functions,
-        );
-        let equation_base = flat.equations.len();
-        for eq in flattened.equations {
-            flat.add_equation(eq);
-        }
-        for mut for_eq in flattened.for_equations {
-            for_eq.first_equation_index += equation_base;
-            flat.add_for_equation(for_eq);
-        }
-        flat.assert_equations.extend(flattened.assert_equations);
-        flat.when_clauses.extend(flattened.when_clauses);
-        flat.definite_roots.extend(flattened.definite_roots);
-        flat.branches.extend(flattened.branches);
-        flat.potential_roots.extend(flattened.potential_roots);
+        flatten_regular_equation(ctx, flat, inst_eq, params)?;
     }
-
-    // Convert initial equations (when-equations are rejected per EQN-006).
     for inst_eq in &class_data.initial_equations {
-        if matches!(&inst_eq.equation, rumoca_ir_ast::Equation::When(_)) {
-            return Err(FlattenError::unsupported_equation(
-                "when-equations are not allowed in initial equations (MLS §8.6)",
-                inst_eq.span,
-            ));
-        }
+        flatten_initial_equation(ctx, flat, inst_eq, params)?;
+    }
+    Ok(())
+}
 
-        let mut flattened =
-            equations::flatten_equation_with_def_map(ctx, inst_eq, prefix, def_map)?;
-        rewrite_function_overrides_in_flattened(
-            &mut flattened,
-            tree,
-            &override_packages,
-            &override_functions,
+fn flatten_regular_equation(
+    ctx: &mut Context,
+    flat: &mut Model,
+    inst_eq: &rumoca_ir_ast::InstanceEquation,
+    params: &ClassFlattenParams<'_>,
+) -> Result<(), FlattenError> {
+    let mut clauses =
+        when_equations::flatten_when_equation(ctx, inst_eq, params.prefix, params.def_map)?;
+    for clause in &mut clauses {
+        rewrite_function_overrides_in_when_clause(
+            clause,
+            params.tree,
+            params.override_packages,
+            params.override_functions,
         );
-        let equation_base = flat.initial_equations.len();
-        for eq in flattened.equations {
-            flat.add_initial_equation(eq);
-        }
-        for mut for_eq in flattened.for_equations {
-            for_eq.first_equation_index += equation_base;
-            flat.add_initial_for_equation(for_eq);
-        }
-        flat.initial_assert_equations
-            .extend(flattened.assert_equations);
-        if !flattened.when_clauses.is_empty() {
-            return Err(FlattenError::unsupported_equation(
-                "when-equations are not allowed in initial equations (MLS §8.6)",
-                inst_eq.span,
-            ));
-        }
+    }
+    flat.when_clauses.extend(clauses);
+
+    let mut flattened =
+        equations::flatten_equation_with_def_map(ctx, inst_eq, params.prefix, params.def_map)?;
+    rewrite_function_overrides_in_flattened(
+        &mut flattened,
+        params.tree,
+        params.override_packages,
+        params.override_functions,
+    );
+    let equation_base = flat.equations.len();
+    for eq in flattened.equations {
+        flat.add_equation(eq);
+    }
+    for mut for_eq in flattened.for_equations {
+        for_eq.first_equation_index += equation_base;
+        flat.add_for_equation(for_eq);
+    }
+    flat.assert_equations.extend(flattened.assert_equations);
+    flat.when_clauses.extend(flattened.when_clauses);
+    flat.definite_roots.extend(flattened.definite_roots);
+    flat.branches.extend(flattened.branches);
+    flat.potential_roots.extend(flattened.potential_roots);
+    Ok(())
+}
+
+fn flatten_initial_equation(
+    ctx: &mut Context,
+    flat: &mut Model,
+    inst_eq: &rumoca_ir_ast::InstanceEquation,
+    params: &ClassFlattenParams<'_>,
+) -> Result<(), FlattenError> {
+    if matches!(&inst_eq.equation, rumoca_ir_ast::Equation::When(_)) {
+        return Err(FlattenError::unsupported_equation(
+            "when-equations are not allowed in initial equations (MLS §8.6)",
+            inst_eq.span,
+        ));
     }
 
-    // Convert algorithms (preserve structure per SPEC_0020)
-    let imports = &ctx.current_imports;
+    let mut flattened =
+        equations::flatten_equation_with_def_map(ctx, inst_eq, params.prefix, params.def_map)?;
+    rewrite_function_overrides_in_flattened(
+        &mut flattened,
+        params.tree,
+        params.override_packages,
+        params.override_functions,
+    );
+    let equation_base = flat.initial_equations.len();
+    for eq in flattened.equations {
+        flat.add_initial_equation(eq);
+    }
+    for mut for_eq in flattened.for_equations {
+        for_eq.first_equation_index += equation_base;
+        flat.add_initial_for_equation(for_eq);
+    }
+    flat.initial_assert_equations
+        .extend(flattened.assert_equations);
+    if !flattened.when_clauses.is_empty() {
+        return Err(FlattenError::unsupported_equation(
+            "when-equations are not allowed in initial equations (MLS §8.6)",
+            inst_eq.span,
+        ));
+    }
+    Ok(())
+}
+
+fn flatten_class_algorithms(
+    flat: &mut Model,
+    class_data: &ClassInstanceData,
+    imports: &qualify::ImportMap,
+    params: &ClassFlattenParams<'_>,
+) -> Result<(), FlattenError> {
     for inst_algs in &class_data.algorithms {
-        let mut flat_alg = flatten_algorithm_section(inst_algs, prefix, imports, def_map)?;
+        let mut flat_alg =
+            flatten_algorithm_section(inst_algs, params.prefix, imports, params.def_map)?;
         rewrite_function_overrides_in_algorithm(
             &mut flat_alg,
-            tree,
-            &override_packages,
-            &override_functions,
+            params.tree,
+            params.override_packages,
+            params.override_functions,
         );
         flat.algorithms.push(flat_alg);
     }
 
-    // Convert initial algorithms
     for inst_algs in &class_data.initial_algorithms {
-        let mut flat_alg = flatten_algorithm_section(inst_algs, prefix, imports, def_map)?;
+        let mut flat_alg =
+            flatten_algorithm_section(inst_algs, params.prefix, imports, params.def_map)?;
         rewrite_function_overrides_in_algorithm(
             &mut flat_alg,
-            tree,
-            &override_packages,
-            &override_functions,
+            params.tree,
+            params.override_packages,
+            params.override_functions,
         );
         flat.initial_algorithms.push(flat_alg);
     }
-
-    ctx.current_class_scope_path = previous_class_scope;
     Ok(())
 }
 
@@ -1291,12 +1346,7 @@ fn canonicalize_class_reference_paths(
 ) -> ast::Expression {
     match expr {
         ast::Expression::ComponentReference(cr) => ast::Expression::ComponentReference(
-            canonicalize_class_component_ref(
-                cr,
-                def_map,
-                class_def_ids,
-                current_class_scope_path,
-            ),
+            canonicalize_class_component_ref(cr, def_map, class_def_ids, current_class_scope_path),
         ),
         ast::Expression::Binary { op, lhs, rhs } => ast::Expression::Binary {
             op: op.clone(),

--- a/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
@@ -29,6 +29,7 @@ impl Context {
             eval_fallback_context: std::cell::OnceCell::new(),
             current_imports: crate::qualify::ImportMap::default(),
             class_def_ids: std::sync::Arc::new(rustc_hash::FxHashSet::default()),
+            current_class_scope_path: None,
         }
     }
 
@@ -976,9 +977,13 @@ pub(crate) fn process_class_instance(
     ctx: &mut Context,
     flat: &mut Model,
     class_data: &ClassInstanceData,
+    class_def_id: Option<rumoca_core::DefId>,
     component_override_map: &ComponentOverrideMap,
     tree: &ClassTree,
 ) -> Result<(), FlattenError> {
+    let previous_class_scope = ctx.current_class_scope_path.clone();
+    ctx.current_class_scope_path = class_def_id.and_then(|id| tree.def_map.get(&id).cloned());
+
     let prefix = &class_data.qualified_name;
     let def_map = Some(&tree.def_map);
     let (override_packages, override_functions) = override_context_for_scope(
@@ -1095,6 +1100,7 @@ pub(crate) fn process_class_instance(
         flat.initial_algorithms.push(flat_alg);
     }
 
+    ctx.current_class_scope_path = previous_class_scope;
     Ok(())
 }
 
@@ -1263,7 +1269,12 @@ pub(crate) fn qualify_expression_imports_with_def_map_ctx(
     def_map: Option<&crate::ResolveDefMap>,
     ctx: &Context,
 ) -> rumoca_ir_flat::Expression {
-    let expr = canonicalize_class_reference_paths(expr, def_map, &ctx.class_def_ids);
+    let expr = canonicalize_class_reference_paths(
+        expr,
+        def_map,
+        &ctx.class_def_ids,
+        ctx.current_class_scope_path.as_deref(),
+    );
     let opts = qualify::QualifyOptions {
         preserve_def_id: true,
         ..qualify::QualifyOptions::default()
@@ -1276,10 +1287,16 @@ fn canonicalize_class_reference_paths(
     expr: &ast::Expression,
     def_map: Option<&crate::ResolveDefMap>,
     class_def_ids: &rustc_hash::FxHashSet<rumoca_core::DefId>,
+    current_class_scope_path: Option<&str>,
 ) -> ast::Expression {
     match expr {
         ast::Expression::ComponentReference(cr) => ast::Expression::ComponentReference(
-            canonicalize_class_component_ref(cr, def_map, class_def_ids),
+            canonicalize_class_component_ref(
+                cr,
+                def_map,
+                class_def_ids,
+                current_class_scope_path,
+            ),
         ),
         ast::Expression::Binary { op, lhs, rhs } => ast::Expression::Binary {
             op: op.clone(),
@@ -1287,11 +1304,13 @@ fn canonicalize_class_reference_paths(
                 lhs,
                 def_map,
                 class_def_ids,
+                current_class_scope_path,
             )),
             rhs: std::sync::Arc::new(canonicalize_class_reference_paths(
                 rhs,
                 def_map,
                 class_def_ids,
+                current_class_scope_path,
             )),
         },
         ast::Expression::Unary { op, rhs } => ast::Expression::Unary {
@@ -1300,13 +1319,26 @@ fn canonicalize_class_reference_paths(
                 rhs,
                 def_map,
                 class_def_ids,
+                current_class_scope_path,
             )),
         },
         ast::Expression::FunctionCall { comp, args } => ast::Expression::FunctionCall {
-            comp: canonicalize_class_component_ref(comp, def_map, class_def_ids),
+            comp: canonicalize_class_component_ref(
+                comp,
+                def_map,
+                class_def_ids,
+                current_class_scope_path,
+            ),
             args: args
                 .iter()
-                .map(|arg| canonicalize_class_reference_paths(arg, def_map, class_def_ids))
+                .map(|arg| {
+                    canonicalize_class_reference_paths(
+                        arg,
+                        def_map,
+                        class_def_ids,
+                        current_class_scope_path,
+                    )
+                })
                 .collect(),
         },
         _ => expr.clone(),
@@ -1317,6 +1349,7 @@ fn canonicalize_class_component_ref(
     cr: &ast::ComponentReference,
     def_map: Option<&crate::ResolveDefMap>,
     class_def_ids: &rustc_hash::FxHashSet<rumoca_core::DefId>,
+    current_class_scope_path: Option<&str>,
 ) -> ast::ComponentReference {
     let Some(def_id) = cr.def_id else {
         return cr.clone();
@@ -1324,16 +1357,15 @@ fn canonicalize_class_component_ref(
     if !class_def_ids.contains(&def_id) {
         return cr.clone();
     }
-    // Preserve member access rooted at lexical class/package aliases (e.g. `Medium.nC`)
-    // so normal instance qualification can produce `s.Medium.nC` rather than
-    // over-qualifying to `s.P.Source.Medium.nC`.
-    if cr.parts.len() > 1 {
-        return cr.clone();
-    }
     let Some(path) = def_map.and_then(|map| map.get(&def_id)) else {
         return cr.clone();
     };
-    let mut parts: Vec<ast::ComponentRefPart> = path
+    let base_path = current_class_scope_path
+        .and_then(|class_scope| path.strip_prefix(class_scope))
+        .and_then(|suffix| suffix.strip_prefix('.'))
+        .filter(|suffix| !suffix.is_empty())
+        .unwrap_or(path.as_str());
+    let mut parts: Vec<ast::ComponentRefPart> = base_path
         .split('.')
         .map(|segment| ast::ComponentRefPart {
             ident: rumoca_ir_ast::Token {

--- a/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
@@ -1324,6 +1324,12 @@ fn canonicalize_class_component_ref(
     if !class_def_ids.contains(&def_id) {
         return cr.clone();
     }
+    // Preserve member access rooted at lexical class/package aliases (e.g. `Medium.nC`)
+    // so normal instance qualification can produce `s.Medium.nC` rather than
+    // over-qualifying to `s.P.Source.Medium.nC`.
+    if cr.parts.len() > 1 {
+        return cr.clone();
+    }
     let Some(path) = def_map.and_then(|map| map.get(&def_id)) else {
         return cr.clone();
     };

--- a/crates/rumoca-phase-flatten/src/pipeline/flatten_pipeline.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/flatten_pipeline.rs
@@ -123,7 +123,14 @@ pub(crate) fn process_class_instances_for_flatten(
         if is_in_disabled_component(&class_data.qualified_name, &overlay.disabled_components) {
             continue;
         }
-        process_class_instance(ctx, flat, class_data, component_override_map, tree)?;
+        process_class_instance(
+            ctx,
+            flat,
+            class_data,
+            class_data.class_def_id,
+            component_override_map,
+            tree,
+        )?;
     }
     Ok(())
 }

--- a/crates/rumoca-phase-flatten/src/pipeline/flatten_pipeline.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/flatten_pipeline.rs
@@ -152,6 +152,8 @@ pub(crate) fn finalize_flat_model(
     mark_record_constructor_calls(flat, tree);
     functions::lower_record_function_params(flat);
     functions::insert_array_size_args(flat);
+    functions::specialize_static_function_params(flat);
+    canonicalize_varrefs_via_record_aliases(flat, ctx);
     drop_invalid_field_access_bindings(flat);
     propagate_unexpanded_record_array_dims(flat, overlay);
     flat.oc_break_edge_scalar_count = vcg::compute_break_edge_scalar_count(

--- a/crates/rumoca-phase-flatten/src/postprocess.rs
+++ b/crates/rumoca-phase-flatten/src/postprocess.rs
@@ -552,6 +552,264 @@ pub(super) fn substitute_known_constants_in_flat(flat: &mut flat::Model, ctx: &C
     substitute_function_bodies(&mut flat.functions, ctx, &live_vars);
 }
 
+/// Canonicalize VarRef names through record aliases when the resolved target
+/// exists in flattened variables.
+///
+/// This keeps equation references aligned with flattened declaration paths
+/// (MLS §7.2.3 alias semantics), instead of carrying intermediate component
+/// implementation paths that do not exist as flat variables.
+pub(super) fn canonicalize_varrefs_via_record_aliases(flat: &mut flat::Model, ctx: &Context) {
+    let known_vars: std::collections::HashSet<flat::VarName> =
+        flat.variables.keys().cloned().collect();
+    if known_vars.is_empty() || ctx.record_aliases.is_empty() {
+        return;
+    }
+
+    let rewrite_name = |name: &flat::VarName| -> flat::VarName {
+        let resolved = ctx.resolve_alias(name.as_str());
+        if resolved == name.as_str() {
+            return name.clone();
+        }
+        let resolved_name = flat::VarName::new(resolved);
+        if known_vars.contains(&resolved_name) {
+            resolved_name
+        } else {
+            name.clone()
+        }
+    };
+
+    rewrite_varrefs_in_opt_exprs(
+        flat.variables.values_mut().flat_map(|v| {
+            [
+                &mut v.binding,
+                &mut v.start,
+                &mut v.min,
+                &mut v.max,
+                &mut v.nominal,
+            ]
+        }),
+        &rewrite_name,
+    );
+    rewrite_varrefs_in_equations(&mut flat.equations, &rewrite_name);
+    rewrite_varrefs_in_equations(&mut flat.initial_equations, &rewrite_name);
+    rewrite_varrefs_in_asserts(&mut flat.assert_equations, &rewrite_name);
+    rewrite_varrefs_in_asserts(&mut flat.initial_assert_equations, &rewrite_name);
+    for algo in flat
+        .algorithms
+        .iter_mut()
+        .chain(flat.initial_algorithms.iter_mut())
+    {
+        rewrite_varrefs_in_statements(&mut algo.statements, &rewrite_name);
+    }
+    for when in &mut flat.when_clauses {
+        rewrite_varrefs_in_expr(&mut when.condition, &rewrite_name);
+        rewrite_varrefs_in_when_equations(&mut when.equations, &rewrite_name);
+    }
+    for function in flat.functions.values_mut() {
+        for param in function
+            .inputs
+            .iter_mut()
+            .chain(function.outputs.iter_mut())
+            .chain(function.locals.iter_mut())
+        {
+            if let Some(default) = &mut param.default {
+                rewrite_varrefs_in_expr(default, &rewrite_name);
+            }
+        }
+        rewrite_varrefs_in_statements(&mut function.body, &rewrite_name);
+    }
+}
+
+fn rewrite_varrefs_in_opt_exprs<'a>(
+    exprs: impl Iterator<Item = &'a mut Option<flat::Expression>>,
+    rewrite_name: &impl Fn(&flat::VarName) -> flat::VarName,
+) {
+    for value in exprs.flatten() {
+        rewrite_varrefs_in_expr(value, rewrite_name);
+    }
+}
+
+fn rewrite_varrefs_in_equations(
+    equations: &mut [flat::Equation],
+    rewrite_name: &impl Fn(&flat::VarName) -> flat::VarName,
+) {
+    for equation in equations {
+        rewrite_varrefs_in_expr(&mut equation.residual, rewrite_name);
+    }
+}
+
+fn rewrite_varrefs_in_asserts(
+    asserts: &mut [flat::AssertEquation],
+    rewrite_name: &impl Fn(&flat::VarName) -> flat::VarName,
+) {
+    for assertion in asserts {
+        rewrite_varrefs_in_expr(&mut assertion.condition, rewrite_name);
+        rewrite_varrefs_in_expr(&mut assertion.message, rewrite_name);
+        if let Some(level) = &mut assertion.level {
+            rewrite_varrefs_in_expr(level, rewrite_name);
+        }
+    }
+}
+
+fn rewrite_varrefs_in_statements(
+    statements: &mut [flat::Statement],
+    rewrite_name: &impl Fn(&flat::VarName) -> flat::VarName,
+) {
+    for statement in statements {
+        match statement {
+            flat::Statement::Assignment { value, .. } | flat::Statement::Reinit { value, .. } => {
+                rewrite_varrefs_in_expr(value, rewrite_name);
+            }
+            flat::Statement::FunctionCall { args, outputs, .. } => {
+                for arg in args {
+                    rewrite_varrefs_in_expr(arg, rewrite_name);
+                }
+                for out in outputs {
+                    rewrite_varrefs_in_expr(out, rewrite_name);
+                }
+            }
+            flat::Statement::If {
+                cond_blocks,
+                else_block,
+            } => {
+                for block in cond_blocks {
+                    rewrite_varrefs_in_expr(&mut block.cond, rewrite_name);
+                    rewrite_varrefs_in_statements(&mut block.stmts, rewrite_name);
+                }
+                if let Some(stmts) = else_block {
+                    rewrite_varrefs_in_statements(stmts, rewrite_name);
+                }
+            }
+            flat::Statement::For { indices, equations } => {
+                for idx in indices {
+                    rewrite_varrefs_in_expr(&mut idx.range, rewrite_name);
+                }
+                rewrite_varrefs_in_statements(equations, rewrite_name);
+            }
+            flat::Statement::While(block) => {
+                rewrite_varrefs_in_expr(&mut block.cond, rewrite_name);
+                rewrite_varrefs_in_statements(&mut block.stmts, rewrite_name);
+            }
+            flat::Statement::When(blocks) => {
+                for block in blocks {
+                    rewrite_varrefs_in_expr(&mut block.cond, rewrite_name);
+                    rewrite_varrefs_in_statements(&mut block.stmts, rewrite_name);
+                }
+            }
+            flat::Statement::Assert {
+                condition,
+                message,
+                level,
+            } => {
+                rewrite_varrefs_in_expr(condition, rewrite_name);
+                rewrite_varrefs_in_expr(message, rewrite_name);
+                if let Some(level) = level {
+                    rewrite_varrefs_in_expr(level, rewrite_name);
+                }
+            }
+            flat::Statement::Empty | flat::Statement::Return | flat::Statement::Break => {}
+        }
+    }
+}
+
+fn rewrite_varrefs_in_when_equations(
+    equations: &mut [flat::WhenEquation],
+    rewrite_name: &impl Fn(&flat::VarName) -> flat::VarName,
+) {
+    for equation in equations {
+        match equation {
+            flat::WhenEquation::Assign { value, .. } | flat::WhenEquation::Reinit { value, .. } => {
+                rewrite_varrefs_in_expr(value, rewrite_name);
+            }
+            flat::WhenEquation::Assert { condition, .. } => {
+                rewrite_varrefs_in_expr(condition, rewrite_name);
+            }
+            flat::WhenEquation::Conditional {
+                branches,
+                else_branch,
+                ..
+            } => {
+                for (condition, nested) in branches {
+                    rewrite_varrefs_in_expr(condition, rewrite_name);
+                    rewrite_varrefs_in_when_equations(nested, rewrite_name);
+                }
+                rewrite_varrefs_in_when_equations(else_branch, rewrite_name);
+            }
+            flat::WhenEquation::FunctionCallOutputs { function, .. } => {
+                rewrite_varrefs_in_expr(function, rewrite_name);
+            }
+            flat::WhenEquation::Terminate { .. } => {}
+        }
+    }
+}
+
+fn rewrite_varrefs_in_expr(
+    expr: &mut flat::Expression,
+    rewrite_name: &impl Fn(&flat::VarName) -> flat::VarName,
+) {
+    match expr {
+        flat::Expression::VarRef { name, .. } => {
+            *name = rewrite_name(name);
+        }
+        flat::Expression::FunctionCall { args, .. }
+        | flat::Expression::BuiltinCall { args, .. } => {
+            for arg in args {
+                rewrite_varrefs_in_expr(arg, rewrite_name);
+            }
+        }
+        flat::Expression::Binary { lhs, rhs, .. } => {
+            rewrite_varrefs_in_expr(lhs, rewrite_name);
+            rewrite_varrefs_in_expr(rhs, rewrite_name);
+        }
+        flat::Expression::Unary { rhs, .. } => rewrite_varrefs_in_expr(rhs, rewrite_name),
+        flat::Expression::If {
+            branches,
+            else_branch,
+        } => {
+            for (cond, value) in branches {
+                rewrite_varrefs_in_expr(cond, rewrite_name);
+                rewrite_varrefs_in_expr(value, rewrite_name);
+            }
+            rewrite_varrefs_in_expr(else_branch, rewrite_name);
+        }
+        flat::Expression::Array { elements, .. } | flat::Expression::Tuple { elements } => {
+            for element in elements {
+                rewrite_varrefs_in_expr(element, rewrite_name);
+            }
+        }
+        flat::Expression::Range { start, step, end } => {
+            rewrite_varrefs_in_expr(start, rewrite_name);
+            if let Some(step_expr) = step {
+                rewrite_varrefs_in_expr(step_expr, rewrite_name);
+            }
+            rewrite_varrefs_in_expr(end, rewrite_name);
+        }
+        flat::Expression::ArrayComprehension {
+            expr,
+            indices,
+            filter,
+        } => {
+            rewrite_varrefs_in_expr(expr, rewrite_name);
+            for idx in indices {
+                rewrite_varrefs_in_expr(&mut idx.range, rewrite_name);
+            }
+            if let Some(filter_expr) = filter {
+                rewrite_varrefs_in_expr(filter_expr, rewrite_name);
+            }
+        }
+        flat::Expression::Index { base, subscripts } => {
+            rewrite_varrefs_in_expr(base, rewrite_name);
+            for subscript in subscripts {
+                if let flat::Subscript::Expr(inner) = subscript {
+                    rewrite_varrefs_in_expr(inner, rewrite_name);
+                }
+            }
+        }
+        flat::Expression::FieldAccess { base, .. } => rewrite_varrefs_in_expr(base, rewrite_name),
+        flat::Expression::Literal(_) | flat::Expression::Empty => {}
+    }
+}
+
 fn substitute_assert_equations(
     equations: &mut [flat::AssertEquation],
     ctx: &Context,
@@ -592,7 +850,339 @@ fn substitute_variable_annotations(
         substitute_opt_expr(&mut var.min, ctx, live_vars, locals);
         substitute_opt_expr(&mut var.max, ctx, live_vars, locals);
         substitute_opt_expr(&mut var.nominal, ctx, live_vars, locals);
+        let scope = crate::path_utils::parent_scope(var.name.as_str()).unwrap_or("");
+        substitute_unqualified_scope_constants_opt(&mut var.binding, scope, ctx, live_vars, locals);
+        substitute_unqualified_scope_constants_opt(&mut var.start, scope, ctx, live_vars, locals);
+        substitute_unqualified_scope_constants_opt(&mut var.min, scope, ctx, live_vars, locals);
+        substitute_unqualified_scope_constants_opt(&mut var.max, scope, ctx, live_vars, locals);
+        substitute_unqualified_scope_constants_opt(&mut var.nominal, scope, ctx, live_vars, locals);
     }
+}
+
+fn substitute_unqualified_scope_constants_opt(
+    expr: &mut Option<flat::Expression>,
+    scope: &str,
+    ctx: &Context,
+    live_vars: &rustc_hash::FxHashSet<String>,
+    locals: &HashSet<String>,
+) {
+    if let Some(expr) = expr {
+        *expr = substitute_unqualified_scope_constants_expr(
+            expr.clone(),
+            scope,
+            ctx,
+            live_vars,
+            locals,
+        );
+    }
+}
+
+fn substitute_unqualified_scope_constants_expr(
+    expr: flat::Expression,
+    scope: &str,
+    ctx: &Context,
+    live_vars: &rustc_hash::FxHashSet<String>,
+    locals: &HashSet<String>,
+) -> flat::Expression {
+    if let flat::Expression::VarRef { name, subscripts } = &expr
+        && subscripts.is_empty()
+        && !crate::path_utils::has_top_level_dot(name.as_str())
+        && !live_vars.contains(name.as_str())
+        && !locals.contains(name.as_str())
+    {
+        return substitute_scoped_simple_var_ref(name.clone(), subscripts.clone(), scope, ctx);
+    }
+    substitute_unqualified_scope_constants_non_var_expr(expr, scope, ctx, live_vars, locals)
+}
+
+fn substitute_unqualified_scope_constants_non_var_expr(
+    expr: flat::Expression,
+    scope: &str,
+    ctx: &Context,
+    live_vars: &rustc_hash::FxHashSet<String>,
+    locals: &HashSet<String>,
+) -> flat::Expression {
+    match expr {
+        flat::Expression::Binary { lhs, rhs, op } => flat::Expression::Binary {
+            lhs: Box::new(substitute_unqualified_scope_constants_expr(
+                *lhs, scope, ctx, live_vars, locals,
+            )),
+            rhs: Box::new(substitute_unqualified_scope_constants_expr(
+                *rhs, scope, ctx, live_vars, locals,
+            )),
+            op,
+        },
+        flat::Expression::Unary { rhs, op } => flat::Expression::Unary {
+            rhs: Box::new(substitute_unqualified_scope_constants_expr(
+                *rhs, scope, ctx, live_vars, locals,
+            )),
+            op,
+        },
+        flat::Expression::FunctionCall {
+            name,
+            args,
+            is_constructor,
+        } => flat::Expression::FunctionCall {
+            name,
+            args: substitute_scoped_expr_vec(args, scope, ctx, live_vars, locals),
+            is_constructor,
+        },
+        flat::Expression::BuiltinCall { function, args } => flat::Expression::BuiltinCall {
+            function,
+            args: substitute_scoped_expr_vec(args, scope, ctx, live_vars, locals),
+        },
+        flat::Expression::Array {
+            elements,
+            is_matrix,
+        } => flat::Expression::Array {
+            elements: substitute_scoped_expr_vec(elements, scope, ctx, live_vars, locals),
+            is_matrix,
+        },
+        flat::Expression::Tuple { elements } => flat::Expression::Tuple {
+            elements: substitute_scoped_expr_vec(elements, scope, ctx, live_vars, locals),
+        },
+        flat::Expression::Range { start, step, end } => flat::Expression::Range {
+            start: Box::new(substitute_unqualified_scope_constants_expr(
+                *start, scope, ctx, live_vars, locals,
+            )),
+            step: step.map(|s| {
+                Box::new(substitute_unqualified_scope_constants_expr(
+                    *s, scope, ctx, live_vars, locals,
+                ))
+            }),
+            end: Box::new(substitute_unqualified_scope_constants_expr(
+                *end, scope, ctx, live_vars, locals,
+            )),
+        },
+        flat::Expression::FieldAccess { base, field } => flat::Expression::FieldAccess {
+            base: Box::new(substitute_unqualified_scope_constants_expr(
+                *base, scope, ctx, live_vars, locals,
+            )),
+            field,
+        },
+        flat::Expression::Index { base, subscripts } => flat::Expression::Index {
+            base: Box::new(substitute_unqualified_scope_constants_expr(
+                *base, scope, ctx, live_vars, locals,
+            )),
+            subscripts: substitute_scoped_subscripts(subscripts, scope, ctx, live_vars, locals),
+        },
+        flat::Expression::If {
+            branches,
+            else_branch,
+        } => substitute_scoped_if_expr(branches, *else_branch, scope, ctx, live_vars, locals),
+        flat::Expression::ArrayComprehension {
+            expr,
+            indices,
+            filter,
+        } => substitute_scoped_array_comprehension_expr(
+            *expr, indices, filter, scope, ctx, live_vars, locals,
+        ),
+        flat::Expression::VarRef { name, subscripts } => {
+            flat::Expression::VarRef { name, subscripts }
+        }
+        other => other,
+    }
+}
+
+fn substitute_scoped_if_expr(
+    branches: Vec<(flat::Expression, flat::Expression)>,
+    else_branch: flat::Expression,
+    scope: &str,
+    ctx: &Context,
+    live_vars: &rustc_hash::FxHashSet<String>,
+    locals: &HashSet<String>,
+) -> flat::Expression {
+    flat::Expression::If {
+        branches: branches
+            .into_iter()
+            .map(|(cond, value)| {
+                (
+                    substitute_unqualified_scope_constants_expr(
+                        cond, scope, ctx, live_vars, locals,
+                    ),
+                    substitute_unqualified_scope_constants_expr(
+                        value, scope, ctx, live_vars, locals,
+                    ),
+                )
+            })
+            .collect(),
+        else_branch: Box::new(substitute_unqualified_scope_constants_expr(
+            else_branch,
+            scope,
+            ctx,
+            live_vars,
+            locals,
+        )),
+    }
+}
+
+fn substitute_scoped_array_comprehension_expr(
+    expr: flat::Expression,
+    indices: Vec<flat::ComprehensionIndex>,
+    filter: Option<Box<flat::Expression>>,
+    scope: &str,
+    ctx: &Context,
+    live_vars: &rustc_hash::FxHashSet<String>,
+    locals: &HashSet<String>,
+) -> flat::Expression {
+    flat::Expression::ArrayComprehension {
+        expr: Box::new(substitute_unqualified_scope_constants_expr(
+            expr, scope, ctx, live_vars, locals,
+        )),
+        indices: indices
+            .into_iter()
+            .map(|mut idx| {
+                idx.range = substitute_unqualified_scope_constants_expr(
+                    idx.range, scope, ctx, live_vars, locals,
+                );
+                idx
+            })
+            .collect(),
+        filter: filter.map(|f| {
+            Box::new(substitute_unqualified_scope_constants_expr(
+                *f, scope, ctx, live_vars, locals,
+            ))
+        }),
+    }
+}
+
+fn substitute_scoped_simple_var_ref(
+    name: flat::VarName,
+    subscripts: Vec<flat::Subscript>,
+    scope: &str,
+    ctx: &Context,
+) -> flat::Expression {
+    if let Some(v) =
+        lookup_constant_expr_with_scope_local(name.as_str(), scope, &ctx.constant_values)
+    {
+        return v;
+    }
+    if let Some(v) = lookup_with_scope_local(name.as_str(), scope, &ctx.real_parameter_values)
+        && v.is_finite()
+    {
+        return flat::Expression::Literal(flat::Literal::Real(v));
+    }
+    if let Some(v) = lookup_with_scope_local(name.as_str(), scope, &ctx.parameter_values) {
+        return flat::Expression::Literal(flat::Literal::Integer(v));
+    }
+    if let Some(v) = lookup_with_scope_local(name.as_str(), scope, &ctx.boolean_parameter_values) {
+        return flat::Expression::Literal(flat::Literal::Boolean(v));
+    }
+    if let Some(v) = lookup_with_scope_local(name.as_str(), scope, &ctx.enum_parameter_values) {
+        return flat::Expression::VarRef {
+            name: flat::VarName::new(v),
+            subscripts: vec![],
+        };
+    }
+    flat::Expression::VarRef { name, subscripts }
+}
+
+fn substitute_scoped_expr_vec(
+    exprs: Vec<flat::Expression>,
+    scope: &str,
+    ctx: &Context,
+    live_vars: &rustc_hash::FxHashSet<String>,
+    locals: &HashSet<String>,
+) -> Vec<flat::Expression> {
+    exprs
+        .into_iter()
+        .map(|expr| {
+            substitute_unqualified_scope_constants_expr(expr, scope, ctx, live_vars, locals)
+        })
+        .collect()
+}
+
+fn substitute_scoped_subscripts(
+    subscripts: Vec<flat::Subscript>,
+    scope: &str,
+    ctx: &Context,
+    live_vars: &rustc_hash::FxHashSet<String>,
+    locals: &HashSet<String>,
+) -> Vec<flat::Subscript> {
+    subscripts
+        .into_iter()
+        .map(|subscript| match subscript {
+            flat::Subscript::Expr(expr) => flat::Subscript::Expr(Box::new(
+                substitute_unqualified_scope_constants_expr(*expr, scope, ctx, live_vars, locals),
+            )),
+            other => other,
+        })
+        .collect()
+}
+
+fn lookup_with_scope_local<V: Clone + PartialEq>(
+    name: &str,
+    scope: &str,
+    map: &rustc_hash::FxHashMap<String, V>,
+) -> Option<V> {
+    let mut current_scope = scope;
+    loop {
+        let qualified = if current_scope.is_empty() {
+            name.to_string()
+        } else {
+            format!("{current_scope}.{name}")
+        };
+        if let Some(val) = map.get(&qualified) {
+            return Some(val.clone());
+        }
+        if let Some(parent_scope) = crate::path_utils::parent_scope(current_scope) {
+            current_scope = parent_scope;
+        } else if !current_scope.is_empty() {
+            current_scope = "";
+        } else {
+            break;
+        }
+    }
+    if let Some(val) = map.get(name) {
+        return Some(val.clone());
+    }
+    if crate::path_utils::has_top_level_dot(name) {
+        return lookup_unique_dotted_suffix_value(name, map).cloned();
+    }
+    None
+}
+
+fn lookup_constant_expr_with_scope_local(
+    name: &str,
+    scope: &str,
+    map: &rustc_hash::FxHashMap<String, flat::Expression>,
+) -> Option<flat::Expression> {
+    let mut current_scope = scope;
+    loop {
+        let qualified = if current_scope.is_empty() {
+            name.to_string()
+        } else {
+            format!("{current_scope}.{name}")
+        };
+        if let Some(val) = map.get(&qualified) {
+            return Some(val.clone());
+        }
+        if let Some(parent_scope) = crate::path_utils::parent_scope(current_scope) {
+            current_scope = parent_scope;
+        } else if !current_scope.is_empty() {
+            current_scope = "";
+        } else {
+            break;
+        }
+    }
+    if let Some(val) = map.get(name) {
+        return Some(val.clone());
+    }
+    if crate::path_utils::has_top_level_dot(name) {
+        let suffix = format!(".{name}");
+        let mut found: Option<flat::Expression> = None;
+        for (key, value) in map {
+            if !key.ends_with(&suffix) {
+                continue;
+            }
+            if found.is_some() {
+                return None;
+            }
+            found = Some(value.clone());
+        }
+        return found;
+    }
+    None
 }
 
 fn substitute_function_bodies(
@@ -608,6 +1198,7 @@ fn substitute_function_bodies(
             .chain(function.locals.iter())
             .map(|param| param.name.clone())
             .collect();
+        let function_scope = crate::path_utils::parent_scope(function.name.as_str()).unwrap_or("");
 
         for param in function
             .inputs
@@ -616,6 +1207,13 @@ fn substitute_function_bodies(
             .chain(function.locals.iter_mut())
         {
             substitute_opt_expr(&mut param.default, ctx, live_vars, &function_locals);
+            substitute_unqualified_scope_constants_opt(
+                &mut param.default,
+                function_scope,
+                ctx,
+                live_vars,
+                &function_locals,
+            );
         }
         for statement in &mut function.body {
             substitute_known_constants_statement(statement, ctx, live_vars, &function_locals);
@@ -712,6 +1310,42 @@ fn substitute_scalar_var_ref(
     if inline_index_base_is_live_or_local(key, live_vars, locals) {
         return None;
     }
+    if let Some(expr) = lookup_scalar_key_value(key, ctx) {
+        return Some(expr);
+    }
+    if let Some(case_variant_key) = resolve_case_variant_symbol_key(key, ctx)
+        && let Some(expr) = lookup_scalar_key_value(&case_variant_key, ctx)
+    {
+        return Some(expr);
+    }
+    if !crate::path_utils::has_top_level_dot(key)
+        && let Some(expr) = lookup_scalar_suffix_value(key, ctx)
+    {
+        return Some(expr);
+    }
+    if let Some(expr) = resolve_inline_indexed_constant(key, ctx) {
+        return Some(expr);
+    }
+
+    if let Some(resolved_key) = resolve_varref_through_constant_aliases(key, ctx)
+        && resolved_key != key
+    {
+        if let Some(expr) = lookup_scalar_key_value(&resolved_key, ctx) {
+            return Some(expr);
+        }
+        if let Some(expr) = resolve_inline_indexed_constant(&resolved_key, ctx) {
+            return Some(expr);
+        }
+        return Some(flat::Expression::VarRef {
+            name: flat::VarName::new(resolved_key),
+            subscripts: vec![],
+        });
+    }
+
+    None
+}
+
+fn lookup_scalar_key_value(key: &str, ctx: &Context) -> Option<flat::Expression> {
     if let Some(v) = resolve_constant_value_expr(key, ctx) {
         return Some(v.clone());
     }
@@ -732,43 +1366,117 @@ fn substitute_scalar_var_ref(
             subscripts: vec![],
         });
     }
-    if let Some(expr) = resolve_inline_indexed_constant(key, ctx) {
-        return Some(expr);
-    }
+    None
+}
 
-    if let Some(resolved_key) = resolve_varref_through_constant_aliases(key, ctx)
-        && resolved_key != key
+fn lookup_scalar_suffix_value(key: &str, ctx: &Context) -> Option<flat::Expression> {
+    if let Some(expr) = lookup_unique_dotted_suffix_expr(key, &ctx.constant_values) {
+        return Some(expr.clone());
+    }
+    if let Some(v) = lookup_unique_dotted_suffix_value(key, &ctx.real_parameter_values)
+        && v.is_finite()
     {
-        if let Some(v) = resolve_constant_value_expr(&resolved_key, ctx) {
-            return Some(v.clone());
-        }
-        if let Some(v) = ctx.real_parameter_values.get(&resolved_key)
-            && v.is_finite()
-        {
-            return Some(flat::Expression::Literal(flat::Literal::Real(*v)));
-        }
-        if let Some(v) = ctx.parameter_values.get(&resolved_key) {
-            return Some(flat::Expression::Literal(flat::Literal::Integer(*v)));
-        }
-        if let Some(v) = ctx.boolean_parameter_values.get(&resolved_key) {
-            return Some(flat::Expression::Literal(flat::Literal::Boolean(*v)));
-        }
-        if let Some(v) = ctx.enum_parameter_values.get(&resolved_key) {
-            return Some(flat::Expression::VarRef {
-                name: flat::VarName::new(v.clone()),
-                subscripts: vec![],
-            });
-        }
-        if let Some(expr) = resolve_inline_indexed_constant(&resolved_key, ctx) {
-            return Some(expr);
-        }
+        return Some(flat::Expression::Literal(flat::Literal::Real(*v)));
+    }
+    if let Some(v) = lookup_unique_dotted_suffix_value(key, &ctx.parameter_values) {
+        return Some(flat::Expression::Literal(flat::Literal::Integer(*v)));
+    }
+    if let Some(v) = lookup_unique_dotted_suffix_value(key, &ctx.boolean_parameter_values) {
+        return Some(flat::Expression::Literal(flat::Literal::Boolean(*v)));
+    }
+    if let Some(v) = lookup_unique_dotted_suffix_value(key, &ctx.enum_parameter_values) {
         return Some(flat::Expression::VarRef {
-            name: flat::VarName::new(resolved_key),
+            name: flat::VarName::new(v.clone()),
             subscripts: vec![],
         });
     }
-
     None
+}
+
+fn resolve_case_variant_symbol_key(key: &str, ctx: &Context) -> Option<String> {
+    if !crate::path_utils::has_top_level_dot(key) {
+        return None;
+    }
+    let mut parts: Vec<String> = key.split('.').map(|s| s.to_string()).collect();
+    if parts.len() < 2 {
+        return None;
+    }
+
+    let mut candidates = Vec::new();
+    for idx in 1..parts.len() {
+        let segment = &parts[idx];
+        let mut chars = segment.chars();
+        let Some(first) = chars.next() else {
+            continue;
+        };
+        if !first.is_ascii_alphabetic() {
+            continue;
+        }
+        let rest = chars.as_str();
+        let flipped = if first.is_ascii_lowercase() {
+            format!("{}{}", first.to_ascii_uppercase(), rest)
+        } else {
+            format!("{}{}", first.to_ascii_lowercase(), rest)
+        };
+
+        let original = parts[idx].clone();
+        parts[idx] = flipped;
+        let candidate = parts.join(".");
+        parts[idx] = original;
+
+        if symbol_key_exists_in_any_context_map(&candidate, ctx) {
+            candidates.push(candidate);
+        }
+    }
+
+    if candidates.len() == 1 {
+        return candidates.into_iter().next();
+    }
+    None
+}
+
+fn symbol_key_exists_in_any_context_map(key: &str, ctx: &Context) -> bool {
+    ctx.constant_values.contains_key(key)
+        || ctx.real_parameter_values.contains_key(key)
+        || ctx.parameter_values.contains_key(key)
+        || ctx.boolean_parameter_values.contains_key(key)
+        || ctx.enum_parameter_values.contains_key(key)
+}
+
+fn lookup_unique_dotted_suffix_value<'a, T: PartialEq>(
+    simple_name: &str,
+    map: &'a rustc_hash::FxHashMap<String, T>,
+) -> Option<&'a T> {
+    let suffix = format!(".{simple_name}");
+    let mut found: Option<&T> = None;
+    for (key, value) in map {
+        if !key.ends_with(&suffix) {
+            continue;
+        }
+        if found.is_some_and(|prev| prev != value) {
+            return None;
+        }
+        found = Some(value);
+    }
+    found
+}
+
+fn lookup_unique_dotted_suffix_expr<'a>(
+    simple_name: &str,
+    map: &'a rustc_hash::FxHashMap<String, flat::Expression>,
+) -> Option<&'a flat::Expression> {
+    let suffix = format!(".{simple_name}");
+    let mut found: Option<&flat::Expression> = None;
+    for (key, value) in map {
+        if !key.ends_with(&suffix) {
+            continue;
+        }
+        if found.is_some() {
+            return None;
+        }
+        found = Some(value);
+    }
+    found
 }
 
 fn inline_index_base_is_live_or_local(
@@ -1221,286 +1929,5 @@ pub(super) fn drop_invalid_field_access_bindings(flat: &mut flat::Model) {
 }
 
 #[cfg(test)]
-mod substitute_constant_tests {
-    use super::*;
-    use rumoca_core::Span;
-
-    fn simple_assignment(value: flat::Expression) -> flat::Statement {
-        flat::Statement::Assignment {
-            comp: flat::ComponentReference {
-                local: false,
-                parts: vec![flat::ComponentRefPart {
-                    ident: "y".to_string(),
-                    subs: vec![],
-                }],
-                def_id: None,
-            },
-            value,
-        }
-    }
-
-    #[test]
-    fn substitutes_known_constants_inside_function_defaults_and_body() {
-        let mut model = flat::Model::new();
-        let mut function = flat::Function::new("Pkg.f", Span::DUMMY);
-        function.add_input(flat::FunctionParam::new("u", "Real").with_default(
-            flat::Expression::VarRef {
-                name: flat::VarName::new("Pkg.Constants.k"),
-                subscripts: vec![],
-            },
-        ));
-        function
-            .body
-            .push(simple_assignment(flat::Expression::VarRef {
-                name: flat::VarName::new("Pkg.Constants.k"),
-                subscripts: vec![],
-            }));
-        model.add_function(function);
-
-        let mut ctx = Context::new();
-        ctx.constant_values.insert(
-            "Pkg.Constants.k".to_string(),
-            flat::Expression::Literal(flat::Literal::Real(42.0)),
-        );
-
-        substitute_known_constants_in_flat(&mut model, &ctx);
-
-        let function = model
-            .functions
-            .get(&flat::VarName::new("Pkg.f"))
-            .expect("function should exist");
-        assert!(matches!(
-            function.inputs[0].default,
-            Some(flat::Expression::Literal(flat::Literal::Real(v))) if (v - 42.0).abs() < f64::EPSILON
-        ));
-        match &function.body[0] {
-            flat::Statement::Assignment { value, .. } => assert!(matches!(
-                value,
-                flat::Expression::Literal(flat::Literal::Real(v)) if (*v - 42.0).abs() < f64::EPSILON
-            )),
-            other => panic!("expected assignment statement, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn does_not_substitute_function_local_names() {
-        let mut model = flat::Model::new();
-        let mut function = flat::Function::new("Pkg.g", Span::DUMMY);
-        function.add_input(flat::FunctionParam::new("k", "Real"));
-        function
-            .body
-            .push(simple_assignment(flat::Expression::VarRef {
-                name: flat::VarName::new("k"),
-                subscripts: vec![],
-            }));
-        model.add_function(function);
-
-        let mut ctx = Context::new();
-        ctx.constant_values.insert(
-            "k".to_string(),
-            flat::Expression::Literal(flat::Literal::Real(7.0)),
-        );
-
-        substitute_known_constants_in_flat(&mut model, &ctx);
-
-        let function = model
-            .functions
-            .get(&flat::VarName::new("Pkg.g"))
-            .expect("function should exist");
-        match &function.body[0] {
-            flat::Statement::Assignment { value, .. } => assert!(matches!(
-                value,
-                flat::Expression::VarRef { name, .. } if name.as_str() == "k"
-            )),
-            other => panic!("expected assignment statement, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn does_not_substitute_indexed_function_local_names() {
-        let mut model = flat::Model::new();
-        let mut function = flat::Function::new("Pkg.g_indexed", Span::DUMMY);
-        function.add_input(flat::FunctionParam::new("table", "Real").with_dims(vec![7, 2]));
-        function
-            .body
-            .push(simple_assignment(flat::Expression::VarRef {
-                name: flat::VarName::new("table"),
-                subscripts: vec![
-                    flat::Subscript::Expr(Box::new(flat::Expression::VarRef {
-                        name: flat::VarName::new("next"),
-                        subscripts: vec![],
-                    })),
-                    flat::Subscript::Index(1),
-                ],
-            }));
-        model.add_function(function);
-
-        let mut ctx = Context::new();
-        ctx.constant_values.insert(
-            "table".to_string(),
-            flat::Expression::BuiltinCall {
-                function: flat::BuiltinFunction::Fill,
-                args: vec![
-                    flat::Expression::Literal(flat::Literal::Real(0.0)),
-                    flat::Expression::Literal(flat::Literal::Integer(0)),
-                    flat::Expression::Literal(flat::Literal::Integer(2)),
-                ],
-            },
-        );
-
-        substitute_known_constants_in_flat(&mut model, &ctx);
-
-        let function = model
-            .functions
-            .get(&flat::VarName::new("Pkg.g_indexed"))
-            .expect("function should exist");
-        match &function.body[0] {
-            flat::Statement::Assignment { value, .. } => match value {
-                flat::Expression::VarRef { name, subscripts } => {
-                    assert_eq!(name.as_str(), "table");
-                    assert_eq!(subscripts.len(), 2);
-                }
-                other => panic!("expected table varref, got {other:?}"),
-            },
-            other => panic!("expected assignment statement, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn substitutes_inline_multi_indexed_constant_varref_names() {
-        let mut model = flat::Model::new();
-        let mut function = flat::Function::new("Pkg.h", Span::DUMMY);
-        function
-            .body
-            .push(simple_assignment(flat::Expression::VarRef {
-                name: flat::VarName::new("Modelica.Blocks.Sources.IntegerTable.table[1,1]"),
-                subscripts: vec![],
-            }));
-        model.add_function(function);
-
-        let mut ctx = Context::new();
-        ctx.constant_values.insert(
-            "Modelica.Blocks.Sources.IntegerTable.table".to_string(),
-            flat::Expression::Array {
-                elements: vec![
-                    flat::Expression::Literal(flat::Literal::Integer(0)),
-                    flat::Expression::Literal(flat::Literal::Integer(1)),
-                ],
-                is_matrix: false,
-            },
-        );
-
-        substitute_known_constants_in_flat(&mut model, &ctx);
-
-        let function = model
-            .functions
-            .get(&flat::VarName::new("Pkg.h"))
-            .expect("function should exist");
-        match &function.body[0] {
-            flat::Statement::Assignment { value, .. } => match value {
-                flat::Expression::Index { base, subscripts } => {
-                    assert!(matches!(
-                        base.as_ref(),
-                        flat::Expression::Array { elements, is_matrix }
-                            if !*is_matrix && elements.len() == 2
-                    ));
-                    assert_eq!(subscripts.len(), 2);
-                    assert!(matches!(
-                        &subscripts[0],
-                        flat::Subscript::Expr(expr)
-                            if matches!(expr.as_ref(), flat::Expression::Literal(flat::Literal::Integer(1)))
-                    ));
-                    assert!(matches!(
-                        &subscripts[1],
-                        flat::Subscript::Expr(expr)
-                            if matches!(expr.as_ref(), flat::Expression::Literal(flat::Literal::Integer(1)))
-                    ));
-                }
-                other => panic!("expected indexed expression, got {other:?}"),
-            },
-            other => panic!("expected assignment statement, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn does_not_substitute_inline_indexed_varref_when_base_is_local() {
-        let mut model = flat::Model::new();
-        let mut function = flat::Function::new("Pkg.inline_local", Span::DUMMY);
-        function.add_input(flat::FunctionParam::new("table", "Real").with_dims(vec![7, 2]));
-        function
-            .body
-            .push(simple_assignment(flat::Expression::VarRef {
-                name: flat::VarName::new("table[1,1]"),
-                subscripts: vec![],
-            }));
-        model.add_function(function);
-
-        let mut ctx = Context::new();
-        ctx.constant_values.insert(
-            "table".to_string(),
-            flat::Expression::BuiltinCall {
-                function: flat::BuiltinFunction::Fill,
-                args: vec![
-                    flat::Expression::Literal(flat::Literal::Real(0.0)),
-                    flat::Expression::Literal(flat::Literal::Integer(0)),
-                    flat::Expression::Literal(flat::Literal::Integer(2)),
-                ],
-            },
-        );
-
-        substitute_known_constants_in_flat(&mut model, &ctx);
-
-        let function = model
-            .functions
-            .get(&flat::VarName::new("Pkg.inline_local"))
-            .expect("function should exist");
-        match &function.body[0] {
-            flat::Statement::Assignment { value, .. } => assert!(matches!(
-                value,
-                flat::Expression::VarRef { name, subscripts }
-                    if name.as_str() == "table[1,1]" && subscripts.is_empty()
-            )),
-            other => panic!("expected assignment statement, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn substitutes_field_access_on_zero_arg_constructor_constants() {
-        let mut model = flat::Model::new();
-        let mut function = flat::Function::new("Pkg.k", Span::DUMMY);
-        function
-            .body
-            .push(simple_assignment(flat::Expression::FieldAccess {
-                base: Box::new(flat::Expression::FunctionCall {
-                    name: flat::VarName::new(
-                        "Modelica.Electrical.Batteries.ParameterRecords.ExampleData",
-                    ),
-                    args: vec![],
-                    is_constructor: true,
-                }),
-                field: "useLinearSOCDependency".to_string(),
-            }));
-        model.add_function(function);
-
-        let mut ctx = Context::new();
-        ctx.boolean_parameter_values.insert(
-            "Modelica.Electrical.Batteries.ParameterRecords.ExampleData.useLinearSOCDependency"
-                .to_string(),
-            false,
-        );
-
-        substitute_known_constants_in_flat(&mut model, &ctx);
-
-        let function = model
-            .functions
-            .get(&flat::VarName::new("Pkg.k"))
-            .expect("function should exist");
-        match &function.body[0] {
-            flat::Statement::Assignment { value, .. } => assert!(matches!(
-                value,
-                flat::Expression::Literal(flat::Literal::Boolean(false))
-            )),
-            other => panic!("expected assignment statement, got {other:?}"),
-        }
-    }
-}
+#[path = "postprocess_tests.rs"]
+mod postprocess_tests;

--- a/crates/rumoca-phase-flatten/src/postprocess_tests.rs
+++ b/crates/rumoca-phase-flatten/src/postprocess_tests.rs
@@ -1,0 +1,439 @@
+use super::*;
+use rumoca_core::Span;
+
+fn simple_assignment(value: flat::Expression) -> flat::Statement {
+    flat::Statement::Assignment {
+        comp: flat::ComponentReference {
+            local: false,
+            parts: vec![flat::ComponentRefPart {
+                ident: "y".to_string(),
+                subs: vec![],
+            }],
+            def_id: None,
+        },
+        value,
+    }
+}
+
+#[test]
+fn canonicalize_varrefs_rewrites_alias_paths_to_existing_flat_vars() {
+    let mut model = flat::Model::new();
+    model.add_variable(
+        flat::VarName::new("pipe.port_a.p"),
+        flat::Variable {
+            name: flat::VarName::new("pipe.port_a.p"),
+            is_primitive: true,
+            ..Default::default()
+        },
+    );
+    model.equations.push(flat::Equation::new(
+        flat::Expression::VarRef {
+            name: flat::VarName::new("pipe.flowModel.port_a.p"),
+            subscripts: vec![],
+        },
+        Span::DUMMY,
+        flat::EquationOrigin::ComponentEquation {
+            component: "pipe".to_string(),
+        },
+    ));
+
+    let mut ctx = Context::new();
+    ctx.record_aliases
+        .insert("pipe.flowModel".to_string(), "pipe".to_string());
+
+    canonicalize_varrefs_via_record_aliases(&mut model, &ctx);
+
+    let flat::Expression::VarRef { name, .. } = &model.equations[0].residual else {
+        panic!("expected varref");
+    };
+    assert_eq!(name.as_str(), "pipe.port_a.p");
+}
+
+#[test]
+fn substitutes_known_constants_inside_function_defaults_and_body() {
+    let mut model = flat::Model::new();
+    let mut function = flat::Function::new("Pkg.f", Span::DUMMY);
+    function.add_input(flat::FunctionParam::new("u", "Real").with_default(
+        flat::Expression::VarRef {
+            name: flat::VarName::new("Pkg.Constants.k"),
+            subscripts: vec![],
+        },
+    ));
+    function
+        .body
+        .push(simple_assignment(flat::Expression::VarRef {
+            name: flat::VarName::new("Pkg.Constants.k"),
+            subscripts: vec![],
+        }));
+    model.add_function(function);
+
+    let mut ctx = Context::new();
+    ctx.constant_values.insert(
+        "Pkg.Constants.k".to_string(),
+        flat::Expression::Literal(flat::Literal::Real(42.0)),
+    );
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+
+    let function = model
+        .functions
+        .get(&flat::VarName::new("Pkg.f"))
+        .expect("function should exist");
+    assert!(matches!(
+        function.inputs[0].default,
+        Some(flat::Expression::Literal(flat::Literal::Real(v))) if (v - 42.0).abs() < f64::EPSILON
+    ));
+    match &function.body[0] {
+        flat::Statement::Assignment { value, .. } => assert!(matches!(
+            value,
+            flat::Expression::Literal(flat::Literal::Real(v)) if (*v - 42.0).abs() < f64::EPSILON
+        )),
+        other => panic!("expected assignment statement, got {other:?}"),
+    }
+}
+
+#[test]
+fn does_not_substitute_function_local_names() {
+    let mut model = flat::Model::new();
+    let mut function = flat::Function::new("Pkg.g", Span::DUMMY);
+    function.add_input(flat::FunctionParam::new("k", "Real"));
+    function
+        .body
+        .push(simple_assignment(flat::Expression::VarRef {
+            name: flat::VarName::new("k"),
+            subscripts: vec![],
+        }));
+    model.add_function(function);
+
+    let mut ctx = Context::new();
+    ctx.constant_values.insert(
+        "k".to_string(),
+        flat::Expression::Literal(flat::Literal::Real(7.0)),
+    );
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+
+    let function = model
+        .functions
+        .get(&flat::VarName::new("Pkg.g"))
+        .expect("function should exist");
+    match &function.body[0] {
+        flat::Statement::Assignment { value, .. } => assert!(matches!(
+            value,
+            flat::Expression::VarRef { name, .. } if name.as_str() == "k"
+        )),
+        other => panic!("expected assignment statement, got {other:?}"),
+    }
+}
+
+#[test]
+fn does_not_substitute_indexed_function_local_names() {
+    let mut model = flat::Model::new();
+    let mut function = flat::Function::new("Pkg.g_indexed", Span::DUMMY);
+    function.add_input(flat::FunctionParam::new("table", "Real").with_dims(vec![7, 2]));
+    function
+        .body
+        .push(simple_assignment(flat::Expression::VarRef {
+            name: flat::VarName::new("table"),
+            subscripts: vec![
+                flat::Subscript::Expr(Box::new(flat::Expression::VarRef {
+                    name: flat::VarName::new("next"),
+                    subscripts: vec![],
+                })),
+                flat::Subscript::Index(1),
+            ],
+        }));
+    model.add_function(function);
+
+    let mut ctx = Context::new();
+    ctx.constant_values.insert(
+        "table".to_string(),
+        flat::Expression::BuiltinCall {
+            function: flat::BuiltinFunction::Fill,
+            args: vec![
+                flat::Expression::Literal(flat::Literal::Real(0.0)),
+                flat::Expression::Literal(flat::Literal::Integer(0)),
+                flat::Expression::Literal(flat::Literal::Integer(2)),
+            ],
+        },
+    );
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+
+    let function = model
+        .functions
+        .get(&flat::VarName::new("Pkg.g_indexed"))
+        .expect("function should exist");
+    match &function.body[0] {
+        flat::Statement::Assignment { value, .. } => match value {
+            flat::Expression::VarRef { name, subscripts } => {
+                assert_eq!(name.as_str(), "table");
+                assert_eq!(subscripts.len(), 2);
+            }
+            other => panic!("expected table varref, got {other:?}"),
+        },
+        other => panic!("expected assignment statement, got {other:?}"),
+    }
+}
+
+#[test]
+fn substitutes_inline_multi_indexed_constant_varref_names() {
+    let mut model = flat::Model::new();
+    let mut function = flat::Function::new("Pkg.h", Span::DUMMY);
+    function
+        .body
+        .push(simple_assignment(flat::Expression::VarRef {
+            name: flat::VarName::new("Modelica.Blocks.Sources.IntegerTable.table[1,1]"),
+            subscripts: vec![],
+        }));
+    model.add_function(function);
+
+    let mut ctx = Context::new();
+    ctx.constant_values.insert(
+        "Modelica.Blocks.Sources.IntegerTable.table".to_string(),
+        flat::Expression::Array {
+            elements: vec![
+                flat::Expression::Literal(flat::Literal::Integer(0)),
+                flat::Expression::Literal(flat::Literal::Integer(1)),
+            ],
+            is_matrix: false,
+        },
+    );
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+
+    let function = model
+        .functions
+        .get(&flat::VarName::new("Pkg.h"))
+        .expect("function should exist");
+    match &function.body[0] {
+        flat::Statement::Assignment { value, .. } => match value {
+            flat::Expression::Index { base, subscripts } => {
+                assert!(matches!(
+                    base.as_ref(),
+                    flat::Expression::Array { elements, is_matrix }
+                        if !*is_matrix && elements.len() == 2
+                ));
+                assert_eq!(subscripts.len(), 2);
+                assert!(matches!(
+                    &subscripts[0],
+                    flat::Subscript::Expr(expr)
+                        if matches!(expr.as_ref(), flat::Expression::Literal(flat::Literal::Integer(1)))
+                ));
+                assert!(matches!(
+                    &subscripts[1],
+                    flat::Subscript::Expr(expr)
+                        if matches!(expr.as_ref(), flat::Expression::Literal(flat::Literal::Integer(1)))
+                ));
+            }
+            other => panic!("expected indexed expression, got {other:?}"),
+        },
+        other => panic!("expected assignment statement, got {other:?}"),
+    }
+}
+
+#[test]
+fn does_not_substitute_inline_indexed_varref_when_base_is_local() {
+    let mut model = flat::Model::new();
+    let mut function = flat::Function::new("Pkg.inline_local", Span::DUMMY);
+    function.add_input(flat::FunctionParam::new("table", "Real").with_dims(vec![7, 2]));
+    function
+        .body
+        .push(simple_assignment(flat::Expression::VarRef {
+            name: flat::VarName::new("table[1,1]"),
+            subscripts: vec![],
+        }));
+    model.add_function(function);
+
+    let mut ctx = Context::new();
+    ctx.constant_values.insert(
+        "table".to_string(),
+        flat::Expression::BuiltinCall {
+            function: flat::BuiltinFunction::Fill,
+            args: vec![
+                flat::Expression::Literal(flat::Literal::Real(0.0)),
+                flat::Expression::Literal(flat::Literal::Integer(0)),
+                flat::Expression::Literal(flat::Literal::Integer(2)),
+            ],
+        },
+    );
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+
+    let function = model
+        .functions
+        .get(&flat::VarName::new("Pkg.inline_local"))
+        .expect("function should exist");
+    match &function.body[0] {
+        flat::Statement::Assignment { value, .. } => assert!(matches!(
+            value,
+            flat::Expression::VarRef { name, subscripts }
+                if name.as_str() == "table[1,1]" && subscripts.is_empty()
+        )),
+        other => panic!("expected assignment statement, got {other:?}"),
+    }
+}
+
+#[test]
+fn substitutes_unqualified_symbol_from_unique_scoped_constant_suffix() {
+    let mut model = flat::Model::new();
+    model.equations.push(flat::Equation::new(
+        flat::Expression::VarRef {
+            name: flat::VarName::new("reference_X"),
+            subscripts: vec![],
+        },
+        Span::DUMMY,
+        flat::EquationOrigin::ComponentEquation {
+            component: "tank.medium".to_string(),
+        },
+    ));
+
+    let mut ctx = Context::new();
+    ctx.constant_values.insert(
+        "tank.medium.reference_X".to_string(),
+        flat::Expression::Array {
+            elements: vec![flat::Expression::Literal(flat::Literal::Real(1.0))],
+            is_matrix: false,
+        },
+    );
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+    assert!(matches!(
+        model.equations[0].residual,
+        flat::Expression::Array { ref elements, is_matrix }
+            if !is_matrix
+                && elements.len() == 1
+                && matches!(elements[0], flat::Expression::Literal(flat::Literal::Real(v)) if (v - 1.0).abs() < f64::EPSILON)
+    ));
+}
+
+#[test]
+fn does_not_substitute_unqualified_symbol_when_scoped_suffix_is_ambiguous() {
+    let mut model = flat::Model::new();
+    model.equations.push(flat::Equation::new(
+        flat::Expression::VarRef {
+            name: flat::VarName::new("reference_X"),
+            subscripts: vec![],
+        },
+        Span::DUMMY,
+        flat::EquationOrigin::ComponentEquation {
+            component: "tank.medium".to_string(),
+        },
+    ));
+
+    let mut ctx = Context::new();
+    ctx.constant_values.insert(
+        "a.medium.reference_X".to_string(),
+        flat::Expression::Array {
+            elements: vec![flat::Expression::Literal(flat::Literal::Real(1.0))],
+            is_matrix: false,
+        },
+    );
+    ctx.constant_values.insert(
+        "b.medium.reference_X".to_string(),
+        flat::Expression::Array {
+            elements: vec![flat::Expression::Literal(flat::Literal::Real(2.0))],
+            is_matrix: false,
+        },
+    );
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+    assert!(matches!(
+        model.equations[0].residual,
+        flat::Expression::VarRef { ref name, ref subscripts }
+            if name.as_str() == "reference_X" && subscripts.is_empty()
+    ));
+}
+
+#[test]
+fn substitutes_case_variant_symbol_when_unique_context_key_exists() {
+    let mut model = flat::Model::new();
+    model.equations.push(flat::Equation::new(
+        flat::Expression::VarRef {
+            name: flat::VarName::new("tank.medium.cv_const"),
+            subscripts: vec![],
+        },
+        Span::DUMMY,
+        flat::EquationOrigin::ComponentEquation {
+            component: "tank.medium".to_string(),
+        },
+    ));
+
+    let mut ctx = Context::new();
+    ctx.real_parameter_values
+        .insert("tank.Medium.cv_const".to_string(), 4184.0);
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+    assert!(matches!(
+        model.equations[0].residual,
+        flat::Expression::Literal(flat::Literal::Real(v)) if (v - 4184.0).abs() < f64::EPSILON
+    ));
+}
+
+#[test]
+fn does_not_substitute_case_variant_symbol_when_ambiguous() {
+    let mut model = flat::Model::new();
+    model.equations.push(flat::Equation::new(
+        flat::Expression::VarRef {
+            name: flat::VarName::new("tank.medium.cv_const"),
+            subscripts: vec![],
+        },
+        Span::DUMMY,
+        flat::EquationOrigin::ComponentEquation {
+            component: "tank.medium".to_string(),
+        },
+    ));
+
+    let mut ctx = Context::new();
+    ctx.real_parameter_values
+        .insert("tank.Medium.cv_const".to_string(), 4184.0);
+    ctx.real_parameter_values
+        .insert("tank.medium.Cv_const".to_string(), 1234.0);
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+    assert!(matches!(
+        model.equations[0].residual,
+        flat::Expression::VarRef { ref name, ref subscripts }
+            if name.as_str() == "tank.medium.cv_const" && subscripts.is_empty()
+    ));
+}
+
+#[test]
+fn substitutes_field_access_on_zero_arg_constructor_constants() {
+    let mut model = flat::Model::new();
+    let mut function = flat::Function::new("Pkg.k", Span::DUMMY);
+    function
+        .body
+        .push(simple_assignment(flat::Expression::FieldAccess {
+            base: Box::new(flat::Expression::FunctionCall {
+                name: flat::VarName::new(
+                    "Modelica.Electrical.Batteries.ParameterRecords.ExampleData",
+                ),
+                args: vec![],
+                is_constructor: true,
+            }),
+            field: "useLinearSOCDependency".to_string(),
+        }));
+    model.add_function(function);
+
+    let mut ctx = Context::new();
+    ctx.boolean_parameter_values.insert(
+        "Modelica.Electrical.Batteries.ParameterRecords.ExampleData.useLinearSOCDependency"
+            .to_string(),
+        false,
+    );
+
+    substitute_known_constants_in_flat(&mut model, &ctx);
+
+    let function = model
+        .functions
+        .get(&flat::VarName::new("Pkg.k"))
+        .expect("function should exist");
+    match &function.body[0] {
+        flat::Statement::Assignment { value, .. } => assert!(matches!(
+            value,
+            flat::Expression::Literal(flat::Literal::Boolean(false))
+        )),
+        other => panic!("expected assignment statement, got {other:?}"),
+    }
+}

--- a/crates/rumoca-phase-flatten/src/vcg.rs
+++ b/crates/rumoca-phase-flatten/src/vcg.rs
@@ -1009,6 +1009,7 @@ mod tests {
         overlay.classes.insert(
             ast::InstanceId::new(1),
             ast::ClassInstanceData {
+                class_def_id: None,
                 qualified_name: ast::QualifiedName::from_ident("root"),
                 resolved_imports: Vec::new(),
                 connections: vec![

--- a/crates/rumoca-phase-flatten/src/when_equations.rs
+++ b/crates/rumoca-phase-flatten/src/when_equations.rs
@@ -16,7 +16,7 @@ use rumoca_ir_flat as flat;
 
 use crate::equations::{build_qualified_name, expand_range_indices, substitute_index_in_equation};
 use crate::errors::FlattenError;
-use crate::{Context, qualify_expression_imports_with_def_map};
+use crate::{Context, qualify_expression_imports_with_def_map_ctx};
 
 /// Flatten a when-equation to a list of WhenClauses.
 ///
@@ -70,8 +70,13 @@ pub(crate) fn flatten_when_block(
     def_map: Option<&crate::ResolveDefMap>,
 ) -> Result<flat::WhenClause, FlattenError> {
     // Qualify the condition expression
-    let condition =
-        qualify_expression_imports_with_def_map(&block.cond, prefix, &ctx.current_imports, def_map);
+    let condition = qualify_expression_imports_with_def_map_ctx(
+        &block.cond,
+        prefix,
+        &ctx.current_imports,
+        def_map,
+        ctx,
+    );
 
     let mut clause = flat::WhenClause::new(condition, span);
 
@@ -106,12 +111,12 @@ fn flatten_when_body_equation(
 ) -> Result<Vec<flat::WhenEquation>, FlattenError> {
     match eq {
         ast::Equation::Simple { lhs, rhs } => {
-            flatten_when_simple_equation(lhs, rhs, prefix, span, &ctx.current_imports, def_map)
+            flatten_when_simple_equation(ctx, lhs, rhs, prefix, span, &ctx.current_imports, def_map)
                 .map(|opt| opt.into_iter().collect())
         }
 
         ast::Equation::FunctionCall { comp, args } => {
-            flatten_when_function_call(comp, args, prefix, span, &ctx.current_imports, def_map)
+            flatten_when_function_call(ctx, comp, args, prefix, span, &ctx.current_imports, def_map)
                 .map(|opt| opt.into_iter().collect())
         }
 
@@ -171,11 +176,12 @@ fn flatten_when_if_equation(
 
     // Process each if/elseif branch
     for block in cond_blocks {
-        let condition = qualify_expression_imports_with_def_map(
+        let condition = qualify_expression_imports_with_def_map_ctx(
             &block.cond,
             prefix,
             &ctx.current_imports,
             def_map,
+            ctx,
         );
         let mut branch_eqs = Vec::new();
 
@@ -344,6 +350,7 @@ fn validate_when_branch_targets(
 /// Handles both simple assignments like `x = expr` and tuple assignments
 /// like `(a, b) = func(args)` for multi-output function calls.
 fn flatten_when_simple_equation(
+    ctx: &Context,
     lhs: &ast::Expression,
     rhs: &ast::Expression,
     prefix: &ast::QualifiedName,
@@ -371,7 +378,8 @@ fn flatten_when_simple_equation(
         }
 
         // Qualify the function call expression
-        let function = qualify_expression_imports_with_def_map(rhs, prefix, imports, def_map);
+        let function =
+            qualify_expression_imports_with_def_map_ctx(rhs, prefix, imports, def_map, ctx);
         let origin = format!(
             "when equation multi-output assignment to ({})",
             outputs
@@ -388,7 +396,7 @@ fn flatten_when_simple_equation(
 
     // Simple single-target assignment
     let target = extract_assignment_target(lhs, prefix)?;
-    let value = qualify_expression_imports_with_def_map(rhs, prefix, imports, def_map);
+    let value = qualify_expression_imports_with_def_map_ctx(rhs, prefix, imports, def_map, ctx);
     let origin = format!("when equation assignment to {}", target);
     Ok(Some(flat::WhenEquation::assign(
         target, value, span, origin,
@@ -397,6 +405,7 @@ fn flatten_when_simple_equation(
 
 /// Flatten a function call in a when-clause (reinit, assert, terminate).
 fn flatten_when_function_call(
+    ctx: &Context,
     comp: &ast::ComponentReference,
     args: &[ast::Expression],
     prefix: &ast::QualifiedName,
@@ -421,8 +430,8 @@ fn flatten_when_function_call(
 
     // Check for known functions (by first part or full qualified name)
     match &**func_name {
-        "reinit" => flatten_reinit_call(args, prefix, span, imports, def_map),
-        "assert" => flatten_assert_call(args, prefix, span, imports, def_map),
+        "reinit" => flatten_reinit_call(ctx, args, prefix, span, imports, def_map),
+        "assert" => flatten_assert_call(ctx, args, prefix, span, imports, def_map),
         "terminate" => flatten_terminate_call(args, span),
         // print() is a side-effect function that outputs debug messages
         // It doesn't contribute to the DAE system, so we skip it
@@ -508,6 +517,7 @@ fn flatten_when_for_equation(
 
 /// Flatten an assert() call: assert(condition, message, level?)
 fn flatten_assert_call(
+    ctx: &Context,
     args: &[ast::Expression],
     prefix: &ast::QualifiedName,
     span: rumoca_core::Span,
@@ -521,7 +531,8 @@ fn flatten_assert_call(
         ));
     }
 
-    let condition = qualify_expression_imports_with_def_map(&args[0], prefix, imports, def_map);
+    let condition =
+        qualify_expression_imports_with_def_map_ctx(&args[0], prefix, imports, def_map, ctx);
     let message =
         extract_string_literal(&args[1]).unwrap_or_else(|| "assertion failed".to_string());
     let origin = "assert in when-clause".to_string();
@@ -571,6 +582,7 @@ fn extract_string_literal(expr: &ast::Expression) -> Option<String> {
 
 /// Flatten a reinit() call: reinit(x, expr)
 fn flatten_reinit_call(
+    ctx: &Context,
     args: &[ast::Expression],
     prefix: &ast::QualifiedName,
     span: rumoca_core::Span,
@@ -585,7 +597,8 @@ fn flatten_reinit_call(
     }
 
     let state = extract_assignment_target(&args[0], prefix)?;
-    let value = qualify_expression_imports_with_def_map(&args[1], prefix, imports, def_map);
+    let value =
+        qualify_expression_imports_with_def_map_ctx(&args[1], prefix, imports, def_map, ctx);
     let origin = format!("reinit({})", state);
 
     // Note: EQN-016 validation (reinit target must be state) is done in ToDae phase

--- a/crates/rumoca-phase-instantiate/src/array_expansion.rs
+++ b/crates/rumoca-phase-instantiate/src/array_expansion.rs
@@ -112,9 +112,20 @@ pub(super) fn expand_array_component(
         // component name would overwrite the per-element indexed binding.
         let previous_binding = ctx.mod_env().active.get(&binding_qn).cloned();
         if let Some(binding_expr) = &scalar_comp.binding {
+            let preserved_source_scope = previous_binding
+                .as_ref()
+                .and_then(|value| value.source_scope.clone());
+            let preserved_source = previous_binding
+                .as_ref()
+                .and_then(|value| value.source.clone())
+                .or_else(|| Some(binding_expr.clone()));
             ctx.mod_env_mut().active.insert(
                 binding_qn.clone(),
-                ast::ModificationValue::simple(binding_expr.clone()),
+                ast::ModificationValue::with_source_scope(
+                    binding_expr.clone(),
+                    preserved_source,
+                    preserved_source_scope,
+                ),
             );
         }
 

--- a/crates/rumoca-phase-instantiate/src/array_expansion.rs
+++ b/crates/rumoca-phase-instantiate/src/array_expansion.rs
@@ -171,6 +171,13 @@ pub(super) fn pre_resolve_array_modifications(
         if comp.each_modifications.contains(name) {
             continue; // `each` modifications are not distributed
         }
+        // Keep component-reference modifiers (for example `R=R`) in symbolic
+        // form so per-element indexing can preserve owner scope (`R[1]`).
+        // Eager resolution here can over-collapse to outer-source expressions
+        // like `RRef.d`, losing the declaring component context.
+        if matches!(expr, ast::Expression::ComponentReference(_)) {
+            continue;
+        }
         let val = resolve_mod_to_array(expr, mod_env, effective_components, tree);
         if matches!(val, ast::Expression::Array { .. }) {
             resolved.push((name.clone(), val));

--- a/crates/rumoca-phase-instantiate/src/lib.rs
+++ b/crates/rumoca-phase-instantiate/src/lib.rs
@@ -1040,6 +1040,7 @@ fn instantiate_class(
 
     let class_data = ast::ClassInstanceData {
         instance_id,
+        class_def_id: class.def_id,
         qualified_name: qualified_name.clone(),
         equations: instance_equations,
         initial_equations: instance_initial_equations,

--- a/crates/rumoca-phase-instantiate/src/mod_env.rs
+++ b/crates/rumoca-phase-instantiate/src/mod_env.rs
@@ -88,7 +88,12 @@ fn insert_modifier_value_with_structural_overrides(
     let (binding_source, binding_source_scope) =
         inherited_modifier_source_metadata(target_name, value_expr, ctx.mod_env()).map_or(
             (Some(value_expr.clone()), insert_ctx.source_scope.clone()),
-            |(src, scope)| (src.or_else(|| Some(value_expr.clone())), scope),
+            |(src, scope)| {
+                (
+                    src.or_else(|| Some(value_expr.clone())),
+                    scope.or_else(|| insert_ctx.source_scope.clone()),
+                )
+            },
         );
     let resolved_expr = resolve_modification_expr(
         value_expr,

--- a/crates/rumoca/tests/mod_propagation_test.rs
+++ b/crates/rumoca/tests/mod_propagation_test.rs
@@ -196,6 +196,60 @@ fn test_modification_propagation_nested() {
     }
 }
 
+#[test]
+fn test_array_modifier_distribution_preserves_binding_source_scope() {
+    let source = r#"
+        record R
+            Real p;
+        end R;
+
+        model Sub
+            parameter R x[2];
+        end Sub;
+
+        model Top
+            parameter Real a[2] = {1.0, 2.0};
+            Sub s(x = {R(a[1]), R(a[2])});
+        end Top;
+    "#;
+
+    let stored_def = parse_to_ast(source, "<test>").expect("parse failed");
+    let tree = ast::ClassTree::from_parsed(stored_def);
+    let parsed = ast::ParsedTree::new(tree);
+    let resolved = resolve(parsed).expect("resolve failed");
+    let tree = resolved.into_inner();
+
+    let overlay = match instantiate_model_with_outcome(&tree, "Top") {
+        InstantiationOutcome::Success(o) => o,
+        InstantiationOutcome::NeedsInner { missing_inners, .. } => {
+            panic!("Needs inner: {:?}", missing_inners);
+        }
+        InstantiationOutcome::Error(e) => {
+            panic!("Error: {:?}", e);
+        }
+    };
+
+    let x1 = find_component(&overlay, "s.x[1]").expect("s.x[1] should exist");
+    let x2 = find_component(&overlay, "s.x[2]").expect("s.x[2] should exist");
+
+    assert!(
+        x1.binding_from_modification,
+        "s.x[1] should be marked as modifier-derived"
+    );
+    assert!(
+        x2.binding_from_modification,
+        "s.x[2] should be marked as modifier-derived"
+    );
+    assert!(
+        x1.binding_source_scope.is_some(),
+        "s.x[1] modifier binding should keep lexical source scope"
+    );
+    assert!(
+        x2.binding_source_scope.is_some(),
+        "s.x[2] modifier binding should keep lexical source scope"
+    );
+}
+
 /// Test that typecheck_instanced evaluates dimensions correctly.
 #[test]
 fn test_dimension_evaluation_after_typecheck() {
@@ -919,4 +973,57 @@ where
             );
         }
     }
+}
+
+#[test]
+fn test_flowmodel_modifier_keeps_enclosing_port_scope() {
+    let source = r#"
+        package Medium
+          function setState_p
+            input Real p;
+            output Real s;
+          algorithm
+            s := p;
+          end setState_p;
+        end Medium;
+
+        connector FluidPort
+          Real p;
+          flow Real m_flow;
+        end FluidPort;
+
+        model FlowModel
+          parameter Real states[2];
+          Real m_flows[1];
+        end FlowModel;
+
+        model StaticPipe
+          FluidPort port_a;
+          FluidPort port_b;
+          FlowModel flowModel(states={
+            Medium.setState_p(port_a.p),
+            Medium.setState_p(port_b.p)});
+        equation
+          port_a.m_flow = flowModel.m_flows[1];
+        end StaticPipe;
+
+        model Top
+          StaticPipe pipe;
+        end Top;
+    "#;
+
+    let compiled = rumoca::Compiler::new()
+        .model("Top")
+        .compile_str(source, "test.mo")
+        .expect("Top should compile");
+
+    let flat_dump = format!("{:#?}", compiled.flat);
+    assert!(
+        !flat_dump.contains("pipe.flowModel.port_a.p"),
+        "flowModel modifier should resolve port_a.p in enclosing scope, got over-qualified ref"
+    );
+    assert!(
+        flat_dump.contains("pipe.port_a.p"),
+        "expected canonical enclosing connector pressure path in flattened model"
+    );
 }

--- a/docs/development_instructions.md
+++ b/docs/development_instructions.md
@@ -147,6 +147,76 @@ evidence block format:
 - Negative/ambiguity regression:
 - Focused runtime/compile check:
 
+## Communication Clarity Rule (Mandatory)
+
+For non-trivial compiler bugs, AI updates must include a plain-language
+explanation in addition to technical details.
+
+Required plain-language content:
+
+1. What is broken
+- One short sentence in everyday language.
+
+2. Where it breaks
+- The exact model + path/symbol + compiler phase.
+
+3. What should happen
+- One short sentence describing expected behavior.
+
+4. Why it broke
+- One short sentence naming the first bad transformation.
+
+5. What changed
+- One short sentence describing the fix and why it is safe.
+
+Do not hide the core issue behind jargon-only explanations.
+If technical terms are used, define them briefly.
+
+## Concrete Example Rule (Mandatory)
+
+For any non-trivial fix or bug explanation, include at least one concrete,
+real example taken from the actual failure location.
+
+Required example content:
+
+1. Show the real code/snippet
+- Use the exact model/code path where the bug was found.
+- For Modelica bugs: include the exact Modelica snippet.
+- For Rust bugs: include the exact Rust snippet.
+- If exact code cannot be shown, include minimal pseudo-code that preserves the
+  real structure and names.
+
+2. Show expected vs actual in plain language
+- "Actual:" one short line describing what Rumoca produced/did.
+- "Expected:" one short line describing what should have happened.
+
+3. Show phase-by-phase mapping
+- One short line per relevant phase (for example resolve, instantiate, flatten,
+  ToDae) describing what happened to the example in that phase.
+- Explicitly identify the first phase where the example becomes wrong.
+
+4. Tie fix directly to that example
+- State exactly what changed and why it corrects that specific example.
+- Avoid abstract explanations that are not anchored in the concrete example.
+
+This rule is mandatory in addition to the Communication Clarity Rule.
+
+## Symptom-Patch Guard (Mandatory)
+
+Before merging a fix, explicitly answer:
+
+1. "Did we change only a validator/checker fallback?"
+- If yes, stop and continue investigation unless Gate 5 is explicitly justified.
+
+2. "Did we identify and patch the first producer of the wrong symbol/value/path?"
+- If no, stop and continue investigation.
+
+3. "Can we point to one concrete before/after artifact proving the producer changed?"
+- If no, fix is not complete.
+
+For symbol-qualification bugs, validation-layer relaxations are temporary triage
+only and must not be final unless an upstream fix is proven infeasible.
+
 ## Symbol Identity & Namespace Discipline (Mandatory)
 
 Do not treat two names as equivalent because they "look related" (for example,

--- a/docs/development_instructions.md
+++ b/docs/development_instructions.md
@@ -328,6 +328,86 @@ If MSL runs show many compile timeouts or very slow compiles:
   profiling/bench workflows) to find the dominant phase/crate before changing
   compile strategy.
 
+## Commit-to-Commit Regression Diff Workflow
+
+When CI quality drops after a compiler change, compare commits with the same
+focused model list before touching code.
+
+1. Pick a focused target list JSON
+- Include the exact models that changed in CI.
+- Keep one list and reuse it across compared commits.
+
+2. Run the same command per commit/worktree
+- Use `RUMOCA_MSL_SIM_TARGETS_FILE=<list>.json`.
+- Capture each run in a separate log file.
+
+3. Compare phase outcomes before percentages
+- `ToDae failed`, `Successfully compiled`, `sim_ok`,
+  `sim_solver_fail`, `sim_timeout`.
+- Do not start from aggregate success rates alone.
+
+4. Diff per-model status transitions
+- Extract `[sim_*] <model>` lines from each log.
+- Identify exact `ok -> fail`, `fail -> ok`, and
+  `not attempted -> attempted` transitions.
+
+5. Interpret transitions before patching
+- `ToDae fail -> sim fail` may indicate upstream compile progress exposing an
+  existing runtime limitation, not a new simulation regression.
+- `ok -> fail` on identical targets is stronger root-cause evidence.
+
+6. Only then inspect emitted IR/flatten artifacts
+- For true `ok -> fail` models, diff emitted names/expressions across commits
+  and patch the first producer phase.
+
+## Flattened/Instantiated Artifact Comparison (Mandatory for Compiler/Solver Triage)
+
+For semantic work and solver/runtime failures, compare compiler-produced
+artifacts, not only test pass/fail summaries.
+
+1. Select one concrete model
+- Regression case: prefer a model with clear `sim_ok -> fail` transition.
+- New behavior case: prefer a model that should exhibit the new rule clearly.
+- Solver/runtime case: prefer a model with reproducible solver failure and a
+  known-good reference run when available.
+- Keep the model in the same filtered CI target set when possible.
+
+2. Generate and diff flattened/DAE artifacts
+- Regression case: compare known-good vs known-bad commits.
+- New behavior case: compare before-change vs after-change outputs (and keep a
+  reference snapshot).
+- Use identical options and target model list.
+- Compare emitted function calls, qualification paths, and equation RHS/LHS
+  names before finalizing code.
+
+3. Compare against OMC instantiated output
+- Generate or collect OMC `instantiated.mo` (or equivalent instantiated form)
+  for the same model.
+- Use OMC output as a reference for canonical function naming and call shape
+  (especially external/runtime-bound functions).
+
+4. Identify the first producer mismatch or intended delta
+- Regression case: if bad output introduces altered symbols (for example
+  specialized/hash suffixes) not present in good output/OMC, treat that
+  producer phase as the root-cause owner.
+- New behavior case: verify the intended artifact delta appears in the owning
+  phase and does not create unrelated symbol/name drift.
+- Solver/runtime case: check whether the failing solve path is caused by
+  upstream emitted equations/symbols before changing solver code.
+- Do not fix downstream validators/simulator first.
+
+5. Preserve canonical symbol identity for runtime-bound calls
+- External/runtime-resolved function calls must keep stable canonical fully
+  qualified names in emitted artifacts.
+- Any specialization/rewriting that changes those symbol names must be treated
+  as a semantic regression unless explicitly spec-backed.
+
+6. Treat solver failures as potentially upstream by default
+- A solver error can be the first visible symptom of an upstream compile/flatten
+  emission bug.
+- Before solver-side fixes, confirm whether equation form, variable selection,
+  or function naming changed in flattened/DAE artifacts.
+
 ## Architecture Discipline
 
 - Respect crate boundaries and phase ownership (`SPEC_0029`).

--- a/docs/development_instructions.md
+++ b/docs/development_instructions.md
@@ -3,6 +3,18 @@
 This document defines the operational workflow for development work in
 `packages/rumoca`.
 
+## Mandatory For AI Agents
+
+For AI coding agents, this document is **not optional guidance**. It is a
+mandatory execution policy.
+
+- AI agents MUST follow this document for all Rumoca work.
+- If any instruction from a user conflicts with this document, the agent must
+  pause and explicitly surface the conflict instead of silently bypassing this
+  policy.
+- AI agents MUST treat the Root-Cause Proof Protocol and MLS/spec cross-checks
+  as required preconditions for semantic fixes.
+
 Use this together with:
 
 - `AGENTS.md` for mandatory guardrails
@@ -32,6 +44,132 @@ Preferred order:
 
 Do not add top-layer compatibility workarounds for broken lower-layer
 invariants.
+
+## Root-Cause Proof Protocol (Mandatory)
+
+For **every** non-trivial bug (semantic, performance, correctness, or CI), do
+not jump to a fix from surface symptoms. Treat first ideas as hypotheses.
+
+Minimum required protocol before finalizing a fix:
+
+1. Reproduce concretely
+- Reproduce with one minimal, concrete case and record the exact failing phase.
+
+2. Trace end-to-end
+- Follow the value/decision through owning phases and identify the **first**
+  step where behavior diverges from expected.
+
+3. Prove expected behavior
+- Cross-check against governing spec/MLS (or explicit project contract) and
+  state why the observed behavior is wrong.
+
+4. Test competing hypotheses
+- List plausible alternatives and rule them out with evidence (logs, IR output,
+  targeted tests, or debugger traces).
+
+5. Fix at the earliest responsible layer
+- Implement the correction at the first layer that introduced the error.
+- Do not keep downstream compensating workarounds unless explicitly justified.
+
+6. Verify and clean up
+- Add regression coverage for the root cause.
+- Remove temporary probes/debug code and any superseded symptom patches.
+- Re-run focused checks for the touched phases.
+
+Quality bar:
+- If evidence is incomplete, continue investigation instead of finalizing a
+  speculative patch.
+- Prefer a slower, proven root-cause fix over a fast symptom fix.
+
+## Enforcement Gates (Mandatory, Blocking)
+
+For any non-trivial semantic/compiler change, AI agents MUST complete all gates
+below before finalizing code changes. If any gate is missing, stop and continue
+investigation; do not patch.
+
+Gate 1: Normative rule anchor
+- Cite the exact MLS and Rumoca spec section(s) that govern the behavior.
+- If no governing rule is found, do not implement semantic changes yet.
+
+Gate 2: First divergence proof
+- Identify the first phase and transformation where actual behavior diverges
+  from expected behavior.
+- Include concrete evidence (IR snapshot, trace, debugger step, or targeted
+  phase output).
+
+Gate 3: Competing hypotheses elimination
+- Provide at least two plausible hypotheses.
+- Reject non-root hypotheses with concrete evidence.
+
+Gate 4: Namespace/symbol identity proof
+- Do not merge or substitute symbol spellings (including case variants,
+  alias-vs-instance names, suffix matches) unless semantic identity is proven
+  by compiler-owned data (scope resolution, alias map, symbol table, or
+  declaration provenance).
+- String similarity is never sufficient proof.
+
+Gate 5: Earliest-owner fix
+- Implement the fix in the earliest phase that introduced the divergence.
+- If a later-phase fix is used, explicitly justify why earlier-phase ownership
+  is infeasible.
+
+Gate 6: Regression + negative control
+- Add a positive regression test for the fixed root cause.
+- Add a negative/ambiguity test proving disallowed behavior is still rejected.
+
+Gate 7: Cleanup and strictness
+- Remove temporary debug instrumentation before finalization.
+- Do not weaken validators/checkers to make failing models pass.
+
+## Required Evidence Block In Agent Updates
+
+For non-trivial fixes, agent progress/final updates MUST include this exact
+evidence block format:
+
+1. Governing rule(s):
+- MLS: ...
+- Rumoca spec: ...
+
+2. First divergence:
+- Phase:
+- Artifact/proof:
+
+3. Rejected hypotheses:
+- H1 ... (rejected because ...)
+- H2 ... (rejected because ...)
+
+4. Fix ownership:
+- Earliest owning phase:
+- Why this layer:
+
+5. Verification:
+- Positive regression:
+- Negative/ambiguity regression:
+- Focused runtime/compile check:
+
+## Symbol Identity & Namespace Discipline (Mandatory)
+
+Do not treat two names as equivalent because they "look related" (for example,
+case-only differences, alias-vs-instance spellings, or shared suffixes).
+
+Required rules:
+
+1. Prove identity from compiler semantics, not string similarity
+- Accept equivalence only when it is established by symbol tables, alias maps,
+  lexical scope resolution, or explicit declaration/flattening provenance.
+
+2. Preserve namespace intent
+- Keep package/type aliases and instance/component namespaces distinct unless
+  MLS/spec and compiler ownership explicitly unify them.
+
+3. If mixed spellings appear, fix the first producer
+- Trace where each spelling is introduced and correct the earliest phase that
+  creates inconsistent qualification.
+- Avoid downstream permissive fallback that silently merges unrelated symbols.
+
+4. Add invariant checks/regressions
+- Add focused tests that fail if namespace/casing inconsistencies reappear.
+- Include at least one negative test proving ambiguous names are not merged.
 
 ## MSL-Backed Development Expectations
 
@@ -68,6 +206,10 @@ Before proposing a semantic fix, provide all of the following:
 - `Rumoca bug`: fix upstream in compiler phases first
 - `Non-standard pattern`: keep strict default; if needed, add explicit opt-in
   compatibility behavior with documentation
+
+Additional mandatory triage note:
+- Include a short `Rejected hypotheses` section for every non-trivial bug,
+  listing plausible explanations you ruled out and the evidence used.
 
 ## Compatibility Policy
 


### PR DESCRIPTION
# Fix function-typed parameters, qualified reference resolution, and compile-time specialization

## Summary

This PR improves Rumoca's handling of several Modelica patterns that previously caused valid MSL models to fail during flattening or ToDae validation, especially around function-typed parameters, redeclared partial functions, scoped defaults, alias/constant propagation, and qualified reference lookup.

User-facing behavior changes:

- Fewer compile-time `unresolved reference` / `unresolved function call` failures for MSL models.
- Function-typed parameters in Modelica functions are handled correctly, including defaults, so valid callback-style patterns compile.
- Partial function redeclare calls are resolved more reliably when a partial stub and concrete executable implementation share the same short name.
- Qualified namespace/package constants such as `Modelica.Constants.inf` are no longer misclassified as missing variables.
- MultiBody-style instance-qualified function calls, for example `world.gravityAcceleration(...)`, preserve their trailing member path instead of collapsing to the owning component.
- Better compile stability from more complete alias/constant propagation and convergence before later phases run.
- Faster compile path for statically-known function parameters via flatten-time specialization.
- Lower ToDae compile-time overhead in runtime precompute by avoiding scalar fixed-point churn and caching clock alias inference.

The practical result is improved MSL compile coverage, especially in `Modelica.Electrical.Spice3`, `Modelica.Fluid`, `Modelica.Media`, `Modelica.Magnetic.*`, and selected `Modelica.Mechanics.MultiBody` examples.

## Commit Range / Logical Commit Summary

Included range starts at:

- `3f0a2dc8d6aafa5f0183f1903c34b1507969f7f4`

GitHub currently exposes this work as a combined commit containing multiple logical commit messages. The relevant logical changes are:

### 1. Improve compile rate for more models

- Fixed function-call lowering in `crates/rumoca-phase-flatten/src/ast_lower.rs` so call targets with a `def_id` plus trailing member segments keep the suffix.
- Concrete fix: `world.gravityAcceleration(...)` no longer collapses to `...Body.world`.
- Added a guarded rule so fully-qualified names such as `Modelica.Mechanics.MultiBody.Frames.nullRotation(...)` are not duplicated.
- Fixed function-call validation in `crates/rumoca-phase-dae/src/variable_analysis.rs`:
  - exact lookup remains first,
  - unique-suffix fallback handles instance-qualified names,
  - reachable calls are recorded using resolved canonical function names.
- Fixed reference validation in `crates/rumoca-phase-dae/src/reference_validation.rs` so namespace-style qualified prefixes are accepted in field access and variable-reference validation.
- Verified focused MultiBody `Parts.Body` examples; the commit message reports a `TOTAL:14 FAIL:0` sweep for those examples.

### 2. Resolve partial function redeclare calls and optimize algorithm-lowering rewrites

- Propagated partial function metadata from flattening into flat IR via `Function.partial`.
- Kept unresolved member-style calls strict while improving qualified suffix lookup for redeclared function targets.
- Made function-call validation prefer a unique executable implementation when a partial stub and concrete redeclare share a short name, notably `setState_pTX`.
- Optimized algorithm lowering by reusing rewrite context, caching known-target subtree checks, and simplifying boolean guard construction.
- Refreshed loop rewrite context after discovered loop targets to avoid stale target-prefix caches.
- Added ToDae regressions for:
  - partial stub + concrete override resolution,
  - unique executable suffix match,
  - preserving failure for unresolved member-style function calls.
- Added compile-only MSL harness support and focused compile cache-mode coverage in balance pipeline tests.

### 3. Eliminate scalar fixed-point churn and cache clock alias inference

- Fixed a compile-time blow-up seen for `Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6`.
- In `runtime_precompute/mod.rs`:
  - stopped base-alias writes for indexed names during compile-time scalar propagation,
  - excluded runtime-driven inputs from compile-time scalar sources,
  - added `RUMOCA_TODAE_PROFILE` timing/stat output for `compile_time_scalars`.
- In `runtime_precompute/clock.rs`:
  - added memoization caches for scalar and timing inference across alias chains.
- Observed rig impact from the commit message:
  - `EngineV6` improved from roughly `12.9s` to `6.9s`,
  - ToDae dropped from roughly `6.5s` to `0.36s`.

### 4. Fix unresolved Modelica names and specialize static function-parameter calls

- Fixed function-parameter calls so valid Modelica patterns like `f(x)` inside functions are accepted.
- Fixed defaults in function arguments so names like `reference_X` resolve to the correct package/member rather than later failing as unresolved references.
- Fixed inconsistent qualified names, for example `Medium` vs `medium`, caused by flatten/injection propagation.
- Fixed propagation convergence so constant/alias updates are fully applied before continuing.
- Fixed scope loss during array/record expansion that could generate wrong variable paths.
- Added flatten-time specialization for statically-known function parameters, both explicit and default, so calls are rewritten to concrete functions earlier.
- Added regression tests for the above failure modes.
- Updated development instructions to require root-cause proof and MLS/spec cross-check before semantic fixes.

### 5. Formatting / lint / development-policy follow-up

- Ran formatting/split-file cleanup.
- Restored lint compatibility.
- Added or expanded development instructions documenting:
  - MLS + spec-first semantic changes,
  - upstream-first fix policy,
  - MSL-backed validation expectations,
  - explicit compatibility-policy requirements,
  - required verification workflow.

## Code Size Budget

- `production_lines_added`: 2070
- `production_lines_deleted`: 63
- `test_lines_added`: 167
- `test_lines_deleted`: 0
- `public_items_added`: 0
- `public_items_removed`: 0
- `files_touched`: 13
- `net_added_lines`: 2316

Because `net_added_lines` is positive:

- Why this net growth is required:
  - This change set adds missing semantic handling for function-typed parameters, scoped default resolution, specialization, partial-function redeclare resolution, improved qualified-name validation, alias/constant propagation convergence, runtime precompute stabilization, and regression coverage across flatten and ToDae. Most growth is implementation plus root-cause regression tests.
- Which code was removed/merged as part of the first compression pass:
  - Existing ad-hoc behavior was merged into shared specialization/rewrite paths; old failing behavior was removed rather than kept in parallel. Cleanup/rewrite work was performed in validation/progression code paths instead of adding separate fallback branches.
- Follow-up cleanup ticket/commit for remaining growth:
  - Planned follow-up: split large helper blocks in `postprocess.rs` / `functions.rs` / ToDae validation into smaller modules and remove any now-redundant rewrite utilities after a broader MSL rerun confirms no regressions.

## Design Notes

### Why each new abstraction was necessary

- `specialize_static_function_params` centralizes one behavior: replace statically-bound function parameters with concrete callees during flatten, instead of repeating similar logic in later phases.
- Shared expression/statement/when walkers were needed to apply the same fix consistently across equations, bindings, algorithms, when-equations, and function bodies.
- Function-call validation needed explicit function-scope awareness so dynamic function-typed parameters are accepted without accidentally treating them as globally-resolvable concrete functions.
- Runtime precompute needed separate handling for true compile-time scalars versus runtime-driven inputs; otherwise indexed aliases could keep the fixed-point loop alive unnecessarily.
- Clock scalar/timing inference needed memoization because alias chains can otherwise re-trigger the same recursive lookup many times.

### Why this was not solved by editing one existing module directly

Existing modules each owned only part of the behavior:

- flattening sees call-site argument/default context,
- postprocess owns substitution and expression/statement rewriting,
- ToDae validation owns executable-function reachability and strict unresolved-call diagnostics,
- runtime precompute owns compile-time scalar extraction and clock/timing inference.

The bug class crosses these phase boundaries. A local patch in only one phase would either miss valid call sites or add a late compatibility workaround instead of preserving the correct IR invariants earlier.

### What duplicate/legacy paths were deleted or avoided

- Redundant symptom-level handling was avoided.
- Fixes were moved to earlier owning phases: flatten, alias/constant propagation, and ToDae validation.
- Later phases do not get new broad compatibility paths for names that should have been normalized earlier.
- The compile-time scalar pass no longer treats runtime inputs as static constants and no longer writes indexed scalar values back into their base array name.

## MSL / Regression Impact

The provided comparison data shows:

- 26 models with improved compile-success status.
- 1 compile-success regression:
  - `Modelica.Electrical.Analog.Examples.Lines.LightningSegmentedTransmissionLine`
- 100+ models with compile-time improvements in the comparison set.
- The largest named ToDae/runtime-precompute improvement from the commit message is `Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6`, improving from roughly `12.9s` to `6.9s`, with ToDae dropping from roughly `6.5s` to `0.36s`.

Notable compile-success improvements include:

- `Modelica.Electrical.Spice3.Examples.FourInverters`
- `Modelica.Electrical.Spice3.Examples.Inverter`
- `Modelica.Electrical.Spice3.Examples.InvertersApartRecord`
- `Modelica.Electrical.Spice3.Examples.InvertersExtendedModel`
- `Modelica.Electrical.Spice3.Examples.Nand`
- `Modelica.Electrical.Spice3.Examples.Nor`
- `Modelica.Fluid.Examples.AST_BatchPlant.Test.OneTank`
- `Modelica.Fluid.Examples.Tanks.EmptyTanks`
- `Modelica.Fluid.Examples.Tanks.ThreeTanks`
- `Modelica.Media.Examples.R134a.R134a1`
- `Modelica.Media.Examples.R134a.R134a2`
- `Modelica.Media.Examples.SolveOneNonlinearEquation.Inverse_sine`
- Multiple `Modelica.Magnetic.*` synchronous machine and moving-coil actuator examples.

Category-level compile improvements from the provided data include:

- `Modelica.Fluid`: baseline `1/23` compiled -> candidate `4/23` compiled (`+3`, +13.04 percentage points).
- `Modelica.Media`: baseline `6/23` compiled -> candidate `9/23` compiled (`+3`, +13.04 percentage points).

## Files / Areas Touched

Core compiler areas:

- `crates/rumoca-phase-flatten/src/functions.rs`
- `crates/rumoca-phase-flatten/src/postprocess.rs`
- `crates/rumoca-phase-flatten/src/pipeline/component_alias_injection.rs`
- `crates/rumoca-phase-flatten/src/pipeline/constant_injection.rs`
- `crates/rumoca-phase-instantiate/src/array_expansion.rs`
- `crates/rumoca-phase-instantiate/src/mod_env.rs`
- `crates/rumoca-phase-dae/src/variable_analysis.rs`
- `crates/rumoca-phase-dae/src/reference_validation.rs`
- `crates/rumoca-phase-dae/src/runtime_precompute/mod.rs`
- `crates/rumoca-phase-dae/src/runtime_precompute/clock.rs`

Regression tests / coverage:

- `crates/rumoca-phase-flatten/src/functions_tests.rs`
- `crates/rumoca-phase-flatten/src/postprocess_tests.rs`
- `crates/rumoca-phase-dae/src/tests/tests_function_param_calls.rs`
- `crates/rumoca/tests/mod_propagation_test.rs`

Development process docs:

- `docs/development_instructions.md`
- `AGENTS.md`
- `docs/philosophy.md`

## Testing

Key commands run / referenced for this change set:

```bash
cargo test -q -p rumoca-phase-flatten specialize_static_function_param
cargo test -q -p rumoca-phase-flatten
RUMOCA_MSL_SIM_TARGETS_FILE=/tmp/msl_targets_check.json \
  RUMOCA_MSL_SIM_SET=full \
  RUMOCA_MSL_SLOW_COMPILE_LOG_SECS=1 \
  cargo test --release -q -p rumoca-test-msl --test msl_tests \
  balance_pipeline::balance_pipeline_core::test_msl_all -- --ignored --nocapture
```

Files changed covered by tests:

- `crates/rumoca-phase-flatten/src/functions.rs` via new specialization regressions.
- `crates/rumoca-phase-flatten/src/postprocess.rs` via function-param/default/scoped rewrite regressions.
- `crates/rumoca-phase-dae/src/tests.rs` and `tests/tests_function_param_calls.rs` via function-typed parameter validation.
- `crates/rumoca/tests/mod_propagation_test.rs` via alias/constant propagation regressions.
- Targeted MSL compile-only subset exercising Fluid, Media, Electrical, Magnetic, and MultiBody regressions.

## Reviewer Notes / Known Risk

The only explicit compile-success regression in the provided comparison data is:

- `Modelica.Electrical.Analog.Examples.Lines.LightningSegmentedTransmissionLine`

That should be checked before merge or tracked as a follow-up if the regression is caused by stricter validation rather than a newly introduced compiler bug.

Compile-time regressions are present for some small/medium examples, notably several `Modelica.Electrical.Digital.*` and battery examples. The tradeoff still appears favorable because the change removes important semantic blockers and improves a large number of compile paths, but the worst compile-time regressions should be watched in the next MSL baseline run.

## Reviewer Checklist

- [x] Size budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths were removed unless explicitly migrating.
- [x] Semantic changes are tied to upstream compiler phases rather than late compatibility fallbacks.
- [x] Regression data includes both improvements and known regressions.
