### PR TITLE
Improve MSL function and when lowering parity

### DIFF
--- a/crates/rumoca-ir-ast/src/instance.rs
+++ b/crates/rumoca-ir-ast/src/instance.rs
@@ -517,6 +517,8 @@ pub struct ClassOverride {
     pub target_def_id: DefId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_ref: Option<ComponentReference>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modifier_args: Vec<Expression>,
 }
 
 pub type ClassOverrideMap = FastIndexMap<DefId, ClassOverride>;
@@ -533,7 +535,13 @@ impl ClassOverride {
             alias_def_id,
             target_def_id,
             target_ref,
+            modifier_args: Vec::new(),
         }
+    }
+
+    pub fn with_modifier_args(mut self, modifier_args: Vec<Expression>) -> Self {
+        self.modifier_args = modifier_args;
+        self
     }
 }
 

--- a/crates/rumoca-phase-dae/src/algorithm_lowering.rs
+++ b/crates/rumoca-phase-dae/src/algorithm_lowering.rs
@@ -651,6 +651,7 @@ fn lookup_algorithm_target_scalar_count(
     dae: &Dae,
     target: &VarName,
     span: Span,
+    allow_parameter_target: bool,
 ) -> Result<usize, String> {
     let target_key = flat_to_dae_var_name(target);
     if let Some(var) = dae
@@ -666,6 +667,10 @@ fn lookup_algorithm_target_scalar_count(
         return Ok(var.size().max(1));
     }
 
+    if allow_parameter_target && let Some(var) = dae.variables.parameters.get(&target_key) {
+        return Ok(var.size().max(1));
+    }
+
     for candidate in subscript_fallback_chain(target.as_str()) {
         let candidate_key = flat_to_dae_var_name(&candidate);
         if dae.variables.states.contains_key(&candidate_key)
@@ -674,6 +679,7 @@ fn lookup_algorithm_target_scalar_count(
             || dae.variables.inputs.contains_key(&candidate_key)
             || dae.variables.discrete_reals.contains_key(&candidate_key)
             || dae.variables.discrete_valued.contains_key(&candidate_key)
+            || (allow_parameter_target && dae.variables.parameters.contains_key(&candidate_key))
         {
             return Ok(1);
         }
@@ -1447,6 +1453,7 @@ fn lower_when_target_branches_to_event_equations(
     targets: WhenAssignmentBranches,
     algorithm_span: Span,
     algorithm_origin: &str,
+    allow_parameter_targets: bool,
 ) -> Result<Vec<rumoca_ir_dae::Equation>, String> {
     let mut lowered = Vec::with_capacity(targets.len());
     for (target, assignment) in targets {
@@ -1464,7 +1471,7 @@ fn lower_when_target_branches_to_event_equations(
             }),
             span,
             format!("algorithm when-assignment ({algorithm_origin})"),
-            lookup_algorithm_target_scalar_count(dae, &target, span)?,
+            lookup_algorithm_target_scalar_count(dae, &target, span, allow_parameter_targets)?,
         );
         lowered.push(eq);
     }
@@ -1476,6 +1483,7 @@ fn lower_algorithm_to_equations(
     dae: &Dae,
     flat: &Model,
     algorithm: &rumoca_ir_flat::Algorithm,
+    allow_parameter_targets: bool,
 ) -> Result<LoweredAlgorithmPartitions, String> {
     if algorithm.statements.is_empty() {
         return Ok(LoweredAlgorithmPartitions::default());
@@ -1505,6 +1513,7 @@ fn lower_algorithm_to_equations(
         when_assignments,
         algorithm.span,
         &algorithm.origin,
+        allow_parameter_targets,
     )? {
         route_lowered_when_equation(dae, &mut lowered, eq);
     }
@@ -1529,11 +1538,14 @@ fn lower_algorithm_to_equations(
         route_lowered_main_algorithm_assignment(
             dae,
             &mut lowered,
-            target,
-            value,
-            span,
-            origin,
+            LoweredMainAlgorithmAssignment {
+                target,
+                value,
+                span,
+                origin,
+            },
             &algorithm.origin,
+            allow_parameter_targets,
         )?;
     }
 
@@ -1556,15 +1568,26 @@ fn route_lowered_when_equation(
     }
 }
 
-fn route_lowered_main_algorithm_assignment(
-    dae: &Dae,
-    lowered: &mut LoweredAlgorithmPartitions,
+struct LoweredMainAlgorithmAssignment {
     target: VarName,
     value: Expression,
     span: Span,
     origin: String,
+}
+
+fn route_lowered_main_algorithm_assignment(
+    dae: &Dae,
+    lowered: &mut LoweredAlgorithmPartitions,
+    assignment: LoweredMainAlgorithmAssignment,
     algorithm_origin: &str,
+    allow_parameter_target: bool,
 ) -> Result<(), String> {
+    let LoweredMainAlgorithmAssignment {
+        target,
+        value,
+        span,
+        origin,
+    } = assignment;
     if let Some(bucket) = discrete_variable_equation_bucket_for_lhs(dae, &target) {
         // MLS §11.1 algorithm assignments are equation-like model behavior.
         // MLS Appendix B stores discrete Real and discrete-valued variables in
@@ -1574,13 +1597,35 @@ fn route_lowered_main_algorithm_assignment(
             flat_to_dae_expression(&value),
             span,
             format!("{} ({})", origin, algorithm_origin),
-            lookup_algorithm_target_scalar_count(dae, &target, span)?,
+            lookup_algorithm_target_scalar_count(dae, &target, span, allow_parameter_target)?,
         );
         match bucket {
             DiscreteEquationBucket::DiscreteValued => lowered.f_m.push(eq),
             DiscreteEquationBucket::DiscreteReal => lowered.f_z.push(eq),
         }
         return Ok(());
+    }
+
+    if allow_parameter_target {
+        let target_key = flat_to_dae_var_name(&target);
+        if let Some(var) = dae.variables.parameters.get(&target_key) {
+            if var.fixed != Some(false) {
+                return Err(format!(
+                    "initial algorithm assignment target `{target}` is a fixed parameter; only parameter fixed=false may be solved during initialization at {:?}",
+                    rumoca_core::span_to_source_span(span)
+                ));
+            }
+            lowered
+                .main
+                .push(rumoca_ir_dae::Equation::explicit_with_scalar_count(
+                    target_key,
+                    flat_to_dae_expression(&value),
+                    span,
+                    format!("{} ({})", origin, algorithm_origin),
+                    lookup_algorithm_target_scalar_count(dae, &target, span, true)?,
+                ));
+            return Ok(());
+        }
     }
 
     let lhs = Expression::VarRef {
@@ -1599,14 +1644,14 @@ fn route_lowered_main_algorithm_assignment(
         flat_to_dae_expression(&residual),
         span,
         format!("{} ({})", origin, algorithm_origin),
-        lookup_algorithm_target_scalar_count(dae, &target, span)?,
+        lookup_algorithm_target_scalar_count(dae, &target, span, allow_parameter_target)?,
     ));
     Ok(())
 }
 
 pub(super) fn lower_algorithms_to_equations(dae: &mut Dae, flat: &Model) -> Result<(), ToDaeError> {
     for algorithm in &flat.algorithms {
-        match lower_algorithm_to_equations(dae, flat, algorithm) {
+        match lower_algorithm_to_equations(dae, flat, algorithm, false) {
             Ok(lowered) => {
                 dae.continuous.equations.extend(lowered.main);
                 dae.discrete.real_updates.extend(lowered.f_z);
@@ -1623,7 +1668,7 @@ pub(super) fn lower_algorithms_to_equations(dae: &mut Dae, flat: &Model) -> Resu
     }
 
     for algorithm in &flat.initial_algorithms {
-        match lower_algorithm_to_equations(dae, flat, algorithm) {
+        match lower_algorithm_to_equations(dae, flat, algorithm, true) {
             Ok(lowered) => {
                 dae.initialization.equations.extend(lowered.main);
                 // MLS §8.6 and §11.1: initial algorithms contribute equations

--- a/crates/rumoca-phase-dae/src/algorithm_lowering/tests.rs
+++ b/crates/rumoca-phase-dae/src/algorithm_lowering/tests.rs
@@ -76,7 +76,8 @@ fn lower_algorithm_uses_statement_span_for_main_assignment_equations() {
         "algorithm",
     );
 
-    let lowered = lower_algorithm_to_equations(&dae, &flat, &algorithm).expect("lower algorithm");
+    let lowered =
+        lower_algorithm_to_equations(&dae, &flat, &algorithm, false).expect("lower algorithm");
 
     assert_eq!(lowered.main.len(), 1);
     assert_eq!(lowered.main[0].span, statement_span);
@@ -125,7 +126,8 @@ fn lower_algorithm_uses_statement_span_for_when_assignment_equations() {
         "algorithm",
     );
 
-    let lowered = lower_algorithm_to_equations(&dae, &flat, &algorithm).expect("lower algorithm");
+    let lowered =
+        lower_algorithm_to_equations(&dae, &flat, &algorithm, false).expect("lower algorithm");
 
     assert_eq!(lowered.f_m.len(), 1);
     assert_eq!(lowered.f_m[0].span, statement_span);
@@ -151,7 +153,7 @@ fn lower_algorithm_rejects_reinit_outside_when_statement() {
         "algorithm",
     );
 
-    let err = match lower_algorithm_to_equations(&dae, &flat, &algorithm) {
+    let err = match lower_algorithm_to_equations(&dae, &flat, &algorithm, false) {
         Ok(_) => panic!("bare reinit() must be rejected"),
         Err(err) => err,
     };

--- a/crates/rumoca-phase-dae/src/binding_conversion.rs
+++ b/crates/rumoca-phase-dae/src/binding_conversion.rs
@@ -633,9 +633,10 @@ fn select_scalar_binding_record_field_alias(
     let selected = rumoca_core::ComponentPath::from_reference(rhs_name)
         .join(&rumoca_core::ComponentPath::from_flat_path(field_name))
         .to_flat_string();
-    if !known_var_names.contains(selected.as_str()) {
+    let Some(selected) = crate::path_utils::resolve_known_path_suffix(&selected, known_var_names)
+    else {
         return binding.clone();
-    }
+    };
 
     Expression::VarRef {
         name: VarName::new(selected).into(),
@@ -822,6 +823,30 @@ mod tests {
                 "{:?}",
                 Expression::VarRef {
                     name: VarName::new("data.frictionParameters.wRef").into(),
+                    subscripts: vec![],
+                    span: rumoca_core::Span::DUMMY,
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_select_scalar_binding_record_field_alias_resolves_misqualified_prefix() {
+        let known_var_names = HashSet::from(["aimcData.statorCoreParameters.wRef".to_string()]);
+        let lhs = VarName::new("aimc.statorCoreParameters.wRef");
+        let binding = Expression::VarRef {
+            name: VarName::new("aimc.aimcData.statorCoreParameters").into(),
+            subscripts: vec![],
+            span: rumoca_core::Span::DUMMY,
+        };
+
+        let selected = select_scalar_binding_record_field_alias(&lhs, &binding, &known_var_names);
+        assert_eq!(
+            format!("{selected:?}"),
+            format!(
+                "{:?}",
+                Expression::VarRef {
+                    name: VarName::new("aimcData.statorCoreParameters.wRef").into(),
                     subscripts: vec![],
                     span: rumoca_core::Span::DUMMY,
                 }

--- a/crates/rumoca-phase-dae/src/path_utils.rs
+++ b/crates/rumoca-phase-dae/src/path_utils.rs
@@ -5,6 +5,22 @@ pub(crate) use rumoca_core::{
     subscript_fallback_chain,
 };
 
+use std::collections::HashSet;
+
+pub(crate) fn resolve_known_path_suffix(
+    name: &str,
+    known_names: &HashSet<String>,
+) -> Option<String> {
+    if known_names.contains(name) {
+        return Some(name.to_string());
+    }
+
+    let path = rumoca_core::ComponentPath::from_flat_path(name);
+    path.suffixes_excluding_self()
+        .map(|suffix| suffix.to_flat_string())
+        .find(|candidate| known_names.contains(candidate))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,5 +107,18 @@ mod tests {
         assert_eq!(strip_all_subscripts("pc[((2*1)-1)].i"), "pc.i");
         assert_eq!(strip_all_subscripts("pin_n[1].v"), "pin_n.v");
         assert_eq!(strip_all_subscripts("R[1].w"), "R.w");
+    }
+
+    #[test]
+    fn test_resolve_known_path_suffix_prefers_nearest_known_suffix() {
+        let known = HashSet::from([
+            "aimcData.statorCoreParameters.wRef".to_string(),
+            "statorCoreParameters.wRef".to_string(),
+        ]);
+
+        assert_eq!(
+            resolve_known_path_suffix("aimc.aimcData.statorCoreParameters.wRef", &known).as_deref(),
+            Some("aimcData.statorCoreParameters.wRef")
+        );
     }
 }

--- a/crates/rumoca-phase-dae/src/pre_lowering.rs
+++ b/crates/rumoca-phase-dae/src/pre_lowering.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use rumoca_core::{ExpressionRewriter, ExpressionVisitor};
 use rumoca_ir_dae::{self as dae, DaeVisitor};
 
-use crate::ToDaeError;
+use crate::{ToDaeError, reference_validation::build_enum_literal_query_set};
 
 /// Lower every `pre()` call in any DAE equation partition to a parameter
 /// reference. SPEC_0007 Stage 3 Contract: no `pre()` survives into f_x, f_z,
@@ -42,6 +42,7 @@ pub(crate) fn lower_pre_operator(dae: &mut dae::Dae) -> Result<(), ToDaeError> {
     collect_pre_targets_from_event_actions(&dae.events.event_actions, &mut pre_targets);
     collect_pre_targets_from_equations(&dae.initialization.equations, &mut pre_targets, true);
 
+    discard_enum_literal_pre_targets(dae, &mut pre_targets);
     resolve_pre_targets(dae, &mut pre_targets)?;
     let mut pre_params: IndexMap<rumoca_core::VarName, dae::Variable> = IndexMap::new();
 
@@ -337,6 +338,14 @@ fn insert_pre_target(
             require_discrete,
             allow_continuous_target,
         });
+}
+
+fn discard_enum_literal_pre_targets(
+    dae: &dae::Dae,
+    targets: &mut IndexMap<rumoca_core::VarName, PreTarget>,
+) {
+    let enum_literals = build_enum_literal_query_set(&dae.symbols.enum_literal_ordinals);
+    targets.retain(|name, _| !enum_literals.contains(name.as_str()));
 }
 
 fn resolve_pre_targets(

--- a/crates/rumoca-phase-dae/src/pre_lowering/tests.rs
+++ b/crates/rumoca-phase-dae/src/pre_lowering/tests.rs
@@ -567,6 +567,66 @@ fn test_lower_pre_rejects_missing_target_variable() -> Result<(), ToDaeError> {
 }
 
 #[test]
+fn test_lower_pre_ignores_enum_literals_in_edge_relations() -> Result<(), ToDaeError> {
+    let mut dae = dae::Dae::new();
+    dae.variables.discrete_valued.insert(
+        rumoca_core::VarName::new("logic"),
+        discrete_valued_var("logic"),
+    );
+    dae.symbols.enum_literal_ordinals.insert(
+        "Modelica.Electrical.Digital.Interfaces.Logic.'1'".to_string(),
+        4,
+    );
+
+    let relation = rumoca_core::Expression::Binary {
+        op: rumoca_core::OpBinary::Eq,
+        lhs: Box::new(var_ref("logic")),
+        rhs: Box::new(var_ref("Modelica.Electrical.Digital.Interfaces.Logic.'1'")),
+        span: rumoca_core::Span::DUMMY,
+    };
+    dae.continuous.equations.push(dae::Equation::residual(
+        rumoca_core::Expression::BuiltinCall {
+            function: rumoca_core::BuiltinFunction::Edge,
+            args: vec![relation],
+            span: rumoca_core::Span::DUMMY,
+        },
+        rumoca_core::Span::default(),
+        "test".to_string(),
+    ));
+
+    lower_pre_operator(&mut dae)?;
+
+    assert!(
+        dae.variables
+            .parameters
+            .contains_key(&rumoca_core::VarName::new("__pre__.logic")),
+        "discrete variable should still get a pre parameter"
+    );
+    assert!(
+        !dae.variables
+            .parameters
+            .contains_key(&rumoca_core::VarName::new(
+                "__pre__.Modelica.Electrical.Digital.Interfaces.Logic.'1'"
+            )),
+        "enum literal must not get a pre parameter"
+    );
+    let rhs = format!("{:?}", dae.continuous.equations[0].rhs);
+    assert!(
+        !rhs.contains("BuiltinFunction::Pre"),
+        "pre operator should be fully lowered: {rhs}"
+    );
+    assert!(
+        rhs.contains("__pre__.logic"),
+        "missing pre logic ref: {rhs}"
+    );
+    assert!(
+        rhs.contains("Modelica.Electrical.Digital.Interfaces.Logic.'1'"),
+        "enum literal should remain as a symbol: {rhs}"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_lower_pre_rejects_continuous_state_target() {
     let mut dae = dae::Dae::new();
     dae.variables

--- a/crates/rumoca-phase-dae/src/reference_validation.rs
+++ b/crates/rumoca-phase-dae/src/reference_validation.rs
@@ -75,7 +75,7 @@ fn build_dae_reference_query_set<'a>(names: impl Iterator<Item = &'a str>) -> Ha
     queries
 }
 
-fn build_enum_literal_query_set(ordinals: &IndexMap<String, i64>) -> HashSet<String> {
+pub(crate) fn build_enum_literal_query_set(ordinals: &IndexMap<String, i64>) -> HashSet<String> {
     let mut queries = HashSet::with_capacity(ordinals.len().saturating_mul(2));
     for literal in ordinals.keys() {
         queries.insert(literal.clone());

--- a/crates/rumoca-phase-dae/src/scalar_inference/inference_and_bindings.rs
+++ b/crates/rumoca-phase-dae/src/scalar_inference/inference_and_bindings.rs
@@ -501,16 +501,10 @@ pub(crate) fn resolve_missing_start_ref(
     name: &VarName,
     known_var_names: &HashSet<String>,
 ) -> VarName {
-    if known_var_names.contains(name.as_str()) {
-        return name.clone();
-    }
-
-    let path = rumoca_core::ComponentPath::from_flat_path(name.as_str());
-    for suffix in path.suffixes_excluding_self() {
-        let candidate = suffix.to_flat_string();
-        if known_var_names.contains(candidate.as_str()) {
-            return VarName::new(candidate);
-        }
+    if let Some(resolved) =
+        crate::path_utils::resolve_known_path_suffix(name.as_str(), known_var_names)
+    {
+        return VarName::new(resolved);
     }
     name.clone()
 }
@@ -597,17 +591,23 @@ fn select_scalar_start_record_alias(
     expr: &Expression,
     known_var_names: &HashSet<String>,
 ) -> Expression {
+    let lhs_path = rumoca_core::ComponentPath::from_flat_path(lhs_name.as_str());
+    let leaf_field = lhs_path.parts().last();
     let Some(lhs_base) = flat::component_base_name(lhs_name.as_str()) else {
-        return expr.clone();
+        return select_leaf_start_record_alias(expr, leaf_field, known_var_names)
+            .unwrap_or_else(|| expr.clone());
     };
     if lhs_base == lhs_name.as_str() {
-        return expr.clone();
+        return select_leaf_start_record_alias(expr, leaf_field, known_var_names)
+            .unwrap_or_else(|| expr.clone());
     }
     let Some(field_suffix) = lhs_name.as_str().strip_prefix(lhs_base.as_str()) else {
-        return expr.clone();
+        return select_leaf_start_record_alias(expr, leaf_field, known_var_names)
+            .unwrap_or_else(|| expr.clone());
     };
     if !field_suffix.starts_with('.') {
-        return expr.clone();
+        return select_leaf_start_record_alias(expr, leaf_field, known_var_names)
+            .unwrap_or_else(|| expr.clone());
     }
 
     match expr {
@@ -617,12 +617,26 @@ fn select_scalar_start_record_alias(
             span,
         } if subscripts.is_empty() => {
             let selected = format!("{}{}", rhs_name.as_str(), field_suffix);
-            if known_var_names.contains(selected.as_str()) {
+            if let Some(selected) =
+                crate::path_utils::resolve_known_path_suffix(&selected, known_var_names)
+            {
                 return Expression::VarRef {
                     name: VarName::new(selected).into(),
                     subscripts: vec![],
                     span: *span,
                 };
+            }
+            if let Some(field) = leaf_field {
+                let selected = format!("{}.{}", rhs_name.as_str(), field);
+                if let Some(selected) =
+                    crate::path_utils::resolve_known_path_suffix(&selected, known_var_names)
+                {
+                    return Expression::VarRef {
+                        name: VarName::new(selected).into(),
+                        subscripts: vec![],
+                        span: *span,
+                    };
+                }
             }
             expr.clone()
         }
@@ -639,16 +653,76 @@ fn select_scalar_start_record_alias(
                 return expr.clone();
             }
             let selected = format!("{}.{}{}", rhs_name.as_str(), field, field_suffix);
-            if known_var_names.contains(selected.as_str()) {
+            if let Some(selected) =
+                crate::path_utils::resolve_known_path_suffix(&selected, known_var_names)
+            {
                 return Expression::VarRef {
                     name: VarName::new(selected).into(),
                     subscripts: vec![],
                     span: *span,
                 };
             }
+            if let Some(lhs_leaf) = leaf_field {
+                let selected = format!("{}.{}.{}", rhs_name.as_str(), field, lhs_leaf);
+                if let Some(selected) =
+                    crate::path_utils::resolve_known_path_suffix(&selected, known_var_names)
+                {
+                    return Expression::VarRef {
+                        name: VarName::new(selected).into(),
+                        subscripts: vec![],
+                        span: *span,
+                    };
+                }
+            }
             expr.clone()
         }
         _ => expr.clone(),
+    }
+}
+
+fn select_leaf_start_record_alias(
+    expr: &Expression,
+    leaf_field: Option<&String>,
+    known_var_names: &HashSet<String>,
+) -> Option<Expression> {
+    let field = leaf_field?;
+    match expr {
+        Expression::VarRef {
+            name: rhs_name,
+            subscripts,
+            span,
+        } if subscripts.is_empty() => {
+            let selected = format!("{}.{}", rhs_name.as_str(), field);
+            crate::path_utils::resolve_known_path_suffix(&selected, known_var_names).map(
+                |selected| Expression::VarRef {
+                    name: VarName::new(selected).into(),
+                    subscripts: vec![],
+                    span: *span,
+                },
+            )
+        }
+        Expression::FieldAccess { base, field, span } => {
+            let Expression::VarRef {
+                name: rhs_name,
+                subscripts,
+                ..
+            } = base.as_ref()
+            else {
+                return None;
+            };
+            if !subscripts.is_empty() {
+                return None;
+            }
+            let selected = format!("{}.{}", rhs_name.as_str(), field);
+            crate::path_utils::resolve_known_path_suffix(&selected, known_var_names).map(
+                |selected| Expression::VarRef {
+                    name: VarName::new(selected).into(),
+                    subscripts: vec![],
+                    span: *span,
+                },
+            )
+        }
+        _ => None,
     }
 }
 

--- a/crates/rumoca-phase-dae/src/tests/algorithm_lowering.rs
+++ b/crates/rumoca-phase-dae/src/tests/algorithm_lowering.rs
@@ -149,6 +149,23 @@ fn add_primitive_real(flat: &mut Model, name: &str) {
     );
 }
 
+fn add_fixed_false_parameter(flat: &mut Model, name: &str) {
+    add_parameter_with_fixed(flat, name, Some(false));
+}
+
+fn add_parameter_with_fixed(flat: &mut Model, name: &str, fixed: Option<bool>) {
+    flat.add_variable(
+        VarName::new(name),
+        flat::Variable {
+            name: VarName::new(name),
+            variability: rumoca_core::Variability::Parameter(rumoca_core::Token::default()),
+            fixed,
+            is_primitive: true,
+            ..Default::default()
+        },
+    );
+}
+
 fn add_discrete_valued(flat: &mut Model, name: &str) {
     flat.add_variable(
         VarName::new(name),
@@ -1129,6 +1146,141 @@ fn test_todae_lowers_top_level_algorithm_assignment_before_for_loop_sequentially
     )
     .expect("top-level sequential algorithm state should stay visible inside following for-loop");
     assert_top_level_assignment_before_loop_lowering(&dae);
+}
+
+#[test]
+fn test_todae_lowers_initial_algorithm_assignment_to_fixed_false_parameter() {
+    let mut flat = Model::new();
+    add_fixed_false_parameter(&mut flat, "k");
+
+    flat.initial_algorithms.push(flat::Algorithm::new(
+        vec![rumoca_core::Statement::Assignment {
+            comp: make_comp_ref("k"),
+            value: rumoca_core::Expression::Literal {
+                value: rumoca_core::Literal::Real(2.0),
+                span: rumoca_core::Span::DUMMY,
+            },
+            span: rumoca_core::Span::DUMMY,
+        }],
+        Span::DUMMY,
+        "initial algorithm from SimpleFriction".to_string(),
+    ));
+
+    let dae = to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect("MLS fixed=false parameters may be solved by initial algorithms");
+
+    assert!(
+        dae.initialization
+            .equations
+            .iter()
+            .any(|eq| eq.lhs.as_ref().is_some_and(|lhs| lhs.as_str() == "k")),
+        "missing initialization equation for fixed=false parameter assignment"
+    );
+    assert!(
+        dae.continuous.equations.is_empty(),
+        "initial parameter assignment must not become a runtime continuous equation"
+    );
+}
+
+#[test]
+fn test_todae_rejects_initial_algorithm_assignment_to_default_fixed_parameter() {
+    let mut flat = Model::new();
+    add_parameter_with_fixed(&mut flat, "k", None);
+
+    flat.initial_algorithms.push(flat::Algorithm::new(
+        vec![rumoca_core::Statement::Assignment {
+            comp: make_comp_ref("k"),
+            value: rumoca_core::Expression::Literal {
+                value: rumoca_core::Literal::Real(2.0),
+                span: rumoca_core::Span::DUMMY,
+            },
+            span: rumoca_core::Span::DUMMY,
+        }],
+        Span::DUMMY,
+        "initial fixed parameter assignment".to_string(),
+    ));
+
+    let err = to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect_err("parameter fixed=true by default must not be solved by initial algorithms");
+
+    assert!(
+        err.to_string().contains("fixed parameter"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_todae_rejects_initial_algorithm_assignment_to_explicit_fixed_parameter() {
+    let mut flat = Model::new();
+    add_parameter_with_fixed(&mut flat, "k", Some(true));
+
+    flat.initial_algorithms.push(flat::Algorithm::new(
+        vec![rumoca_core::Statement::Assignment {
+            comp: make_comp_ref("k"),
+            value: rumoca_core::Expression::Literal {
+                value: rumoca_core::Literal::Real(2.0),
+                span: rumoca_core::Span::DUMMY,
+            },
+            span: rumoca_core::Span::DUMMY,
+        }],
+        Span::DUMMY,
+        "initial fixed parameter assignment".to_string(),
+    ));
+
+    let err = to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect_err("parameter fixed=true must not be solved by initial algorithms");
+
+    assert!(
+        err.to_string().contains("fixed parameter"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_todae_rejects_runtime_algorithm_assignment_to_parameter() {
+    let mut flat = Model::new();
+    add_fixed_false_parameter(&mut flat, "k");
+
+    flat.algorithms.push(flat::Algorithm::new(
+        vec![rumoca_core::Statement::Assignment {
+            comp: make_comp_ref("k"),
+            value: rumoca_core::Expression::Literal {
+                value: rumoca_core::Literal::Real(2.0),
+                span: rumoca_core::Span::DUMMY,
+            },
+            span: rumoca_core::Span::DUMMY,
+        }],
+        Span::DUMMY,
+        "runtime parameter assignment".to_string(),
+    ));
+
+    let err = to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect_err("regular algorithm sections must not assign parameters");
+
+    assert!(
+        matches!(err, ToDaeError::UnsupportedAlgorithm { ref section, .. } if section == "model"),
+        "expected unsupported model algorithm diagnostic, got {err:?}"
+    );
 }
 
 #[test]

--- a/crates/rumoca-phase-dae/src/tests/root/input_promotion_indexed.rs
+++ b/crates/rumoca-phase-dae/src/tests/root/input_promotion_indexed.rs
@@ -1,0 +1,198 @@
+use super::*;
+
+#[test]
+fn test_equation_defined_indexed_array_input_promotes_internal_input() {
+    let mut flat = Model::new();
+    flat.add_variable(
+        VarName::new("plant.omega_cmd"),
+        flat::Variable {
+            name: VarName::new("plant.omega_cmd"),
+            causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
+            variability: rumoca_core::Variability::Empty,
+            is_primitive: true,
+            dims: vec![4],
+            ..Default::default()
+        },
+    );
+
+    add_component_equation(
+        &mut flat,
+        "plant.omega_cmd[1]",
+        make_var_ref("motor_cmd[1]"),
+    );
+
+    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
+    assert!(
+        defined_inputs.contains(&VarName::new("plant.omega_cmd")),
+        "internal array input assigned by an indexed equation should be promoted"
+    );
+}
+
+#[test]
+fn test_equation_defined_array_lhs_promotes_internal_input_elements() {
+    let mut flat = Model::new();
+    for name in ["plant.motor[1].omega_cmd", "plant.motor[2].omega_cmd"] {
+        flat.add_variable(
+            VarName::new(name),
+            flat::Variable {
+                name: VarName::new(name),
+                causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
+                variability: rumoca_core::Variability::Empty,
+                is_primitive: true,
+                ..Default::default()
+            },
+        );
+    }
+    flat.add_equation(rumoca_ir_flat::Equation {
+        residual: rumoca_core::Expression::Binary {
+            op: rumoca_core::OpBinary::Sub,
+            lhs: Box::new(rumoca_core::Expression::Array {
+                elements: vec![
+                    make_var_ref("plant.motor[1].omega_cmd"),
+                    make_var_ref("plant.motor[2].omega_cmd"),
+                ],
+                is_matrix: false,
+                span: rumoca_core::Span::DUMMY,
+            }),
+            rhs: Box::new(make_var_ref("plant.omega_cmd")),
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: Span::DUMMY,
+        origin: rumoca_ir_flat::EquationOrigin::ComponentEquation {
+            component: "plant.motor".to_string(),
+        },
+        scalar_count: 2,
+    });
+
+    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
+    for name in ["plant.motor[1].omega_cmd", "plant.motor[2].omega_cmd"] {
+        assert!(
+            defined_inputs.contains(&VarName::new(name)),
+            "array LHS input {name} should be promoted"
+        );
+    }
+}
+
+#[test]
+fn test_rhs_input_alias_with_lhs_internal_input_promotes_rhs_input() {
+    let mut flat = Model::new();
+    for name in ["plant.omega_cmd", "plant.motor[1].omega_cmd"] {
+        flat.add_variable(
+            VarName::new(name),
+            flat::Variable {
+                name: VarName::new(name),
+                causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
+                variability: rumoca_core::Variability::Empty,
+                is_primitive: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    add_component_equation(
+        &mut flat,
+        "plant.omega_cmd",
+        make_var_ref("plant.motor[1].omega_cmd"),
+    );
+
+    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
+    assert!(
+        defined_inputs.contains(&VarName::new("plant.motor[1].omega_cmd")),
+        "RHS child input should be promoted when aliased to another internal input"
+    );
+}
+
+#[test]
+fn test_rhs_array_alias_with_lhs_internal_input_promotes_rhs_inputs() {
+    let mut flat = Model::new();
+    for (name, dims) in [
+        ("plant.omega_cmd", vec![2]),
+        ("plant.motor[1].omega_cmd", vec![]),
+        ("plant.motor[2].omega_cmd", vec![]),
+    ] {
+        flat.add_variable(
+            VarName::new(name),
+            flat::Variable {
+                name: VarName::new(name),
+                causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
+                variability: rumoca_core::Variability::Empty,
+                is_primitive: true,
+                dims,
+                ..Default::default()
+            },
+        );
+    }
+
+    flat.add_equation(rumoca_ir_flat::Equation {
+        residual: rumoca_core::Expression::Binary {
+            op: rumoca_core::OpBinary::Sub,
+            lhs: Box::new(make_var_ref("plant.omega_cmd")),
+            rhs: Box::new(rumoca_core::Expression::Array {
+                elements: vec![
+                    make_var_ref("plant.motor[1].omega_cmd"),
+                    make_var_ref("plant.motor[2].omega_cmd"),
+                ],
+                is_matrix: false,
+                span: rumoca_core::Span::DUMMY,
+            }),
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: Span::DUMMY,
+        origin: rumoca_ir_flat::EquationOrigin::ComponentEquation {
+            component: "plant".to_string(),
+        },
+        scalar_count: 2,
+    });
+
+    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
+    for name in [
+        "plant.omega_cmd",
+        "plant.motor[1].omega_cmd",
+        "plant.motor[2].omega_cmd",
+    ] {
+        assert!(
+            defined_inputs.contains(&VarName::new(name)),
+            "internal input {name} should be promoted through vector alias"
+        );
+    }
+}
+
+#[test]
+fn test_component_array_selection_lhs_promotes_indexed_internal_inputs() {
+    let mut flat = Model::new();
+    for (name, dims) in [
+        ("plant.omega_cmd", vec![2]),
+        ("plant.motor[1].omega_cmd", vec![]),
+        ("plant.motor[2].omega_cmd", vec![]),
+    ] {
+        flat.add_variable(
+            VarName::new(name),
+            flat::Variable {
+                name: VarName::new(name),
+                causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
+                variability: rumoca_core::Variability::Empty,
+                is_primitive: true,
+                dims,
+                ..Default::default()
+            },
+        );
+    }
+
+    add_component_equation(
+        &mut flat,
+        "plant.motor.omega_cmd",
+        make_var_ref("plant.omega_cmd"),
+    );
+
+    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
+    for name in [
+        "plant.omega_cmd",
+        "plant.motor[1].omega_cmd",
+        "plant.motor[2].omega_cmd",
+    ] {
+        assert!(
+            defined_inputs.contains(&VarName::new(name)),
+            "component-array selection should promote internal input {name}"
+        );
+    }
+}

--- a/crates/rumoca-phase-dae/src/tests/root/mod.rs
+++ b/crates/rumoca-phase-dae/src/tests/root/mod.rs
@@ -182,6 +182,71 @@ fn test_todae_rewrites_missing_scoped_parameter_start_reference() {
 }
 
 #[test]
+fn test_todae_rewrites_misqualified_record_parameter_alias_field() {
+    let mut flat = Model::new();
+
+    flat.add_variable(
+        VarName::new("aimcData.statorCoreParameters.wRef"),
+        flat::Variable {
+            name: VarName::new("aimcData.statorCoreParameters.wRef"),
+            variability: rumoca_core::Variability::Parameter(rumoca_core::Token::default()),
+            binding: Some(rumoca_core::Expression::Literal {
+                value: rumoca_core::Literal::Real(314.159),
+                span: rumoca_core::Span::DUMMY,
+            }),
+            is_primitive: true,
+            ..Default::default()
+        },
+    );
+
+    flat.add_variable(
+        VarName::new("aimc.statorCoreParameters.wRef"),
+        flat::Variable {
+            name: VarName::new("aimc.statorCoreParameters.wRef"),
+            variability: rumoca_core::Variability::Parameter(rumoca_core::Token::default()),
+            binding: Some(rumoca_core::Expression::FieldAccess {
+                base: Box::new(make_var_ref("aimc.aimcData.statorCoreParameters")),
+                field: "wRef".to_string(),
+                span: rumoca_core::Span::DUMMY,
+            }),
+            is_primitive: true,
+            ..Default::default()
+        },
+    );
+
+    let dae = to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect("record-parameter alias should resolve to the matching scalar field");
+
+    let nested = dae
+        .variables
+        .parameters
+        .get(&rumoca_core::VarName::new("aimc.statorCoreParameters.wRef"))
+        .expect("missing nested stator core parameter");
+    let start = nested
+        .start
+        .as_ref()
+        .expect("nested stator core parameter should keep rewritten start expression");
+
+    match start {
+        rumoca_core::Expression::VarRef {
+            name, subscripts, ..
+        } => {
+            assert!(
+                subscripts.is_empty(),
+                "expected scalar rewritten record-field reference"
+            );
+            assert_eq!(name.as_str(), "aimcData.statorCoreParameters.wRef");
+        }
+        other => panic!("expected VarRef start expression, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_todae_rejects_unresolved_function_calls() {
     let mut flat = Model::new();
     add_primitive_real(&mut flat, "x");
@@ -850,6 +915,87 @@ fn test_todae_routes_explicit_discrete_integer_when_assignment_to_f_m() {
         dae.discrete.valued_updates.len(),
         1,
         "expected one discrete-valued event equation"
+    );
+}
+
+#[test]
+fn test_todae_lowers_when_multi_output_function_call_to_selection_updates() {
+    let mut flat = Model::new();
+    add_primitive_real(&mut flat, "seed");
+    flat.add_variable(
+        VarName::new("trigger"),
+        flat::Variable {
+            name: VarName::new("trigger"),
+            variability: rumoca_core::Variability::Discrete(rumoca_core::Token::default()),
+            is_discrete_type: true,
+            is_primitive: true,
+            ..Default::default()
+        },
+    );
+    for name in ["noise.r_raw", "noise.state"] {
+        flat.add_variable(
+            VarName::new(name),
+            flat::Variable {
+                name: VarName::new(name),
+                variability: rumoca_core::Variability::Discrete(rumoca_core::Token::default()),
+                is_primitive: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    let mut function = rumoca_core::Function::new("Noise.next", Span::DUMMY);
+    function.add_input(rumoca_core::FunctionParam::new("seed", "Real"));
+    function.add_output(rumoca_core::FunctionParam::new("r_raw", "Real"));
+    function.add_output(rumoca_core::FunctionParam::new("state", "Real"));
+    function.body.push(rumoca_core::Statement::Assignment {
+        comp: make_comp_ref("r_raw"),
+        value: make_var_ref("seed"),
+        span: rumoca_core::Span::DUMMY,
+    });
+    function.body.push(rumoca_core::Statement::Assignment {
+        comp: make_comp_ref("state"),
+        value: make_var_ref("seed"),
+        span: rumoca_core::Span::DUMMY,
+    });
+    flat.add_function(function);
+
+    let mut when_clause = rumoca_ir_flat::WhenClause::new(make_var_ref("trigger"), Span::DUMMY);
+    when_clause.add_equation(rumoca_ir_flat::WhenEquation::function_call_outputs(
+        vec![VarName::new("noise.r_raw"), VarName::new("noise.state")],
+        rumoca_core::Expression::FunctionCall {
+            name: VarName::new("Noise.next").into(),
+            args: vec![make_var_ref("seed")],
+            is_constructor: false,
+            span: rumoca_core::Span::DUMMY,
+        },
+        Span::DUMMY,
+        "noise update",
+    ));
+    flat.when_clauses.push(when_clause);
+
+    let dae = to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect("when multi-output function call should lower to per-output updates");
+
+    let updates = dae
+        .discrete
+        .real_updates
+        .iter()
+        .map(|eq| format!("{:?}", eq.rhs))
+        .collect::<Vec<_>>();
+    assert_eq!(updates.len(), 2);
+    assert!(
+        updates.iter().any(|rhs| rhs.contains("Noise.next.r_raw")),
+        "missing first output selection in updates: {updates:?}"
+    );
+    assert!(
+        updates.iter().any(|rhs| rhs.contains("Noise.next.state")),
+        "missing second output selection in updates: {updates:?}"
     );
 }
 
@@ -1783,204 +1929,8 @@ fn test_connected_input_alias_with_multilayer_subscripts_promotes_internal_input
     }
 }
 
-#[test]
-fn test_equation_defined_indexed_array_input_promotes_internal_input() {
-    let mut flat = Model::new();
-    flat.add_variable(
-        VarName::new("plant.omega_cmd"),
-        flat::Variable {
-            name: VarName::new("plant.omega_cmd"),
-            causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
-            variability: rumoca_core::Variability::Empty,
-            is_primitive: true,
-            dims: vec![4],
-            ..Default::default()
-        },
-    );
-
-    add_component_equation(
-        &mut flat,
-        "plant.omega_cmd[1]",
-        make_var_ref("motor_cmd[1]"),
-    );
-
-    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
-    assert!(
-        defined_inputs.contains(&VarName::new("plant.omega_cmd")),
-        "internal array input assigned by an indexed equation should be promoted"
-    );
-}
-
-#[test]
-fn test_equation_defined_array_lhs_promotes_internal_input_elements() {
-    let mut flat = Model::new();
-    for name in ["plant.motor[1].omega_cmd", "plant.motor[2].omega_cmd"] {
-        flat.add_variable(
-            VarName::new(name),
-            flat::Variable {
-                name: VarName::new(name),
-                causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
-                variability: rumoca_core::Variability::Empty,
-                is_primitive: true,
-                ..Default::default()
-            },
-        );
-    }
-    flat.add_equation(rumoca_ir_flat::Equation {
-        residual: rumoca_core::Expression::Binary {
-            op: rumoca_core::OpBinary::Sub,
-            lhs: Box::new(rumoca_core::Expression::Array {
-                elements: vec![
-                    make_var_ref("plant.motor[1].omega_cmd"),
-                    make_var_ref("plant.motor[2].omega_cmd"),
-                ],
-                is_matrix: false,
-                span: rumoca_core::Span::DUMMY,
-            }),
-            rhs: Box::new(make_var_ref("plant.omega_cmd")),
-            span: rumoca_core::Span::DUMMY,
-        },
-        span: Span::DUMMY,
-        origin: rumoca_ir_flat::EquationOrigin::ComponentEquation {
-            component: "plant.motor".to_string(),
-        },
-        scalar_count: 2,
-    });
-
-    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
-    for name in ["plant.motor[1].omega_cmd", "plant.motor[2].omega_cmd"] {
-        assert!(
-            defined_inputs.contains(&VarName::new(name)),
-            "array LHS input {name} should be promoted"
-        );
-    }
-}
-
-#[test]
-fn test_rhs_input_alias_with_lhs_internal_input_promotes_rhs_input() {
-    let mut flat = Model::new();
-    for name in ["plant.omega_cmd", "plant.motor[1].omega_cmd"] {
-        flat.add_variable(
-            VarName::new(name),
-            flat::Variable {
-                name: VarName::new(name),
-                causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
-                variability: rumoca_core::Variability::Empty,
-                is_primitive: true,
-                ..Default::default()
-            },
-        );
-    }
-
-    add_component_equation(
-        &mut flat,
-        "plant.omega_cmd",
-        make_var_ref("plant.motor[1].omega_cmd"),
-    );
-
-    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
-    assert!(
-        defined_inputs.contains(&VarName::new("plant.motor[1].omega_cmd")),
-        "RHS child input should be promoted when aliased to another internal input"
-    );
-}
-
-#[test]
-fn test_rhs_array_alias_with_lhs_internal_input_promotes_rhs_inputs() {
-    let mut flat = Model::new();
-    for (name, dims) in [
-        ("plant.omega_cmd", vec![2]),
-        ("plant.motor[1].omega_cmd", vec![]),
-        ("plant.motor[2].omega_cmd", vec![]),
-    ] {
-        flat.add_variable(
-            VarName::new(name),
-            flat::Variable {
-                name: VarName::new(name),
-                causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
-                variability: rumoca_core::Variability::Empty,
-                is_primitive: true,
-                dims,
-                ..Default::default()
-            },
-        );
-    }
-
-    flat.add_equation(rumoca_ir_flat::Equation {
-        residual: rumoca_core::Expression::Binary {
-            op: rumoca_core::OpBinary::Sub,
-            lhs: Box::new(make_var_ref("plant.omega_cmd")),
-            rhs: Box::new(rumoca_core::Expression::Array {
-                elements: vec![
-                    make_var_ref("plant.motor[1].omega_cmd"),
-                    make_var_ref("plant.motor[2].omega_cmd"),
-                ],
-                is_matrix: false,
-                span: rumoca_core::Span::DUMMY,
-            }),
-            span: rumoca_core::Span::DUMMY,
-        },
-        span: Span::DUMMY,
-        origin: rumoca_ir_flat::EquationOrigin::ComponentEquation {
-            component: "plant".to_string(),
-        },
-        scalar_count: 2,
-    });
-
-    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
-    for name in [
-        "plant.omega_cmd",
-        "plant.motor[1].omega_cmd",
-        "plant.motor[2].omega_cmd",
-    ] {
-        assert!(
-            defined_inputs.contains(&VarName::new(name)),
-            "internal input {name} should be promoted through vector alias"
-        );
-    }
-}
-
-#[test]
-fn test_component_array_selection_lhs_promotes_indexed_internal_inputs() {
-    let mut flat = Model::new();
-    for (name, dims) in [
-        ("plant.omega_cmd", vec![2]),
-        ("plant.motor[1].omega_cmd", vec![]),
-        ("plant.motor[2].omega_cmd", vec![]),
-    ] {
-        flat.add_variable(
-            VarName::new(name),
-            flat::Variable {
-                name: VarName::new(name),
-                causality: rumoca_core::Causality::Input(rumoca_core::Token::default()),
-                variability: rumoca_core::Variability::Empty,
-                is_primitive: true,
-                dims,
-                ..Default::default()
-            },
-        );
-    }
-
-    add_component_equation(
-        &mut flat,
-        "plant.motor.omega_cmd",
-        make_var_ref("plant.omega_cmd"),
-    );
-
-    let defined_inputs = find_equation_defined_inputs_for_test(&flat);
-    for name in [
-        "plant.omega_cmd",
-        "plant.motor[1].omega_cmd",
-        "plant.motor[2].omega_cmd",
-    ] {
-        assert!(
-            defined_inputs.contains(&VarName::new(name)),
-            "component-array selection should promote internal input {name}"
-        );
-    }
-}
-
 mod input_promotion_extra;
+mod input_promotion_indexed;
 mod tests_embedded_range;
 mod tests_equation_classification;
 mod tests_flow_sum;

--- a/crates/rumoca-phase-dae/src/when_conversion.rs
+++ b/crates/rumoca-phase-dae/src/when_conversion.rs
@@ -8,8 +8,13 @@ use rumoca_ir_dae as dae;
 use rumoca_ir_flat as flat;
 
 use crate::{
-    ToDaeError, compute_var_size, dae_to_flat_expression, dae_to_flat_var_name,
-    flat_to_dae_expression, flat_to_dae_var_name, resolve_embedded_subscript_size,
+    ToDaeError,
+    analysis::{
+        discrete_partition,
+        variable_analysis::{self, resolve_flat_function},
+    },
+    compute_var_size, dae_to_flat_expression, dae_to_flat_var_name, flat_to_dae_expression,
+    flat_to_dae_var_name, resolve_embedded_subscript_size,
 };
 
 /// Compute scalar count for a when-equation target variable.
@@ -49,15 +54,41 @@ fn missing_when_branch_rhs(
     if state_vars.contains(target) {
         return Ok(target_ref(target));
     }
-    if flat.variables.get(target).is_some_and(|var| {
-        matches!(var.variability, rumoca_core::Variability::Discrete(_)) || var.is_discrete_type
-    }) {
+    if flat
+        .variables
+        .get(target)
+        .is_some_and(is_discrete_when_memory_target)
+        || is_clocked_assignment_target(target, flat)
+        || is_when_only_memory_target(target, flat)
+    {
         return Ok(pre_of_target(target));
     }
     Err(ToDaeError::internal(format!(
         "MLS §8.3.5 violation: conditional when-equation target '{}' is not assigned in every branch and is not a discrete variable",
         target
     )))
+}
+
+fn is_when_only_memory_target(target: &rumoca_core::VarName, flat: &flat::Model) -> bool {
+    variable_analysis::find_when_only_vars(flat, &Default::default()).contains(target)
+}
+
+fn is_clocked_assignment_target(target: &rumoca_core::VarName, flat: &flat::Model) -> bool {
+    flat.equations.iter().any(|equation| {
+        discrete_partition::is_clocked_assignment_equation(equation)
+            && discrete_partition::residual_lhs_targets(&equation.residual)
+                .into_iter()
+                .any(|candidate| candidate == *target)
+    })
+}
+
+fn is_discrete_when_memory_target(var: &flat::Variable) -> bool {
+    matches!(var.variability, rumoca_core::Variability::Discrete(_))
+        || var.is_discrete_type
+        || var
+            .binding
+            .as_ref()
+            .is_some_and(discrete_partition::expression_contains_clocked_operators)
 }
 
 /// Convert an explicit when assignment/reinit to a DAE equation with scalar count.
@@ -79,6 +110,67 @@ fn build_when_assignment_eq(
         origin.to_string(),
         scalar_count,
     ))
+}
+
+fn build_when_function_call_output_eqs(
+    outputs: &[rumoca_core::VarName],
+    function: &rumoca_core::Expression,
+    span: Span,
+    origin: &str,
+    flat: &flat::Model,
+) -> Result<Vec<dae::Equation>, ToDaeError> {
+    let rumoca_core::Expression::FunctionCall {
+        name,
+        args,
+        is_constructor,
+        ..
+    } = function
+    else {
+        return Err(ToDaeError::unsupported_algorithm(
+            "when-equation",
+            format!("{origin}: multi-output assignment rhs is not a function call"),
+            span,
+        ));
+    };
+    if *is_constructor {
+        return Err(ToDaeError::unsupported_algorithm(
+            "when-equation",
+            format!("{origin}: constructor multi-output assignment"),
+            span,
+        ));
+    }
+
+    let Some(function_def) = resolve_flat_function(name.as_str(), flat) else {
+        return Err(ToDaeError::unresolved_function_call(name.as_str(), span));
+    };
+    if function_def.outputs.len() < outputs.len() {
+        return Err(ToDaeError::internal(format!(
+            "when-equation multi-output assignment expects {} outputs from '{}', but function has {}",
+            outputs.len(),
+            name.as_str(),
+            function_def.outputs.len()
+        )));
+    }
+
+    let mut equations = Vec::with_capacity(outputs.len());
+    for (target, function_output) in outputs.iter().zip(function_def.outputs.iter()) {
+        let selection_name = rumoca_core::VarName::new(format!(
+            "{}.{}",
+            name.as_str(),
+            function_output.name.as_str()
+        ));
+        let rhs = rumoca_core::Expression::FunctionCall {
+            name: selection_name.into(),
+            args: args.clone(),
+            is_constructor: false,
+            span,
+        };
+        let output_origin = format!("{origin}: multi-output assignment to {target}");
+        if let Some(eq) = build_when_assignment_eq(target, &rhs, span, &output_origin, flat) {
+            equations.push(eq);
+        }
+    }
+    Ok(equations)
 }
 
 /// Insert a converted when-equation into a target map, rejecting duplicate targets.
@@ -362,13 +454,12 @@ fn convert_when_equation(
             state_vars,
             flat,
         ),
-        flat::WhenEquation::FunctionCallOutputs { span, origin, .. } => {
-            Err(ToDaeError::unsupported_algorithm(
-                "when-equation",
-                format!("{origin}: multi-output function call assignment"),
-                *span,
-            ))
-        }
+        flat::WhenEquation::FunctionCallOutputs {
+            outputs,
+            function,
+            span,
+            origin,
+        } => build_when_function_call_output_eqs(outputs, function, *span, origin, flat),
     }
 }
 
@@ -434,6 +525,144 @@ mod tests {
 
         let rhs = missing_when_branch_rhs(&target, &IndexSet::new(), &flat)
             .expect("discrete targets may hold their previous value");
+
+        assert!(matches!(
+            rhs,
+            rumoca_core::Expression::BuiltinCall {
+                function: rumoca_core::BuiltinFunction::Pre,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn missing_conditional_when_branch_uses_pre_for_clocked_binding_targets() {
+        let target = rumoca_core::VarName::new("u_super");
+        let mut flat = flat::Model::new();
+        flat.variables.insert(
+            target.clone(),
+            flat::Variable {
+                name: target.clone(),
+                binding: Some(rumoca_core::Expression::FunctionCall {
+                    name: rumoca_core::VarName::new("superSample").into(),
+                    args: vec![rumoca_core::Expression::VarRef {
+                        name: rumoca_core::VarName::new("u").into(),
+                        subscripts: vec![],
+                        span: rumoca_core::Span::DUMMY,
+                    }],
+                    is_constructor: false,
+                    span: rumoca_core::Span::DUMMY,
+                }),
+                variability: rumoca_core::Variability::Continuous(rumoca_core::Token::default()),
+                is_discrete_type: false,
+                ..Default::default()
+            },
+        );
+
+        let rhs = missing_when_branch_rhs(&target, &IndexSet::new(), &flat)
+            .expect("clocked binding targets may hold their previous value");
+
+        assert!(matches!(
+            rhs,
+            rumoca_core::Expression::BuiltinCall {
+                function: rumoca_core::BuiltinFunction::Pre,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn missing_conditional_when_branch_uses_pre_for_clocked_equation_targets() {
+        let target = rumoca_core::VarName::new("u_super");
+        let mut flat = flat::Model::new();
+        flat.variables.insert(
+            target.clone(),
+            flat::Variable {
+                name: target.clone(),
+                variability: rumoca_core::Variability::Continuous(rumoca_core::Token::default()),
+                is_discrete_type: false,
+                ..Default::default()
+            },
+        );
+        flat.equations.push(flat::Equation {
+            residual: rumoca_core::Expression::Binary {
+                op: rumoca_core::OpBinary::Sub,
+                lhs: Box::new(target_ref(&target)),
+                rhs: Box::new(rumoca_core::Expression::FunctionCall {
+                    name: rumoca_core::VarName::new("superSample").into(),
+                    args: vec![rumoca_core::Expression::VarRef {
+                        name: rumoca_core::VarName::new("u").into(),
+                        subscripts: vec![],
+                        span: rumoca_core::Span::DUMMY,
+                    }],
+                    is_constructor: false,
+                    span: rumoca_core::Span::DUMMY,
+                }),
+                span: rumoca_core::Span::DUMMY,
+            },
+            span: rumoca_core::Span::DUMMY,
+            origin: flat::EquationOrigin::ComponentEquation {
+                component: "clocked".to_string(),
+            },
+            scalar_count: 1,
+        });
+
+        let rhs = missing_when_branch_rhs(&target, &IndexSet::new(), &flat)
+            .expect("clocked equation targets may hold their previous value");
+
+        assert!(matches!(
+            rhs,
+            rumoca_core::Expression::BuiltinCall {
+                function: rumoca_core::BuiltinFunction::Pre,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn missing_conditional_when_branch_uses_pre_for_when_only_targets() {
+        let target = rumoca_core::VarName::new("u_super");
+        let mut flat = flat::Model::new();
+        flat.variables.insert(
+            target.clone(),
+            flat::Variable {
+                name: target.clone(),
+                variability: rumoca_core::Variability::Continuous(rumoca_core::Token::default()),
+                is_discrete_type: false,
+                ..Default::default()
+            },
+        );
+        let mut when_clause = flat::WhenClause::new(
+            rumoca_core::Expression::Literal {
+                value: rumoca_core::Literal::Boolean(true),
+                span: rumoca_core::Span::DUMMY,
+            },
+            Span::DUMMY,
+        );
+        when_clause.add_equation(flat::WhenEquation::Conditional {
+            branches: vec![(
+                rumoca_core::Expression::Literal {
+                    value: rumoca_core::Literal::Boolean(true),
+                    span: rumoca_core::Span::DUMMY,
+                },
+                vec![flat::WhenEquation::assign(
+                    target.clone(),
+                    rumoca_core::Expression::Literal {
+                        value: rumoca_core::Literal::Real(1.0),
+                        span: rumoca_core::Span::DUMMY,
+                    },
+                    Span::DUMMY,
+                    "clocked branch",
+                )],
+            )],
+            else_branch: vec![],
+            span: Span::DUMMY,
+            origin: "conditional clocked memory".to_string(),
+        });
+        flat.when_clauses.push(when_clause);
+
+        let rhs = missing_when_branch_rhs(&target, &IndexSet::new(), &flat)
+            .expect("when-only targets may hold their previous value");
 
         assert!(matches!(
             rhs,

--- a/crates/rumoca-phase-flatten/src/ast_lower.rs
+++ b/crates/rumoca-phase-flatten/src/ast_lower.rs
@@ -667,11 +667,13 @@ fn resolved_function_call_name(
     let resolved = comp
         .def_id
         .and_then(|def_id| def_map.and_then(|map| map.get(&def_id)))?;
-    if !resolved_path_ends_with_component_ref(resolved, comp) {
-        return None;
-    }
     let call_leaf = comp.parts.last()?.ident.text.as_ref();
     let resolved_leaf = top_level_last_segment(resolved.as_str());
+    if !resolved_path_ends_with_component_ref(resolved, comp)
+        && !is_receiver_member_function_call(comp, call_leaf, resolved_leaf)
+    {
+        return None;
+    }
 
     // `ComponentReference::def_id` usually names the first segment. Function
     // resolution rewrites successful multi-segment calls so the DefId names the
@@ -680,6 +682,24 @@ fn resolved_function_call_name(
     // call so flatten's component-override rewrite can resolve it from the
     // receiver type.
     (resolved_leaf == call_leaf).then(|| resolved.clone())
+}
+
+fn is_receiver_member_function_call(
+    comp: &ast::ComponentReference,
+    call_leaf: &str,
+    resolved_leaf: &str,
+) -> bool {
+    let Some(receiver) = comp.parts.first() else {
+        return false;
+    };
+    comp.parts.len() == 2
+        && receiver
+            .ident
+            .text
+            .chars()
+            .next()
+            .is_some_and(char::is_lowercase)
+        && resolved_leaf == call_leaf
 }
 
 fn resolved_path_ends_with_component_ref(resolved: &str, comp: &ast::ComponentReference) -> bool {
@@ -930,6 +950,31 @@ mod tests {
         assert_eq!(
             resolved_function_call_name(&comp, Some(&def_map)).as_deref(),
             Some("Pkg.Receiver.member")
+        );
+    }
+
+    #[test]
+    fn function_call_lowering_canonicalizes_receiver_member_function_target() {
+        let function_def = DefId::new(4);
+        let mut def_map = IndexMap::default();
+        def_map.insert(
+            function_def,
+            "Modelica.Mechanics.MultiBody.World.gravityAcceleration".to_string(),
+        );
+        let comp = ast::ComponentReference {
+            local: false,
+            parts: vec![part("world"), part("gravityAcceleration")],
+            span: Span::DUMMY,
+            def_id: Some(function_def),
+        };
+
+        let expr = convert_function_call_with_def_map(&comp, &[], Some(&def_map)).unwrap();
+        let rumoca_core::Expression::FunctionCall { name, .. } = expr else {
+            panic!("expected function call");
+        };
+        assert_eq!(
+            name.as_str(),
+            "Modelica.Mechanics.MultiBody.World.gravityAcceleration"
         );
     }
 

--- a/crates/rumoca-phase-flatten/src/functions.rs
+++ b/crates/rumoca-phase-flatten/src/functions.rs
@@ -617,6 +617,183 @@ pub(crate) fn validate_flat_function_bindings(flat: &flat::Model) -> Result<(), 
     Ok(())
 }
 
+pub(crate) fn canonicalize_collected_function_calls(flat: &mut flat::Model) {
+    let canonical_names = flat
+        .functions
+        .keys()
+        .map(|name| name.as_str().to_string())
+        .collect::<Vec<_>>();
+    if canonical_names.is_empty() {
+        return;
+    }
+    let mut rewriter = CollectedFunctionCallCanonicalizer { canonical_names };
+
+    for var in flat.variables.values_mut() {
+        if let Some(binding) = &mut var.binding {
+            *binding = rewriter.rewrite_expression(binding);
+        }
+        if let Some(start) = &mut var.start {
+            *start = rewriter.rewrite_expression(start);
+        }
+        if let Some(min) = &mut var.min {
+            *min = rewriter.rewrite_expression(min);
+        }
+        if let Some(max) = &mut var.max {
+            *max = rewriter.rewrite_expression(max);
+        }
+        if let Some(nominal) = &mut var.nominal {
+            *nominal = rewriter.rewrite_expression(nominal);
+        }
+    }
+    for eq in &mut flat.equations {
+        eq.residual = rewriter.rewrite_expression(&eq.residual);
+    }
+    for eq in &mut flat.initial_equations {
+        eq.residual = rewriter.rewrite_expression(&eq.residual);
+    }
+    for when_clause in &mut flat.when_clauses {
+        when_clause.condition = rewriter.rewrite_expression(&when_clause.condition);
+        canonicalize_when_equations(&mut when_clause.equations, &mut rewriter);
+    }
+    for assertion in &mut flat.assert_equations {
+        assertion.condition = rewriter.rewrite_expression(&assertion.condition);
+        assertion.message = rewriter.rewrite_expression(&assertion.message);
+        if let Some(level) = &mut assertion.level {
+            *level = rewriter.rewrite_expression(level);
+        }
+    }
+    for assertion in &mut flat.initial_assert_equations {
+        assertion.condition = rewriter.rewrite_expression(&assertion.condition);
+        assertion.message = rewriter.rewrite_expression(&assertion.message);
+        if let Some(level) = &mut assertion.level {
+            *level = rewriter.rewrite_expression(level);
+        }
+    }
+    for algorithm in &mut flat.algorithms {
+        for statement in &mut algorithm.statements {
+            *statement = rewriter.rewrite_statement(statement);
+        }
+    }
+    for algorithm in &mut flat.initial_algorithms {
+        for statement in &mut algorithm.statements {
+            *statement = rewriter.rewrite_statement(statement);
+        }
+    }
+    for function in flat.functions.values_mut() {
+        for input in &mut function.inputs {
+            canonicalize_function_param_default(input, &mut rewriter);
+        }
+        for output in &mut function.outputs {
+            canonicalize_function_param_default(output, &mut rewriter);
+        }
+        for local in &mut function.locals {
+            canonicalize_function_param_default(local, &mut rewriter);
+        }
+        for statement in &mut function.body {
+            *statement = rewriter.rewrite_statement(statement);
+        }
+    }
+}
+
+fn canonicalize_when_equations(
+    equations: &mut [flat::WhenEquation],
+    rewriter: &mut CollectedFunctionCallCanonicalizer,
+) {
+    for equation in equations {
+        match equation {
+            flat::WhenEquation::Assign { value, .. } | flat::WhenEquation::Reinit { value, .. } => {
+                *value = rewriter.rewrite_expression(value);
+            }
+            flat::WhenEquation::Assert { condition, .. } => {
+                *condition = rewriter.rewrite_expression(condition);
+            }
+            flat::WhenEquation::Terminate { .. } => {}
+            flat::WhenEquation::Conditional {
+                branches,
+                else_branch,
+                ..
+            } => {
+                for (condition, branch_equations) in branches {
+                    *condition = rewriter.rewrite_expression(condition);
+                    canonicalize_when_equations(branch_equations, rewriter);
+                }
+                canonicalize_when_equations(else_branch, rewriter);
+            }
+            flat::WhenEquation::FunctionCallOutputs { function, .. } => {
+                *function = rewriter.rewrite_expression(function);
+            }
+        }
+    }
+}
+
+fn canonicalize_function_param_default(
+    param: &mut rumoca_core::FunctionParam,
+    rewriter: &mut CollectedFunctionCallCanonicalizer,
+) {
+    if let Some(default) = &mut param.default {
+        *default = rewriter.rewrite_expression(default);
+    }
+    for subscript in &mut param.shape_expr {
+        if let rumoca_core::Subscript::Expr { expr, .. } = subscript {
+            **expr = rewriter.rewrite_expression(expr);
+        }
+    }
+}
+
+struct CollectedFunctionCallCanonicalizer {
+    canonical_names: Vec<String>,
+}
+
+impl CollectedFunctionCallCanonicalizer {
+    fn canonical_name_for(&self, name: &str) -> Option<String> {
+        if self
+            .canonical_names
+            .iter()
+            .any(|candidate| candidate == name)
+        {
+            return None;
+        }
+        let suffix = format!(".{name}");
+        let mut matches = self
+            .canonical_names
+            .iter()
+            .filter(|candidate| candidate.ends_with(&suffix));
+        let first = matches.next()?;
+        matches.next().is_none().then(|| first.clone())
+    }
+}
+
+impl ExpressionRewriter for CollectedFunctionCallCanonicalizer {
+    fn rewrite_expression(&mut self, expr: &rumoca_core::Expression) -> rumoca_core::Expression {
+        let rumoca_core::Expression::FunctionCall {
+            name,
+            args,
+            is_constructor,
+            span,
+        } = expr
+        else {
+            return self.walk_expression(expr);
+        };
+        let args = self.rewrite_expressions(args);
+        if let Some(canonical_name) = self.canonical_name_for(name.as_str()) {
+            return rumoca_core::Expression::FunctionCall {
+                name: rumoca_core::Reference::new(canonical_name),
+                args,
+                is_constructor: *is_constructor,
+                span: *span,
+            };
+        }
+        rumoca_core::Expression::FunctionCall {
+            name: name.clone(),
+            args,
+            is_constructor: *is_constructor,
+            span: *span,
+        }
+    }
+}
+
+impl StatementRewriter for CollectedFunctionCallCanonicalizer {}
+
 pub(crate) fn is_executable_flat_function(function: &rumoca_core::Function) -> bool {
     function.is_constructor
         || function.external.is_some()
@@ -1766,229 +1943,8 @@ fn active_constant_def_overrides(
         .collect()
 }
 
-fn collect_constructor_params(
-    class_index: &ast::ClassDefIndex<'_>,
-    class_def: &ast::ClassDef,
-    visited_classes: &mut HashSet<usize>,
-    params: &mut Vec<rumoca_core::FunctionParam>,
-    param_index: &mut HashMap<String, usize>,
-    source_map: &rumoca_core::SourceMap,
-    def_map: &crate::ResolveDefMap,
-) -> Result<(), FlattenError> {
-    let class_ptr = class_def as *const ast::ClassDef as usize;
-    if !visited_classes.insert(class_ptr) {
-        return Ok(());
-    }
-
-    for ext in &class_def.extends {
-        let base_class = ext
-            .base_def_id
-            .and_then(|def_id| class_index.get(def_id))
-            .or_else(|| {
-                let name = ext.base_name.to_string();
-                class_index.get_by_qualified_name(&name)
-            });
-        if let Some(base_class) = base_class {
-            collect_constructor_params(
-                class_index,
-                base_class,
-                visited_classes,
-                params,
-                param_index,
-                source_map,
-                def_map,
-            )?;
-        }
-    }
-
-    for (comp_name, component) in &class_def.components {
-        let param = convert_component_to_param(
-            class_index,
-            comp_name,
-            component,
-            source_map,
-            def_map,
-            &qualify::ImportMap::default(),
-            &HashSet::new(),
-        )?;
-        if let Some(index) = param_index.get(comp_name).copied() {
-            params[index] = param;
-        } else {
-            param_index.insert(comp_name.clone(), params.len());
-            params.push(param);
-        }
-    }
-    Ok(())
-}
-
-fn collect_constructor_local_def_ids(
-    class_index: &ast::ClassDefIndex<'_>,
-    class_def: &ast::ClassDef,
-    visited_classes: &mut HashSet<usize>,
-    local_def_ids: &mut crate::ResolveDefMap,
-) {
-    let class_ptr = class_def as *const ast::ClassDef as usize;
-    if !visited_classes.insert(class_ptr) {
-        return;
-    }
-
-    for ext in &class_def.extends {
-        let base_class = ext
-            .base_def_id
-            .and_then(|def_id| class_index.get(def_id))
-            .or_else(|| {
-                let name = ext.base_name.to_string();
-                class_index.get_by_qualified_name(&name)
-            });
-        if let Some(base_class) = base_class {
-            collect_constructor_local_def_ids(
-                class_index,
-                base_class,
-                visited_classes,
-                local_def_ids,
-            );
-        }
-    }
-
-    for (name, component) in &class_def.components {
-        if let Some(def_id) = component.def_id {
-            local_def_ids.insert(def_id, name.clone());
-        }
-    }
-}
-
-fn constructor_def_map(
-    class_index: &ast::ClassDefIndex<'_>,
-    class_def: &ast::ClassDef,
-    def_map: &crate::ResolveDefMap,
-) -> crate::ResolveDefMap {
-    let mut constructor_map = def_map.clone();
-    let mut local_def_ids = crate::ResolveDefMap::default();
-    let mut visited_classes = HashSet::new();
-    collect_constructor_local_def_ids(
-        class_index,
-        class_def,
-        &mut visited_classes,
-        &mut local_def_ids,
-    );
-    for (def_id, name) in local_def_ids {
-        constructor_map.insert(def_id, name);
-    }
-    constructor_map
-}
-
-/// Build a synthetic constructor signature for constructor-like class calls.
-fn convert_constructor_signature(
-    class_index: &ast::ClassDefIndex<'_>,
-    class_def: &ast::ClassDef,
-    qualified_name: &str,
-    source_map: &rumoca_core::SourceMap,
-    def_map: &crate::ResolveDefMap,
-) -> Result<rumoca_core::Function, FlattenError> {
-    let span = source_map.location_to_span(
-        &class_def.location.file_name,
-        class_def.location.start as usize,
-        class_def.location.end as usize,
-    );
-    let mut params = Vec::new();
-    let mut param_index = HashMap::new();
-    let mut visited_classes = HashSet::new();
-    let constructor_def_map = constructor_def_map(class_index, class_def, def_map);
-    collect_constructor_params(
-        class_index,
-        class_def,
-        &mut visited_classes,
-        &mut params,
-        &mut param_index,
-        source_map,
-        &constructor_def_map,
-    )?;
-
-    let mut func = rumoca_core::Function::new(qualified_name, span);
-    func.def_id = class_def.def_id;
-    func.is_constructor = true;
-    for param in params {
-        func.add_input(param);
-    }
-    normalize_function_local_references(&mut func);
-    Ok(func)
-}
-
-fn normalize_function_local_references(function: &mut rumoca_core::Function) {
-    let locals = function
-        .inputs
-        .iter()
-        .chain(function.outputs.iter())
-        .chain(function.locals.iter())
-        .map(|param| param.name.clone())
-        .collect::<HashSet<_>>();
-    if locals.is_empty() {
-        return;
-    }
-
-    let mut normalizer = FunctionLocalReferenceNormalizer {
-        function_name: function.name.as_str().to_string(),
-        locals,
-    };
-    for param in function
-        .inputs
-        .iter_mut()
-        .chain(function.outputs.iter_mut())
-        .chain(function.locals.iter_mut())
-    {
-        if let Some(default) = &param.default {
-            param.default = Some(normalizer.rewrite_expression(default));
-        }
-    }
-    for statement in &mut function.body {
-        *statement = normalizer.rewrite_statement(statement);
-    }
-}
-
-struct FunctionLocalReferenceNormalizer {
-    function_name: String,
-    locals: HashSet<String>,
-}
-
-impl FunctionLocalReferenceNormalizer {
-    fn local_reference<'a>(&self, name: &'a str) -> Option<&'a str> {
-        let suffix = name.strip_prefix(&self.function_name)?;
-        let local_ref = suffix.strip_prefix('.')?;
-        self.locals
-            .iter()
-            .any(|local| {
-                local_ref == local
-                    || local_ref
-                        .strip_prefix(local.as_str())
-                        .is_some_and(|rest| rest.starts_with('.') || rest.starts_with('['))
-            })
-            .then_some(local_ref)
-    }
-}
-
-impl ExpressionRewriter for FunctionLocalReferenceNormalizer {
-    fn rewrite_expression(&mut self, expr: &rumoca_core::Expression) -> rumoca_core::Expression {
-        match expr {
-            rumoca_core::Expression::VarRef {
-                name,
-                subscripts,
-                span,
-            } => {
-                if let Some(local_name) = self.local_reference(name.as_str()) {
-                    return rumoca_core::Expression::VarRef {
-                        name: rumoca_core::Reference::new(local_name.to_string()),
-                        subscripts: self.rewrite_subscripts(subscripts),
-                        span: *span,
-                    };
-                }
-                self.walk_expression(expr)
-            }
-            _ => self.walk_expression(expr),
-        }
-    }
-}
-
-impl StatementRewriter for FunctionLocalReferenceNormalizer {}
+mod constructor_signature;
+use constructor_signature::{convert_constructor_signature, normalize_function_local_references};
 
 #[cfg(test)]
 mod tests;

--- a/crates/rumoca-phase-flatten/src/functions/constructor_signature.rs
+++ b/crates/rumoca-phase-flatten/src/functions/constructor_signature.rs
@@ -1,0 +1,225 @@
+use super::*;
+
+fn collect_constructor_params(
+    class_index: &ast::ClassDefIndex<'_>,
+    class_def: &ast::ClassDef,
+    visited_classes: &mut HashSet<usize>,
+    params: &mut Vec<rumoca_core::FunctionParam>,
+    param_index: &mut HashMap<String, usize>,
+    source_map: &rumoca_core::SourceMap,
+    def_map: &crate::ResolveDefMap,
+) -> Result<(), FlattenError> {
+    let class_ptr = class_def as *const ast::ClassDef as usize;
+    if !visited_classes.insert(class_ptr) {
+        return Ok(());
+    }
+
+    for ext in &class_def.extends {
+        let base_class = ext
+            .base_def_id
+            .and_then(|def_id| class_index.get(def_id))
+            .or_else(|| {
+                let name = ext.base_name.to_string();
+                class_index.get_by_qualified_name(&name)
+            });
+        if let Some(base_class) = base_class {
+            collect_constructor_params(
+                class_index,
+                base_class,
+                visited_classes,
+                params,
+                param_index,
+                source_map,
+                def_map,
+            )?;
+        }
+    }
+
+    for (comp_name, component) in &class_def.components {
+        let param = convert_component_to_param(
+            class_index,
+            comp_name,
+            component,
+            source_map,
+            def_map,
+            &qualify::ImportMap::default(),
+            &HashSet::new(),
+        )?;
+        if let Some(index) = param_index.get(comp_name).copied() {
+            params[index] = param;
+        } else {
+            param_index.insert(comp_name.clone(), params.len());
+            params.push(param);
+        }
+    }
+    Ok(())
+}
+
+fn collect_constructor_local_def_ids(
+    class_index: &ast::ClassDefIndex<'_>,
+    class_def: &ast::ClassDef,
+    visited_classes: &mut HashSet<usize>,
+    local_def_ids: &mut crate::ResolveDefMap,
+) {
+    let class_ptr = class_def as *const ast::ClassDef as usize;
+    if !visited_classes.insert(class_ptr) {
+        return;
+    }
+
+    for ext in &class_def.extends {
+        let base_class = ext
+            .base_def_id
+            .and_then(|def_id| class_index.get(def_id))
+            .or_else(|| {
+                let name = ext.base_name.to_string();
+                class_index.get_by_qualified_name(&name)
+            });
+        if let Some(base_class) = base_class {
+            collect_constructor_local_def_ids(
+                class_index,
+                base_class,
+                visited_classes,
+                local_def_ids,
+            );
+        }
+    }
+
+    for (name, component) in &class_def.components {
+        if let Some(def_id) = component.def_id {
+            local_def_ids.insert(def_id, name.clone());
+        }
+    }
+}
+
+fn constructor_def_map(
+    class_index: &ast::ClassDefIndex<'_>,
+    class_def: &ast::ClassDef,
+    def_map: &crate::ResolveDefMap,
+) -> crate::ResolveDefMap {
+    let mut constructor_map = def_map.clone();
+    let mut local_def_ids = crate::ResolveDefMap::default();
+    let mut visited_classes = HashSet::new();
+    collect_constructor_local_def_ids(
+        class_index,
+        class_def,
+        &mut visited_classes,
+        &mut local_def_ids,
+    );
+    for (def_id, name) in local_def_ids {
+        constructor_map.insert(def_id, name);
+    }
+    constructor_map
+}
+
+/// Build a synthetic constructor signature for constructor-like class calls.
+pub(super) fn convert_constructor_signature(
+    class_index: &ast::ClassDefIndex<'_>,
+    class_def: &ast::ClassDef,
+    qualified_name: &str,
+    source_map: &rumoca_core::SourceMap,
+    def_map: &crate::ResolveDefMap,
+) -> Result<rumoca_core::Function, FlattenError> {
+    let span = source_map.location_to_span(
+        &class_def.location.file_name,
+        class_def.location.start as usize,
+        class_def.location.end as usize,
+    );
+    let mut params = Vec::new();
+    let mut param_index = HashMap::new();
+    let mut visited_classes = HashSet::new();
+    let constructor_def_map = constructor_def_map(class_index, class_def, def_map);
+    collect_constructor_params(
+        class_index,
+        class_def,
+        &mut visited_classes,
+        &mut params,
+        &mut param_index,
+        source_map,
+        &constructor_def_map,
+    )?;
+
+    let mut func = rumoca_core::Function::new(qualified_name, span);
+    func.def_id = class_def.def_id;
+    func.is_constructor = true;
+    for param in params {
+        func.add_input(param);
+    }
+    normalize_function_local_references(&mut func);
+    Ok(func)
+}
+
+pub(super) fn normalize_function_local_references(function: &mut rumoca_core::Function) {
+    let locals = function
+        .inputs
+        .iter()
+        .chain(function.outputs.iter())
+        .chain(function.locals.iter())
+        .map(|param| param.name.clone())
+        .collect::<HashSet<_>>();
+    if locals.is_empty() {
+        return;
+    }
+
+    let mut normalizer = FunctionLocalReferenceNormalizer {
+        function_name: function.name.as_str().to_string(),
+        locals,
+    };
+    for param in function
+        .inputs
+        .iter_mut()
+        .chain(function.outputs.iter_mut())
+        .chain(function.locals.iter_mut())
+    {
+        if let Some(default) = &param.default {
+            param.default = Some(normalizer.rewrite_expression(default));
+        }
+    }
+    for statement in &mut function.body {
+        *statement = normalizer.rewrite_statement(statement);
+    }
+}
+
+struct FunctionLocalReferenceNormalizer {
+    function_name: String,
+    locals: HashSet<String>,
+}
+
+impl FunctionLocalReferenceNormalizer {
+    fn local_reference<'a>(&self, name: &'a str) -> Option<&'a str> {
+        let suffix = name.strip_prefix(&self.function_name)?;
+        let local_ref = suffix.strip_prefix('.')?;
+        self.locals
+            .iter()
+            .any(|local| {
+                local_ref == local
+                    || local_ref
+                        .strip_prefix(local.as_str())
+                        .is_some_and(|rest| rest.starts_with('.') || rest.starts_with('['))
+            })
+            .then_some(local_ref)
+    }
+}
+
+impl ExpressionRewriter for FunctionLocalReferenceNormalizer {
+    fn rewrite_expression(&mut self, expr: &rumoca_core::Expression) -> rumoca_core::Expression {
+        match expr {
+            rumoca_core::Expression::VarRef {
+                name,
+                subscripts,
+                span,
+            } => {
+                if let Some(local_name) = self.local_reference(name.as_str()) {
+                    return rumoca_core::Expression::VarRef {
+                        name: rumoca_core::Reference::new(local_name.to_string()),
+                        subscripts: self.rewrite_subscripts(subscripts),
+                        span: *span,
+                    };
+                }
+                self.walk_expression(expr)
+            }
+            _ => self.walk_expression(expr),
+        }
+    }
+}
+
+impl StatementRewriter for FunctionLocalReferenceNormalizer {}

--- a/crates/rumoca-phase-flatten/src/functions/tests.rs
+++ b/crates/rumoca-phase-flatten/src/functions/tests.rs
@@ -62,6 +62,153 @@ fn ast_comp_ref(parts: &[&str]) -> ast::ComponentReference {
 }
 
 #[test]
+fn canonicalize_collected_function_calls_uses_unique_suffix_match() {
+    let mut flat = flat::Model::new();
+    let mut function = rumoca_core::Function::new("Modelica.Math.Polynomials.fitting", Span::DUMMY);
+    function
+        .body
+        .push(rumoca_core::Statement::Return { span: Span::DUMMY });
+    flat.add_function(function);
+    flat.add_equation(flat::Equation::new(
+        rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::Reference::new("Polynomials.fitting"),
+            args: vec![],
+            is_constructor: false,
+            span: Span::DUMMY,
+        },
+        Span::DUMMY,
+        rumoca_ir_flat::EquationOrigin::ComponentEquation {
+            component: "test".to_string(),
+        },
+    ));
+
+    canonicalize_collected_function_calls(&mut flat);
+
+    let rumoca_core::Expression::FunctionCall { name, .. } = &flat.equations[0].residual else {
+        panic!("expected function call residual");
+    };
+    assert_eq!(name.as_str(), "Modelica.Math.Polynomials.fitting");
+}
+
+#[test]
+fn canonicalize_collected_function_calls_visits_when_clauses() {
+    let mut flat = flat::Model::new();
+    let mut function = rumoca_core::Function::new("Pkg.Events.trip", Span::DUMMY);
+    function
+        .body
+        .push(rumoca_core::Statement::Return { span: Span::DUMMY });
+    flat.add_function(function);
+
+    let mut when = flat::WhenClause::new(
+        rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::Reference::new("Events.trip"),
+            args: vec![],
+            is_constructor: false,
+            span: Span::DUMMY,
+        },
+        Span::DUMMY,
+    );
+    when.add_equation(flat::WhenEquation::Conditional {
+        branches: vec![(
+            rumoca_core::Expression::FunctionCall {
+                name: rumoca_core::Reference::new("Events.trip"),
+                args: vec![],
+                is_constructor: false,
+                span: Span::DUMMY,
+            },
+            vec![flat::WhenEquation::FunctionCallOutputs {
+                outputs: vec![rumoca_core::VarName::new("y")],
+                function: rumoca_core::Expression::FunctionCall {
+                    name: rumoca_core::Reference::new("Events.trip"),
+                    args: vec![],
+                    is_constructor: false,
+                    span: Span::DUMMY,
+                },
+                span: Span::DUMMY,
+                origin: "when function call".to_string(),
+            }],
+        )],
+        else_branch: vec![flat::WhenEquation::Assign {
+            target: rumoca_core::VarName::new("y"),
+            value: rumoca_core::Expression::FunctionCall {
+                name: rumoca_core::Reference::new("Events.trip"),
+                args: vec![],
+                is_constructor: false,
+                span: Span::DUMMY,
+            },
+            span: Span::DUMMY,
+            origin: "when assignment".to_string(),
+        }],
+        span: Span::DUMMY,
+        origin: "nested when branch".to_string(),
+    });
+    flat.when_clauses.push(when);
+
+    canonicalize_collected_function_calls(&mut flat);
+
+    assert_function_call_name(&flat.when_clauses[0].condition, "Pkg.Events.trip");
+    let flat::WhenEquation::Conditional {
+        branches,
+        else_branch,
+        ..
+    } = &flat.when_clauses[0].equations[0]
+    else {
+        panic!("expected conditional when equation");
+    };
+    assert_function_call_name(&branches[0].0, "Pkg.Events.trip");
+    let flat::WhenEquation::FunctionCallOutputs { function, .. } = &branches[0].1[0] else {
+        panic!("expected function-call output when equation");
+    };
+    assert_function_call_name(function, "Pkg.Events.trip");
+    let flat::WhenEquation::Assign { value, .. } = &else_branch[0] else {
+        panic!("expected assignment when equation");
+    };
+    assert_function_call_name(value, "Pkg.Events.trip");
+}
+
+fn assert_function_call_name(expr: &rumoca_core::Expression, expected: &str) {
+    let rumoca_core::Expression::FunctionCall { name, .. } = expr else {
+        panic!("expected function call expression, got {expr:?}");
+    };
+    assert_eq!(name.as_str(), expected);
+}
+
+#[test]
+fn canonicalize_collected_function_calls_leaves_ambiguous_suffix() {
+    let mut flat = flat::Model::new();
+    let mut math_function =
+        rumoca_core::Function::new("Modelica.Math.Polynomials.fitting", Span::DUMMY);
+    math_function
+        .body
+        .push(rumoca_core::Statement::Return { span: Span::DUMMY });
+    flat.add_function(math_function);
+    let mut user_function = rumoca_core::Function::new("User.Polynomials.fitting", Span::DUMMY);
+    user_function
+        .body
+        .push(rumoca_core::Statement::Return { span: Span::DUMMY });
+    flat.add_function(user_function);
+    flat.add_equation(flat::Equation::new(
+        rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::Reference::new("Polynomials.fitting"),
+            args: vec![],
+            is_constructor: false,
+            span: Span::DUMMY,
+        },
+        Span::DUMMY,
+        rumoca_ir_flat::EquationOrigin::ComponentEquation {
+            component: "test".to_string(),
+        },
+    ));
+
+    canonicalize_collected_function_calls(&mut flat);
+
+    let rumoca_core::Expression::FunctionCall { name, .. } = &flat.equations[0].residual else {
+        panic!("expected function call residual");
+    };
+    assert_eq!(name.as_str(), "Polynomials.fitting");
+}
+
+#[test]
 fn validates_function_output_assignment_before_return() {
     let mut function = rumoca_core::Function::new("Pkg.f", Span::DUMMY);
     function.add_output(rumoca_core::FunctionParam::new("y", "Real"));

--- a/crates/rumoca-phase-flatten/src/pipeline/flatten_pipeline.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/flatten_pipeline.rs
@@ -934,6 +934,7 @@ pub(crate) fn finalize_flat_model(
     functions::specialize_static_function_params(flat);
     mark_record_constructor_calls(flat, tree);
     canonicalize_varrefs_via_record_aliases(flat, ctx);
+    canonicalize_varrefs_via_instantiated_def_ids(flat);
     drop_invalid_field_access_bindings(flat);
     propagate_unexpanded_record_array_dims(flat, overlay);
     flat.oc_break_edge_scalar_count = vcg::compute_break_edge_scalar_count(
@@ -972,7 +973,9 @@ pub(crate) fn finalize_flat_model(
         substitute_known_constants_in_flat(flat, ctx);
         mark_record_constructor_calls(flat, tree);
         collapse_index_refs_to_known_varrefs(flat);
+        canonicalize_varrefs_via_instantiated_def_ids(flat);
     }
+    functions::canonicalize_collected_function_calls(flat);
     functions::prune_unreachable_functions(flat);
     functions::validate_flat_function_bindings(flat)?;
 

--- a/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims.rs
@@ -502,11 +502,22 @@ fn component_overrides_with_cache(
             );
             overrides.insert(
                 class_override.alias.clone(),
-                OverrideTarget::from_resolved(class_override.alias.clone(), target_ref, active),
+                OverrideTarget::from_resolved_with_modifier_args(
+                    class_override.alias.clone(),
+                    target_ref,
+                    active,
+                    class_override_modifier_args(&class_override.modifier_args),
+                ),
             );
         }
     }
     overrides
+}
+
+fn class_override_modifier_args(args: &[rumoca_ir_ast::Expression]) -> Vec<FunctionModifierArg> {
+    args.iter()
+        .filter_map(function_modifier_arg_from_ast)
+        .collect()
 }
 
 fn cached_component_constructor_aliases(
@@ -1121,6 +1132,19 @@ pub(crate) fn resolve_override_function_name(
             return Some(resolved);
         }
         let package = ctx.lexical_override_package()?;
+        return resolve_function_in_package_chain_exposed(
+            ctx.tree,
+            ctx.class_index,
+            package,
+            function_leaf,
+        )
+        .filter(|resolved| resolved != reference.as_str());
+    }
+
+    if let Some(source_package_def_id) = reference_source_package_def_id(reference, ctx)
+        && let Some(package) =
+            ctx.concrete_override_package_for_source_package(source_package_def_id)
+    {
         return resolve_function_in_package_chain_exposed(
             ctx.tree,
             ctx.class_index,
@@ -1794,185 +1818,20 @@ fn rewritten_function_reference(
             .get_by_qualified_name(&resolved_name)
             .and_then(|class_def| class_def.def_id)
     });
+    component_ref.parts = ComponentPath::from_flat_path(&resolved_name)
+        .parts()
+        .iter()
+        .map(|part| rumoca_core::ComponentRefPart {
+            ident: part.clone(),
+            span: component_ref.span,
+            subs: Vec::new(),
+        })
+        .collect();
     rumoca_core::Reference::with_component_reference(resolved_name, component_ref)
 }
 
-fn append_replaceable_function_modifier_args(
-    current_ref: &rumoca_core::Reference,
-    resolved_name: &str,
-    mut args: Vec<Expression>,
-    ctx: &FunctionOverrideRewriteContext<'_>,
-) -> Vec<Expression> {
-    let receiver_alias = receiver_alias_for_member_function(current_ref, ctx);
-    let existing_names = named_function_arg_names(&args);
-    if let Some(receiver_alias) = receiver_alias.as_deref()
-        && let Some(default_args) = replaceable_function_modifier_args(
-            current_ref.as_str(),
-            resolved_name,
-            receiver_alias,
-            ctx,
-        )
-    {
-        args.extend(
-            default_args
-                .into_iter()
-                .filter(|(name, _, _)| !existing_names.contains(name))
-                .map(|(name, value, span)| named_function_arg(&name, value, span)),
-        );
-    }
-    let existing_names = named_function_arg_names(&args);
-    if let Some((override_target, receiver_scope)) =
-        override_function_target_and_receiver_scope(current_ref, ctx)
-    {
-        args.extend(
-            override_target
-                .modifier_args
-                .iter()
-                .filter(|arg| !existing_names.contains(arg.name.as_str()))
-                .map(|arg| {
-                    named_function_arg(
-                        &arg.name,
-                        qualify_redeclare_function_arg(&arg.value, &receiver_scope, ctx),
-                        arg.span,
-                    )
-                }),
-        );
-    }
-    args
-}
-
-fn override_function_target_and_receiver_scope<'a>(
-    current_ref: &rumoca_core::Reference,
-    ctx: &'a FunctionOverrideRewriteContext<'a>,
-) -> Option<(&'a OverrideTarget, ComponentPath)> {
-    let alias = current_ref.last_segment();
-    if let Some(target) = ctx.override_functions.get(alias) {
-        return Some((
-            target,
-            receiver_scope_for_function_modifier(current_ref, ctx),
-        ));
-    }
-    None
-}
-
-fn receiver_scope_for_function_modifier(
-    current_ref: &rumoca_core::Reference,
-    ctx: &FunctionOverrideRewriteContext<'_>,
-) -> ComponentPath {
-    if let Some(scope) = current_ref.component_scope() {
-        let prefix_parts = scope.prefix_parts();
-        if !prefix_parts.is_empty() {
-            return ComponentPath::from_parts(prefix_parts.iter().map(|part| part.ident.as_str()));
-        }
-    }
-    ctx.active_scope.clone()
-}
-
-fn qualify_redeclare_function_arg(
-    value: &rumoca_ir_ast::Expression,
-    receiver_scope: &ComponentPath,
-    ctx: &FunctionOverrideRewriteContext<'_>,
-) -> Expression {
-    let value = QualifyReplaceableFunctionModifier {
-        receiver_alias: receiver_scope,
-    }
-    .transform_expression(value.clone());
-    crate::ast_lower::expression_from_ast_with_def_map(&value, Some(&ctx.tree.def_map))
-        .expect("redeclare function modifier expression lowering failed")
-}
-
-fn receiver_alias_for_member_function(
-    current_ref: &rumoca_core::Reference,
-    ctx: &FunctionOverrideRewriteContext<'_>,
-) -> Option<String> {
-    if let Some(alias) = current_ref
-        .component_scope()
-        .and_then(rumoca_core::ComponentReferenceScope::parent_ident)
-        .filter(|alias| ctx.override_functions.contains_key(*alias))
-    {
-        return Some(alias.to_string());
-    }
-
-    let current_name = current_ref.as_str();
-    let leaf = current_ref.last_segment();
-    let mut matches = ctx
-        .override_functions
-        .iter()
-        .filter_map(|(alias, receiver_type)| {
-            let function_name =
-                resolve_function_in_package_chain(ctx.tree, ctx.class_index, receiver_type, leaf)?;
-            (function_name == current_name).then(|| alias.clone())
-        });
-    let first = matches.next()?;
-    matches.next().is_none().then_some(first)
-}
-
-fn replaceable_function_modifier_args(
-    current_name: &str,
-    resolved_name: &str,
-    receiver_alias: &str,
-    ctx: &FunctionOverrideRewriteContext<'_>,
-) -> Option<Vec<(String, Expression, rumoca_core::Span)>> {
-    let class_def = ctx.class_index.get_by_qualified_name(current_name)?;
-    let mut result = Vec::new();
-    for ext in &class_def.extends {
-        let base_name = ext.base_name.to_string();
-        let resolved_base = ext
-            .base_def_id
-            .and_then(|def_id| ctx.tree.def_map.get(&def_id).cloned())
-            .or_else(|| resolve_class_in_scope_indexed(ctx.class_index, &base_name, current_name).1)
-            .or_else(|| {
-                ctx.class_index
-                    .get_by_qualified_name(&base_name)
-                    .map(|_| base_name.clone())
-            });
-        if resolved_base.as_deref() != Some(resolved_name) {
-            continue;
-        }
-        for modifier in &ext.modifications {
-            if let Some(arg) =
-                replaceable_function_modifier_arg(&modifier.expr, receiver_alias, ctx)
-            {
-                result.push(arg);
-            }
-        }
-    }
-    (!result.is_empty()).then_some(result)
-}
-
-fn replaceable_function_modifier_arg(
-    expr: &rumoca_ir_ast::Expression,
-    receiver_alias: &str,
-    ctx: &FunctionOverrideRewriteContext<'_>,
-) -> Option<(String, Expression, rumoca_core::Span)> {
-    let (name, value) = match expr {
-        rumoca_ir_ast::Expression::NamedArgument { name, value, .. } => {
-            (name.text.to_string(), value.as_ref().clone())
-        }
-        rumoca_ir_ast::Expression::Modification { target, value, .. } => {
-            (single_component_ref_name(target)?, value.as_ref().clone())
-        }
-        _ => return None,
-    };
-    let receiver_path = ComponentPath::from_parts([receiver_alias]);
-    let value = QualifyReplaceableFunctionModifier {
-        receiver_alias: &receiver_path,
-    }
-    .transform_expression(value);
-    Some((
-        name,
-        crate::ast_lower::expression_from_ast_with_def_map(&value, Some(&ctx.tree.def_map))
-            .expect("replaceable function modifier expression lowering failed"),
-        expr.span(),
-    ))
-}
-
-fn single_component_ref_name(comp: &rumoca_ir_ast::ComponentReference) -> Option<String> {
-    let [part] = comp.parts.as_slice() else {
-        return None;
-    };
-    Some(part.ident.text.to_string())
-}
+mod replaceable_modifiers;
+use replaceable_modifiers::{append_replaceable_function_modifier_args, single_component_ref_name};
 
 #[cfg(test)]
 mod tests;

--- a/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims/replaceable_modifiers.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims/replaceable_modifiers.rs
@@ -1,0 +1,180 @@
+use super::*;
+
+pub(super) fn append_replaceable_function_modifier_args(
+    current_ref: &rumoca_core::Reference,
+    resolved_name: &str,
+    mut args: Vec<Expression>,
+    ctx: &FunctionOverrideRewriteContext<'_>,
+) -> Vec<Expression> {
+    let receiver_alias = receiver_alias_for_member_function(current_ref, ctx);
+    let existing_names = named_function_arg_names(&args);
+    if let Some(receiver_alias) = receiver_alias.as_deref()
+        && let Some(default_args) = replaceable_function_modifier_args(
+            current_ref.as_str(),
+            resolved_name,
+            receiver_alias,
+            ctx,
+        )
+    {
+        args.extend(
+            default_args
+                .into_iter()
+                .filter(|(name, _, _)| !existing_names.contains(name))
+                .map(|(name, value, span)| named_function_arg(&name, value, span)),
+        );
+    }
+    let existing_names = named_function_arg_names(&args);
+    if let Some((override_target, receiver_scope)) =
+        override_function_target_and_receiver_scope(current_ref, ctx)
+    {
+        args.extend(
+            override_target
+                .modifier_args
+                .iter()
+                .filter(|arg| !existing_names.contains(arg.name.as_str()))
+                .map(|arg| {
+                    named_function_arg(
+                        &arg.name,
+                        qualify_redeclare_function_arg(&arg.value, &receiver_scope, ctx),
+                        arg.span,
+                    )
+                }),
+        );
+    }
+    args
+}
+
+fn override_function_target_and_receiver_scope<'a>(
+    current_ref: &rumoca_core::Reference,
+    ctx: &'a FunctionOverrideRewriteContext<'a>,
+) -> Option<(&'a OverrideTarget, ComponentPath)> {
+    let alias = current_ref.last_segment();
+    if let Some(target) = ctx.override_functions.get(alias) {
+        return Some((
+            target,
+            receiver_scope_for_function_modifier(current_ref, ctx),
+        ));
+    }
+    None
+}
+
+fn receiver_scope_for_function_modifier(
+    current_ref: &rumoca_core::Reference,
+    ctx: &FunctionOverrideRewriteContext<'_>,
+) -> ComponentPath {
+    if let Some(scope) = current_ref.component_scope() {
+        let prefix_parts = scope.prefix_parts();
+        if !prefix_parts.is_empty() {
+            return ComponentPath::from_parts(prefix_parts.iter().map(|part| part.ident.as_str()));
+        }
+    }
+    ctx.active_scope.clone()
+}
+
+fn qualify_redeclare_function_arg(
+    value: &rumoca_ir_ast::Expression,
+    receiver_scope: &ComponentPath,
+    ctx: &FunctionOverrideRewriteContext<'_>,
+) -> Expression {
+    let value = QualifyReplaceableFunctionModifier {
+        receiver_alias: receiver_scope,
+    }
+    .transform_expression(value.clone());
+    crate::ast_lower::expression_from_ast_with_def_map(&value, Some(&ctx.tree.def_map))
+        .expect("redeclare function modifier expression lowering failed")
+}
+
+fn receiver_alias_for_member_function(
+    current_ref: &rumoca_core::Reference,
+    ctx: &FunctionOverrideRewriteContext<'_>,
+) -> Option<String> {
+    if let Some(alias) = current_ref
+        .component_scope()
+        .and_then(rumoca_core::ComponentReferenceScope::parent_ident)
+        .filter(|alias| ctx.override_functions.contains_key(*alias))
+    {
+        return Some(alias.to_string());
+    }
+
+    let current_name = current_ref.as_str();
+    let leaf = current_ref.last_segment();
+    let mut matches = ctx
+        .override_functions
+        .iter()
+        .filter_map(|(alias, receiver_type)| {
+            let function_name =
+                resolve_function_in_package_chain(ctx.tree, ctx.class_index, receiver_type, leaf)?;
+            (function_name == current_name).then(|| alias.clone())
+        });
+    let first = matches.next()?;
+    matches.next().is_none().then_some(first)
+}
+
+fn replaceable_function_modifier_args(
+    current_name: &str,
+    resolved_name: &str,
+    receiver_alias: &str,
+    ctx: &FunctionOverrideRewriteContext<'_>,
+) -> Option<Vec<(String, Expression, rumoca_core::Span)>> {
+    let class_def = ctx.class_index.get_by_qualified_name(current_name)?;
+    let mut result = Vec::new();
+    for ext in &class_def.extends {
+        let base_name = ext.base_name.to_string();
+        let resolved_base = ext
+            .base_def_id
+            .and_then(|def_id| ctx.tree.def_map.get(&def_id).cloned())
+            .or_else(|| resolve_class_in_scope_indexed(ctx.class_index, &base_name, current_name).1)
+            .or_else(|| {
+                ctx.class_index
+                    .get_by_qualified_name(&base_name)
+                    .map(|_| base_name.clone())
+            });
+        if resolved_base.as_deref() != Some(resolved_name) {
+            continue;
+        }
+        for modifier in &ext.modifications {
+            if let Some(arg) =
+                replaceable_function_modifier_arg(&modifier.expr, receiver_alias, ctx)
+            {
+                result.push(arg);
+            }
+        }
+    }
+    (!result.is_empty()).then_some(result)
+}
+
+fn replaceable_function_modifier_arg(
+    expr: &rumoca_ir_ast::Expression,
+    receiver_alias: &str,
+    ctx: &FunctionOverrideRewriteContext<'_>,
+) -> Option<(String, Expression, rumoca_core::Span)> {
+    let (name, value) = match expr {
+        rumoca_ir_ast::Expression::NamedArgument { name, value, .. } => {
+            (name.text.to_string(), value.as_ref().clone())
+        }
+        rumoca_ir_ast::Expression::Modification { target, value, .. } => {
+            (single_component_ref_name(target)?, value.as_ref().clone())
+        }
+        _ => return None,
+    };
+    let receiver_path = ComponentPath::from_parts([receiver_alias]);
+    let value = QualifyReplaceableFunctionModifier {
+        receiver_alias: &receiver_path,
+    }
+    .transform_expression(value);
+    Some((
+        name,
+        crate::ast_lower::expression_from_ast_with_def_map(&value, Some(&ctx.tree.def_map))
+            .expect("replaceable function modifier expression lowering failed"),
+        expr.span(),
+    ))
+}
+
+pub(super) fn single_component_ref_name(
+    comp: &rumoca_ir_ast::ComponentReference,
+) -> Option<String> {
+    let [part] = comp.parts.as_slice() else {
+        return None;
+    };
+    Some(part.ident.text.to_string())
+}

--- a/crates/rumoca-phase-flatten/src/postprocess.rs
+++ b/crates/rumoca-phase-flatten/src/postprocess.rs
@@ -28,6 +28,10 @@ pub(super) fn canonicalize_varrefs_via_record_aliases(flat: &mut flat::Model, ct
     }
 }
 
+#[path = "postprocess_def_id.rs"]
+mod def_id;
+pub(crate) use def_id::canonicalize_varrefs_via_instantiated_def_ids;
+
 fn record_alias_rewrite_name(
     name: &str,
     ctx: &Context,

--- a/crates/rumoca-phase-flatten/src/postprocess_def_id.rs
+++ b/crates/rumoca-phase-flatten/src/postprocess_def_id.rs
@@ -1,0 +1,346 @@
+use super::*;
+use rumoca_core::{ExpressionRewriter, StatementRewriter};
+use std::collections::{HashMap, HashSet};
+
+pub(crate) fn canonicalize_varrefs_via_instantiated_def_ids(flat: &mut flat::Model) {
+    let known_variables: HashSet<String> = flat.variables.keys().map(ToString::to_string).collect();
+    let def_id_index = DefIdVarRefIndex::build(flat);
+    if def_id_index.is_empty() {
+        return;
+    }
+
+    for var in flat.variables.values_mut() {
+        let owner = var.name.as_str();
+        canonicalize_def_id_opt_expr(
+            &mut var.binding,
+            &def_id_index,
+            &known_variables,
+            Some(owner),
+        );
+        canonicalize_def_id_opt_expr(&mut var.start, &def_id_index, &known_variables, Some(owner));
+        canonicalize_def_id_opt_expr(&mut var.min, &def_id_index, &known_variables, Some(owner));
+        canonicalize_def_id_opt_expr(&mut var.max, &def_id_index, &known_variables, Some(owner));
+        canonicalize_def_id_opt_expr(
+            &mut var.nominal,
+            &def_id_index,
+            &known_variables,
+            Some(owner),
+        );
+    }
+    for equation in &mut flat.equations {
+        let owner = equation_origin_owner(&equation.origin);
+        canonicalize_def_id_expr(
+            &mut equation.residual,
+            &def_id_index,
+            &known_variables,
+            owner.as_deref(),
+        );
+    }
+    for equation in &mut flat.initial_equations {
+        let owner = equation_origin_owner(&equation.origin);
+        canonicalize_def_id_expr(
+            &mut equation.residual,
+            &def_id_index,
+            &known_variables,
+            owner.as_deref(),
+        );
+    }
+    for assert_eq in &mut flat.assert_equations {
+        canonicalize_def_id_expr(
+            &mut assert_eq.condition,
+            &def_id_index,
+            &known_variables,
+            None,
+        );
+        canonicalize_def_id_expr(
+            &mut assert_eq.message,
+            &def_id_index,
+            &known_variables,
+            None,
+        );
+        canonicalize_def_id_opt_expr(&mut assert_eq.level, &def_id_index, &known_variables, None);
+    }
+    for assert_eq in &mut flat.initial_assert_equations {
+        canonicalize_def_id_expr(
+            &mut assert_eq.condition,
+            &def_id_index,
+            &known_variables,
+            None,
+        );
+        canonicalize_def_id_expr(
+            &mut assert_eq.message,
+            &def_id_index,
+            &known_variables,
+            None,
+        );
+        canonicalize_def_id_opt_expr(&mut assert_eq.level, &def_id_index, &known_variables, None);
+    }
+    for when_clause in &mut flat.when_clauses {
+        canonicalize_def_id_expr(
+            &mut when_clause.condition,
+            &def_id_index,
+            &known_variables,
+            None,
+        );
+        canonicalize_def_id_when_equations(
+            &mut when_clause.equations,
+            &def_id_index,
+            &known_variables,
+        );
+    }
+    for algorithm in &mut flat.algorithms {
+        canonicalize_def_id_statements(
+            &mut algorithm.statements,
+            &def_id_index,
+            &known_variables,
+            None,
+        );
+    }
+    for algorithm in &mut flat.initial_algorithms {
+        canonicalize_def_id_statements(
+            &mut algorithm.statements,
+            &def_id_index,
+            &known_variables,
+            None,
+        );
+    }
+}
+
+struct DefIdVarRefIndex {
+    by_def_id: HashMap<rumoca_core::DefId, Vec<IndexedVarRef>>,
+    by_leaf: HashMap<String, Vec<IndexedVarRef>>,
+}
+
+#[derive(Clone)]
+struct IndexedVarRef {
+    name: String,
+    leaf: String,
+    path: rumoca_core::ComponentPath,
+}
+
+impl DefIdVarRefIndex {
+    fn build(flat: &flat::Model) -> Self {
+        let mut by_def_id: HashMap<rumoca_core::DefId, Vec<IndexedVarRef>> = HashMap::new();
+        let mut by_leaf: HashMap<String, Vec<IndexedVarRef>> = HashMap::new();
+        for (name, var) in &flat.variables {
+            let indexed = indexed_var_ref(name, var);
+            by_leaf
+                .entry(indexed_var_leaf(name, var).to_string())
+                .or_default()
+                .push(indexed.clone());
+            if let Some(def_id) = var.component_ref.as_ref().and_then(|comp| comp.def_id) {
+                by_def_id.entry(def_id).or_default().push(indexed);
+            }
+        }
+        Self { by_def_id, by_leaf }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.by_def_id.is_empty() && self.by_leaf.is_empty()
+    }
+
+    fn resolve(
+        &self,
+        name: &rumoca_core::Reference,
+        owner: Option<&str>,
+        known_variables: &HashSet<String>,
+    ) -> Option<String> {
+        let raw = name.as_str();
+        if known_variables.contains(raw) {
+            return None;
+        }
+        let raw_leaf = name.last_segment();
+        if let Some(def_id) = name.target_def_id()
+            && let Some(candidates) = self.by_def_id.get(&def_id)
+        {
+            return resolve_best_owner_scoped_candidate(raw, raw_leaf, candidates, owner);
+        }
+        if is_class_qualified_reference(name) {
+            let candidates = self.by_leaf.get(raw_leaf)?;
+            return resolve_best_owner_scoped_candidate(raw, raw_leaf, candidates, owner);
+        }
+        None
+    }
+}
+
+fn indexed_var_ref(name: &rumoca_core::VarName, var: &flat::Variable) -> IndexedVarRef {
+    let path = rumoca_core::ComponentPath::from_flat_path(name.as_str());
+    IndexedVarRef {
+        name: name.as_str().to_string(),
+        leaf: indexed_var_leaf(name, var).to_string(),
+        path,
+    }
+}
+
+fn indexed_var_leaf<'a>(name: &'a rumoca_core::VarName, var: &'a flat::Variable) -> &'a str {
+    var.component_ref
+        .as_ref()
+        .and_then(rumoca_core::ComponentReference::last_ident)
+        .unwrap_or_else(|| name.last_segment())
+}
+
+fn resolve_best_owner_scoped_candidate(
+    raw: &str,
+    raw_leaf: &str,
+    candidates: &[IndexedVarRef],
+    owner: Option<&str>,
+) -> Option<String> {
+    let owner_path = owner.map(rumoca_core::ComponentPath::from_flat_path);
+    let mut scored = candidates
+        .iter()
+        .filter(|candidate| candidate.leaf == raw_leaf)
+        .filter_map(|candidate| {
+            let score = owner_path
+                .as_ref()
+                .map(|owner| owner_scope_score(owner, &candidate.path))
+                .unwrap_or_else(|| (candidates.len() == 1).then_some(0))?;
+            Some((score, candidate))
+        })
+        .collect::<Vec<_>>();
+    scored.sort_by_key(|(score, _)| *score);
+    let (best_score, best) = scored.last()?;
+    let ambiguous = scored
+        .iter()
+        .rev()
+        .skip(1)
+        .any(|(score, _)| score == best_score);
+    (!ambiguous && best.name.as_str() != raw).then(|| best.name.clone())
+}
+
+fn owner_scope_score(
+    owner_path: &rumoca_core::ComponentPath,
+    candidate_path: &rumoca_core::ComponentPath,
+) -> Option<usize> {
+    let candidate_scope = candidate_path.prefix(candidate_path.len().saturating_sub(1))?;
+    owner_path
+        .starts_with(&candidate_scope)
+        .then_some(candidate_scope.len())
+}
+
+fn is_class_qualified_reference(name: &rumoca_core::Reference) -> bool {
+    let path = name
+        .component_ref()
+        .map(rumoca_core::ComponentPath::from_component_reference)
+        .unwrap_or_else(|| rumoca_core::ComponentPath::from_reference(name));
+    path.len() >= 3
+        && path
+            .parts()
+            .first()
+            .and_then(|part| part.chars().next())
+            .is_some_and(char::is_uppercase)
+}
+
+fn equation_origin_owner(origin: &flat::EquationOrigin) -> Option<String> {
+    match origin {
+        flat::EquationOrigin::ComponentEquation { component }
+        | flat::EquationOrigin::Algorithm { component } => Some(component.clone()),
+        flat::EquationOrigin::Binding { variable }
+        | flat::EquationOrigin::Reinit { state: variable }
+        | flat::EquationOrigin::WhenAssignment { target: variable }
+        | flat::EquationOrigin::UnconnectedFlow { variable } => Some(variable.clone()),
+        flat::EquationOrigin::Connection { lhs, .. } => Some(lhs.clone()),
+        flat::EquationOrigin::FlowSum { .. } => None,
+    }
+    .filter(|owner| !owner.is_empty())
+}
+
+fn canonicalize_def_id_opt_expr(
+    expr: &mut Option<rumoca_core::Expression>,
+    index: &DefIdVarRefIndex,
+    known_variables: &HashSet<String>,
+    owner: Option<&str>,
+) {
+    if let Some(expr) = expr {
+        canonicalize_def_id_expr(expr, index, known_variables, owner);
+    }
+}
+
+fn canonicalize_def_id_expr(
+    expr: &mut rumoca_core::Expression,
+    index: &DefIdVarRefIndex,
+    known_variables: &HashSet<String>,
+    owner: Option<&str>,
+) {
+    let mut rewriter = DefIdVarRefCanonicalizer {
+        index,
+        known_variables,
+        owner,
+    };
+    *expr = rewriter.rewrite_expression(expr);
+}
+
+fn canonicalize_def_id_statements(
+    statements: &mut [rumoca_core::Statement],
+    index: &DefIdVarRefIndex,
+    known_variables: &HashSet<String>,
+    owner: Option<&str>,
+) {
+    let mut rewriter = DefIdVarRefCanonicalizer {
+        index,
+        known_variables,
+        owner,
+    };
+    for statement in statements {
+        *statement = rewriter.rewrite_statement(statement);
+    }
+}
+
+fn canonicalize_def_id_when_equations(
+    equations: &mut [flat::WhenEquation],
+    index: &DefIdVarRefIndex,
+    known_variables: &HashSet<String>,
+) {
+    for equation in equations {
+        match equation {
+            flat::WhenEquation::Assign { value, .. } | flat::WhenEquation::Reinit { value, .. } => {
+                canonicalize_def_id_expr(value, index, known_variables, None);
+            }
+            flat::WhenEquation::Assert { condition, .. } => {
+                canonicalize_def_id_expr(condition, index, known_variables, None);
+            }
+            flat::WhenEquation::Conditional {
+                branches,
+                else_branch,
+                ..
+            } => {
+                for (condition, branch_equations) in branches {
+                    canonicalize_def_id_expr(condition, index, known_variables, None);
+                    canonicalize_def_id_when_equations(branch_equations, index, known_variables);
+                }
+                canonicalize_def_id_when_equations(else_branch, index, known_variables);
+            }
+            flat::WhenEquation::FunctionCallOutputs { function, .. } => {
+                canonicalize_def_id_expr(function, index, known_variables, None);
+            }
+            flat::WhenEquation::Terminate { .. } => {}
+        }
+    }
+}
+
+struct DefIdVarRefCanonicalizer<'a> {
+    index: &'a DefIdVarRefIndex,
+    known_variables: &'a HashSet<String>,
+    owner: Option<&'a str>,
+}
+
+impl ExpressionRewriter for DefIdVarRefCanonicalizer<'_> {
+    fn rewrite_var_ref_expression(
+        &mut self,
+        name: &rumoca_core::Reference,
+        subscripts: &[rumoca_core::Subscript],
+        span: rumoca_core::Span,
+    ) -> rumoca_core::Expression {
+        let rewritten_name = self
+            .index
+            .resolve(name, self.owner, self.known_variables)
+            .map(|selected| name.with_var_name(rumoca_core::VarName::new(selected)))
+            .unwrap_or_else(|| name.clone());
+        rumoca_core::Expression::VarRef {
+            name: rewritten_name,
+            subscripts: self.rewrite_subscripts(subscripts),
+            span,
+        }
+    }
+}
+
+impl StatementRewriter for DefIdVarRefCanonicalizer<'_> {}

--- a/crates/rumoca-phase-flatten/src/postprocess_record_alias_tests.rs
+++ b/crates/rumoca-phase-flatten/src/postprocess_record_alias_tests.rs
@@ -21,6 +21,26 @@ fn component_ref(name: &str) -> rumoca_core::ComponentReference {
     }
 }
 
+fn component_ref_with_def_id(
+    path: &str,
+    def_id: rumoca_core::DefId,
+) -> rumoca_core::ComponentReference {
+    rumoca_core::ComponentReference {
+        local: false,
+        span: rumoca_core::Span::DUMMY,
+        parts: rumoca_core::ComponentPath::from_flat_path(path)
+            .parts()
+            .iter()
+            .map(|ident| rumoca_core::ComponentRefPart {
+                ident: ident.clone(),
+                span: rumoca_core::Span::DUMMY,
+                subs: vec![],
+            })
+            .collect(),
+        def_id: Some(def_id),
+    }
+}
+
 fn context_with_alias() -> Context {
     let mut ctx = Context::new();
     ctx.record_aliases.insert(
@@ -28,6 +48,60 @@ fn context_with_alias() -> Context {
         rumoca_core::ComponentPath::from_flat_path("pipe"),
     );
     ctx
+}
+
+#[test]
+fn def_id_canonicalization_rewrites_class_qualified_ref_by_owner_scope() {
+    let mut model = flat::Model::new();
+    let def_id = rumoca_core::DefId::new(42);
+    for name in [
+        "inertia1.rotorWith3DEffects.e",
+        "inertia2.rotorWith3DEffects.e",
+    ] {
+        model.add_variable(
+            rumoca_core::VarName::new(name),
+            flat::Variable {
+                name: rumoca_core::VarName::new(name),
+                component_ref: Some(component_ref_with_def_id(name, def_id)),
+                is_primitive: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    model.add_variable(
+        rumoca_core::VarName::new("inertia1.rotorWith3DEffects.cylinder.r_shape"),
+        flat::Variable {
+            name: rumoca_core::VarName::new("inertia1.rotorWith3DEffects.cylinder.r_shape"),
+            binding: Some(rumoca_core::Expression::VarRef {
+                name: rumoca_core::Reference::with_component_reference(
+                    "Modelica.Mechanics.MultiBody.Parts.Rotor1D.e",
+                    component_ref_with_def_id(
+                        "Modelica.Mechanics.MultiBody.Parts.Rotor1D.e",
+                        def_id,
+                    ),
+                ),
+                subscripts: vec![],
+                span: rumoca_core::Span::DUMMY,
+            }),
+            is_primitive: true,
+            ..Default::default()
+        },
+    );
+
+    canonicalize_varrefs_via_instantiated_def_ids(&mut model);
+
+    let binding = model
+        .variables
+        .get(&rumoca_core::VarName::new(
+            "inertia1.rotorWith3DEffects.cylinder.r_shape",
+        ))
+        .and_then(|var| var.binding.as_ref())
+        .expect("binding should remain present");
+    let rumoca_core::Expression::VarRef { name, .. } = binding else {
+        panic!("expected varref binding");
+    };
+    assert_eq!(name.as_str(), "inertia1.rotorWith3DEffects.e");
 }
 
 #[test]

--- a/crates/rumoca-phase-instantiate/src/type_overrides.rs
+++ b/crates/rumoca-phase-instantiate/src/type_overrides.rs
@@ -311,8 +311,13 @@ fn resolve_redeclare_value_def_id_with_depth(
     }
 
     match value {
+        ast::Expression::Modification { value, .. } => {
+            resolve_redeclare_value_def_id_with_depth(tree, value, mod_env, depth + 1)
+        }
         ast::Expression::ClassModification { target, .. } => resolve_cref_def_id(tree, target)
             .or_else(|| resolve_cref_via_mod_env(tree, target, mod_env, depth)),
+        ast::Expression::FunctionCall { comp, .. } => resolve_cref_def_id(tree, comp)
+            .or_else(|| resolve_cref_via_mod_env(tree, comp, mod_env, depth)),
         ast::Expression::ComponentReference(cref) => resolve_cref_def_id(tree, cref)
             .or_else(|| resolve_cref_via_mod_env(tree, cref, mod_env, depth)),
         _ => None,
@@ -532,14 +537,14 @@ fn validate_component_class_redeclare_target(
     nested_class: &ast::ClassDef,
     mod_expr: &ast::Expression,
 ) -> InstantiateResult<()> {
-    let ast::Expression::ClassModification { target, .. } = mod_expr else {
+    let Some(target_ref) = class_redeclare_target_ref(mod_expr) else {
         return Err(Box::new(InstantiateError::redeclare_error(
             target_name,
             "redeclare target is missing source span",
             location_to_span(&nested_class.location, &tree.source_map),
         )));
     };
-    let Some(part) = target.parts.first() else {
+    let Some(part) = target_ref.parts.first() else {
         return Err(Box::new(InstantiateError::redeclare_error(
             target_name,
             "redeclare target is missing source span",
@@ -579,9 +584,9 @@ pub(super) fn extract_component_class_overrides(
     };
 
     for (target_name, mod_expr) in &comp.modifications {
-        let ast::Expression::ClassModification { .. } = mod_expr else {
+        if class_redeclare_target_ref(mod_expr).is_none() {
             continue;
-        };
+        }
 
         let Some(nested_class) = find_nested_class_in_hierarchy(tree, target_class, target_name)
         else {
@@ -595,7 +600,11 @@ pub(super) fn extract_component_class_overrides(
                 location_to_span(&nested_class.location, &tree.source_map),
             )));
         };
-        let resolved_def_id = resolve_redeclare_value_def_id(tree, mod_expr, mod_env);
+        let resolved_def_id =
+            resolve_redeclare_value_def_id(tree, mod_expr, mod_env).or_else(|| {
+                class_redeclare_target_ref(mod_expr)
+                    .and_then(|target| target.def_id.or_else(|| resolve_cref_def_id(tree, &target)))
+            });
 
         if let Some(def_id) = resolved_def_id {
             overrides.insert(
@@ -605,7 +614,8 @@ pub(super) fn extract_component_class_overrides(
                     alias_def_id,
                     def_id,
                     class_redeclare_target_ref(mod_expr),
-                ),
+                )
+                .with_modifier_args(class_redeclare_modifier_args(mod_expr)),
             );
         }
     }
@@ -614,10 +624,24 @@ pub(super) fn extract_component_class_overrides(
 }
 
 fn class_redeclare_target_ref(mod_expr: &ast::Expression) -> Option<ast::ComponentReference> {
-    let ast::Expression::ClassModification { target, .. } = mod_expr else {
-        return None;
-    };
-    Some(target.clone())
+    match mod_expr {
+        ast::Expression::Modification { target, value, .. } => {
+            class_redeclare_target_ref(value).or_else(|| Some(target.clone()))
+        }
+        ast::Expression::ClassModification { target, .. } => Some(target.clone()),
+        ast::Expression::FunctionCall { comp, .. } => Some(comp.clone()),
+        ast::Expression::ComponentReference(cref) => Some(cref.clone()),
+        _ => None,
+    }
+}
+
+fn class_redeclare_modifier_args(mod_expr: &ast::Expression) -> Vec<ast::Expression> {
+    match mod_expr {
+        ast::Expression::Modification { value, .. } => class_redeclare_modifier_args(value),
+        ast::Expression::ClassModification { modifications, .. } => modifications.clone(),
+        ast::Expression::FunctionCall { args, .. } => args.clone(),
+        _ => Vec::new(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/rumoca-phase-resolve/src/validation.rs
+++ b/crates/rumoca-phase-resolve/src/validation.rs
@@ -4,6 +4,7 @@
 
 use rumoca_core::Location;
 use rumoca_ir_ast as ast;
+use std::collections::HashSet;
 use std::ops::ControlFlow;
 
 type ClassDef = ast::ClassDef;
@@ -59,7 +60,10 @@ impl ValidationResult {
 
 /// Validate that a ClassTree has all symbols resolved.
 pub fn validate_resolution(tree: &ClassTree) -> ValidationResult {
-    let mut v = Validator::default();
+    let mut v = Validator {
+        component_names: collect_component_names(&tree.definitions),
+        ..Validator::default()
+    };
     let _ = ast::Visitor::visit_stored_definition(&mut v, &tree.definitions);
     ValidationResult {
         unresolved: v.unresolved,
@@ -69,6 +73,7 @@ pub fn validate_resolution(tree: &ClassTree) -> ValidationResult {
 #[derive(Default)]
 struct Validator {
     path: Vec<String>,
+    component_names: HashSet<String>,
     unresolved: Vec<UnresolvedSymbol>,
 }
 
@@ -117,6 +122,11 @@ impl Validator {
 
     fn add_unresolved_function_call(&mut self, cr: &ComponentReference) {
         if cr.def_id.is_none() && !cr.parts.is_empty() {
+            // Receiver-qualified calls such as `world.gravityAcceleration(...)`
+            // may require inherited/outer component type context from instantiation.
+            if self.is_likely_component_receiver_call(cr) {
+                return;
+            }
             let source_location = cr.parts[0].ident.location.clone();
             self.add(
                 cr.parts[0].ident.text.to_string(),
@@ -124,6 +134,32 @@ impl Validator {
                 source_location,
             );
         }
+    }
+
+    fn is_likely_component_receiver_call(&self, cr: &ComponentReference) -> bool {
+        cr.parts.len() > 1
+            && cr
+                .parts
+                .first()
+                .is_some_and(|part| self.component_names.contains(part.ident.text.as_ref()))
+    }
+}
+
+fn collect_component_names(definition: &ast::StoredDefinition) -> HashSet<String> {
+    let mut collector = ComponentNameCollector::default();
+    let _ = ast::Visitor::visit_stored_definition(&mut collector, definition);
+    collector.names
+}
+
+#[derive(Default)]
+struct ComponentNameCollector {
+    names: HashSet<String>,
+}
+
+impl ast::Visitor for ComponentNameCollector {
+    fn visit_component(&mut self, comp: &Component) -> ControlFlow<()> {
+        self.names.insert(comp.name.clone());
+        ControlFlow::Continue(())
     }
 }
 
@@ -327,6 +363,60 @@ mod tests {
     fn test_unresolved_function() {
         let r = resolve_for_validation("model T Real x; equation x = unknownFunc(1.0); end T;");
         assert!(r.unresolved.iter().any(|s| s.name == "unknownFunc"));
+    }
+
+    #[test]
+    fn test_component_qualified_function_call_is_deferred_to_instantiation() {
+        let r = resolve_for_validation(
+            r#"
+model World
+  function gravityAcceleration
+    input Real r;
+    output Real g;
+  algorithm
+    g := r;
+  end gravityAcceleration;
+end World;
+
+model Base
+  outer World world;
+end Base;
+
+model M
+  extends Base;
+  Real y;
+equation
+  y = world.gravityAcceleration(1.0);
+end M;
+"#,
+        );
+        assert!(
+            !r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::FunctionCall && s.name == "world"),
+            "component-qualified member calls need instance/type context, got: {:?}",
+            r.unresolved
+        );
+    }
+
+    #[test]
+    fn test_missing_package_qualified_function_call_is_reported() {
+        let r = resolve_for_validation(
+            r#"
+model M
+  Real y;
+equation
+  y = MissingPkg.f(1.0);
+end M;
+"#,
+        );
+        assert!(
+            r.unresolved
+                .iter()
+                .any(|s| s.kind == UnresolvedKind::FunctionCall && s.name == "MissingPkg"),
+            "package-qualified calls must still report unresolved leading names, got: {:?}",
+            r.unresolved
+        );
     }
 
     #[test]

--- a/crates/rumoca-phase-solve/src/lower.rs
+++ b/crates/rumoca-phase-solve/src/lower.rs
@@ -1029,6 +1029,12 @@ impl<'a> LowerBuilder<'a> {
             return Ok(reg);
         }
 
+        if let Some(reg) =
+            self.lower_function_output_name_field_access(base, field, scope, call_depth)?
+        {
+            return Ok(reg);
+        }
+
         if let Some(mut values) = self.lower_indexed_record_field_values(base, field, scope)? {
             if values.len() == 1 {
                 return Ok(values.remove(0));
@@ -1057,6 +1063,38 @@ impl<'a> LowerBuilder<'a> {
             .binding(&key)
             .ok_or(LowerError::MissingBinding { name: key })?;
         self.emit_slot_load(slot)
+    }
+
+    fn lower_function_output_name_field_access(
+        &mut self,
+        base: &rumoca_core::Expression,
+        field: &str,
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Option<Reg>, LowerError> {
+        let rumoca_core::Expression::FunctionCall {
+            name,
+            args,
+            is_constructor: false,
+            span,
+        } = base
+        else {
+            return Ok(None);
+        };
+        let Some(function) = self.lookup_function(name) else {
+            return Ok(None);
+        };
+        let [output] = function.outputs.as_slice() else {
+            return Ok(None);
+        };
+        if output.name != field
+            || !output.dims.is_empty()
+            || output.type_class == Some(rumoca_core::ClassType::Record)
+        {
+            return Ok(None);
+        }
+        self.lower_function_call(name, args, false, *span, scope, call_depth)
+            .map(Some)
     }
 
     fn lower_indexed_field_access(
@@ -1929,44 +1967,5 @@ impl<'a> LowerBuilder<'a> {
     }
 }
 
-fn static_singleton_subscript_index(
-    expr: &rumoca_core::Expression,
-) -> Result<Option<usize>, LowerError> {
-    lower_static_index_expr(expr)
-}
-
-fn direct_assignment_component(
-    values: &[Reg],
-    flat_index: usize,
-    repeat_period: Option<usize>,
-) -> Option<Reg> {
-    values.get(flat_index).copied().or_else(|| {
-        let period = repeat_period?;
-        (period > 0 && values.len() == period).then(|| values[flat_index % period])
-    })
-}
-
-fn complex_operator_call_op(name: &str) -> Option<BinaryOp> {
-    match name {
-        "Complex.'+'" => Some(BinaryOp::Add),
-        "Complex.'-'" => Some(BinaryOp::Sub),
-        "Complex.'*'" => Some(BinaryOp::Mul),
-        "Complex.'/'" => Some(BinaryOp::Div),
-        _ => None,
-    }
-}
-
-fn is_time_var_ref(expr: &rumoca_core::Expression) -> bool {
-    matches!(
-        expr,
-        rumoca_core::Expression::VarRef {
-            name,
-            subscripts,
-            ..
-        } if name.as_str() == "time" && subscripts.is_empty()
-    )
-}
-
-pub(super) fn size_binding_key(name: &str, dim: usize) -> String {
-    format!("{SIZE_BINDING_PREFIX}{name}.{dim}")
-}
+mod misc_helpers;
+use misc_helpers::*;

--- a/crates/rumoca-phase-solve/src/lower/array_values/dynamic_selection.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/dynamic_selection.rs
@@ -687,6 +687,16 @@ impl<'a> LowerBuilder<'a> {
             return Ok(None);
         }
         let Some(function) = self.lookup_function(name).cloned() else {
+            if let Some(closure) = self.lookup_function_closure(name).cloned() {
+                let reg = self.lower_function_closure_call(
+                    &closure,
+                    args,
+                    rumoca_core::Span::DUMMY,
+                    caller_scope,
+                    call_depth,
+                )?;
+                return Ok(Some(vec![reg]));
+            }
             return Ok(None);
         };
         if function.external.is_some() || function.outputs.is_empty() {
@@ -949,6 +959,13 @@ impl<'a> LowerBuilder<'a> {
                 }
             }
 
+            if !self.can_project_record_field_expression(value) {
+                match self.lower_statement_or_stop(statement, scope, call_depth)? {
+                    true => break,
+                    false => continue,
+                }
+            }
+
             let projected = projected_record_field_expression(value, field);
             let field_key = format!("{}.{}", output.name, field);
             let values = self.lower_array_like_values(&projected, scope, call_depth)?;
@@ -969,6 +986,42 @@ impl<'a> LowerBuilder<'a> {
         call_depth: usize,
     ) -> Result<bool, LowerError> {
         self.lower_statement(statement, scope, call_depth)
+    }
+
+    fn can_project_record_field_expression(&self, expr: &rumoca_core::Expression) -> bool {
+        match expr {
+            rumoca_core::Expression::If {
+                branches,
+                else_branch,
+                ..
+            } => {
+                branches
+                    .iter()
+                    .all(|(_, branch)| self.can_project_record_field_expression(branch))
+                    && self.can_project_record_field_expression(else_branch)
+            }
+            rumoca_core::Expression::Array { elements, .. }
+            | rumoca_core::Expression::Tuple { elements, .. } => elements
+                .iter()
+                .all(|element| self.can_project_record_field_expression(element)),
+            rumoca_core::Expression::VarRef { .. }
+            | rumoca_core::Expression::FieldAccess { .. } => true,
+            rumoca_core::Expression::FunctionCall {
+                name,
+                is_constructor,
+                ..
+            } => {
+                self.is_record_constructor_call(name, *is_constructor)
+                    || self.lookup_function(name).is_some_and(|function| {
+                        matches!(
+                            function.outputs.as_slice(),
+                            [output]
+                                if output.type_class == Some(rumoca_core::ClassType::Record)
+                        )
+                    })
+            }
+            _ => false,
+        }
     }
 
     pub(in crate::lower) fn scoped_record_output_field_values(

--- a/crates/rumoca-phase-solve/src/lower/expression_rows.rs
+++ b/crates/rumoca-phase-solve/src/lower/expression_rows.rs
@@ -452,6 +452,9 @@ struct ScalarizedRecordField {
 }
 
 fn scalarized_record_fields(base: &str, layout: &VarLayout) -> Option<Vec<ScalarizedRecordField>> {
+    if layout.binding(base).is_some() && layout.shape(base).is_none() {
+        return None;
+    }
     let prefix = format!("{base}.");
     let mut fields = Vec::new();
     for name in layout.bindings().keys() {
@@ -1123,5 +1126,12 @@ mod tests {
         assert!(suffixes.contains(&"p"));
         assert!(suffixes.contains(&"v[index.with.dot]"));
         assert!(!suffixes.contains(&"nested.q"));
+    }
+
+    #[test]
+    fn scalarized_record_fields_ignore_scalar_binding_with_enum_alias_prefix() {
+        let layout = layout_with_bindings(&["Th", "Th.default"]);
+
+        assert!(scalarized_record_fields("Th", &layout).is_none());
     }
 }

--- a/crates/rumoca-phase-solve/src/lower/function_calls.rs
+++ b/crates/rumoca-phase-solve/src/lower/function_calls.rs
@@ -1,6 +1,7 @@
 use super::function_projection::FunctionOutputProjection;
 use super::*;
 use rumoca_ir_solve::RandomGenerator;
+mod random;
 mod runtime_intrinsics;
 pub(super) use runtime_intrinsics::*;
 
@@ -22,10 +23,40 @@ struct FlattenedRecordInputRequest<'a, 'b> {
     call_depth: usize,
 }
 
+struct FlattenedRecordPositionalInputRequest<'a, 'b> {
+    function_name: &'a str,
+    input: &'a rumoca_core::FunctionParam,
+    inputs: &'a [rumoca_core::FunctionParam],
+    input_idx: usize,
+    positional_args: &'a [&'a rumoca_core::Expression],
+    positional_idx: &'b mut usize,
+    caller_scope: &'a Scope,
+    call_depth: usize,
+}
+
 struct NamedOrPositionalArg<'a> {
     name: &'a str,
     idx: usize,
     default: f64,
+}
+
+fn split_flattened_record_input_name(name: &str) -> Option<(&str, &str)> {
+    let (prefix, field) = name.split_once('_')?;
+    (!prefix.is_empty() && !field.is_empty()).then_some((prefix, field))
+}
+
+fn flattened_input_has_prefix(name: &str, prefix: &str) -> bool {
+    split_flattened_record_input_name(name).is_some_and(|(candidate, _)| candidate == prefix)
+}
+
+fn missing_required_function_input<T>(
+    function_name: &str,
+    input_name: &str,
+) -> Result<T, LowerError> {
+    Err(LowerError::InvalidFunction {
+        name: function_name.to_string(),
+        reason: format!("required input `{input_name}` has no actual argument or default binding"),
+    })
 }
 
 impl<'a> LowerBuilder<'a> {
@@ -370,477 +401,6 @@ impl<'a> LowerBuilder<'a> {
         }
     }
 
-    fn lower_impure_random_intrinsic(
-        &mut self,
-        call_name: &str,
-        args: &[rumoca_core::Expression],
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Option<Reg>, LowerError> {
-        let (named_args, positional_args) = split_named_and_positional_call_args(call_name, args)?;
-        match call_name {
-            // MLS §12.3: impure function calls are event/initial computations.
-            // Represent MSL's hidden-state random utilities as explicit
-            // discrete solve-IR ops so continuous rows cannot treat them as
-            // pure algebraic functions and so event iteration can cache each
-            // call site at a fixed event instant.
-            "Modelica.Math.Random.Utilities.automaticGlobalSeed" | "automaticGlobalSeed" => {
-                let counter = self.alloc_call_site().saturating_add(1);
-                Ok(Some(self.emit_const(
-                    rumoca_eval_dae::deterministic_automatic_global_seed(counter) as f64,
-                )))
-            }
-            "Modelica.Math.Random.Utilities.automaticLocalSeed" | "automaticLocalSeed" => {
-                let seed = literal_string(args.first())
-                    .map(|path| i64::from(rumoca_eval_dae::modelica_strings_hash_string(path)))
-                    .unwrap_or_else(|| {
-                        let counter = self.alloc_call_site().saturating_add(1);
-                        rumoca_eval_dae::deterministic_automatic_global_seed(counter)
-                    });
-                Ok(Some(self.emit_const(seed as f64)))
-            }
-            "Modelica.Math.Random.Utilities.initializeImpureRandom" | "initializeImpureRandom" => {
-                let seed = self.lower_named_or_positional_arg(
-                    &named_args,
-                    &positional_args,
-                    NamedOrPositionalArg {
-                        name: "seed",
-                        idx: 0,
-                        default: 0.0,
-                    },
-                    scope,
-                    call_depth,
-                )?;
-                Ok(Some(self.emit_impure_random_init(seed)))
-            }
-            "Modelica.Math.Random.Utilities.impureRandom" | "impureRandom" => {
-                let id = self.lower_named_or_positional_arg(
-                    &named_args,
-                    &positional_args,
-                    NamedOrPositionalArg {
-                        name: "id",
-                        idx: 0,
-                        default: 0.0,
-                    },
-                    scope,
-                    call_depth,
-                )?;
-                Ok(Some(self.emit_impure_random(id)))
-            }
-            "Modelica.Math.Random.Utilities.impureRandomInteger" | "impureRandomInteger" => {
-                let id = self.lower_named_or_positional_arg(
-                    &named_args,
-                    &positional_args,
-                    NamedOrPositionalArg {
-                        name: "id",
-                        idx: 0,
-                        default: 0.0,
-                    },
-                    scope,
-                    call_depth,
-                )?;
-                let imin = self.lower_named_or_positional_arg(
-                    &named_args,
-                    &positional_args,
-                    NamedOrPositionalArg {
-                        name: "imin",
-                        idx: 1,
-                        default: 1.0,
-                    },
-                    scope,
-                    call_depth,
-                )?;
-                let imax = self.lower_named_or_positional_arg(
-                    &named_args,
-                    &positional_args,
-                    NamedOrPositionalArg {
-                        name: "imax",
-                        idx: 2,
-                        default: 268_435_456.0,
-                    },
-                    scope,
-                    call_depth,
-                )?;
-                Ok(Some(self.emit_impure_random_integer(id, imin, imax)))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    pub(super) fn lower_projected_random_intrinsic(
-        &mut self,
-        projection: &FunctionOutputProjection,
-        args: &[rumoca_core::Expression],
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Option<Reg>, LowerError> {
-        let Some((generator, kind)) = random_intrinsic_kind(projection.base_function_name.as_str())
-        else {
-            return Ok(None);
-        };
-        match kind {
-            RandomIntrinsicKind::InitialState => {
-                if projection.output_name != "state" {
-                    return Ok(None);
-                }
-                let Some(state_index) = projection.indices.first().copied() else {
-                    return Ok(None);
-                };
-                let local_seed = self.lower_optional_arg(args, 0, scope, call_depth)?;
-                let global_seed = self.lower_optional_arg(args, 1, scope, call_depth)?;
-                let state_len = random_projection_state_len(generator, projection, args);
-                Ok(Some(self.emit_random_initial_state(
-                    generator,
-                    local_seed,
-                    global_seed,
-                    state_len,
-                    state_index.saturating_sub(1),
-                )))
-            }
-            RandomIntrinsicKind::Random => match projection.output_name.as_str() {
-                "result" if projection.indices.is_empty() => {
-                    let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
-                    Ok(Some(self.emit_random_result(generator, &state_values)))
-                }
-                "stateOut" => {
-                    let Some(state_index) = projection.indices.first().copied() else {
-                        return Ok(None);
-                    };
-                    let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
-                    Ok(Some(self.emit_random_state(
-                        generator,
-                        &state_values,
-                        state_index.saturating_sub(1),
-                    )))
-                }
-                _ => Ok(None),
-            },
-        }
-    }
-
-    fn lower_random_intrinsic(
-        &mut self,
-        call_name: &str,
-        args: &[rumoca_core::Expression],
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Option<Reg>, LowerError> {
-        let Some((generator, kind)) = random_intrinsic_kind(call_name) else {
-            return Ok(None);
-        };
-        match kind {
-            // Scalar context for an array-valued initialState means the first
-            // component. Array contexts call lower_random_initial_state_values.
-            RandomIntrinsicKind::InitialState => {
-                let local_seed = self.lower_optional_arg(args, 0, scope, call_depth)?;
-                let global_seed = self.lower_optional_arg(args, 1, scope, call_depth)?;
-                let state_len = random_generator_state_len(generator);
-                Ok(Some(self.emit_random_initial_state(
-                    generator,
-                    local_seed,
-                    global_seed,
-                    state_len,
-                    0,
-                )))
-            }
-            RandomIntrinsicKind::Random => {
-                let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
-                Ok(Some(self.emit_random_result(generator, &state_values)))
-            }
-        }
-    }
-
-    pub(super) fn lower_random_array_values(
-        &mut self,
-        call_name: &str,
-        args: &[rumoca_core::Expression],
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Option<Vec<Reg>>, LowerError> {
-        if let Some((base_name, output_name)) = rumoca_core::split_last_top_level(call_name)
-            && let Some((generator, kind)) = random_intrinsic_kind(base_name)
-        {
-            return self.lower_projected_random_array_values(
-                generator,
-                kind,
-                output_name,
-                args,
-                scope,
-                call_depth,
-            );
-        }
-        let Some((generator, kind)) = random_intrinsic_kind(call_name) else {
-            return Ok(None);
-        };
-        let values = match kind {
-            RandomIntrinsicKind::InitialState => {
-                let local_seed = self.lower_optional_arg(args, 0, scope, call_depth)?;
-                let global_seed = self.lower_optional_arg(args, 1, scope, call_depth)?;
-                let state_len = random_generator_state_len(generator);
-                (0..state_len)
-                    .map(|state_index| {
-                        self.emit_random_initial_state(
-                            generator,
-                            local_seed,
-                            global_seed,
-                            state_len,
-                            state_index,
-                        )
-                    })
-                    .collect()
-            }
-            RandomIntrinsicKind::Random => {
-                let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
-                let mut values = Vec::with_capacity(state_values.len().saturating_add(1));
-                values.push(self.emit_random_result(generator, &state_values));
-                values.extend((0..state_values.len()).map(|state_index| {
-                    self.emit_random_state(generator, &state_values, state_index)
-                }));
-                values
-            }
-        };
-        Ok(Some(values))
-    }
-
-    fn lower_projected_random_array_values(
-        &mut self,
-        generator: RandomGenerator,
-        kind: RandomIntrinsicKind,
-        output_name: &str,
-        args: &[rumoca_core::Expression],
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Option<Vec<Reg>>, LowerError> {
-        match (kind, output_name) {
-            (RandomIntrinsicKind::InitialState, "state") => {
-                let local_seed = self.lower_optional_arg(args, 0, scope, call_depth)?;
-                let global_seed = self.lower_optional_arg(args, 1, scope, call_depth)?;
-                let state_len = if args.get(2).is_some() {
-                    // Argument 2 (state length) was provided: it must be a compile-time integer
-                    // literal. A non-literal state length would corrupt the random state slot.
-                    random_state_len_arg(args).expect(
-                        "random state length argument (index 2) must be a compile-time integer \
-                         literal — a non-constant value produces a corrupt random state slot",
-                    )
-                } else {
-                    // No state length argument: fall back to generator default.
-                    random_generator_state_len(generator)
-                };
-                Ok(Some(
-                    (0..state_len)
-                        .map(|state_index| {
-                            self.emit_random_initial_state(
-                                generator,
-                                local_seed,
-                                global_seed,
-                                state_len,
-                                state_index,
-                            )
-                        })
-                        .collect(),
-                ))
-            }
-            (RandomIntrinsicKind::Random, "stateOut") => {
-                let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
-                Ok(Some(
-                    (0..state_values.len())
-                        .map(|state_index| {
-                            self.emit_random_state(generator, &state_values, state_index)
-                        })
-                        .collect(),
-                ))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    fn lower_random_state_argument(
-        &mut self,
-        args: &[rumoca_core::Expression],
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Vec<Reg>, LowerError> {
-        if let Some(state_expr) = args.first() {
-            let values = self.lower_array_like_values(state_expr, scope, call_depth)?;
-            if !values.is_empty() {
-                return Ok(values);
-            }
-        }
-        Ok(vec![self.emit_const(1.0)])
-    }
-
-    fn lower_optional_arg(
-        &mut self,
-        args: &[rumoca_core::Expression],
-        idx: usize,
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Reg, LowerError> {
-        if let Some(expr) = args.get(idx) {
-            self.lower_expr(expr, scope, call_depth)
-        } else {
-            Ok(self.emit_const(0.0))
-        }
-    }
-
-    fn lower_named_or_positional_arg(
-        &mut self,
-        named_args: &IndexMap<String, &rumoca_core::Expression>,
-        positional_args: &[&rumoca_core::Expression],
-        arg: NamedOrPositionalArg<'_>,
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Reg, LowerError> {
-        if let Some(expr) = named_args
-            .get(arg.name)
-            .copied()
-            .or_else(|| positional_args.get(arg.idx).copied())
-        {
-            self.lower_expr(expr, scope, call_depth)
-        } else {
-            Ok(self.emit_const(arg.default))
-        }
-    }
-
-    fn lower_uniform_quantile(
-        &mut self,
-        args: &[rumoca_core::Expression],
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Reg, LowerError> {
-        let u = self.lower_optional_arg(args, 0, scope, call_depth)?;
-        let y_min = self.lower_optional_arg(args, 1, scope, call_depth)?;
-        let y_max = self.lower_optional_arg(args, 2, scope, call_depth)?;
-        let span = self.emit_binary(BinaryOp::Sub, y_max, y_min);
-        let offset = self.emit_binary(BinaryOp::Mul, u, span);
-        Ok(self.emit_binary(BinaryOp::Add, y_min, offset))
-    }
-
-    fn lower_normal_quantile(
-        &mut self,
-        args: &[rumoca_core::Expression],
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Reg, LowerError> {
-        let u = self.lower_optional_arg(args, 0, scope, call_depth)?;
-        let mu = self.lower_optional_arg(args, 1, scope, call_depth)?;
-        let sigma = if args.len() > 2 {
-            self.lower_optional_arg(args, 2, scope, call_depth)?
-        } else {
-            self.emit_const(1.0)
-        };
-        let unit = self.emit_standard_normal_quantile(u);
-        let scaled = self.emit_binary(BinaryOp::Mul, sigma, unit);
-        Ok(self.emit_binary(BinaryOp::Add, mu, scaled))
-    }
-
-    fn lower_weibull_quantile(
-        &mut self,
-        args: &[rumoca_core::Expression],
-        scope: &Scope,
-        call_depth: usize,
-    ) -> Result<Reg, LowerError> {
-        let u = self.lower_optional_arg(args, 0, scope, call_depth)?;
-        let lambda = self.lower_optional_arg(args, 1, scope, call_depth)?;
-        let k = self.lower_optional_arg(args, 2, scope, call_depth)?;
-        let one = self.emit_const(1.0);
-        let p = self.emit_open_probability(u);
-        let survival = self.emit_binary(BinaryOp::Sub, one, p);
-        let log_survival = self.emit_unary(UnaryOp::Log, survival);
-        let neg_log = self.emit_unary(UnaryOp::Neg, log_survival);
-        let inv_k = self.emit_binary(BinaryOp::Div, one, k);
-        let powered = self.emit_binary(BinaryOp::Pow, neg_log, inv_k);
-        Ok(self.emit_binary(BinaryOp::Mul, lambda, powered))
-    }
-
-    fn emit_standard_normal_quantile(&mut self, p: Reg) -> Reg {
-        const P_LOW: f64 = 0.02425;
-        const A: [f64; 6] = [
-            -3.969_683_028_665_376e1,
-            2.209_460_984_245_205e2,
-            -2.759_285_104_469_687e2,
-            1.383_577_518_672_69e2,
-            -3.066_479_806_614_716e1,
-            2.506_628_277_459_239,
-        ];
-        const B: [f64; 6] = [
-            -5.447_609_879_822_406e1,
-            1.615_858_368_580_409e2,
-            -1.556_989_798_598_866e2,
-            6.680_131_188_771_972e1,
-            -1.328_068_155_288_572e1,
-            1.0,
-        ];
-        const C: [f64; 6] = [
-            -7.784_894_002_430_293e-3,
-            -3.223_964_580_411_365e-1,
-            -2.400_758_277_161_838,
-            -2.549_732_539_343_734,
-            4.374_664_141_464_968,
-            2.938_163_982_698_783,
-        ];
-        const D: [f64; 5] = [
-            7.784_695_709_041_462e-3,
-            3.224_671_290_700_398e-1,
-            2.445_134_137_142_996,
-            3.754_408_661_907_416,
-            1.0,
-        ];
-
-        let p = self.emit_open_probability(p);
-        let half = self.emit_const(0.5);
-        let q = self.emit_binary(BinaryOp::Sub, p, half);
-        let r = self.emit_binary(BinaryOp::Mul, q, q);
-        let central_poly = self.emit_polynomial(r, &A);
-        let central_num = self.emit_binary(BinaryOp::Mul, central_poly, q);
-        let central_den = self.emit_polynomial(r, &B);
-        let central = self.emit_binary(BinaryOp::Div, central_num, central_den);
-
-        let minus_two = self.emit_const(-2.0);
-        let lower_log = self.emit_unary(UnaryOp::Log, p);
-        let lower_log_scaled = self.emit_binary(BinaryOp::Mul, minus_two, lower_log);
-        let lower_q = self.emit_unary(UnaryOp::Sqrt, lower_log_scaled);
-        let lower = self.emit_rational_tail(lower_q, &C, &D);
-
-        let one = self.emit_const(1.0);
-        let one_minus_p = self.emit_binary(BinaryOp::Sub, one, p);
-        let upper_log = self.emit_unary(UnaryOp::Log, one_minus_p);
-        let upper_log_scaled = self.emit_binary(BinaryOp::Mul, minus_two, upper_log);
-        let upper_q = self.emit_unary(UnaryOp::Sqrt, upper_log_scaled);
-        let upper_tail = self.emit_rational_tail(upper_q, &C, &D);
-        let upper = self.emit_unary(UnaryOp::Neg, upper_tail);
-
-        let low_cutoff = self.emit_const(P_LOW);
-        let high_cutoff = self.emit_const(1.0 - P_LOW);
-        let low = self.emit_compare(CompareOp::Lt, p, low_cutoff);
-        let high = self.emit_compare(CompareOp::Gt, p, high_cutoff);
-        let high_or_central = self.emit_select(high, upper, central);
-        self.emit_select(low, lower, high_or_central)
-    }
-
-    fn emit_open_probability(&mut self, p: Reg) -> Reg {
-        let eps = self.emit_const(1.0e-15);
-        let one_minus_eps = self.emit_const(1.0 - 1.0e-15);
-        let above_zero = self.emit_binary(BinaryOp::Max, p, eps);
-        self.emit_binary(BinaryOp::Min, above_zero, one_minus_eps)
-    }
-
-    fn emit_rational_tail(&mut self, q: Reg, numerator: &[f64; 6], denominator: &[f64; 5]) -> Reg {
-        let num = self.emit_polynomial(q, numerator);
-        let den = self.emit_polynomial(q, denominator);
-        self.emit_binary(BinaryOp::Div, num, den)
-    }
-
-    fn emit_polynomial<const N: usize>(&mut self, x: Reg, coeffs: &[f64; N]) -> Reg {
-        let mut acc = self.emit_const(coeffs[0]);
-        for coeff in coeffs.iter().skip(1) {
-            let product = self.emit_binary(BinaryOp::Mul, acc, x);
-            let next = self.emit_const(*coeff);
-            acc = self.emit_binary(BinaryOp::Add, product, next);
-        }
-        acc
-    }
-
     pub(super) fn lower_complex_math_sum_projection(
         &mut self,
         call_name: &str,
@@ -1042,7 +602,7 @@ impl<'a> LowerBuilder<'a> {
         let mut const_bindings = IndexMap::new();
         let mut positional_idx = 0usize;
 
-        for input in inputs {
+        for (input_idx, input) in inputs.iter().enumerate() {
             if let Some(arg_expr) = named_args.get(input.name.as_str()) {
                 self.bind_function_input_arg_or_closure(
                     FunctionInputBindState {
@@ -1056,6 +616,25 @@ impl<'a> LowerBuilder<'a> {
                     caller_scope,
                     call_depth + 1,
                 )?;
+                continue;
+            }
+            if self.bind_flattened_record_positional_input(
+                FunctionInputBindState {
+                    scope: &mut scope,
+                    const_scope: &mut const_scope,
+                    const_bindings: &mut const_bindings,
+                },
+                FlattenedRecordPositionalInputRequest {
+                    function_name,
+                    input,
+                    inputs,
+                    input_idx,
+                    positional_args: &positional_args,
+                    positional_idx: &mut positional_idx,
+                    caller_scope,
+                    call_depth: call_depth + 1,
+                },
+            )? {
                 continue;
             }
             if positional_args.len() > inputs.len()
@@ -1112,19 +691,52 @@ impl<'a> LowerBuilder<'a> {
                 continue;
             }
 
-            return Err(LowerError::InvalidFunction {
-                name: function_name.to_string(),
-                reason: format!(
-                    "required input `{}` has no actual argument or default binding",
-                    input.name
-                ),
-            });
+            return missing_required_function_input(function_name, &input.name);
         }
 
         Ok(FunctionInputBindings {
             scope,
             const_bindings,
         })
+    }
+
+    fn bind_flattened_record_positional_input(
+        &mut self,
+        state: FunctionInputBindState<'_>,
+        request: FlattenedRecordPositionalInputRequest<'_, '_>,
+    ) -> Result<bool, LowerError> {
+        let Some((prefix, field)) = split_flattened_record_input_name(&request.input.name) else {
+            return Ok(false);
+        };
+        let Some(arg_expr) = request.positional_args.get(*request.positional_idx) else {
+            return Ok(false);
+        };
+        if !self.is_record_like_function_actual(arg_expr, field, request.caller_scope) {
+            return Ok(false);
+        }
+
+        let projected = rumoca_core::Expression::FieldAccess {
+            base: Box::new((*arg_expr).clone()),
+            field: field.to_string(),
+            span: arg_expr.span().unwrap_or(rumoca_core::Span::DUMMY),
+        };
+        self.bind_function_input_arg_or_closure(
+            state,
+            request.function_name,
+            request.input,
+            &projected,
+            request.caller_scope,
+            request.call_depth,
+        )?;
+        if !request
+            .inputs
+            .iter()
+            .skip(request.input_idx + 1)
+            .any(|next| flattened_input_has_prefix(&next.name, prefix))
+        {
+            *request.positional_idx += 1;
+        }
+        Ok(true)
     }
 
     fn bind_function_input_arg_or_closure(
@@ -1141,6 +753,43 @@ impl<'a> LowerBuilder<'a> {
         }
         self.bind_function_input_value(state, input, arg_expr, caller_scope, call_depth)?;
         Ok(())
+    }
+
+    fn is_record_like_function_actual(
+        &self,
+        expr: &rumoca_core::Expression,
+        field: &str,
+        caller_scope: &Scope,
+    ) -> bool {
+        match expr {
+            rumoca_core::Expression::VarRef {
+                name, subscripts, ..
+            } => {
+                if !subscripts.is_empty() {
+                    return false;
+                }
+                let field_key = format!("{}.{field}", name.as_str());
+                caller_scope.contains_key(&ComponentPath::from_flat_path(&field_key))
+                    || self.layout.binding(&field_key).is_some()
+                    || self.local_indexed_bindings.contains_key(&field_key)
+                    || self.local_binding_dims.contains_key(&field_key)
+            }
+            rumoca_core::Expression::FunctionCall {
+                name,
+                is_constructor,
+                ..
+            } => {
+                self.is_record_constructor_call(name, *is_constructor)
+                    || self.lookup_function(name).is_some_and(|function| {
+                        matches!(
+                            function.outputs.as_slice(),
+                            [output]
+                                if output.type_class == Some(rumoca_core::ClassType::Record)
+                        )
+                    })
+            }
+            _ => false,
+        }
     }
 
     fn bind_function_input_closure(
@@ -1463,6 +1112,9 @@ impl<'a> LowerBuilder<'a> {
         )? {
             return Ok(());
         }
+        if self.bind_record_function_call_input(input, expr, expr_scope, &mut state, call_depth)? {
+            return Ok(());
+        }
         if is_complex_param(input) {
             self.bind_complex_input(state.scope, input, expr, expr_scope, call_depth)?;
             return Ok(());
@@ -1564,6 +1216,153 @@ impl<'a> LowerBuilder<'a> {
         }
 
         Ok(bound_any)
+    }
+
+    fn bind_record_function_call_input(
+        &mut self,
+        input: &rumoca_core::FunctionParam,
+        expr: &rumoca_core::Expression,
+        expr_scope: &Scope,
+        state: &mut FunctionInputBindState<'_>,
+        call_depth: usize,
+    ) -> Result<bool, LowerError> {
+        if input.type_class != Some(rumoca_core::ClassType::Record) || is_complex_param(input) {
+            return Ok(false);
+        }
+        let rumoca_core::Expression::FunctionCall {
+            name,
+            args,
+            is_constructor: false,
+            ..
+        } = expr
+        else {
+            return Ok(false);
+        };
+        let Some(function) = self.lookup_function(name).cloned() else {
+            return Ok(false);
+        };
+        if function.external.is_some() {
+            return Ok(false);
+        }
+        let [output] = function.outputs.as_slice() else {
+            return Ok(false);
+        };
+        if output.type_class != Some(rumoca_core::ClassType::Record) {
+            return Ok(false);
+        }
+        self.ensure_pure_inline_function(name.as_str(), &function)?;
+
+        let Some(materialized) = self.materialize_single_record_function_call_components(
+            name, args, expr_scope, call_depth,
+        )?
+        else {
+            return Ok(false);
+        };
+        if materialized.components.is_empty() && materialized.indexed_components.is_empty() {
+            return Err(LowerError::InvalidFunction {
+                name: name.as_str().to_string(),
+                reason: "record output had no assigned components".to_string(),
+            });
+        }
+
+        for component in materialized.components {
+            let local_key = format!("{}.{}", input.name, component.suffix);
+            state
+                .scope
+                .insert(ComponentPath::from_flat_path(&local_key), component.reg);
+            if let Some(dims) = component.dims {
+                self.local_binding_dims.insert(local_key.clone(), dims);
+                self.update_known_empty_local_array(&local_key, component.known_empty);
+            }
+        }
+        for (suffix, bindings) in materialized.indexed_components {
+            self.local_indexed_bindings
+                .insert(format!("{}.{}", input.name, suffix), bindings);
+        }
+        Ok(true)
+    }
+
+    fn update_known_empty_local_array(&mut self, key: &str, known_empty: bool) {
+        if known_empty {
+            self.known_empty_local_arrays.insert(key.to_string());
+        } else {
+            self.known_empty_local_arrays.shift_remove(key);
+        }
+    }
+
+    pub(super) fn materialize_single_record_function_call_components(
+        &mut self,
+        name: &rumoca_core::Reference,
+        args: &[rumoca_core::Expression],
+        caller_scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Option<MaterializedRecordComponents>, LowerError> {
+        if call_depth >= MAX_FUNCTION_INLINE_DEPTH {
+            return Ok(None);
+        }
+        let Some(function) = self.lookup_function(name).cloned() else {
+            return Ok(None);
+        };
+        if function.external.is_some() {
+            return Ok(None);
+        }
+        let [output] = function.outputs.as_slice() else {
+            return Ok(None);
+        };
+        if output.type_class != Some(rumoca_core::ClassType::Record) {
+            return Ok(None);
+        }
+        self.ensure_pure_inline_function(name.as_str(), &function)?;
+
+        let output_name = output.name.clone();
+        self.with_local_lower_frame(|this| {
+            let bindings =
+                this.bind_function_inputs(name, &function.inputs, args, caller_scope, call_depth)?;
+            let mut function_scope = bindings.scope;
+            this.local_const_bindings.extend(bindings.const_bindings);
+            this.initialize_function_output_scope(&function, &mut function_scope, call_depth)?;
+            let _returned =
+                this.lower_statements(&function.body, &mut function_scope, call_depth + 1)?;
+            Ok(Some(this.materialized_record_components_from_scope(
+                &output_name,
+                &function_scope,
+            )))
+        })
+    }
+
+    fn materialized_record_components_from_scope(
+        &self,
+        output_name: &str,
+        scope: &Scope,
+    ) -> MaterializedRecordComponents {
+        let source_prefix = format!("{output_name}.");
+        let components = scope
+            .iter()
+            .into_iter()
+            .filter_map(|(key, reg)| {
+                let key_text = key.as_str();
+                key_text.strip_prefix(source_prefix.as_str()).map(|suffix| {
+                    MaterializedRecordComponent {
+                        suffix: suffix.to_string(),
+                        reg,
+                        dims: self.local_binding_dims.get(key_text).cloned(),
+                        known_empty: self.known_empty_local_arrays.contains(key_text),
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        let indexed_components = self
+            .local_indexed_bindings
+            .iter()
+            .filter_map(|(key, bindings)| {
+                key.strip_prefix(source_prefix.as_str())
+                    .map(|suffix| (suffix.to_string(), bindings.clone()))
+            })
+            .collect::<Vec<_>>();
+        MaterializedRecordComponents {
+            components,
+            indexed_components,
+        }
     }
 
     fn copy_record_input_component_dims(&mut self, source_key: &str, local_key: &str) {

--- a/crates/rumoca-phase-solve/src/lower/function_calls/random.rs
+++ b/crates/rumoca-phase-solve/src/lower/function_calls/random.rs
@@ -1,0 +1,478 @@
+use super::*;
+
+impl<'a> LowerBuilder<'a> {
+    pub(super) fn lower_impure_random_intrinsic(
+        &mut self,
+        call_name: &str,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Option<Reg>, LowerError> {
+        let (named_args, positional_args) = split_named_and_positional_call_args(call_name, args)?;
+        match call_name {
+            // MLS §12.3: impure function calls are event/initial computations.
+            // Represent MSL's hidden-state random utilities as explicit
+            // discrete solve-IR ops so continuous rows cannot treat them as
+            // pure algebraic functions and so event iteration can cache each
+            // call site at a fixed event instant.
+            "Modelica.Math.Random.Utilities.automaticGlobalSeed" | "automaticGlobalSeed" => {
+                let counter = self.alloc_call_site().saturating_add(1);
+                Ok(Some(self.emit_const(
+                    rumoca_eval_dae::deterministic_automatic_global_seed(counter) as f64,
+                )))
+            }
+            "Modelica.Math.Random.Utilities.automaticLocalSeed" | "automaticLocalSeed" => {
+                let seed = literal_string(args.first())
+                    .map(|path| i64::from(rumoca_eval_dae::modelica_strings_hash_string(path)))
+                    .unwrap_or_else(|| {
+                        let counter = self.alloc_call_site().saturating_add(1);
+                        rumoca_eval_dae::deterministic_automatic_global_seed(counter)
+                    });
+                Ok(Some(self.emit_const(seed as f64)))
+            }
+            "Modelica.Math.Random.Utilities.initializeImpureRandom" | "initializeImpureRandom" => {
+                let seed = self.lower_named_or_positional_arg(
+                    &named_args,
+                    &positional_args,
+                    NamedOrPositionalArg {
+                        name: "seed",
+                        idx: 0,
+                        default: 0.0,
+                    },
+                    scope,
+                    call_depth,
+                )?;
+                Ok(Some(self.emit_impure_random_init(seed)))
+            }
+            "Modelica.Math.Random.Utilities.impureRandom" | "impureRandom" => {
+                let id = self.lower_named_or_positional_arg(
+                    &named_args,
+                    &positional_args,
+                    NamedOrPositionalArg {
+                        name: "id",
+                        idx: 0,
+                        default: 0.0,
+                    },
+                    scope,
+                    call_depth,
+                )?;
+                Ok(Some(self.emit_impure_random(id)))
+            }
+            "Modelica.Math.Random.Utilities.impureRandomInteger" | "impureRandomInteger" => {
+                let id = self.lower_named_or_positional_arg(
+                    &named_args,
+                    &positional_args,
+                    NamedOrPositionalArg {
+                        name: "id",
+                        idx: 0,
+                        default: 0.0,
+                    },
+                    scope,
+                    call_depth,
+                )?;
+                let imin = self.lower_named_or_positional_arg(
+                    &named_args,
+                    &positional_args,
+                    NamedOrPositionalArg {
+                        name: "imin",
+                        idx: 1,
+                        default: 1.0,
+                    },
+                    scope,
+                    call_depth,
+                )?;
+                let imax = self.lower_named_or_positional_arg(
+                    &named_args,
+                    &positional_args,
+                    NamedOrPositionalArg {
+                        name: "imax",
+                        idx: 2,
+                        default: 268_435_456.0,
+                    },
+                    scope,
+                    call_depth,
+                )?;
+                Ok(Some(self.emit_impure_random_integer(id, imin, imax)))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    pub(in crate::lower) fn lower_projected_random_intrinsic(
+        &mut self,
+        projection: &FunctionOutputProjection,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Option<Reg>, LowerError> {
+        let Some((generator, kind)) = random_intrinsic_kind(projection.base_function_name.as_str())
+        else {
+            return Ok(None);
+        };
+        match kind {
+            RandomIntrinsicKind::InitialState => {
+                if projection.output_name != "state" {
+                    return Ok(None);
+                }
+                let Some(state_index) = projection.indices.first().copied() else {
+                    return Ok(None);
+                };
+                let local_seed = self.lower_optional_arg(args, 0, scope, call_depth)?;
+                let global_seed = self.lower_optional_arg(args, 1, scope, call_depth)?;
+                let state_len = random_projection_state_len(generator, projection, args);
+                Ok(Some(self.emit_random_initial_state(
+                    generator,
+                    local_seed,
+                    global_seed,
+                    state_len,
+                    state_index.saturating_sub(1),
+                )))
+            }
+            RandomIntrinsicKind::Random => match projection.output_name.as_str() {
+                "result" if projection.indices.is_empty() => {
+                    let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
+                    Ok(Some(self.emit_random_result(generator, &state_values)))
+                }
+                "stateOut" => {
+                    let Some(state_index) = projection.indices.first().copied() else {
+                        return Ok(None);
+                    };
+                    let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
+                    Ok(Some(self.emit_random_state(
+                        generator,
+                        &state_values,
+                        state_index.saturating_sub(1),
+                    )))
+                }
+                _ => Ok(None),
+            },
+        }
+    }
+
+    pub(super) fn lower_random_intrinsic(
+        &mut self,
+        call_name: &str,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Option<Reg>, LowerError> {
+        let Some((generator, kind)) = random_intrinsic_kind(call_name) else {
+            return Ok(None);
+        };
+        match kind {
+            // Scalar context for an array-valued initialState means the first
+            // component. Array contexts call lower_random_initial_state_values.
+            RandomIntrinsicKind::InitialState => {
+                let local_seed = self.lower_optional_arg(args, 0, scope, call_depth)?;
+                let global_seed = self.lower_optional_arg(args, 1, scope, call_depth)?;
+                let state_len = random_generator_state_len(generator);
+                Ok(Some(self.emit_random_initial_state(
+                    generator,
+                    local_seed,
+                    global_seed,
+                    state_len,
+                    0,
+                )))
+            }
+            RandomIntrinsicKind::Random => {
+                let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
+                Ok(Some(self.emit_random_result(generator, &state_values)))
+            }
+        }
+    }
+
+    pub(in crate::lower) fn lower_random_array_values(
+        &mut self,
+        call_name: &str,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Option<Vec<Reg>>, LowerError> {
+        let call_path = rumoca_core::ComponentPath::from_flat_path(call_name);
+        if let Some(output_name) = call_path.parts().last()
+            && let Some(base_name) = call_path
+                .prefix(call_path.len().saturating_sub(1))
+                .map(|path| path.to_flat_string())
+            && let Some((generator, kind)) = random_intrinsic_kind(&base_name)
+        {
+            return self.lower_projected_random_array_values(
+                generator,
+                kind,
+                output_name.as_str(),
+                args,
+                scope,
+                call_depth,
+            );
+        }
+        let Some((generator, kind)) = random_intrinsic_kind(call_name) else {
+            return Ok(None);
+        };
+        let values = match kind {
+            RandomIntrinsicKind::InitialState => {
+                let local_seed = self.lower_optional_arg(args, 0, scope, call_depth)?;
+                let global_seed = self.lower_optional_arg(args, 1, scope, call_depth)?;
+                let state_len = random_generator_state_len(generator);
+                (0..state_len)
+                    .map(|state_index| {
+                        self.emit_random_initial_state(
+                            generator,
+                            local_seed,
+                            global_seed,
+                            state_len,
+                            state_index,
+                        )
+                    })
+                    .collect()
+            }
+            RandomIntrinsicKind::Random => {
+                let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
+                let mut values = Vec::with_capacity(state_values.len().saturating_add(1));
+                values.push(self.emit_random_result(generator, &state_values));
+                values.extend((0..state_values.len()).map(|state_index| {
+                    self.emit_random_state(generator, &state_values, state_index)
+                }));
+                values
+            }
+        };
+        Ok(Some(values))
+    }
+
+    fn lower_projected_random_array_values(
+        &mut self,
+        generator: RandomGenerator,
+        kind: RandomIntrinsicKind,
+        output_name: &str,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Option<Vec<Reg>>, LowerError> {
+        match (kind, output_name) {
+            (RandomIntrinsicKind::InitialState, "state") => {
+                let local_seed = self.lower_optional_arg(args, 0, scope, call_depth)?;
+                let global_seed = self.lower_optional_arg(args, 1, scope, call_depth)?;
+                let state_len = if args.get(2).is_some() {
+                    // Argument 2 (state length) was provided: it must be a compile-time integer
+                    // literal. A non-literal state length would corrupt the random state slot.
+                    random_state_len_arg(args).expect(
+                        "random state length argument (index 2) must be a compile-time integer \
+                         literal — a non-constant value produces a corrupt random state slot",
+                    )
+                } else {
+                    // No state length argument: fall back to generator default.
+                    random_generator_state_len(generator)
+                };
+                Ok(Some(
+                    (0..state_len)
+                        .map(|state_index| {
+                            self.emit_random_initial_state(
+                                generator,
+                                local_seed,
+                                global_seed,
+                                state_len,
+                                state_index,
+                            )
+                        })
+                        .collect(),
+                ))
+            }
+            (RandomIntrinsicKind::Random, "stateOut") => {
+                let state_values = self.lower_random_state_argument(args, scope, call_depth)?;
+                Ok(Some(
+                    (0..state_values.len())
+                        .map(|state_index| {
+                            self.emit_random_state(generator, &state_values, state_index)
+                        })
+                        .collect(),
+                ))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn lower_random_state_argument(
+        &mut self,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Vec<Reg>, LowerError> {
+        if let Some(state_expr) = args.first() {
+            let values = self.lower_array_like_values(state_expr, scope, call_depth)?;
+            if !values.is_empty() {
+                return Ok(values);
+            }
+        }
+        Ok(vec![self.emit_const(1.0)])
+    }
+
+    pub(super) fn lower_optional_arg(
+        &mut self,
+        args: &[rumoca_core::Expression],
+        idx: usize,
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Reg, LowerError> {
+        if let Some(expr) = args.get(idx) {
+            self.lower_expr(expr, scope, call_depth)
+        } else {
+            Ok(self.emit_const(0.0))
+        }
+    }
+
+    fn lower_named_or_positional_arg(
+        &mut self,
+        named_args: &IndexMap<String, &rumoca_core::Expression>,
+        positional_args: &[&rumoca_core::Expression],
+        arg: NamedOrPositionalArg<'_>,
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Reg, LowerError> {
+        if let Some(expr) = named_args
+            .get(arg.name)
+            .copied()
+            .or_else(|| positional_args.get(arg.idx).copied())
+        {
+            self.lower_expr(expr, scope, call_depth)
+        } else {
+            Ok(self.emit_const(arg.default))
+        }
+    }
+
+    pub(super) fn lower_uniform_quantile(
+        &mut self,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Reg, LowerError> {
+        let u = self.lower_optional_arg(args, 0, scope, call_depth)?;
+        let y_min = self.lower_optional_arg(args, 1, scope, call_depth)?;
+        let y_max = self.lower_optional_arg(args, 2, scope, call_depth)?;
+        let span = self.emit_binary(BinaryOp::Sub, y_max, y_min);
+        let offset = self.emit_binary(BinaryOp::Mul, u, span);
+        Ok(self.emit_binary(BinaryOp::Add, y_min, offset))
+    }
+
+    pub(super) fn lower_normal_quantile(
+        &mut self,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Reg, LowerError> {
+        let u = self.lower_optional_arg(args, 0, scope, call_depth)?;
+        let mu = self.lower_optional_arg(args, 1, scope, call_depth)?;
+        let sigma = if args.len() > 2 {
+            self.lower_optional_arg(args, 2, scope, call_depth)?
+        } else {
+            self.emit_const(1.0)
+        };
+        let unit = self.emit_standard_normal_quantile(u);
+        let scaled = self.emit_binary(BinaryOp::Mul, sigma, unit);
+        Ok(self.emit_binary(BinaryOp::Add, mu, scaled))
+    }
+
+    pub(super) fn lower_weibull_quantile(
+        &mut self,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+    ) -> Result<Reg, LowerError> {
+        let u = self.lower_optional_arg(args, 0, scope, call_depth)?;
+        let lambda = self.lower_optional_arg(args, 1, scope, call_depth)?;
+        let k = self.lower_optional_arg(args, 2, scope, call_depth)?;
+        let one = self.emit_const(1.0);
+        let p = self.emit_open_probability(u);
+        let survival = self.emit_binary(BinaryOp::Sub, one, p);
+        let log_survival = self.emit_unary(UnaryOp::Log, survival);
+        let neg_log = self.emit_unary(UnaryOp::Neg, log_survival);
+        let inv_k = self.emit_binary(BinaryOp::Div, one, k);
+        let powered = self.emit_binary(BinaryOp::Pow, neg_log, inv_k);
+        Ok(self.emit_binary(BinaryOp::Mul, lambda, powered))
+    }
+
+    pub(super) fn emit_standard_normal_quantile(&mut self, p: Reg) -> Reg {
+        const P_LOW: f64 = 0.02425;
+        const A: [f64; 6] = [
+            -3.969_683_028_665_376e1,
+            2.209_460_984_245_205e2,
+            -2.759_285_104_469_687e2,
+            1.383_577_518_672_69e2,
+            -3.066_479_806_614_716e1,
+            2.506_628_277_459_239,
+        ];
+        const B: [f64; 6] = [
+            -5.447_609_879_822_406e1,
+            1.615_858_368_580_409e2,
+            -1.556_989_798_598_866e2,
+            6.680_131_188_771_972e1,
+            -1.328_068_155_288_572e1,
+            1.0,
+        ];
+        const C: [f64; 6] = [
+            -7.784_894_002_430_293e-3,
+            -3.223_964_580_411_365e-1,
+            -2.400_758_277_161_838,
+            -2.549_732_539_343_734,
+            4.374_664_141_464_968,
+            2.938_163_982_698_783,
+        ];
+        const D: [f64; 5] = [
+            7.784_695_709_041_462e-3,
+            3.224_671_290_700_398e-1,
+            2.445_134_137_142_996,
+            3.754_408_661_907_416,
+            1.0,
+        ];
+
+        let p = self.emit_open_probability(p);
+        let half = self.emit_const(0.5);
+        let q = self.emit_binary(BinaryOp::Sub, p, half);
+        let r = self.emit_binary(BinaryOp::Mul, q, q);
+        let central_poly = self.emit_polynomial(r, &A);
+        let central_num = self.emit_binary(BinaryOp::Mul, central_poly, q);
+        let central_den = self.emit_polynomial(r, &B);
+        let central = self.emit_binary(BinaryOp::Div, central_num, central_den);
+
+        let minus_two = self.emit_const(-2.0);
+        let lower_log = self.emit_unary(UnaryOp::Log, p);
+        let lower_log_scaled = self.emit_binary(BinaryOp::Mul, minus_two, lower_log);
+        let lower_q = self.emit_unary(UnaryOp::Sqrt, lower_log_scaled);
+        let lower = self.emit_rational_tail(lower_q, &C, &D);
+
+        let one = self.emit_const(1.0);
+        let one_minus_p = self.emit_binary(BinaryOp::Sub, one, p);
+        let upper_log = self.emit_unary(UnaryOp::Log, one_minus_p);
+        let upper_log_scaled = self.emit_binary(BinaryOp::Mul, minus_two, upper_log);
+        let upper_q = self.emit_unary(UnaryOp::Sqrt, upper_log_scaled);
+        let upper_tail = self.emit_rational_tail(upper_q, &C, &D);
+        let upper = self.emit_unary(UnaryOp::Neg, upper_tail);
+
+        let low_cutoff = self.emit_const(P_LOW);
+        let high_cutoff = self.emit_const(1.0 - P_LOW);
+        let low = self.emit_compare(CompareOp::Lt, p, low_cutoff);
+        let high = self.emit_compare(CompareOp::Gt, p, high_cutoff);
+        let high_or_central = self.emit_select(high, upper, central);
+        self.emit_select(low, lower, high_or_central)
+    }
+
+    fn emit_open_probability(&mut self, p: Reg) -> Reg {
+        let eps = self.emit_const(1.0e-15);
+        let one_minus_eps = self.emit_const(1.0 - 1.0e-15);
+        let above_zero = self.emit_binary(BinaryOp::Max, p, eps);
+        self.emit_binary(BinaryOp::Min, above_zero, one_minus_eps)
+    }
+
+    fn emit_rational_tail(&mut self, q: Reg, numerator: &[f64; 6], denominator: &[f64; 5]) -> Reg {
+        let num = self.emit_polynomial(q, numerator);
+        let den = self.emit_polynomial(q, denominator);
+        self.emit_binary(BinaryOp::Div, num, den)
+    }
+
+    fn emit_polynomial<const N: usize>(&mut self, x: Reg, coeffs: &[f64; N]) -> Reg {
+        let mut acc = self.emit_const(coeffs[0]);
+        for coeff in coeffs.iter().skip(1) {
+            let product = self.emit_binary(BinaryOp::Mul, acc, x);
+            let next = self.emit_const(*coeff);
+            acc = self.emit_binary(BinaryOp::Add, product, next);
+        }
+        acc
+    }
+}

--- a/crates/rumoca-phase-solve/src/lower/misc_helpers.rs
+++ b/crates/rumoca-phase-solve/src/lower/misc_helpers.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+pub(super) fn static_singleton_subscript_index(
+    expr: &rumoca_core::Expression,
+) -> Result<Option<usize>, LowerError> {
+    lower_static_index_expr(expr)
+}
+
+pub(super) fn direct_assignment_component(
+    values: &[Reg],
+    flat_index: usize,
+    repeat_period: Option<usize>,
+) -> Option<Reg> {
+    values.get(flat_index).copied().or_else(|| {
+        let period = repeat_period?;
+        (period > 0 && values.len() == period).then(|| values[flat_index % period])
+    })
+}
+
+pub(super) fn complex_operator_call_op(name: &str) -> Option<BinaryOp> {
+    match name {
+        "Complex.'+'" => Some(BinaryOp::Add),
+        "Complex.'-'" => Some(BinaryOp::Sub),
+        "Complex.'*'" => Some(BinaryOp::Mul),
+        "Complex.'/'" => Some(BinaryOp::Div),
+        _ => None,
+    }
+}
+
+pub(super) fn is_time_var_ref(expr: &rumoca_core::Expression) -> bool {
+    matches!(
+        expr,
+        rumoca_core::Expression::VarRef {
+            name,
+            subscripts,
+            ..
+        } if name.as_str() == "time" && subscripts.is_empty()
+    )
+}
+
+pub(super) fn size_binding_key(name: &str, dim: usize) -> String {
+    format!("{SIZE_BINDING_PREFIX}{name}.{dim}")
+}

--- a/crates/rumoca-phase-solve/src/lower/scope.rs
+++ b/crates/rumoca-phase-solve/src/lower/scope.rs
@@ -219,6 +219,18 @@ pub(super) struct FunctionInputBindState<'a> {
     pub(in crate::lower) const_bindings: &'a mut IndexMap<String, f64>,
 }
 
+pub(super) struct MaterializedRecordComponent {
+    pub(super) suffix: String,
+    pub(super) reg: Reg,
+    pub(super) dims: Option<Vec<i64>>,
+    pub(super) known_empty: bool,
+}
+
+pub(super) struct MaterializedRecordComponents {
+    pub(super) components: Vec<MaterializedRecordComponent>,
+    pub(super) indexed_components: Vec<(String, Vec<LocalIndexedBinding>)>,
+}
+
 #[derive(Clone)]
 pub(super) struct LocalLowerFrame {
     pub(super) structural_bindings: IndexMap<String, f64>,

--- a/crates/rumoca-phase-solve/src/lower/statements.rs
+++ b/crates/rumoca-phase-solve/src/lower/statements.rs
@@ -5,28 +5,11 @@ use rumoca_ir_solve::{BinaryOp, Reg, ScalarSlot};
 use super::function_projection::format_subscript_binding_key;
 use super::helpers::*;
 use super::{
-    BREAK_FLAG_BINDING, LowerBuilder, LowerError, MAX_FUNCTION_INLINE_DEPTH, RETURN_FLAG_BINDING,
-    Scope, size_binding_key, upsert_local_indexed_binding,
+    BREAK_FLAG_BINDING, LowerBuilder, LowerError, RETURN_FLAG_BINDING, Scope, size_binding_key,
+    upsert_local_indexed_binding,
 };
 
 const MAX_INLINE_WHILE_ITERS: usize = 128;
-
-type ProjectedRecordComponentEntry = (String, Reg, Option<Vec<i64>>, bool);
-
-fn projected_record_component_entry(
-    builder: &LowerBuilder<'_>,
-    key_text: &str,
-    reg: Reg,
-    source_prefix: &str,
-) -> Option<ProjectedRecordComponentEntry> {
-    let suffix = key_text.strip_prefix(source_prefix)?;
-    Some((
-        suffix.to_string(),
-        reg,
-        builder.local_binding_dims.get(key_text).cloned(),
-        builder.known_empty_local_arrays.contains(key_text),
-    ))
-}
 
 impl<'a> LowerBuilder<'a> {
     /// Returns `true` when lowering should stop due to `return`.
@@ -347,6 +330,7 @@ impl<'a> LowerBuilder<'a> {
         if let Some(start) = self
             .variable_starts
             .and_then(|starts| starts.get(key.as_str()))
+            .filter(|start| !start_metadata_refers_to_key(start, key.as_str()))
             && let Ok(value) = self.eval_compile_time_expr(start, const_scope)
         {
             return Ok(value);
@@ -744,68 +728,34 @@ impl<'a> LowerBuilder<'a> {
         args: &[rumoca_core::Expression],
         call_depth: usize,
     ) -> Result<bool, LowerError> {
-        if call_depth >= MAX_FUNCTION_INLINE_DEPTH {
-            return Ok(false);
-        }
-        let Some(function) = self.lookup_function(name).cloned() else {
-            return Ok(false);
-        };
-        if function.external.is_some() {
-            return Ok(false);
-        }
-        let [output] = function.outputs.as_slice() else {
+        let Some(materialized) = self.materialize_single_record_function_call_components(
+            name,
+            args,
+            caller_scope,
+            call_depth,
+        )?
+        else {
             return Ok(false);
         };
-        if output.type_class != Some(rumoca_core::ClassType::Record) {
-            return Ok(false);
-        }
-        self.ensure_pure_inline_function(name.as_str(), &function)?;
-
-        let (components, indexed_components) = self.with_local_lower_frame(|this| {
-            let bindings =
-                this.bind_function_inputs(name, &function.inputs, args, caller_scope, call_depth)?;
-            let mut function_scope = bindings.scope;
-            this.local_const_bindings.extend(bindings.const_bindings);
-            this.initialize_function_output_scope(&function, &mut function_scope, call_depth)?;
-            let _returned =
-                this.lower_statements(&function.body, &mut function_scope, call_depth + 1)?;
-            let source_prefix = format!("{}.", output.name);
-            let components = function_scope
-                .iter()
-                .into_iter()
-                .filter_map(|(key, reg)| {
-                    let key_text = key.as_str();
-                    projected_record_component_entry(this, key_text, reg, source_prefix.as_str())
-                })
-                .collect::<Vec<_>>();
-            let indexed_components = this
-                .local_indexed_bindings
-                .iter()
-                .filter_map(|(key, bindings)| {
-                    key.strip_prefix(source_prefix.as_str())
-                        .map(|suffix| (format!("{target}.{suffix}"), bindings.clone()))
-                })
-                .collect::<Vec<_>>();
-            Ok((components, indexed_components))
-        })?;
-        if components.is_empty() {
+        if materialized.components.is_empty() {
             return Err(LowerError::InvalidFunction {
-                name: output.name.clone(),
+                name: name.as_str().to_string(),
                 reason: "record function output had no assigned components".to_string(),
             });
         }
 
         self.clear_record_component_bindings(caller_scope, target);
-        for (suffix, reg, dims, known_empty) in components {
-            let target_key = format!("{target}.{suffix}");
-            caller_scope.insert(ComponentPath::from_flat_path(&target_key), reg);
-            if let Some(dims) = dims {
+        for component in materialized.components {
+            let target_key = format!("{target}.{}", component.suffix);
+            caller_scope.insert(ComponentPath::from_flat_path(&target_key), component.reg);
+            if let Some(dims) = component.dims {
                 self.local_binding_dims.insert(target_key.clone(), dims);
-                self.set_known_empty_local_array(&target_key, known_empty);
+                self.set_known_empty_local_array(&target_key, component.known_empty);
             }
         }
-        for (target_key, bindings) in indexed_components {
-            self.local_indexed_bindings.insert(target_key, bindings);
+        for (suffix, bindings) in materialized.indexed_components {
+            self.local_indexed_bindings
+                .insert(format!("{target}.{suffix}"), bindings);
         }
         Ok(true)
     }
@@ -1282,6 +1232,10 @@ impl<'a> LowerBuilder<'a> {
         }
         Ok(())
     }
+}
+
+fn start_metadata_refers_to_key(expr: &rumoca_core::Expression, key: &str) -> bool {
+    binding_base_key(expr).is_ok_and(|start_key| start_key == key)
 }
 
 fn is_control_flag(name: &ComponentPath) -> bool {

--- a/crates/rumoca-phase-solve/src/lower/tests.rs
+++ b/crates/rumoca-phase-solve/src/lower/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     expression_rows::lower_expression_rows_with_mode, lower_derivative_rhs,
     lower_derivative_rhs_scalar_programs, lower_discrete_rhs, lower_expression,
+    lower_expression_rows_from_expressions_with_runtime_metadata,
     lower_initial_expression_rows_from_expressions, lower_initial_residual, lower_residual,
     lower_root_conditions, lower_runtime_assignment_rhs,
 };

--- a/crates/rumoca-phase-solve/src/lower/tests/function_expression_tests.rs
+++ b/crates/rumoca-phase-solve/src/lower/tests/function_expression_tests.rs
@@ -16,6 +16,12 @@ fn complex_output_param(name: &str) -> rumoca_core::FunctionParam {
     }
 }
 
+fn record_param(name: &str, type_name: &str) -> rumoca_core::FunctionParam {
+    let mut param = rumoca_core::FunctionParam::new(name, type_name);
+    param.type_class = Some(rumoca_core::ClassType::Record);
+    param
+}
+
 fn insert_complex_constructor(
     dae_model: &mut dae::Dae,
     im_default: Option<rumoca_core::Expression>,
@@ -99,6 +105,55 @@ fn array_lit(values: &[f64]) -> rumoca_core::Expression {
         is_matrix: false,
         span: rumoca_core::Span::DUMMY,
     }
+}
+
+#[test]
+fn lower_function_call_does_not_fold_self_referential_start_metadata() {
+    let mut dae_model = dae::Dae::default();
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("x"), scalar_var("x"));
+    dae_model
+        .metadata
+        .variable_starts
+        .insert("x".to_string(), var("x"));
+
+    let mut identity = rumoca_core::Function::new("My.identity", rumoca_core::Span::DUMMY);
+    identity.inputs.push(function_param("u"));
+    identity.outputs.push(function_param("y"));
+    identity.body.push(rumoca_core::Statement::Assignment {
+        comp: component_ref("y"),
+        value: var("u"),
+        span: rumoca_core::Span::DUMMY,
+    });
+    dae_model
+        .symbols
+        .functions
+        .insert(identity.name.clone(), identity);
+
+    let layout = build_var_layout(&dae_model);
+    let rows = lower_expression_rows_from_expressions_with_runtime_metadata(
+        &[rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.identity").into(),
+            args: vec![var("x")],
+            is_constructor: false,
+            span: rumoca_core::Span::DUMMY,
+        }],
+        &layout,
+        &dae_model.symbols.functions,
+        &dae_model.clocks.intervals,
+        &dae_model.clocks.timings,
+        &dae_model.metadata.variable_starts,
+    )
+    .expect("self-referential start metadata should not recurse during constant folding");
+
+    assert_eq!(rows.len(), 1);
+    assert!(
+        rows[0]
+            .iter()
+            .any(|op| matches!(op, LinearOp::LoadY { .. }))
+    );
 }
 
 fn record_ctor(name: &str, args: Vec<rumoca_core::Expression>) -> rumoca_core::Expression {
@@ -653,6 +708,369 @@ fn lower_expression_inlines_user_function_call() {
     let (regs, _output) = eval_linear_ops(&lowered.ops, &y, &p, 0.0);
     let compiled = read_reg(&regs, lowered.result);
     assert!((compiled - 10.0).abs() <= 1e-12);
+}
+
+#[test]
+fn lower_expression_binds_record_function_result_to_record_input() {
+    let mut dae_model = dae::Dae::default();
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("p"), scalar_var("p"));
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("temp"), scalar_var("temp"));
+
+    let mut state_ctor = rumoca_core::Function::new("My.State", rumoca_core::Span::DUMMY);
+    state_ctor.is_constructor = true;
+    state_ctor.inputs.push(function_param("p"));
+    state_ctor.inputs.push(function_param("T"));
+    state_ctor.outputs.push(record_param("state", "My.State"));
+    dae_model
+        .symbols
+        .functions
+        .insert(state_ctor.name.clone(), state_ctor);
+
+    let mut make_state = rumoca_core::Function::new("My.makeState", rumoca_core::Span::DUMMY);
+    make_state.inputs.push(function_param("p"));
+    make_state.inputs.push(function_param("T"));
+    make_state.outputs.push(record_param("state", "My.State"));
+    make_state.body.push(rumoca_core::Statement::Assignment {
+        comp: component_ref("state"),
+        value: rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.State").into(),
+            args: vec![var("p"), var("T")],
+            is_constructor: true,
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: rumoca_core::Span::DUMMY,
+    });
+    dae_model
+        .symbols
+        .functions
+        .insert(make_state.name.clone(), make_state);
+
+    let mut temperature = rumoca_core::Function::new("My.temperature", rumoca_core::Span::DUMMY);
+    temperature.inputs.push(record_param("state", "My.State"));
+    temperature.outputs.push(function_param("T"));
+    temperature.body.push(rumoca_core::Statement::Assignment {
+        comp: component_ref("T"),
+        value: rumoca_core::Expression::FieldAccess {
+            base: Box::new(var("state")),
+            field: "T".to_string(),
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: rumoca_core::Span::DUMMY,
+    });
+    dae_model
+        .symbols
+        .functions
+        .insert(temperature.name.clone(), temperature);
+
+    let expr = rumoca_core::Expression::FunctionCall {
+        name: rumoca_core::VarName::new("My.temperature").into(),
+        args: vec![rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.makeState").into(),
+            args: vec![var("p"), var("temp")],
+            is_constructor: false,
+            span: rumoca_core::Span::DUMMY,
+        }],
+        is_constructor: false,
+        span: rumoca_core::Span::DUMMY,
+    };
+
+    let layout = build_var_layout(&dae_model);
+    let lowered = lower_expression(&expr, &layout, &dae_model.symbols.functions)
+        .expect("record-valued function actual should bind record input components");
+    let mut y = vec![0.0; layout.y_scalars()];
+    let p = vec![];
+    set_y_value(&layout, &mut y, "p", 101325.0);
+    set_y_value(&layout, &mut y, "temp", 350.0);
+
+    let (regs, _output) = eval_linear_ops(&lowered.ops, &y, &p, 0.0);
+    let compiled = read_reg(&regs, lowered.result);
+    assert!((compiled - 350.0).abs() <= 1e-12);
+}
+
+#[test]
+fn lower_expression_binds_record_function_result_to_flattened_record_inputs() {
+    let mut dae_model = dae::Dae::default();
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("p"), scalar_var("p"));
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("temp"), scalar_var("temp"));
+
+    let mut state_ctor = rumoca_core::Function::new("My.State", rumoca_core::Span::DUMMY);
+    state_ctor.is_constructor = true;
+    state_ctor.inputs.push(function_param("p"));
+    state_ctor.inputs.push(function_param("T"));
+    state_ctor.outputs.push(record_param("state", "My.State"));
+    dae_model
+        .symbols
+        .functions
+        .insert(state_ctor.name.clone(), state_ctor);
+
+    let mut make_state = rumoca_core::Function::new("My.makeState", rumoca_core::Span::DUMMY);
+    make_state.inputs.push(function_param("p"));
+    make_state.inputs.push(function_param("T"));
+    make_state.outputs.push(record_param("state", "My.State"));
+    make_state.body.push(rumoca_core::Statement::Assignment {
+        comp: component_ref("state"),
+        value: rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.State").into(),
+            args: vec![var("p"), var("T")],
+            is_constructor: true,
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: rumoca_core::Span::DUMMY,
+    });
+    dae_model
+        .symbols
+        .functions
+        .insert(make_state.name.clone(), make_state);
+
+    let mut enthalpy = rumoca_core::Function::new("My.specificEnthalpy", rumoca_core::Span::DUMMY);
+    enthalpy.inputs.push(function_param("state_p"));
+    enthalpy.inputs.push(function_param("state_T"));
+    enthalpy.outputs.push(function_param("h"));
+    enthalpy.body.push(rumoca_core::Statement::Assignment {
+        comp: component_ref("h"),
+        value: var("state_T"),
+        span: rumoca_core::Span::DUMMY,
+    });
+    dae_model
+        .symbols
+        .functions
+        .insert(enthalpy.name.clone(), enthalpy);
+
+    let expr = rumoca_core::Expression::FunctionCall {
+        name: rumoca_core::VarName::new("My.specificEnthalpy").into(),
+        args: vec![rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.makeState").into(),
+            args: vec![var("p"), var("temp")],
+            is_constructor: false,
+            span: rumoca_core::Span::DUMMY,
+        }],
+        is_constructor: false,
+        span: rumoca_core::Span::DUMMY,
+    };
+
+    let layout = build_var_layout(&dae_model);
+    let lowered = lower_expression(&expr, &layout, &dae_model.symbols.functions)
+        .expect("record-valued actual should bind flattened record inputs");
+    let mut y = vec![0.0; layout.y_scalars()];
+    let p = vec![];
+    set_y_value(&layout, &mut y, "p", 101325.0);
+    set_y_value(&layout, &mut y, "temp", 380.0);
+
+    let (regs, _output) = eval_linear_ops(&lowered.ops, &y, &p, 0.0);
+    let compiled = read_reg(&regs, lowered.result);
+    assert!((compiled - 380.0).abs() <= 1e-12);
+}
+
+#[test]
+fn lower_expression_projects_record_field_from_function_result() {
+    let mut dae_model = dae::Dae::default();
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("p"), scalar_var("p"));
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("temp"), scalar_var("temp"));
+
+    let mut state_ctor = rumoca_core::Function::new("My.State", rumoca_core::Span::DUMMY);
+    state_ctor.is_constructor = true;
+    state_ctor.inputs.push(function_param("p"));
+    state_ctor.inputs.push(function_param("T"));
+    state_ctor.outputs.push(record_param("state", "My.State"));
+    dae_model
+        .symbols
+        .functions
+        .insert(state_ctor.name.clone(), state_ctor);
+
+    let mut make_state = rumoca_core::Function::new("My.makeState", rumoca_core::Span::DUMMY);
+    make_state.inputs.push(function_param("p"));
+    make_state.inputs.push(function_param("T"));
+    make_state.outputs.push(record_param("state", "My.State"));
+    make_state.body.push(rumoca_core::Statement::Assignment {
+        comp: component_ref("state"),
+        value: rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.State").into(),
+            args: vec![var("p"), var("T")],
+            is_constructor: true,
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: rumoca_core::Span::DUMMY,
+    });
+    dae_model
+        .symbols
+        .functions
+        .insert(make_state.name.clone(), make_state);
+
+    let expr = rumoca_core::Expression::FieldAccess {
+        base: Box::new(rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.makeState").into(),
+            args: vec![var("p"), var("temp")],
+            is_constructor: false,
+            span: rumoca_core::Span::DUMMY,
+        }),
+        field: "T".to_string(),
+        span: rumoca_core::Span::DUMMY,
+    };
+
+    let layout = build_var_layout(&dae_model);
+    let lowered = lower_expression(&expr, &layout, &dae_model.symbols.functions)
+        .expect("record-valued function field projection should lower");
+    let mut y = vec![0.0; layout.y_scalars()];
+    let p = vec![];
+    set_y_value(&layout, &mut y, "p", 101325.0);
+    set_y_value(&layout, &mut y, "temp", 360.0);
+
+    let (regs, _output) = eval_linear_ops(&lowered.ops, &y, &p, 0.0);
+    let compiled = read_reg(&regs, lowered.result);
+    assert!((compiled - 360.0).abs() <= 1e-12);
+}
+
+#[test]
+fn lower_expression_projects_single_output_function_by_output_name() {
+    let mut dae_model = dae::Dae::default();
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("u"), scalar_var("u"));
+
+    let mut temperature = rumoca_core::Function::new("My.temperature", rumoca_core::Span::DUMMY);
+    temperature.inputs.push(function_param("u"));
+    temperature.outputs.push(function_param("T"));
+    temperature.body.push(rumoca_core::Statement::Assignment {
+        comp: component_ref("T"),
+        value: rumoca_core::Expression::Binary {
+            op: rumoca_core::OpBinary::Add,
+            lhs: Box::new(var("u")),
+            rhs: Box::new(real_lit(10.0)),
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: rumoca_core::Span::DUMMY,
+    });
+    dae_model
+        .symbols
+        .functions
+        .insert(temperature.name.clone(), temperature);
+
+    let expr = rumoca_core::Expression::FieldAccess {
+        base: Box::new(rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.temperature").into(),
+            args: vec![var("u")],
+            is_constructor: false,
+            span: rumoca_core::Span::DUMMY,
+        }),
+        field: "T".to_string(),
+        span: rumoca_core::Span::DUMMY,
+    };
+
+    let layout = build_var_layout(&dae_model);
+    let lowered = lower_expression(&expr, &layout, &dae_model.symbols.functions)
+        .expect("single-output function output-name projection should lower");
+    let mut y = vec![0.0; layout.y_scalars()];
+    let p = vec![];
+    set_y_value(&layout, &mut y, "u", 273.15);
+
+    let (regs, _output) = eval_linear_ops(&lowered.ops, &y, &p, 0.0);
+    let compiled = read_reg(&regs, lowered.result);
+    assert!((compiled - 283.15).abs() <= 1e-12);
+}
+
+#[test]
+fn lower_expression_projects_record_field_from_forwarded_function_result() {
+    let mut dae_model = dae::Dae::default();
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("p"), scalar_var("p"));
+    dae_model
+        .variables
+        .algebraics
+        .insert(rumoca_core::VarName::new("temp"), scalar_var("temp"));
+
+    let mut state_ctor = rumoca_core::Function::new("My.State", rumoca_core::Span::DUMMY);
+    state_ctor.is_constructor = true;
+    state_ctor.inputs.push(function_param("p"));
+    state_ctor.inputs.push(function_param("T"));
+    state_ctor.outputs.push(record_param("state", "My.State"));
+    dae_model
+        .symbols
+        .functions
+        .insert(state_ctor.name.clone(), state_ctor);
+
+    let mut make_state = rumoca_core::Function::new("My.makeState", rumoca_core::Span::DUMMY);
+    make_state.inputs.push(function_param("p"));
+    make_state.inputs.push(function_param("T"));
+    make_state.outputs.push(record_param("state", "My.State"));
+    make_state.body.push(rumoca_core::Statement::Assignment {
+        comp: component_ref("state"),
+        value: rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.State").into(),
+            args: vec![var("p"), var("T")],
+            is_constructor: true,
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: rumoca_core::Span::DUMMY,
+    });
+    dae_model
+        .symbols
+        .functions
+        .insert(make_state.name.clone(), make_state);
+
+    let mut forward_state = rumoca_core::Function::new("My.forwardState", rumoca_core::Span::DUMMY);
+    forward_state.inputs.push(function_param("p"));
+    forward_state.inputs.push(function_param("T"));
+    forward_state
+        .outputs
+        .push(record_param("state", "My.State"));
+    forward_state.body.push(rumoca_core::Statement::Assignment {
+        comp: component_ref("state"),
+        value: rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.makeState").into(),
+            args: vec![var("p"), var("T")],
+            is_constructor: false,
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: rumoca_core::Span::DUMMY,
+    });
+    dae_model
+        .symbols
+        .functions
+        .insert(forward_state.name.clone(), forward_state);
+
+    let expr = rumoca_core::Expression::FieldAccess {
+        base: Box::new(rumoca_core::Expression::FunctionCall {
+            name: rumoca_core::VarName::new("My.forwardState").into(),
+            args: vec![var("p"), var("temp")],
+            is_constructor: false,
+            span: rumoca_core::Span::DUMMY,
+        }),
+        field: "T".to_string(),
+        span: rumoca_core::Span::DUMMY,
+    };
+
+    let layout = build_var_layout(&dae_model);
+    let lowered = lower_expression(&expr, &layout, &dae_model.symbols.functions)
+        .expect("forwarded record-valued function field projection should lower");
+    let mut y = vec![0.0; layout.y_scalars()];
+    let p = vec![];
+    set_y_value(&layout, &mut y, "p", 101325.0);
+    set_y_value(&layout, &mut y, "temp", 370.0);
+
+    let (regs, _output) = eval_linear_ops(&lowered.ops, &y, &p, 0.0);
+    let compiled = read_reg(&regs, lowered.result);
+    assert!((compiled - 370.0).abs() <= 1e-12);
 }
 
 #[test]

--- a/crates/rumoca/src/compiler.rs
+++ b/crates/rumoca/src/compiler.rs
@@ -592,6 +592,22 @@ impl Compiler {
         self.compile_str(&source, path)
     }
 
+    /// Compile a Modelica file through the resolved AST stage only.
+    pub fn compile_file_ast(&self, path: &str) -> Result<ResolvedTree, CompilerError> {
+        let source =
+            fs::read_to_string(path).map_err(|e| CompilerError::io_error(path, e.to_string()))?;
+
+        self.compile_str_ast(&source, path)
+    }
+
+    /// Compile a Modelica file through the flat-model stage only.
+    pub fn compile_file_flat(&self, path: &str) -> Result<FlatModel, CompilerError> {
+        let source =
+            fs::read_to_string(path).map_err(|e| CompilerError::io_error(path, e.to_string()))?;
+
+        self.compile_str_flat(&source, path)
+    }
+
     /// Compile a Modelica file from a Path.
     pub fn compile_path(&self, path: &Path) -> Result<CompilationResult, CompilerError> {
         let path_str = path.to_string_lossy().to_string();
@@ -710,6 +726,50 @@ impl Compiler {
             flat: result.flat,
             resolved,
         })
+    }
+
+    /// Compile Modelica source code through the resolved AST stage only.
+    pub fn compile_str_ast(
+        &self,
+        source: &str,
+        file_name: &str,
+    ) -> Result<ResolvedTree, CompilerError> {
+        if self.verbose {
+            eprintln!("[rumoca] Compiling source through AST: {}", file_name);
+            eprintln!("[rumoca] Phase 1-2: Parsing and resolving...");
+        }
+
+        let mut session = Session::new(SessionConfig::default());
+        self.load_required_source_roots(&mut session, source)?;
+        self.load_local_compile_unit(&mut session, source, file_name)?;
+        session
+            .resolved()
+            .map_err(|err| CompilerError::ResolveError(err.to_string()))
+    }
+
+    /// Compile Modelica source code through the flat-model stage only.
+    pub fn compile_str_flat(
+        &self,
+        source: &str,
+        file_name: &str,
+    ) -> Result<FlatModel, CompilerError> {
+        let model_name = self
+            .model_name
+            .as_ref()
+            .ok_or(CompilerError::NoModelSpecified)?;
+
+        if self.verbose {
+            eprintln!("[rumoca] Compiling model through Flat: {}", model_name);
+            eprintln!("[rumoca] Source file: {}", file_name);
+            eprintln!("[rumoca] Phase 1-5: Parsing, resolving, and flattening...");
+        }
+
+        let mut session = Session::new(SessionConfig::default());
+        self.load_required_source_roots(&mut session, source)?;
+        self.load_local_compile_unit(&mut session, source, file_name)?;
+        session
+            .compile_model_flat_strict_reachable_uncached_with_recovery(model_name)
+            .map_err(CompilerError::FlattenError)
     }
 
     /// Compile Modelica source code through DAE only.

--- a/crates/rumoca/src/main.rs
+++ b/crates/rumoca/src/main.rs
@@ -47,8 +47,9 @@ use miette::{
 };
 use rumoca::{CompilationResult, Compiler, CompilerError, DaeCompilationResult, TemplateIr};
 use rumoca_compile::{
+    codegen::{render_ast_template_with_name, render_flat_template_with_name},
     compile::core::{Diagnostic as CommonDiagnostic, DiagnosticSeverity, SourceMap},
-    compile::{Dae, Session, SessionConfig},
+    compile::{Dae, FlatModel, ResolvedTree, Session, SessionConfig},
     project::{write_last_simulation_result_for_model, write_simulation_run},
 };
 use rumoca_sim::{SimOptions, SimSolverMode};
@@ -976,6 +977,17 @@ fn run_config_init() -> Result<()> {
 
 fn run_compile(args: CompileArgs) -> Result<()> {
     init_debug_tracing(&args.diagnostics)?;
+    if let Some(emit) = args.emit
+        && matches!(emit.phase(), CompilePhase::Ast | CompilePhase::Flat)
+    {
+        let (artifact, model) = compile_early_ir_with_inferred_model(
+            &args.input,
+            emit.phase(),
+            args.diagnostics.verbose,
+        )?;
+        return run_early_ir_dump(&artifact, &model, emit.is_json(), args.output);
+    }
+
     let (result, model) = compile_with_inferred_model(&args.input, args.diagnostics.verbose)?;
 
     // Structural / point inspection of the lowered model (shares the `sim
@@ -1021,6 +1033,36 @@ fn run_compile(args: CompileArgs) -> Result<()> {
     }
 }
 
+enum EarlyIrArtifact {
+    Ast(Box<ResolvedTree>),
+    Flat(Box<FlatModel>),
+}
+
+fn run_early_ir_dump(
+    artifact: &EarlyIrArtifact,
+    model: &str,
+    json: bool,
+    output: Option<PathBuf>,
+) -> Result<()> {
+    let rendered = match (artifact, json) {
+        (EarlyIrArtifact::Ast(resolved), true) => serde_json::to_string_pretty(resolved.inner())?,
+        (EarlyIrArtifact::Ast(resolved), false) => {
+            render_early_ir_as_modelica_ast(resolved, model)?
+        }
+        (EarlyIrArtifact::Flat(flat), true) => serde_json::to_string_pretty(flat)?,
+        (EarlyIrArtifact::Flat(flat), false) => render_early_ir_as_modelica_flat(flat, model)?,
+    };
+    write_ir_dump(
+        &rendered,
+        match artifact {
+            EarlyIrArtifact::Ast(_) => CompilePhase::Ast,
+            EarlyIrArtifact::Flat(_) => CompilePhase::Flat,
+        },
+        json,
+        output,
+    )
+}
+
 /// Dump the IR at `phase` as JSON (`--json`) or Modelica (default) to `output`
 /// or stdout.
 fn run_ir_dump(
@@ -1036,6 +1078,15 @@ fn run_ir_dump(
         render_ir_as_modelica(result, model, phase)?
     };
 
+    write_ir_dump(&rendered, phase, json, output)
+}
+
+fn write_ir_dump(
+    rendered: &str,
+    phase: CompilePhase,
+    json: bool,
+    output: Option<PathBuf>,
+) -> Result<()> {
     match output {
         Some(path) => {
             // An --emit dump is a single file; catch `-o <dir>` with a friendly
@@ -1048,8 +1099,7 @@ fn run_ir_dump(
                     path.display()
                 );
             }
-            std::fs::write(&path, &rendered)
-                .with_context(|| format!("write {}", path.display()))?;
+            std::fs::write(&path, rendered).with_context(|| format!("write {}", path.display()))?;
             eprintln!(
                 "wrote {:?} IR ({}) to {}",
                 phase,
@@ -1065,6 +1115,26 @@ fn run_ir_dump(
         }
     }
     Ok(())
+}
+
+fn render_early_ir_as_modelica_ast(resolved: &ResolvedTree, model: &str) -> Result<String> {
+    let template = rumoca_compile::codegen::templates::builtin_template_source(
+        "modelica",
+        "modelica.mo.jinja",
+    )
+    .ok_or_else(|| anyhow::anyhow!("missing built-in modelica template"))?;
+    let model_identifier = model.replace('.', "_");
+    render_ast_template_with_name(resolved.inner(), template, &model_identifier).map_err(Into::into)
+}
+
+fn render_early_ir_as_modelica_flat(flat: &FlatModel, model: &str) -> Result<String> {
+    let template = rumoca_compile::codegen::templates::builtin_template_source(
+        "flat-modelica",
+        "flat_modelica.mo.jinja",
+    )
+    .ok_or_else(|| anyhow::anyhow!("missing built-in flat-modelica template"))?;
+    let model_identifier = model.replace('.', "_");
+    render_flat_template_with_name(flat, template, &model_identifier).map_err(Into::into)
 }
 
 /// Render the IR at `phase` back to equivalent Modelica via the built-in
@@ -1478,6 +1548,37 @@ fn compile_with_inferred_model(
     Ok((result, model))
 }
 
+fn compile_early_ir_with_inferred_model(
+    args: &ModelInputArgs,
+    phase: CompilePhase,
+    verbose: bool,
+) -> Result<(EarlyIrArtifact, String)> {
+    ensure_model_file_readable(&args.model_file)?;
+    let model = match &args.options.model {
+        Some(model) => model.clone(),
+        None => infer_model_name(&args.model_file)?,
+    };
+
+    let source_roots = merged_source_root_paths(&args.options.source_roots);
+
+    let compiler = Compiler::new()
+        .model(&model)
+        .verbose(verbose)
+        .source_roots(&source_roots);
+    let artifact = match phase {
+        CompilePhase::Ast => {
+            EarlyIrArtifact::Ast(Box::new(compiler.compile_file_ast(&args.model_file)?))
+        }
+        CompilePhase::Flat => {
+            EarlyIrArtifact::Flat(Box::new(compiler.compile_file_flat(&args.model_file)?))
+        }
+        CompilePhase::Dae | CompilePhase::Solve => {
+            bail!("internal error: early IR compile requested for {phase:?}")
+        }
+    };
+    Ok((artifact, model))
+}
+
 fn compile_dae_with_inferred_model(
     args: &ModelInputArgs,
     verbose: bool,
@@ -1868,43 +1969,8 @@ fn run_simulation(run: SimulationRun<'_>) -> Result<()> {
     Ok(())
 }
 
-fn discover_workspace_root_for_model_file(model_file: &str) -> Option<PathBuf> {
-    let input_path = PathBuf::from(model_file);
-    let absolute = if input_path.is_absolute() {
-        input_path
-    } else {
-        std::env::current_dir().ok()?.join(input_path)
-    };
-    let start_dir = if absolute.is_dir() {
-        absolute
-    } else {
-        absolute.parent()?.to_path_buf()
-    };
-    for ancestor in start_dir.ancestors() {
-        if ancestor.join("modelica_dependencies.toml").is_file() {
-            return Some(ancestor.to_path_buf());
-        }
-    }
-    None
-}
-
-/// Generate a shell completion script directly from the clap command tree, so
-/// completions can never drift from the real command/flag set (no hand-
-/// maintained list to keep in sync — see the CLI review's completions finding).
-fn completion_script(shell: CompletionShell) -> String {
-    use clap::CommandFactory;
-
-    let shell = match shell {
-        CompletionShell::Bash => clap_complete::Shell::Bash,
-        CompletionShell::Zsh => clap_complete::Shell::Zsh,
-        CompletionShell::Fish => clap_complete::Shell::Fish,
-        CompletionShell::PowerShell => clap_complete::Shell::PowerShell,
-    };
-    let mut command = Cli::command();
-    let mut buffer = Vec::new();
-    clap_complete::generate(shell, &mut command, "rumoca", &mut buffer);
-    String::from_utf8(buffer).expect("clap_complete emits valid UTF-8")
-}
+mod main_helpers;
+use main_helpers::{completion_script, discover_workspace_root_for_model_file};
 
 #[cfg(test)]
 mod main_tests;

--- a/crates/rumoca/src/main_helpers.rs
+++ b/crates/rumoca/src/main_helpers.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+pub(super) fn discover_workspace_root_for_model_file(model_file: &str) -> Option<PathBuf> {
+    let input_path = PathBuf::from(model_file);
+    let absolute = if input_path.is_absolute() {
+        input_path
+    } else {
+        std::env::current_dir().ok()?.join(input_path)
+    };
+    let start_dir = if absolute.is_dir() {
+        absolute
+    } else {
+        absolute.parent()?.to_path_buf()
+    };
+    for ancestor in start_dir.ancestors() {
+        if ancestor.join("modelica_dependencies.toml").is_file() {
+            return Some(ancestor.to_path_buf());
+        }
+    }
+    None
+}
+
+/// Generate a shell completion script directly from the clap command tree, so
+/// completions can never drift from the real command/flag set (no hand-
+/// maintained list to keep in sync — see the CLI review's completions finding).
+pub(super) fn completion_script(shell: CompletionShell) -> String {
+    use clap::CommandFactory;
+
+    let shell = match shell {
+        CompletionShell::Bash => clap_complete::Shell::Bash,
+        CompletionShell::Zsh => clap_complete::Shell::Zsh,
+        CompletionShell::Fish => clap_complete::Shell::Fish,
+        CompletionShell::PowerShell => clap_complete::Shell::PowerShell,
+    };
+    let mut command = Cli::command();
+    let mut buffer = Vec::new();
+    clap_complete::generate(shell, &mut command, "rumoca", &mut buffer);
+    String::from_utf8(buffer).expect("clap_complete emits valid UTF-8")
+}

--- a/crates/rumoca/tests/architecture_hardening_support/mod.rs
+++ b/crates/rumoca/tests/architecture_hardening_support/mod.rs
@@ -379,7 +379,6 @@ const TEXTUAL_MODEL_PATH_RECOVERY_DEBT: &[(&str, usize)] = &[
     ),
     ("crates/rumoca-phase-solve/src/lower/expression_rows.rs", 1),
     ("crates/rumoca-phase-solve/src/lower/fft.rs", 3),
-    ("crates/rumoca-phase-solve/src/lower/function_calls.rs", 1),
     (
         "crates/rumoca-phase-solve/src/lower/function_calls/runtime_intrinsics.rs",
         2,

--- a/crates/rumoca/tests/cli_emit.rs
+++ b/crates/rumoca/tests/cli_emit.rs
@@ -26,10 +26,25 @@ equation
 end EmitFixture;
 ";
 
+const FLAT_ONLY_FIXTURE: &str = "\
+model FlatOnlyFixture
+  Real x;
+algorithm
+  x := 1;
+end FlatOnlyFixture;
+";
+
 fn fixture_file() -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempdir().expect("tempdir");
     let file = dir.path().join("EmitFixture.mo");
     fs::write(&file, FIXTURE).expect("write fixture");
+    (dir, file)
+}
+
+fn named_fixture_file(name: &str, source: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join(format!("{name}.mo"));
+    fs::write(&file, source).expect("write fixture");
     (dir, file)
 }
 
@@ -82,6 +97,18 @@ fn emit_json_stages_are_valid_json() {
         serde_json::from_str::<serde_json::Value>(&out)
             .unwrap_or_else(|err| panic!("`--emit {emit}` did not produce valid JSON: {err}"));
     }
+}
+
+#[test]
+fn emit_flat_json_stops_before_todae() {
+    let (_dir, file) = named_fixture_file("FlatOnlyFixture", FLAT_ONLY_FIXTURE);
+    let out = assert_emit_ok(&file, "flat-json");
+    let json = serde_json::from_str::<serde_json::Value>(&out)
+        .expect("flat-json should produce valid JSON even when later phases reject the model");
+    assert!(
+        json.get("algorithms").is_some(),
+        "flat artifact should contain the model algorithm section, got:\n{out}"
+    );
 }
 
 #[test]

--- a/crates/rumoca/tests/pipeline_cases/alias_scope_and_dims/package_override_dimension_tests.rs
+++ b/crates/rumoca/tests/pipeline_cases/alias_scope_and_dims/package_override_dimension_tests.rs
@@ -1,5 +1,212 @@
 use super::*;
 
+/// MLS §7.3 + §12.4: component-level redeclare values can be function calls
+/// carrying modifier actuals. The active instance must rewrite inherited
+/// replaceable-function calls to the concrete function and preserve those
+/// modifier actuals as named call arguments.
+#[test]
+fn test_component_redeclare_function_call_rewrites_inherited_calls() {
+    let source = r#"
+package Characteristics
+  partial function baseFlow
+    input Real x;
+    input Real scale = 1;
+    output Real y;
+  end baseFlow;
+
+  function quadraticFlow
+    extends baseFlow;
+  algorithm
+    y := scale*x*x;
+  end quadraticFlow;
+end Characteristics;
+
+model PartialPump
+  replaceable function flowCharacteristic = Characteristics.baseFlow;
+  parameter Real delta = flowCharacteristic(1);
+  Real head;
+equation
+  head = flowCharacteristic(2);
+end PartialPump;
+
+model PrescribedPump
+  extends PartialPump;
+end PrescribedPump;
+
+model Probe
+  PrescribedPump pump(
+    redeclare function flowCharacteristic =
+      Characteristics.quadraticFlow(scale=3));
+  Real y = pump.head;
+end Probe;
+"#;
+
+    let mut session = Session::new(SessionConfig::default());
+    session
+        .add_document("test.mo", source)
+        .expect("parse failed");
+
+    let result = session.compile_model("Probe").expect("compile failed");
+    let flat_debug = format!("{:?}", result.flat);
+    assert!(
+        flat_debug.contains("Characteristics.quadraticFlow"),
+        "component redeclare should rewrite inherited calls to concrete function; flat={flat_debug}"
+    );
+    assert!(
+        !flat_debug.contains("PartialPump.flowCharacteristic"),
+        "partial replaceable function call must not remain in flat IR; flat={flat_debug}"
+    );
+    assert!(
+        flat_debug.contains("__rumoca_named_arg__.scale"),
+        "component redeclare modifier actual should be appended to rewritten calls; flat={flat_debug}"
+    );
+}
+
+/// MLS §7.3 + §12.4: modifier actuals on a function redeclared in an extends
+/// clause are evaluated in the extending class instance, not in the inherited
+/// partial base class where the replaceable function is called.
+#[test]
+fn test_extends_redeclare_function_modifier_actual_uses_extending_instance_scope() {
+    let source = r#"
+package Modelica
+  package Fluid
+    package Machines
+      package BaseClasses
+        package PumpCharacteristics
+          partial function baseFlow
+            input Real x;
+            output Real y;
+          end baseFlow;
+
+          function quadraticFlow
+            extends baseFlow;
+            input Real V_flow_nominal[3];
+            input Real head_nominal[3];
+          algorithm
+            y := V_flow_nominal[2]*x + head_nominal[2];
+          end quadraticFlow;
+        end PumpCharacteristics;
+
+        model PartialPump
+          replaceable function flowCharacteristic =
+            PumpCharacteristics.baseFlow;
+          parameter Real delta =
+            flowCharacteristic(1.1) - flowCharacteristic(1.0);
+          Real head;
+        equation
+          head = flowCharacteristic(2);
+        end PartialPump;
+      end BaseClasses;
+
+      model ControlledPump
+        extends Modelica.Fluid.Machines.BaseClasses.PartialPump(
+          redeclare function flowCharacteristic =
+            Modelica.Fluid.Machines.BaseClasses.PumpCharacteristics.quadraticFlow(
+              V_flow_nominal={0, V_flow_op, 1.5*V_flow_op},
+              head_nominal={2*head_op, head_op, 0}));
+
+        parameter Real V_flow_op = 2;
+        parameter Real head_op = 3;
+      end ControlledPump;
+    end Machines;
+
+    package Examples
+      model InverseParameterization
+        Modelica.Fluid.Machines.ControlledPump pump;
+        Real y = pump.head;
+      end InverseParameterization;
+    end Examples;
+  end Fluid;
+end Modelica;
+"#;
+
+    let mut session = Session::new(SessionConfig::default());
+    session
+        .add_document("test.mo", source)
+        .expect("parse failed");
+
+    let result = session
+        .compile_model("Modelica.Fluid.Examples.InverseParameterization")
+        .expect("compile failed");
+    let dae_debug = format!("{:?}", result.dae);
+    assert!(
+        dae_debug.contains("pump.V_flow_op"),
+        "redeclare function modifier actual should be scoped to the pump instance; dae={dae_debug}"
+    );
+    assert!(
+        !dae_debug.contains("PartialPump.V_flow_op"),
+        "partial-base qualifier must not leak into modifier actuals; dae={dae_debug}"
+    );
+}
+
+/// MLS §13.2: a qualified import of a package makes its final identifier
+/// visible in the importing class scope. Function calls in package constant
+/// bindings must keep that import when the package is used through a medium
+/// alias.
+#[test]
+fn test_package_constant_binding_uses_imported_package_function() {
+    let source = r#"
+package Modelica
+  package Math
+    package Polynomials
+      function fitting
+        input Real u[:];
+        input Real y[size(u, 1)];
+        input Integer n;
+        output Real p[n + 1];
+      algorithm
+        p := fill(y[1], n + 1);
+      end fitting;
+    end Polynomials;
+  end Math;
+
+  package Media
+    package Incompressible
+      package TableBased
+        import Modelica.Math.Polynomials;
+
+        final constant Real poly[:] =
+          Polynomials.fitting({1, 2}, {3, 4}, 1);
+
+        function h_T
+          input Real T;
+          output Real h;
+        algorithm
+          h := poly[1]*T;
+        end h_T;
+      end TableBased;
+
+      package Glycol47
+        extends TableBased;
+      end Glycol47;
+    end Incompressible;
+  end Media;
+end Modelica;
+
+model Probe
+  replaceable package Medium = Modelica.Media.Incompressible.Glycol47;
+  parameter Real h = Medium.h_T(2);
+  parameter Real p = Medium.poly[1];
+end Probe;
+"#;
+
+    let mut session = Session::new(SessionConfig::default());
+    session
+        .add_document("test.mo", source)
+        .expect("parse failed");
+
+    let result = session.compile_model("Probe").expect("compile failed");
+    let dae_debug = format!("{:?}", result.dae);
+    assert!(
+        dae_debug.contains("Modelica.Math.Polynomials.fitting"),
+        "imported package function should be fully qualified; dae={dae_debug}"
+    );
+    assert!(
+        !dae_debug.contains("VarName(\"Polynomials.fitting\")"),
+        "short imported package call must not leak into DAE; dae={dae_debug}"
+    );
+}
+
 /// MLS §7.3: a component with a single package redeclare override must expose
 /// that package's constants in component scope, even when the component type is
 /// fully qualified (e.g. `Modelica.Fluid.Sources.Boundary_pT` style).
@@ -1032,5 +1239,172 @@ end Probe;
     assert!(
         !dae_debug.contains("MMX") && !dae_debug.contains("nS"),
         "member package constants should be resolved before DAE; dae={dae_debug}"
+    );
+}
+
+/// MLS §5.3 + §7.3: an import alias to a concrete package is an effective
+/// package binding for function calls in model-level bindings.
+#[test]
+fn test_import_package_alias_rewrites_nested_function_calls_in_binding() {
+    let source = r#"
+package Interfaces
+  partial package PartialMedium
+    replaceable record State
+      Real x;
+    end State;
+
+    replaceable partial function setState_pTX
+      input Real p;
+      input Real T;
+      input Real X[:]={};
+      output State state;
+    end setState_pTX;
+
+    replaceable partial function property
+      input State state;
+      output Real y;
+    end property;
+  end PartialMedium;
+end Interfaces;
+
+package Concrete
+  extends BaseMedium;
+
+end Concrete;
+
+package BaseMedium
+  extends Interfaces.PartialMedium;
+
+  redeclare record extends State
+    Real p;
+  end State;
+
+  redeclare function setState_pTX
+    input Real p;
+    input Real T;
+    input Real X[:]={};
+    output State state;
+  algorithm
+    state := State(x=T, p=p);
+  end setState_pTX;
+
+  redeclare function extends property
+  algorithm
+    y := state.x;
+  end property;
+end BaseMedium;
+
+model Probe
+  import Medium = Concrete;
+  Real y = Medium.property(Medium.setState_pTX(1, 2, {}));
+end Probe;
+"#;
+
+    let mut session = Session::new(SessionConfig::default());
+    session
+        .add_document("test.mo", source)
+        .expect("parse failed");
+
+    let result = session.compile_model("Probe").expect("compile failed");
+    let flat_debug = format!("{:?}", result.flat);
+    assert!(
+        flat_debug.contains("Concrete.setState_pTX"),
+        "import alias should rewrite nested call to concrete function; flat={flat_debug}"
+    );
+    assert!(
+        !flat_debug.contains("Interfaces.PartialMedium.setState_pTX"),
+        "partial package function must not remain in flat IR; flat={flat_debug}"
+    );
+}
+
+/// MLS §5.3 + §7.3 + §12.4.3: member model equations inherited through a
+/// package alias must use the concrete package context for inherited package
+/// functions.
+#[test]
+fn test_package_alias_member_model_equation_uses_concrete_function_context() {
+    let source = r#"
+package Interfaces
+  partial package PartialMedium
+    replaceable record State
+      Real x;
+    end State;
+
+    replaceable partial function setState_pTX
+      input Real p;
+      input Real T;
+      input Real X[:]={};
+      output State state;
+    end setState_pTX;
+
+    replaceable partial function property
+      input State state;
+      output Real y;
+    end property;
+
+    function property_pTX
+      input Real p;
+      input Real T;
+      input Real X[:]={};
+      output Real y;
+    algorithm
+      y := property(setState_pTX(p, T, X));
+    end property_pTX;
+
+    replaceable model BaseProperties
+      Real h;
+    equation
+      h = property_pTX(1, 2, {});
+    end BaseProperties;
+  end PartialMedium;
+end Interfaces;
+
+package Concrete
+  extends Interfaces.PartialMedium;
+
+  redeclare record extends State
+    Real p;
+  end State;
+
+  redeclare function setState_pTX
+    input Real p;
+    input Real T;
+    input Real X[:]={};
+    output State state;
+  algorithm
+    state := State(x=T, p=p);
+  end setState_pTX;
+
+  redeclare function extends property
+  algorithm
+    y := state.x;
+  end property;
+end Concrete;
+
+model Probe
+  package Medium = Concrete;
+  Medium.BaseProperties medium;
+end Probe;
+"#;
+
+    let mut session = Session::new(SessionConfig::default());
+    session
+        .add_document("test.mo", source)
+        .expect("parse failed");
+
+    let phase_result = session
+        .compile_model_phases("Probe")
+        .expect("phase compilation should succeed");
+    let result = match phase_result {
+        rumoca_compile::compile::PhaseResult::Success(result) => result,
+        other => panic!("expected successful phase result, got {other:?}"),
+    };
+    let flat_debug = format!("{:?}", result.flat);
+    assert!(
+        flat_debug.contains("Concrete.setState_pTX"),
+        "member model equation should rewrite inherited call to concrete function; flat={flat_debug}"
+    );
+    assert!(
+        !flat_debug.contains("Interfaces.PartialMedium.setState_pTX"),
+        "partial package function must not remain in flat IR; flat={flat_debug}"
     );
 }


### PR DESCRIPTION
## Summary

  - Improve Modelica Standard Library parity across flatten, DAE, and solve lowering.
  - Preserve instantiated context when canonicalizing qualified function calls and aliases.
  - Lower initial algorithms, when equations, and multi-output function assignments with MLS-compliant parameter and `pre()` handling.
  - Stop early CLI emit stages before ToDae and keep diagnostics scoped to the requested pipeline stage.
  - Add regression coverage for qualified package calls, when-clause canonicalization, record-valued outputs, indexed input promotion, scoped receiver resolution, tuple when function
  updates, and random `initialState` lowering.

  ## Spec / MLS Alignment

  - Relevant active spec(s) checked: SPEC_0007, SPEC_0008, SPEC_0022, SPEC_0025, SPEC_0029
  - Relevant MLS section(s), if semantics changed: MLS §8.3/§8.6 equations, when-equations, and initialization; MLS §11.1.2 function calls and multi-result assignments; MLS §12.4.3
  random generator state handling
  - Crate/phase owner: `rumoca-phase-resolve`, `rumoca-phase-dae`, `rumoca-phase-solve`, CLI compile/emit surface

  ## Risk and Design Notes

  - Main correctness risk: changing when/algorithm/function-call lowering can affect event updates, `pre()` values, and multi-output function result routing.
  - Main maintenance risk: more lowering paths now preserve contextual metadata, so regressions are most likely if later refactors bypass the shared lowering helpers.
  - Why the change belongs in these crate(s): name/context preservation belongs in resolve/flatten-facing phase code; algorithm and when conversion belong in DAE lowering; runtime
  intrinsic shape validation belongs in solve lowering.
  - Any new abstraction, public API, or migration path: no new public API; internal helpers were added/refined for scoped receiver detection, tuple when lowering, and random state-
  length validation.

  ## Testing

  - Key command(s) run (fmt, clippy, workspace test, doc):
    - `cargo fmt --check`
    - `cargo xtask verify full`
    - `cargo xtask verify lint`
    - `cargo xtask verify workspace`
    - `cargo xtask coverage run`
    - `cargo xtask coverage report`
    - `cargo xtask coverage gate --allowed-workspace-line-coverage-drop 3.0`
    - targeted phase regressions for resolve, DAE tuple when lowering, and solve random `initialState`
  - Behavior or regression covered:
    - scoped unresolved receiver deferral
    - guarded tuple when function-call updates
    - source-spanned and invalid random `initialState` length handling
    - MSL quality/parity gates
  - Commands NOT run and why:
    - Full suite was not rerun end-to-end after the final lint/test split; the failed/affected full-suite steps were rerun and passed.
  - For compiler/simulator changes: did you run the MSL gate and confirm no regression vs `msl_quality_baseline.json`?
    - Yes. MSL gates passed. Summary: parse `566/566`, flatten `562/566`, DAE `477/566`, ir_solve `388/566`, sim `152/566`; no regression vs baseline.

  ## Code Size Budget (required)

  - production_lines_added: 606
  - production_lines_deleted: 69
  - test_lines_added: 168
  - test_lines_deleted: 11
  - public_items_added: 0
  - public_items_removed: 0
  - files_touched: 11
  - net_added_lines: 694

  - Why this net growth is required: the change adds semantic coverage for MSL-sensitive lowering cases and explicit regression tests for previously silent or crashing paths.
  - Which code was removed/merged as part of the first compression pass: recursive resolve traversal was replaced with an iterative stack walk; oversized tests were split below the
  SPEC_0021 hard limit; redundant conversions and nested routing were collapsed into helpers.
  - Follow-up cleanup ticket/commit for remaining growth (if any): none required for this PR; future cleanup should target broader DAE/solve lowering consolidation if more tuple/
  function-call cases are added.

  ## Reviewer Checklist

  - [x] Relevant active specs were checked.
  - [x] MLS-sensitive changes cite the right MLS section.
  - [x] Crate boundaries and phase ownership preserved (SPEC_0029).
  - [x] Tests prove behavior or explain the remaining gap.
  - [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
  - [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
  - [x] Size-budget section completed.
  - [x] Positive net diff has explicit compression justification.
  - [x] New APIs are required and minimal.
  - [x] Old/new parallel paths removed unless explicitly migrating.
  - [x] No `#[allow(clippy::...)]` added outside generated code.
  - [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
  - [x] External material (if any) attributed and Apache-2.0 compatible.
