### PR TITLE
Deploy docs and playground Pages on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -808,6 +808,19 @@ jobs:
         with:
           path: gh-pages/
 
+  deploy-pages:
+    name: Deploy Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build-wasm]
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
   # ============================================================================
   # Cross-platform Rust binary builds
   # ============================================================================
@@ -1051,11 +1064,8 @@ jobs:
   deploy:
     name: Deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect-release-tag.outputs.is_release == 'true'
-    needs: [detect-release-tag, lint, test, coverage-gate, msl-quality-gate, docs, vscode, build-wasm, build-rust-binaries, build-python-wheels, build-python-sdist]
+    needs: [detect-release-tag, lint, test, coverage-gate, msl-quality-gate, docs, vscode, deploy-pages, build-rust-binaries, build-python-wheels, build-python-sdist]
     runs-on: ubuntu-24.04
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -1078,10 +1088,6 @@ jobs:
       - name: Distribution policy note
         run: |
           echo "As of v0.8.0, Rust distribution is via GitHub Releases binaries (not crates.io)."
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
 
       - name: Download all artifacts
         uses: actions/download-artifact@v5


### PR DESCRIPTION
## Summary

- GitHub Pages deployment now runs on every successful `main` push after the WASM/Pages artifact is built, so the playground and mdBook outputs are deployed together.
- Closes #172. The live `user-guide` and `dev-guide` URLs currently redirect to the custom domain and return 404, while the workflow only deployed Pages inside a release-gated job.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0025, SPEC_0021.
- Relevant MLS section(s), if semantics changed: N/A; CI deployment only.
- Crate/phase owner: `.github/workflows/ci.yml`.

## Risk and Design Notes

- Main correctness risk: Pages deployment could run before the Pages artifact exists.
- Main maintenance risk: release publishing and Pages publishing could become coupled again.
- Why the change belongs in these crate(s): GitHub Pages deployment ownership is in the CI workflow that builds and uploads the Pages artifact.
- Any new abstraction, public API, or migration path: none.

## Testing

- Key command(s) run (fmt, clippy, workspace test, doc): `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`; live URL checks for `https://cognipilot.github.io/rumoca/user-guide/` and `/dev-guide/` showing custom-domain 404s before this fix; recent main CI inspection showing `Build WASM` succeeded and release-gated `Deploy` was skipped.
- Behavior or regression covered: the job graph now has a dedicated `deploy-pages` job depending on `build-wasm`, and the release job waits on `deploy-pages` instead of owning the Pages deployment step.
- Commands NOT run and why: Cargo fmt/clippy/test/doc were not run because this PR only changes GitHub Actions YAML; full workflow execution is expected through PR CI.
- For compiler/simulator changes: did you run the MSL gate
  (`cargo test --release --package rumoca-test-msl --features msl-full-test --test msl_tests
  balance_pipeline::balance_pipeline_core::test_msl_all -- --nocapture`) and
  confirm no regression vs `msl_quality_baseline.json`? N/A; no compiler or simulator behavior changed.

## Code Size Budget (required)

- production_lines_added: 14
- production_lines_deleted: 8
- test_lines_added: 0
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 1
- net_added_lines: 6

- Why this net growth is required: a separate Pages deployment job is needed so main-push deployments are not hidden behind release-tag detection.
- Which code was removed/merged as part of the first compression pass: the release job's embedded `deploy-pages` step and GitHub Pages environment were removed so release publishing no longer owns Pages deployment.
- Follow-up cleanup ticket/commit for remaining growth (if any): none planned.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [ ] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.
