### PR TITLE
Improve VS Code interactive scenario launch and reset handling

### DIFF
--- a/crates/rumoca-sim/src/diffsol.rs
+++ b/crates/rumoca-sim/src/diffsol.rs
@@ -170,6 +170,10 @@ impl SimStepper {
         self.inner.step(dt)
     }
 
+    pub(crate) fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
+        self.inner.reset(t_start)
+    }
+
     pub(crate) fn time(&self) -> f64 {
         self.inner.time()
     }
@@ -207,6 +211,10 @@ impl InteractiveStepper for SimStepper {
         opts: rumoca_solver::SimOptions,
     ) -> Result<Self, Self::Error> {
         Self::new(dae_model, opts)
+    }
+
+    fn reset(&mut self, t_start: f64) -> Result<(), Self::Error> {
+        Self::reset(self, t_start)
     }
 
     fn set_input(&mut self, name: &str, value: f64) -> Result<(), Self::Error> {

--- a/crates/rumoca-sim/src/interactive_stepper.rs
+++ b/crates/rumoca-sim/src/interactive_stepper.rs
@@ -8,6 +8,7 @@ pub trait InteractiveStepper: Sized {
     type Error: Error + Send + Sync + 'static;
 
     fn new_from_dae(dae_model: &dae::Dae, opts: SimOptions) -> Result<Self, Self::Error>;
+    fn reset(&mut self, t_start: f64) -> Result<(), Self::Error>;
     fn set_input(&mut self, name: &str, value: f64) -> Result<(), Self::Error>;
     fn step(&mut self, dt: f64) -> Result<(), Self::Error>;
     fn time(&self) -> f64;

--- a/crates/rumoca-sim/src/rk45.rs
+++ b/crates/rumoca-sim/src/rk45.rs
@@ -66,6 +66,10 @@ impl SimStepper {
         self.inner.step(dt)
     }
 
+    pub fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
+        self.inner.reset(t_start)
+    }
+
     pub fn time(&self) -> f64 {
         self.inner.time()
     }
@@ -99,6 +103,10 @@ impl InteractiveStepper for SimStepper {
         opts: rumoca_solver::SimOptions,
     ) -> Result<Self, Self::Error> {
         Self::new(dae_model, opts)
+    }
+
+    fn reset(&mut self, t_start: f64) -> Result<(), Self::Error> {
+        Self::reset(self, t_start)
     }
 
     fn set_input(&mut self, name: &str, value: f64) -> Result<(), Self::Error> {

--- a/crates/rumoca-sim/src/runner/executor.rs
+++ b/crates/rumoca-sim/src/runner/executor.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::{InteractiveStepper, SimOptions, SimPacingMode, SimSolverMode};
+use crate::{InteractiveStepper, SimPacingMode};
 use anyhow::{Context, Result};
 use rumoca_codec::{PackCodec, UnpackCodec};
 use rumoca_input::{
@@ -365,9 +365,6 @@ struct FrameCtx<'a> {
     realtime: &'a Arc<AtomicBool>,
     quit: &'a Arc<AtomicBool>,
     external_interface: &'a Arc<Mutex<Option<ExternalInterfaceProcess>>>,
-    model_source: &'a str,
-    model_name: &'a str,
-    source_roots: &'a [PathBuf],
     debug: bool,
     dt: f64,
     mode: SimPacingMode,
@@ -384,9 +381,6 @@ struct FrameState {
 
 pub struct SimLoopArgs<'a> {
     pub cfg: &'a SimulationConfig,
-    pub model_source: &'a str,
-    pub model_name: &'a str,
-    pub source_roots: &'a [PathBuf],
     pub http_port: u16,
     pub ws_port: u16,
     pub debug: bool,
@@ -425,9 +419,6 @@ where
 {
     let SimLoopArgs {
         cfg,
-        model_source,
-        model_name,
-        source_roots,
         http_port,
         ws_port,
         debug,
@@ -512,9 +503,6 @@ where
         realtime: &realtime,
         quit: &quit,
         external_interface: &external_interface,
-        model_source,
-        model_name,
-        source_roots,
         debug,
         dt: cfg.sim.dt,
         mode,
@@ -783,12 +771,6 @@ impl FrameCtx<'_> {
                 engine,
                 stepper,
                 ResetRuntime {
-                    model_source: self.model_source,
-                    model_name: self.model_name,
-                    source_roots: self.source_roots,
-                    dt: self.dt,
-                    pacing_mode: self.mode,
-                    solver_mode: SimSolverMode::parse_request(self.cfg.sim.solver.as_deref()).0,
                     external_handle: self.external_interface,
                 },
             )?;
@@ -922,12 +904,6 @@ fn apply_received(
 }
 
 struct ResetRuntime<'a> {
-    model_source: &'a str,
-    model_name: &'a str,
-    source_roots: &'a [PathBuf],
-    dt: f64,
-    pacing_mode: SimPacingMode,
-    solver_mode: SimSolverMode,
     external_handle: &'a Arc<Mutex<Option<ExternalInterfaceProcess>>>,
 }
 
@@ -953,31 +929,10 @@ where
     }
     if reset_cfg.rebuild_stepper {
         let reset_time = stepper.time();
-        let mut session = rumoca_compile::compile::Session::default();
-        super::load_source_roots_into_session(&mut session, runtime.source_roots)?;
-        session
-            .add_document(&format!("{}.mo", runtime.model_name), runtime.model_source)
-            .map_err(|e| anyhow::anyhow!("reset: parse failed: {e}"))?;
-        let result = super::compile_model_with_diagnostics(
-            &mut session,
-            runtime.model_name,
-            "reset: compilation failed",
-        )?;
-        let new_stepper = S::new_from_dae(
-            &result.dae,
-            SimOptions {
-                t_start: reset_time,
-                rtol: 1e-3,
-                atol: 1e-3,
-                dt: Some(runtime.dt),
-                solver_mode: runtime.solver_mode,
-                pacing_mode: runtime.pacing_mode,
-                ..Default::default()
-            },
-        )
-        .context("reset: stepper creation failed")?;
-        *stepper = new_stepper;
-        eprintln!("[reset] stepper rebuilt");
+        stepper
+            .reset(reset_time)
+            .context("reset: stepper reset failed")?;
+        eprintln!("[reset] stepper reset");
     }
     Ok(())
 }

--- a/crates/rumoca-sim/src/runner/mod.rs
+++ b/crates/rumoca-sim/src/runner/mod.rs
@@ -232,9 +232,6 @@ pub fn run(args: SimArgs) -> std::result::Result<(), RunnerError> {
         &mut stepper,
         executor::SimLoopArgs {
             cfg: &args.config,
-            model_source: &args.model_source,
-            model_name: &args.model_name,
-            source_roots: &args.source_roots,
             http_port: args.http_port,
             ws_port: args.ws_port,
             debug: args.debug,

--- a/crates/rumoca-sim/src/sim_stepper.rs
+++ b/crates/rumoca-sim/src/sim_stepper.rs
@@ -53,6 +53,19 @@ impl SimStepper {
         }
     }
 
+    pub fn reset(&mut self, t_start: f64) -> Result<(), SimulationDiagnosticError> {
+        match &mut self.inner {
+            #[cfg(feature = "solver-diffsol")]
+            SimStepperInner::Bdf(stepper) => stepper
+                .reset(t_start)
+                .map_err(|err| SimulationDiagnosticError::Solver(err.to_string())),
+            #[cfg(feature = "solver-rk45")]
+            SimStepperInner::RkLike(stepper) => stepper
+                .reset(t_start)
+                .map_err(|err| SimulationDiagnosticError::Solver(err.to_string())),
+        }
+    }
+
     pub fn set_inputs(&mut self, inputs: &[(&str, f64)]) -> Result<(), SimulationDiagnosticError> {
         for (name, value) in inputs {
             self.set_input(name, *value)?;
@@ -136,6 +149,10 @@ impl InteractiveStepper for SimStepper {
 
     fn new_from_dae(dae_model: &dae::Dae, opts: SimOptions) -> Result<Self, Self::Error> {
         Self::new_with_diagnostics(dae_model, opts)
+    }
+
+    fn reset(&mut self, t_start: f64) -> Result<(), Self::Error> {
+        Self::reset(self, t_start)
     }
 
     fn set_input(&mut self, name: &str, value: f64) -> Result<(), Self::Error> {

--- a/crates/rumoca-solver-diffsol/src/stepper.rs
+++ b/crates/rumoca-solver-diffsol/src/stepper.rs
@@ -6,7 +6,8 @@ use diffsol::{OdeSolverMethod, VectorHost};
 use rumoca_eval_solve::{self as solve_eval, SolveRuntime};
 use rumoca_ir_solve as solve;
 use rumoca_solver::{
-    SimOptions, implicit_residual_is_zero_through_interval, runtime_root_event_application_time,
+    SimOptions, event_solver_step_cap, implicit_residual_is_zero_through_interval,
+    runtime_root_event_application_time,
 };
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -15,24 +16,34 @@ use std::sync::Arc;
 
 use crate::{
     LinearSolver, OdeModel, RuntimeParameters, SimError, apply_event_updates, bdf_derivative_guess,
-    build_ode_problem_with_runtime_params_and_initial, initial_bdf_state,
+    build_ode_problem_with_runtime_params_and_initial, initial_bdf_state, reset_solver_state,
     settle_algebraics_and_relation_memory, solver_call, write_state_to_solver,
 };
 
 type StepFn = Box<dyn FnMut(f64) -> Result<StepAdvance, SimError>>;
+type ResetFn = Box<dyn FnMut(f64, &BdfResetSnapshot) -> Result<(), SimError>>;
 
 pub struct SimStepper {
     _runtime_context: solve_eval::SimulationContext,
     step_fn: StepFn,
     time_fn: Box<dyn Fn() -> f64>,
     y_fn: Box<dyn Fn() -> Vec<f64>>,
-    reset_fn: Box<dyn FnMut(f64) -> Result<(), SimError>>,
+    event_reset_fn: Box<dyn FnMut(f64) -> Result<(), SimError>>,
+    reset_fn: ResetFn,
     refresh_input_fn: Box<dyn FnMut() -> Result<(), SimError>>,
     project_fn: Box<dyn FnMut() -> Result<(), SimError>>,
     runtime: SolveRuntime,
     runtime_params: RuntimeParameters,
+    reset_snapshot: BdfResetSnapshot,
     input_values: HashMap<String, f64>,
     inputs_dirty: bool,
+}
+
+#[derive(Clone)]
+struct BdfResetSnapshot {
+    y: Vec<f64>,
+    dy: Vec<f64>,
+    params: Vec<f64>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -80,6 +91,11 @@ impl SimStepper {
         let solver = solver_call("BDF new", || {
             diffsol::Bdf::<_, _, _, diffsol::NoAug<_>>::new(problem_ref, state, newton())
         })?;
+        let reset_snapshot = BdfResetSnapshot {
+            y: solver.state().y.as_slice().to_vec(),
+            dy: solver.state().dy.as_slice().to_vec(),
+            params: runtime_params.borrow().to_vec(),
+        };
         let solver = Rc::new(RefCell::new(solver));
 
         let step_fn = make_step_fn(Rc::clone(&solver), model, runtime_params.clone(), &opts)?;
@@ -88,38 +104,39 @@ impl SimStepper {
         let y_solver = Rc::clone(&solver);
         let y_fn = Box::new(move || y_solver.borrow().state().y.as_slice().to_vec());
         let reset_solver = Rc::clone(&solver);
-        let reset_model = model.clone();
-        let reset_opts = opts.clone();
-        let reset_params = runtime_params.clone();
-        let reset_fn = Box::new(move |t_start: f64| {
+        let event_reset_solver = Rc::clone(&solver);
+        let event_reset_model = model.clone();
+        let event_reset_opts = opts.clone();
+        let event_reset_params = runtime_params.clone();
+        let event_reset_fn = Box::new(move |t_start: f64| {
             let initial_y = {
-                let solver = reset_solver.borrow();
+                let solver = event_reset_solver.borrow();
                 solver.state().y.as_slice().to_vec()
             };
-            let ode_model = Arc::new(OdeModel::new(&reset_model)?);
-            let reset_runtime = SolveRuntime::new(&reset_model);
+            let ode_model = Arc::new(OdeModel::new(&event_reset_model)?);
+            let reset_runtime = SolveRuntime::new(&event_reset_model);
             let initial_y = settled_problem_y(
-                &reset_model,
+                &event_reset_model,
                 &reset_runtime,
                 &ode_model,
-                &reset_opts,
-                &reset_params,
+                &event_reset_opts,
+                &event_reset_params,
                 t_start,
                 initial_y,
             )?;
             let problem = build_ode_problem_with_runtime_params_and_initial(
-                &reset_model,
-                &reset_opts,
-                reset_params.clone(),
+                &event_reset_model,
+                &event_reset_opts,
+                event_reset_params.clone(),
                 t_start,
                 initial_y.clone(),
                 ode_model.clone(),
             )?;
             let problem_ref = Box::leak(Box::new(problem));
             let state = {
-                let params = reset_params.borrow();
+                let params = event_reset_params.borrow();
                 initial_bdf_state(
-                    &reset_model,
+                    &event_reset_model,
                     &ode_model,
                     problem_ref,
                     &initial_y,
@@ -129,8 +146,21 @@ impl SimStepper {
             let rebuilt = solver_call("BDF new", || {
                 diffsol::Bdf::<_, _, _, diffsol::NoAug<_>>::new(problem_ref, state, newton())
             })?;
-            *reset_solver.borrow_mut() = rebuilt;
+            *event_reset_solver.borrow_mut() = rebuilt;
             Ok(())
+        });
+        let reset_opts = opts.clone();
+        let reset_params = runtime_params.clone();
+        let reset_fn = Box::new(move |t_start: f64, snapshot: &BdfResetSnapshot| {
+            reset_solver_state(
+                &mut *reset_solver.borrow_mut(),
+                &reset_params,
+                &snapshot.y,
+                &snapshot.dy,
+                &snapshot.params,
+                t_start,
+                event_solver_step_cap(reset_opts.dt),
+            )
         });
         let project_fn = make_project_fn(
             Rc::clone(&solver),
@@ -152,11 +182,13 @@ impl SimStepper {
             step_fn,
             time_fn,
             y_fn,
+            event_reset_fn,
             reset_fn,
             refresh_input_fn,
             project_fn,
             runtime,
             runtime_params,
+            reset_snapshot,
             input_values: HashMap::new(),
             inputs_dirty: false,
         })
@@ -198,9 +230,15 @@ impl SimStepper {
         if advance.hit_root {
             (self.project_fn)()?;
             let reset_time = runtime_root_event_application_time(self.time(), f64::INFINITY);
-            (self.reset_fn)(reset_time)?;
+            (self.event_reset_fn)(reset_time)?;
         }
         Ok(())
+    }
+
+    pub fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
+        self.input_values.clear();
+        self.inputs_dirty = false;
+        (self.reset_fn)(t_start, &self.reset_snapshot)
     }
 
     pub fn time(&self) -> f64 {
@@ -575,6 +613,37 @@ mod tests {
         assert!((stepper.time() - 0.032).abs() <= 1.0e-12);
         let x = stepper.get("x").expect("x should be visible");
         assert!(x.abs() <= 1.0e-12, "x={x}");
+    }
+
+    #[test]
+    fn bdf_stepper_reset_restores_cached_initial_state() {
+        let model = single_input_integrator();
+        let mut stepper = SimStepper::new(
+            &model,
+            SimOptions {
+                rtol: 1.0e-8,
+                atol: 1.0e-10,
+                dt: Some(1.0e-3),
+                ..Default::default()
+            },
+        )
+        .expect("stepper should build");
+
+        stepper.set_input("u", 2.0).expect("input should exist");
+        stepper.step(0.05).expect("stepper should advance");
+        assert!(stepper.get("x").unwrap_or_default() > 0.05);
+
+        stepper
+            .reset(7.25)
+            .expect("reset should restore cached initial state");
+
+        assert!((stepper.time() - 7.25).abs() <= 1.0e-12);
+        assert!(stepper.get("x").unwrap_or_default().abs() <= 1.0e-12);
+        assert_eq!(
+            stepper.get("u"),
+            None,
+            "reset should clear stale input overrides"
+        );
     }
 
     #[test]

--- a/crates/rumoca-solver-rk45/src/lib.rs
+++ b/crates/rumoca-solver-rk45/src/lib.rs
@@ -1,9 +1,4 @@
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    sync::atomic::{AtomicU64, Ordering},
-    time::Instant,
-};
+use std::{cell::RefCell, collections::HashMap, time::Instant};
 
 use rumoca_eval_solve::{EventUpdateRowFilter, ProjectedEventUpdateInput, SolveRuntime};
 use rumoca_ir_solve as solve;
@@ -16,15 +11,19 @@ use rumoca_solver::{
     root_crossings_with_relation_memory, root_value_crossed, runtime_event_horizon, timeline,
 };
 
+mod reset;
+mod trace;
+
+use reset::Rk45ResetSnapshot;
+use trace::{
+    record_derivative_eval_trace, record_root_eval_trace, reset_rk_eval_trace,
+    rk_eval_trace_enabled, trace_rk_eval_snapshot,
+};
+
 const MIN_STEP: f64 = 1.0e-12;
 const ROOT_BISECTION_ITERS: usize = 48;
 const UPDATE_MAX_ITERS: usize = 32;
 const ALGEBRAIC_REFRESH_TOL: f64 = 1.0e-10;
-
-static RK_DERIVATIVE_CALLS: AtomicU64 = AtomicU64::new(0);
-static RK_DERIVATIVE_NANOS: AtomicU64 = AtomicU64::new(0);
-static RK_ROOT_CALLS: AtomicU64 = AtomicU64::new(0);
-static RK_ROOT_NANOS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, thiserror::Error)]
 pub enum SimError {
@@ -61,51 +60,6 @@ impl From<TimeoutExceeded> for SimError {
     }
 }
 
-fn rk_eval_trace_enabled() -> bool {
-    tracing::enabled!(target: "rumoca_solver_rk45::eval", tracing::Level::DEBUG)
-}
-
-fn reset_rk_eval_trace() {
-    if !rk_eval_trace_enabled() {
-        return;
-    }
-    for counter in [
-        &RK_DERIVATIVE_CALLS,
-        &RK_DERIVATIVE_NANOS,
-        &RK_ROOT_CALLS,
-        &RK_ROOT_NANOS,
-    ] {
-        counter.store(0, Ordering::Relaxed);
-    }
-}
-
-fn trace_rk_eval_snapshot(label: &str) {
-    if !rk_eval_trace_enabled() {
-        return;
-    }
-    let derivative_calls = RK_DERIVATIVE_CALLS.load(Ordering::Relaxed);
-    let derivative_nanos = RK_DERIVATIVE_NANOS.load(Ordering::Relaxed);
-    let root_calls = RK_ROOT_CALLS.load(Ordering::Relaxed);
-    let root_nanos = RK_ROOT_NANOS.load(Ordering::Relaxed);
-    tracing::debug!(
-        target: "rumoca_solver_rk45::eval",
-        "{label}: derivatives={} ({:.3}ms) roots={} ({:.3}ms) total_eval={:.3}ms",
-        derivative_calls,
-        nanos_to_ms(derivative_nanos),
-        root_calls,
-        nanos_to_ms(root_nanos),
-        nanos_to_ms(derivative_nanos.saturating_add(root_nanos))
-    );
-}
-
-fn elapsed_nanos_u64(start: Instant) -> u64 {
-    start.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64
-}
-
-fn nanos_to_ms(nanos: u64) -> f64 {
-    nanos as f64 / 1.0e6
-}
-
 #[derive(Debug, Clone)]
 pub struct StepperState {
     pub time: f64,
@@ -117,13 +71,6 @@ pub struct SimStepper {
     backend: Rk45Backend<'static>,
     reset_snapshot: Rk45ResetSnapshot,
     input_values: HashMap<String, f64>,
-}
-
-#[derive(Clone)]
-struct Rk45ResetSnapshot {
-    state: Vec<f64>,
-    params: Vec<f64>,
-    next_step: f64,
 }
 
 impl SimStepper {
@@ -474,31 +421,6 @@ impl<'a> Rk45Backend<'a> {
         }
     }
 
-    fn reset_snapshot(&self) -> Rk45ResetSnapshot {
-        Rk45ResetSnapshot {
-            state: self.state.clone(),
-            params: self.params.clone(),
-            next_step: self.next_step,
-        }
-    }
-
-    fn reset_to_snapshot(&mut self, snapshot: &Rk45ResetSnapshot, t_start: f64) {
-        self.time = t_start;
-        self.state.clone_from(&snapshot.state);
-        self.params.clone_from(&snapshot.params);
-        self.next_step = snapshot.next_step;
-        self.stop_schedule = SolveStopSchedule::new(&self.model.model.problem, t_start, self.t_end);
-        self.termination = None;
-        self.pending_root_crossings.clear();
-        self.pending_event_pre_y = None;
-        self.pending_event_pre_p = None;
-        self.boundary_event_pre_y = None;
-        self.boundary_event_pre_p = None;
-        self.post_event_eval_time = None;
-        self.solver_y_guess.borrow_mut().clear();
-        self.clear_runtime_caches();
-    }
-
     fn trial_step(&self, h: f64, event_boundary: Option<f64>) -> Result<TrialStep, SimError> {
         self.trial_step_from(self.time, &self.state, h, event_boundary)
     }
@@ -521,8 +443,7 @@ impl<'a> Rk45Backend<'a> {
             )
             .map_err(Into::into);
         if let Some(start) = start {
-            RK_DERIVATIVE_CALLS.fetch_add(1, Ordering::Relaxed);
-            RK_DERIVATIVE_NANOS.fetch_add(elapsed_nanos_u64(start), Ordering::Relaxed);
+            record_derivative_eval_trace(start);
         }
         result
     }
@@ -877,8 +798,7 @@ impl<'a> Rk45Backend<'a> {
             })
             .map_err(Into::into);
         if let Some(start) = start {
-            RK_ROOT_CALLS.fetch_add(1, Ordering::Relaxed);
-            RK_ROOT_NANOS.fetch_add(elapsed_nanos_u64(start), Ordering::Relaxed);
+            record_root_eval_trace(start);
         }
         result
     }

--- a/crates/rumoca-solver-rk45/src/lib.rs
+++ b/crates/rumoca-solver-rk45/src/lib.rs
@@ -115,7 +115,15 @@ pub struct StepperState {
 pub struct SimStepper {
     runtime: &'static SolveRuntime,
     backend: Rk45Backend<'static>,
+    reset_snapshot: Rk45ResetSnapshot,
     input_values: HashMap<String, f64>,
+}
+
+#[derive(Clone)]
+struct Rk45ResetSnapshot {
+    state: Vec<f64>,
+    params: Vec<f64>,
+    next_step: f64,
 }
 
 impl SimStepper {
@@ -128,9 +136,11 @@ impl SimStepper {
         let runtime = Box::leak(Box::new(SolveRuntime::new(model)));
         let mut backend = Rk45Backend::new(runtime, &opts)?;
         backend.init()?;
+        let reset_snapshot = backend.reset_snapshot();
         Ok(Self {
             runtime,
             backend,
+            reset_snapshot,
             input_values: HashMap::new(),
         })
     }
@@ -166,6 +176,13 @@ impl SimStepper {
         }
         let target = self.backend.time + dt;
         advance_backend_to(&mut self.backend, target)
+    }
+
+    pub fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
+        self.input_values.clear();
+        self.backend
+            .reset_to_snapshot(&self.reset_snapshot, t_start);
+        Ok(())
     }
 
     pub fn time(&self) -> f64 {
@@ -455,6 +472,31 @@ impl<'a> Rk45Backend<'a> {
         for (dst, src) in self.state.iter_mut().zip(solver_y.iter().copied()) {
             *dst = src;
         }
+    }
+
+    fn reset_snapshot(&self) -> Rk45ResetSnapshot {
+        Rk45ResetSnapshot {
+            state: self.state.clone(),
+            params: self.params.clone(),
+            next_step: self.next_step,
+        }
+    }
+
+    fn reset_to_snapshot(&mut self, snapshot: &Rk45ResetSnapshot, t_start: f64) {
+        self.time = t_start;
+        self.state.clone_from(&snapshot.state);
+        self.params.clone_from(&snapshot.params);
+        self.next_step = snapshot.next_step;
+        self.stop_schedule = SolveStopSchedule::new(&self.model.model.problem, t_start, self.t_end);
+        self.termination = None;
+        self.pending_root_crossings.clear();
+        self.pending_event_pre_y = None;
+        self.pending_event_pre_p = None;
+        self.boundary_event_pre_y = None;
+        self.boundary_event_pre_p = None;
+        self.post_event_eval_time = None;
+        self.solver_y_guess.borrow_mut().clear();
+        self.clear_runtime_caches();
     }
 
     fn trial_step(&self, h: f64, event_boundary: Option<f64>) -> Result<TrialStep, SimError> {
@@ -1666,6 +1708,42 @@ mod tests {
         assert_eq!(outcome, StepUntilOutcome::StopReached);
         assert!((backend.read_state().t - 0.1).abs() <= 1.0e-12);
         assert!((backend.state[0] - 1.2).abs() <= 1.0e-6);
+    }
+
+    #[test]
+    fn rk45_stepper_reset_restores_cached_initial_state() {
+        let mut model = single_state_model(vec![vec![
+            LinearOp::LoadP { dst: 0, index: 0 },
+            LinearOp::StoreOutput { src: 0 },
+        ]]);
+        model.problem.solve_layout.compiled_parameter_len = 1;
+        model.problem.solve_layout.input_scalar_names = vec!["u".to_string()];
+        model.parameters = vec![0.0];
+        let mut stepper = SimStepper::new(
+            &model,
+            SimOptions {
+                solver_mode: SimSolverMode::RkLike,
+                dt: Some(0.01),
+                ..Default::default()
+            },
+        )
+        .expect("stepper should build");
+
+        stepper.set_input("u", 4.0).expect("input should exist");
+        stepper.step(0.1).expect("stepper should advance");
+        assert!(stepper.get("x").unwrap_or_default() > 1.1);
+
+        stepper
+            .reset(12.5)
+            .expect("reset should restore cached initial state");
+
+        assert!((stepper.time() - 12.5).abs() <= 1.0e-12);
+        assert!((stepper.get("x").unwrap_or_default() - 1.0).abs() <= 1.0e-12);
+        assert_eq!(
+            stepper.get("u"),
+            None,
+            "reset should clear stale input overrides"
+        );
     }
 
     #[test]

--- a/crates/rumoca-solver-rk45/src/reset.rs
+++ b/crates/rumoca-solver-rk45/src/reset.rs
@@ -1,0 +1,37 @@
+use rumoca_solver::SolveStopSchedule;
+
+use super::Rk45Backend;
+
+#[derive(Clone)]
+pub(super) struct Rk45ResetSnapshot {
+    state: Vec<f64>,
+    params: Vec<f64>,
+    next_step: f64,
+}
+
+impl Rk45Backend<'_> {
+    pub(super) fn reset_snapshot(&self) -> Rk45ResetSnapshot {
+        Rk45ResetSnapshot {
+            state: self.state.clone(),
+            params: self.params.clone(),
+            next_step: self.next_step,
+        }
+    }
+
+    pub(super) fn reset_to_snapshot(&mut self, snapshot: &Rk45ResetSnapshot, t_start: f64) {
+        self.time = t_start;
+        self.state.clone_from(&snapshot.state);
+        self.params.clone_from(&snapshot.params);
+        self.next_step = snapshot.next_step;
+        self.stop_schedule = SolveStopSchedule::new(&self.model.model.problem, t_start, self.t_end);
+        self.termination = None;
+        self.pending_root_crossings.clear();
+        self.pending_event_pre_y = None;
+        self.pending_event_pre_p = None;
+        self.boundary_event_pre_y = None;
+        self.boundary_event_pre_p = None;
+        self.post_event_eval_time = None;
+        self.solver_y_guess.borrow_mut().clear();
+        self.clear_runtime_caches();
+    }
+}

--- a/crates/rumoca-solver-rk45/src/trace.rs
+++ b/crates/rumoca-solver-rk45/src/trace.rs
@@ -1,0 +1,64 @@
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+static RK_DERIVATIVE_CALLS: AtomicU64 = AtomicU64::new(0);
+static RK_DERIVATIVE_NANOS: AtomicU64 = AtomicU64::new(0);
+static RK_ROOT_CALLS: AtomicU64 = AtomicU64::new(0);
+static RK_ROOT_NANOS: AtomicU64 = AtomicU64::new(0);
+
+pub(super) fn rk_eval_trace_enabled() -> bool {
+    tracing::enabled!(target: "rumoca_solver_rk45::eval", tracing::Level::DEBUG)
+}
+
+pub(super) fn reset_rk_eval_trace() {
+    if !rk_eval_trace_enabled() {
+        return;
+    }
+    for counter in [
+        &RK_DERIVATIVE_CALLS,
+        &RK_DERIVATIVE_NANOS,
+        &RK_ROOT_CALLS,
+        &RK_ROOT_NANOS,
+    ] {
+        counter.store(0, Ordering::Relaxed);
+    }
+}
+
+pub(super) fn record_derivative_eval_trace(start: Instant) {
+    RK_DERIVATIVE_CALLS.fetch_add(1, Ordering::Relaxed);
+    RK_DERIVATIVE_NANOS.fetch_add(elapsed_nanos_u64(start), Ordering::Relaxed);
+}
+
+pub(super) fn record_root_eval_trace(start: Instant) {
+    RK_ROOT_CALLS.fetch_add(1, Ordering::Relaxed);
+    RK_ROOT_NANOS.fetch_add(elapsed_nanos_u64(start), Ordering::Relaxed);
+}
+
+pub(super) fn trace_rk_eval_snapshot(label: &str) {
+    if !rk_eval_trace_enabled() {
+        return;
+    }
+    let derivative_calls = RK_DERIVATIVE_CALLS.load(Ordering::Relaxed);
+    let derivative_nanos = RK_DERIVATIVE_NANOS.load(Ordering::Relaxed);
+    let root_calls = RK_ROOT_CALLS.load(Ordering::Relaxed);
+    let root_nanos = RK_ROOT_NANOS.load(Ordering::Relaxed);
+    tracing::debug!(
+        target: "rumoca_solver_rk45::eval",
+        "{label}: derivatives={} ({:.3}ms) roots={} ({:.3}ms) total_eval={:.3}ms",
+        derivative_calls,
+        nanos_to_ms(derivative_nanos),
+        root_calls,
+        nanos_to_ms(root_nanos),
+        nanos_to_ms(derivative_nanos.saturating_add(root_nanos))
+    );
+}
+
+fn elapsed_nanos_u64(start: Instant) -> u64 {
+    start.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64
+}
+
+fn nanos_to_ms(nanos: u64) -> f64 {
+    nanos as f64 / 1.0e6
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1183,6 +1183,22 @@ function hasRumocaMarker(text: string): boolean {
     return /^[ \t]*\[rumoca\][ \t]*$/m.test(text);
 }
 
+async function scenarioDocumentFromCommandResource(
+    resource: vscode.Uri | undefined,
+): Promise<vscode.TextDocument | undefined> {
+    if (resource?.scheme === 'file') {
+        const document = await vscode.workspace.openTextDocument(resource);
+        if (isSimulationRunnableDocument(document)) {
+            return document;
+        }
+    }
+
+    const editor = vscode.window.activeTextEditor;
+    return editor && isSimulationRunnableDocument(editor.document)
+        ? editor.document
+        : undefined;
+}
+
 function isModelicaSourceDocument(document: vscode.TextDocument): boolean {
     return document.uri.fsPath.toLowerCase().endsWith('.mo');
 }
@@ -1389,6 +1405,63 @@ const DEFAULT_CODEGEN_TARGET_ID = 'sympy';
 const CODEGEN_SETTINGS_STATE_KEY = 'rumoca.codegenSettings';
 const SELECTED_SIMULATION_MODELS_STATE_KEY = 'rumoca.selectedSimulationModelsByDocument';
 const LIVE_VIEWER_READY_PREFIX = 'rumoca-viewer-ready ';
+const MAX_INTERACTIVE_FAILURE_LINES = 30;
+
+function stripAnsiControlCodes(text: string): string {
+    return text.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+}
+
+function rememberInteractiveOutput(recentLines: string[], text: string): void {
+    const normalized = stripAnsiControlCodes(text).replace(/\r/g, '\n');
+    for (const rawLine of normalized.split('\n')) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('[sim] t=')) {
+            continue;
+        }
+        recentLines.push(line);
+    }
+    while (recentLines.length > MAX_INTERACTIVE_FAILURE_LINES) {
+        recentLines.shift();
+    }
+}
+
+function collectPortNumbers(lines: string[]): string[] {
+    const ports = new Set<string>();
+    for (const line of lines) {
+        for (const match of line.matchAll(/\b(?:port\s+|localhost:|0\.0\.0\.0:)(\d{2,5})\b/g)) {
+            ports.add(match[1]);
+        }
+    }
+    return [...ports];
+}
+
+function summarizeInteractiveFailure(recentLines: string[]): string | undefined {
+    const combined = recentLines.join('\n');
+    const portConflictLines = recentLines.filter((line) =>
+        /Address already in use|Failed to bind .*port|HTTP server error/i.test(line)
+    );
+    if (portConflictLines.length > 0) {
+        const ports = collectPortNumbers(portConflictLines);
+        const portText = ports.length > 0 ? ` ${ports.join('/')}` : '';
+        return `viewer port${ports.length === 1 ? '' : 's'}${portText} already in use; stop the running Rumoca simulation or choose different ports in the scenario config.`;
+    }
+
+    const missingSourceRoot = combined.match(/source-root path does not exist:\s*([^\n]+)/);
+    if (missingSourceRoot) {
+        return `missing Modelica source root: ${missingSourceRoot[1].trim()}. Run cargo xtask repo modelica-deps ensure for the example dependencies.`;
+    }
+
+    const unexpectedArg = combined.match(/unexpected argument ['"]([^'"]+)['"]/);
+    if (unexpectedArg) {
+        return `unsupported rumoca CLI argument ${unexpectedArg[1]}; update the extension launch command or the rumoca binary.`;
+    }
+
+    return [...recentLines].reverse().find((line) =>
+        !line.startsWith('Finished ')
+        && !line.startsWith('Running ')
+        && line !== 'rumoca sim'
+    );
+}
 
 // Benchmark/smoke instrumentation (no environment variables). The LSP benchmark
 // harness records timing artifacts by setting workspace settings such as
@@ -2914,24 +2987,18 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!rumocaPath) {
             throw new Error('rumoca executable not found. Configure rumoca.serverPath or add rumoca to PATH.');
         }
-        const port = typeof scenario.httpPort === 'number' && Number.isFinite(scenario.httpPort)
-            ? scenario.httpPort
-            : undefined;
-        const wsPort = typeof scenario.websocketPort === 'number' && Number.isFinite(scenario.websocketPort)
-            ? scenario.websocketPort
-            : undefined;
+        const expectsLiveViewer = scenario.viewerMode === 'external_web' || scenario.interactive === true;
         const args = [
             'sim',
             '--config',
             document.uri.fsPath,
-            ...(port && port > 0 ? ['--http-port', String(port)] : []),
-            ...(wsPort && wsPort > 0 ? ['--ws-port', String(wsPort)] : []),
         ];
         const writeEmitter = new vscode.EventEmitter<string>();
         const closeEmitter = new vscode.EventEmitter<number>();
         let child: ChildProcessWithoutNullStreams | undefined;
         let lineBuffer = '';
         let viewerOpened = false;
+        const recentOutputLines: string[] = [];
 
         const openViewerFromReadyLine = (line: string) => {
             if (!line.startsWith(LIVE_VIEWER_READY_PREFIX) || viewerOpened) {
@@ -2954,6 +3021,7 @@ export async function activate(context: vscode.ExtensionContext) {
         };
         const handleOutput = (chunk: Buffer) => {
             const text = chunk.toString();
+            rememberInteractiveOutput(recentOutputLines, text);
             lineBuffer += text.replace(/\r/g, '');
             const lines = lineBuffer.split('\n');
             lineBuffer = lines.pop() ?? '';
@@ -2993,10 +3061,25 @@ export async function activate(context: vscode.ExtensionContext) {
                         closeEmitter.fire(1);
                     });
                     child.on('exit', (code) => {
-                        if (!viewerOpened && port && port > 0) {
-                            vscode.window.showWarningMessage('Rumoca exited before the interactive viewer was ready.');
+                        const exitCode = code ?? 0;
+                        if (exitCode !== 0) {
+                            writeEmitter.fire(`\r\nRumoca exited with code ${exitCode}.\r\n`);
                         }
-                        closeEmitter.fire(code ?? 0);
+                        if (!viewerOpened && expectsLiveViewer) {
+                            const summary = summarizeInteractiveFailure(recentOutputLines);
+                            const detail = summary ? ` ${summary}` : ' See the Rumoca terminal for details.';
+                            const message = `Rumoca exited before the interactive viewer was ready (exit code ${exitCode}).${detail}`;
+                            if (exitCode !== 0) {
+                                const model = trimMaybeString(scenario.model);
+                                if (model) {
+                                    setSimulationDiagnostic(document, model, message);
+                                }
+                                vscode.window.showErrorMessage(message);
+                            } else {
+                                vscode.window.showWarningMessage(message);
+                            }
+                        }
+                        closeEmitter.fire(0);
                     });
                 },
                 close: () => {
@@ -3012,7 +3095,7 @@ export async function activate(context: vscode.ExtensionContext) {
             },
         });
         terminal.show();
-        if (port && port > 0) {
+        if (expectsLiveViewer) {
             vscode.window.showInformationMessage(`Started Rumoca interactive simulation; viewer opens after compile.`);
         } else {
             vscode.window.showInformationMessage('Started Rumoca interactive simulation in the terminal.');
@@ -3622,14 +3705,13 @@ export async function activate(context: vscode.ExtensionContext) {
         log(`Rendered target for ${model}: ${target} -> ${outputRoot}`);
     };
 
-    const simulateCommand = vscode.commands.registerCommand('rumoca.simulateModel', async () => {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor || !isSimulationRunnableDocument(editor.document)) {
+    const simulateCommand = vscode.commands.registerCommand('rumoca.simulateModel', async (resource?: vscode.Uri) => {
+        const document = await scenarioDocumentFromCommandResource(resource);
+        if (!document) {
             vscode.window.showErrorMessage('No active Rumoca scenario editor.');
             return;
         }
 
-        const document = editor.document;
         if (document.isUntitled || document.isDirty) {
             const saved = await document.save();
             if (!saved) {
@@ -3766,12 +3848,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const simulationSettingsCommand = vscode.commands.registerCommand(
         'rumoca.openSimulationSettings',
-        async () => {
-            const editor = vscode.window.activeTextEditor;
-            if (!editor || !isSimulationRunnableDocument(editor.document)) {
+        async (resource?: vscode.Uri) => {
+            const document = await scenarioDocumentFromCommandResource(resource);
+            if (!document) {
                 vscode.window.showErrorMessage('Open a Rumoca scenario file to configure it.');
                 return;
             }
+            const editor = await vscode.window.showTextDocument(document, { preview: false });
             await openUnifiedSettingsForEditor(editor);
         },
     );

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1408,7 +1408,22 @@ const LIVE_VIEWER_READY_PREFIX = 'rumoca-viewer-ready ';
 const MAX_INTERACTIVE_FAILURE_LINES = 30;
 
 function stripAnsiControlCodes(text: string): string {
-    return text.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+    let stripped = '';
+    for (let i = 0; i < text.length; i += 1) {
+        if (text.charCodeAt(i) !== 27 || text[i + 1] !== '[') {
+            stripped += text[i];
+            continue;
+        }
+        i += 2;
+        while (i < text.length) {
+            const code = text.charCodeAt(i);
+            if ((code >= 65 && code <= 90) || (code >= 97 && code <= 122)) {
+                break;
+            }
+            i += 1;
+        }
+    }
+    return stripped;
 }
 
 function rememberInteractiveOutput(recentLines: string[], text: string): void {

--- a/editors/vscode/tests/simulation_command_resync.test.mjs
+++ b/editors/vscode/tests/simulation_command_resync.test.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const extensionSourcePath = path.join(testDir, "..", "src", "extension.ts");
+const simulateCommandStartPattern =
+  "const simulateCommand = vscode.commands.registerCommand('rumoca.simulateModel', async (resource?: vscode.Uri) => {";
 
 function readExtensionSource() {
   return fs.readFileSync(extensionSourcePath, "utf8");
@@ -22,7 +24,7 @@ function sliceFrom(source, startPattern, endPattern) {
 test("simulate command has no sidecar resync dependency before starting the run", () => {
   const simulateCommandBlock = sliceFrom(
     readExtensionSource(),
-    "const simulateCommand = vscode.commands.registerCommand('rumoca.simulateModel', async () => {",
+    simulateCommandStartPattern,
     "context.subscriptions.push(simulateCommand);",
   );
 
@@ -42,7 +44,7 @@ test("simulate command publishes failures to Problems diagnostics", () => {
   const source = readExtensionSource();
   const simulateCommandBlock = sliceFrom(
     source,
-    "const simulateCommand = vscode.commands.registerCommand('rumoca.simulateModel', async () => {",
+    simulateCommandStartPattern,
     "context.subscriptions.push(simulateCommand);",
   );
 
@@ -103,6 +105,71 @@ test("interactive viewer launch waits for runner ready output", () => {
   );
 });
 
+test("interactive viewer launch does not pass unsupported port flags", () => {
+  const source = readExtensionSource();
+  const startInteractiveScenarioBlock = sliceFrom(
+    source,
+    "const startInteractiveScenario = async (",
+    "const wireResultsPanelMessageHandling = (panel: vscode.WebviewPanel) => {",
+  );
+
+  assert.equal(
+    startInteractiveScenarioBlock.includes("--http-port"),
+    false,
+    "rumoca sim --config reads HTTP transport from the scenario file",
+  );
+  assert.equal(
+    startInteractiveScenarioBlock.includes("--ws-port"),
+    false,
+    "rumoca sim --config reads WebSocket transport from the scenario file",
+  );
+  assert.equal(
+    startInteractiveScenarioBlock.includes("document.uri.fsPath"),
+    true,
+    "interactive runs should still launch the selected scenario config",
+  );
+});
+
+test("interactive viewer launch reports actionable process failures", () => {
+  const source = readExtensionSource();
+  const startInteractiveScenarioBlock = sliceFrom(
+    source,
+    "const startInteractiveScenario = async (",
+    "const wireResultsPanelMessageHandling = (panel: vscode.WebviewPanel) => {",
+  );
+
+  assert.equal(
+    source.includes("function summarizeInteractiveFailure("),
+    true,
+    "interactive process output should be summarized before showing failure messages",
+  );
+  assert.equal(
+    source.includes("Address already in use"),
+    true,
+    "port conflicts should be recognized as a first-class interactive failure",
+  );
+  assert.equal(
+    source.includes("source-root path does not exist"),
+    true,
+    "missing Modelica dependency roots should be recognized as a first-class interactive failure",
+  );
+  assert.equal(
+    startInteractiveScenarioBlock.includes("rememberInteractiveOutput(recentOutputLines, text);"),
+    true,
+    "interactive runs should keep recent output for failure messages",
+  );
+  assert.equal(
+    startInteractiveScenarioBlock.includes("setSimulationDiagnostic(document, model, message);"),
+    true,
+    "interactive run failures should be published to Problems diagnostics",
+  );
+  assert.equal(
+    startInteractiveScenarioBlock.includes("closeEmitter.fire(0);"),
+    true,
+    "normal rumoca process exits should avoid VS Code's misleading terminal-launch failure toast",
+  );
+});
+
 test("viewer prefer_external controls embedded versus browser presentation", () => {
   const source = readExtensionSource();
   const startInteractiveScenarioBlock = sliceFrom(
@@ -112,7 +179,7 @@ test("viewer prefer_external controls embedded versus browser presentation", () 
   );
   const simulateCommandBlock = sliceFrom(
     source,
-    "const simulateCommand = vscode.commands.registerCommand('rumoca.simulateModel', async () => {",
+    simulateCommandStartPattern,
     "context.subscriptions.push(simulateCommand);",
   );
 
@@ -140,5 +207,35 @@ test("viewer prefer_external controls embedded versus browser presentation", () 
     simulateCommandBlock.includes("openResultsPanelForRun("),
     true,
     "batch plotting should still default to the embedded VS Code results panel",
+  );
+});
+
+test("scenario toolbar commands honor the menu resource URI", () => {
+  const source = readExtensionSource();
+  const simulateCommandBlock = sliceFrom(
+    source,
+    simulateCommandStartPattern,
+    "context.subscriptions.push(simulateCommand);",
+  );
+  const simulationSettingsCommandBlock = sliceFrom(
+    source,
+    "const simulationSettingsCommand = vscode.commands.registerCommand(",
+    "context.subscriptions.push(simulationSettingsCommand);",
+  );
+
+  assert.equal(
+    source.includes("async function scenarioDocumentFromCommandResource("),
+    true,
+    "extension should resolve a scenario document from the editor title resource URI",
+  );
+  assert.equal(
+    simulateCommandBlock.includes("scenarioDocumentFromCommandResource(resource)"),
+    true,
+    "run command should use the menu resource URI before falling back to the active editor",
+  );
+  assert.equal(
+    simulationSettingsCommandBlock.includes("scenarioDocumentFromCommandResource(resource)"),
+    true,
+    "settings command should use the menu resource URI before falling back to the active editor",
   );
 });


### PR DESCRIPTION
## Summary

- VS Code scenario run/settings commands now honor the resource URI passed by editor title/run menu actions before falling back to the active editor.
- Interactive scenario launches now call `rumoca sim --config <scenario>` without adding unsupported `--http-port` / `--ws-port` overrides; the scenario TOML remains the source of truth for transport settings.
- Interactive run failures now surface actionable messages from recent process output, including port conflicts and missing Modelica source roots, instead of only showing the generic viewer-ready warning.
- Interactive reset now uses solver-owned cached initial-state snapshots instead of recompiling the Modelica model and re-solving initialization on every reset.
- Refs #171.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0025, SPEC_0021, SPEC_0029.
- Relevant MLS section(s), if semantics changed: N/A; editor command dispatch, user diagnostics, and interactive runtime reset plumbing only.
- Crate/phase owner: editors/vscode, rumoca-sim, rumoca-solver-rk45, rumoca-solver-diffsol.

## Risk and Design Notes

- Main correctness risk: solver reset must restore the settled post-initialization state and parameter/event-memory vector while not interfering with Diffsol root-event resets.
- Main maintenance risk: static VS Code command contract tests can become brittle if command registration or launch assembly is heavily refactored.
- Why the change belongs in these crate(s): the VS Code extension owns editor toolbar command routing and editor-facing failure messages; the solver steppers own backend-specific reset state; the sim runner owns interactive reset dispatch.
- Any new abstraction, public API, or migration path: adds `InteractiveStepper::reset(t_start)` and backend stepper reset methods; no migration path needed because these are internal crate APIs.

## Testing

- Key command(s) run (fmt, clippy, workspace test, doc): `npm test -- --test-name-pattern='interactive viewer launch'` from `editors/vscode`; `cargo test -p rumoca-solver-rk45 rk45_stepper_reset_restores_cached_initial_state -- --nocapture`; `cargo test -p rumoca-solver-diffsol bdf_stepper_reset_restores_cached_initial_state -- --nocapture`; `cargo check -p rumoca`; `cargo fmt --check`; `cargo run -p rumoca -- sim --config <temporary quadrotor config on 8090/8091>` plus a WebSocket reset probe.
- Behavior or regression covered: scenario toolbar commands resolve the passed `vscode.Uri` resource and still fall back to the active editor; interactive launch no longer passes unsupported port flags; process failures are summarized into user-facing diagnostics and errors; RK and BDF steppers reset to cached initial state and clear stale input overrides; quadrotor reset stream stayed live with `max_gap_after_reset_ms=64` in the local probe.
- Commands NOT run and why: workspace clippy/test/doc were not run locally due scope and time; full CI is expected to cover repository gates after push. The full MSL gate was not run locally; this PR does not change compiler lowering semantics or batch simulation parity, but CI will still run the configured MSL jobs.
- For compiler/simulator changes: did you run the MSL gate
  (`cargo test --release --package rumoca-test-msl --features msl-full-test --test msl_tests
  balance_pipeline::balance_pipeline_core::test_msl_all -- --nocapture`) and
  confirm no regression vs `msl_quality_baseline.json`? Not locally; queued CI MSL gates must pass before checking this off.

## Code Size Budget (required)

- production_lines_added: 244
- production_lines_deleted: 92
- test_lines_added: 164
- test_lines_deleted: 3
- public_items_added: 1
- public_items_removed: 0
- files_touched: 10
- net_added_lines: 313

- Why this net growth is required: the PR now covers editor resource routing, actionable interactive launch errors, and solver-owned cached reset support for both RK-like and BDF interactive backends.
- Which code was removed/merged as part of the first compression pass: duplicated active-editor checks in the run/settings commands were replaced by a helper; unsupported port override assembly was removed; normal child-process exits no longer use the misleading VS Code terminal-launch failure path; the runner's compile-on-reset path and reset-only model source/root plumbing were removed.
- Follow-up cleanup ticket/commit for remaining growth (if any): none planned.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.
