### PR TITLE
Make CI cache steps best effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
 
       - name: Cache rustup toolchain
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: |
             ~/.rustup/toolchains
@@ -174,6 +175,7 @@ jobs:
 
       - name: Cache cargo
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry
@@ -182,6 +184,7 @@ jobs:
 
       - name: Cache MSL
         uses: actions/cache@v5
+        continue-on-error: true
         id: msl-cache
         with:
           path: target/msl/ModelicaStandardLibrary-4.1.0
@@ -189,6 +192,7 @@ jobs:
 
       - name: Cache CMM
         uses: actions/cache@v5
+        continue-on-error: true
         id: cmm-cache
         with:
           path: target/cmm/CMM-v0.0.1
@@ -284,6 +288,7 @@ jobs:
 
       - name: Cache cargo
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: |
             /opt/rumoca/cargo/registry
@@ -340,6 +345,7 @@ jobs:
 
       - name: Cache cargo
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry
@@ -348,6 +354,7 @@ jobs:
 
       - name: Cache MSL
         uses: actions/cache@v5
+        continue-on-error: true
         id: msl-cache-editor
         with:
           path: target/msl/ModelicaStandardLibrary-4.1.0
@@ -409,6 +416,7 @@ jobs:
 
       - name: Cache cargo
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry
@@ -455,6 +463,7 @@ jobs:
 
       - name: Cache cargo
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry
@@ -463,6 +472,7 @@ jobs:
 
       - name: Cache MSL
         uses: actions/cache@v5
+        continue-on-error: true
         id: msl-cache
         with:
           path: target/msl/ModelicaStandardLibrary-4.1.0
@@ -706,6 +716,7 @@ jobs:
 
       - name: Cache cargo
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry
@@ -746,6 +757,7 @@ jobs:
 
       - name: Cache cargo
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary

- All GitHub Actions cache steps now run best-effort with `continue-on-error: true`.
- This prevents transient or corrupt cache restore/save failures from aborting jobs before the real build/test command runs, as seen in PR #179's Windows test job failing in `Cache cargo`.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0025, SPEC_0021.
- Relevant MLS section(s), if semantics changed: N/A; CI workflow behavior only.
- Crate/phase owner: `.github/workflows/ci.yml`.

## Risk and Design Notes

- Main correctness risk: a cache failure could be missed in logs while the job rebuilds from scratch.
- Main maintenance risk: duplicated cache-step policy could drift if future cache steps omit `continue-on-error`.
- Why the change belongs in these crate(s): CI cache behavior is owned by the GitHub Actions workflow.
- Any new abstraction, public API, or migration path: none.

## Testing

- Key command(s) run (fmt, clippy, workspace test, doc): `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`; `rg` count check confirming 12 `actions/cache@v5` steps and 12 `continue-on-error: true` entries.
- Behavior or regression covered: every cache step in the workflow is non-blocking, including rustup, cargo, MSL, CMM, editor, coverage, and WASM caches.
- Commands NOT run and why: Cargo fmt/clippy/test/doc were not run because this PR only changes GitHub Actions YAML; full behavior is validated by PR CI.
- For compiler/simulator changes: did you run the MSL gate
  (`cargo test --release --package rumoca-test-msl --features msl-full-test --test msl_tests
  balance_pipeline::balance_pipeline_core::test_msl_all -- --nocapture`) and
  confirm no regression vs `msl_quality_baseline.json`? N/A; no compiler or simulator behavior changed.

## Code Size Budget (required)

- production_lines_added: 12
- production_lines_deleted: 0
- test_lines_added: 0
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 1
- net_added_lines: 12

- Why this net growth is required: each cache step needs an explicit best-effort policy so cache infrastructure cannot block verification.
- Which code was removed/merged as part of the first compression pass: no redundant cache wrapper exists to merge; this is the minimal GitHub Actions syntax for best-effort cache steps.
- Follow-up cleanup ticket/commit for remaining growth (if any): consider extracting cache policy into a reusable workflow/action if cache step count grows further.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.
