### PR TITLE
Add Dymola formatter profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,8 @@ jobs:
 
       - name: Run tests (Linux monitored)
         if: runner.os == 'Linux'
+        env:
+          REQUIRE_MSL_FMT_DRIFT: "1"
         shell: bash
         run: |
           set -euo pipefail
@@ -262,6 +264,8 @@ jobs:
 
       - name: Run tests
         if: runner.os != 'Linux'
+        env:
+          REQUIRE_MSL_FMT_DRIFT: "1"
         run: cargo xtask verify workspace
 
       - name: Build all binaries

--- a/crates/rumoca-bind-python/src/lib.rs
+++ b/crates/rumoca-bind-python/src/lib.rs
@@ -1128,9 +1128,9 @@ mod tests {
 
     #[test]
     fn test_format_valid() {
-        let formatted = format_source("model M Real x; end M;", None).expect("format");
-        assert!(formatted.contains("model M"));
-        assert!(formatted.ends_with('\n'));
+        let source = "model M Real x; end M;";
+        let formatted = format_source(source, None).expect("format");
+        assert_eq!(formatted, "model M Real x; end M;\n");
     }
 
     #[test]

--- a/crates/rumoca-compile/src/lib.rs
+++ b/crates/rumoca-compile/src/lib.rs
@@ -87,6 +87,7 @@ pub mod parsing {
     };
     pub use rumoca_ir_ast::{
         ClassDef, ComponentReference, Expression, StoredDefinition, TerminalType,
+        walk_component_reference_default,
     };
 
     pub use crate::merge::{

--- a/crates/rumoca-ir-ast/src/lib.rs
+++ b/crates/rumoca-ir-ast/src/lib.rs
@@ -61,8 +61,9 @@ use std::{fmt::Debug, fmt::Display};
 pub use visitor::{
     ComponentReferenceContext, ExpressionContext, ExpressionTransformer, FunctionCallContext,
     NameContext, SubscriptContext, TypeNameContext, VisitScope, Visitor, collect_component_refs,
-    contains_component_ref, contains_function_call, walk_equation_default, walk_expression_default,
-    walk_statement_default,
+    contains_component_ref, contains_function_call, walk_class_def_default, walk_component_default,
+    walk_component_reference_default, walk_equation_default, walk_expression_default,
+    walk_extend_default, walk_statement_default,
 };
 
 pub type AstIndexMap<K, V> = IndexMap<K, V, rustc_hash::FxBuildHasher>;

--- a/crates/rumoca-ir-ast/src/nodes.rs
+++ b/crates/rumoca-ir-ast/src/nodes.rs
@@ -102,6 +102,18 @@ pub struct Component {
     pub shape_is_modification: bool,
     /// Annotation arguments (e.g., from `annotation(Icon(...), Dialog(...))`)
     pub annotation: Vec<Expression>,
+    /// Ordered source-form modifier arguments from the component declaration.
+    ///
+    /// These preserve the syntax inside `x(...)` before semantic component
+    /// attributes are split into `start`, `binding`, `shape`, and
+    /// `modifications`.
+    pub source_modifications: Vec<Expression>,
+    /// Parallel to `source_modifications` - true if the source modifier has an `each` prefix.
+    pub source_modification_each_flags: Vec<bool>,
+    /// Parallel to `source_modifications` - true if the source modifier has a `final` prefix.
+    pub source_modification_final_flags: Vec<bool>,
+    /// Parallel to `source_modifications` - true if the source modifier is a redeclaration.
+    pub source_modification_redeclare_flags: Vec<bool>,
     /// Component modifications (e.g., R=10 in `Resistor R1(R=10)`)
     /// Maps parameter name to its modified value expression
     pub modifications: AstIndexMap<String, Expression>,
@@ -213,6 +225,10 @@ impl Default for Component {
             shape_expr: Vec::new(),
             shape_is_modification: false,
             annotation: Vec::new(),
+            source_modifications: Vec::new(),
+            source_modification_each_flags: Vec::new(),
+            source_modification_final_flags: Vec::new(),
+            source_modification_redeclare_flags: Vec::new(),
             modifications: AstIndexMap::default(),
             location: Location::default(),
             condition: None,

--- a/crates/rumoca-ir-ast/src/visitor.rs
+++ b/crates/rumoca-ir-ast/src/visitor.rs
@@ -13,7 +13,9 @@ mod tests;
 pub use query::{collect_component_refs, contains_component_ref, contains_function_call};
 pub use read_only::{
     ComponentReferenceContext, ExpressionContext, FunctionCallContext, NameContext,
-    SubscriptContext, TypeNameContext, VisitScope, Visitor, walk_equation_default,
-    walk_expr_function_call_ctx_default, walk_expression_default, walk_statement_default,
+    SubscriptContext, TypeNameContext, VisitScope, Visitor, walk_class_def_default,
+    walk_component_default, walk_component_reference_default, walk_equation_default,
+    walk_expr_function_call_ctx_default, walk_expression_default, walk_extend_default,
+    walk_statement_default,
 };
 pub use rewrite::ExpressionTransformer;

--- a/crates/rumoca-ir-ast/src/visitor/read_only.rs
+++ b/crates/rumoca-ir-ast/src/visitor/read_only.rs
@@ -90,6 +90,7 @@ pub fn walk_expr_function_call_ctx_default<V: Visitor + ?Sized>(
     args: &[Expression],
     ctx: FunctionCallContext,
 ) -> ControlFlow<()> {
+    visitor.enter_expr_function_call(comp, args, ctx)?;
     if matches!(ctx, FunctionCallContext::Expression) {
         visitor.visit_component_reference_ctx(
             comp,
@@ -99,11 +100,29 @@ pub fn walk_expr_function_call_ctx_default<V: Visitor + ?Sized>(
     visitor.visit_expr_function_call(comp, args)
 }
 
+/// Default recursion for a component reference.
+pub fn walk_component_reference_default<V: Visitor + ?Sized>(
+    visitor: &mut V,
+    cr: &ComponentReference,
+) -> ControlFlow<()> {
+    visitor.enter_component_reference(cr)?;
+    for part in &cr.parts {
+        let Some(subs) = &part.subs else {
+            continue;
+        };
+        for subscript in subs {
+            visitor.visit_subscript_ctx(subscript, SubscriptContext::ComponentReferencePart)?;
+        }
+    }
+    Continue(())
+}
+
 /// Default recursion for an expression node.
 pub fn walk_expression_default<V: Visitor + ?Sized>(
     visitor: &mut V,
     expr: &Expression,
 ) -> ControlFlow<()> {
+    visitor.enter_expression(expr)?;
     match expr {
         Expression::Empty { .. } | Expression::Terminal { .. } => Continue(()),
         Expression::Range {
@@ -246,6 +265,102 @@ pub fn walk_statement_default<V: Visitor + ?Sized>(
     }
 }
 
+/// Default recursion for a component declaration.
+pub fn walk_component_default<V: Visitor + ?Sized>(
+    visitor: &mut V,
+    comp: &Component,
+) -> ControlFlow<()> {
+    visitor.enter_component(comp)?;
+    visitor.visit_type_name(&comp.type_name, TypeNameContext::ComponentType)?;
+    if let Some(constrainedby) = &comp.constrainedby {
+        visitor.visit_type_name(constrainedby, TypeNameContext::ComponentConstrainedBy)?;
+    }
+    for subscript in &comp.shape_expr {
+        visitor.visit_subscript_ctx(subscript, SubscriptContext::ComponentShape)?;
+    }
+    if !matches!(comp.start, Expression::Empty { .. }) {
+        visitor.visit_expression_ctx(&comp.start, ExpressionContext::ComponentStart)?;
+    }
+    if let Some(binding) = &comp.binding {
+        visitor.visit_expression_ctx(binding, ExpressionContext::ComponentBinding)?;
+    }
+    if comp.source_modifications.is_empty() {
+        for (_, mod_expr) in &comp.modifications {
+            visitor.visit_expression_ctx(mod_expr, ExpressionContext::ComponentModification)?;
+        }
+    } else {
+        for source_modification in &comp.source_modifications {
+            visitor.visit_expression_ctx(
+                source_modification,
+                ExpressionContext::ComponentModification,
+            )?;
+        }
+    }
+    if let Some(cond) = &comp.condition {
+        visitor.visit_expression_ctx(cond, ExpressionContext::ComponentCondition)?;
+    }
+    for annotation in &comp.annotation {
+        visitor.visit_expression_ctx(annotation, ExpressionContext::ComponentAnnotation)?;
+    }
+    Continue(())
+}
+
+/// Default recursion for an extends clause.
+pub fn walk_extend_default<V: Visitor + ?Sized>(visitor: &mut V, ext: &Extend) -> ControlFlow<()> {
+    visitor.enter_extend(ext)?;
+    visitor.visit_type_name(&ext.base_name, TypeNameContext::ExtendsBase)?;
+    for modification in &ext.modifications {
+        visitor.visit_expression_ctx(&modification.expr, ExpressionContext::ExtendModification)?;
+    }
+    for annotation in &ext.annotation {
+        visitor.visit_expression_ctx(annotation, ExpressionContext::ExtendAnnotation)?;
+    }
+    Continue(())
+}
+
+/// Default recursion for a class definition.
+pub fn walk_class_def_default<V: Visitor + ?Sized>(
+    visitor: &mut V,
+    class: &ClassDef,
+) -> ControlFlow<()> {
+    visitor.enter_class_def(class)?;
+    visitor.enter_scope(VisitScope::Class(class))?;
+    let result = (|| {
+        if let Some(constrainedby) = &class.constrainedby {
+            visitor.visit_type_name(constrainedby, TypeNameContext::ClassConstrainedBy)?;
+        }
+        for ext in &class.extends {
+            visitor.visit_extend(ext)?;
+        }
+        visitor.visit_each(&class.imports, V::visit_import)?;
+        for subscript in &class.array_subscripts {
+            visitor.visit_subscript_ctx(subscript, SubscriptContext::ClassArraySubscript)?;
+        }
+        for (_, nested) in &class.classes {
+            visitor.visit_class_def(nested)?;
+        }
+        for (_, comp) in &class.components {
+            visitor.visit_component(comp)?;
+        }
+        visitor.visit_each(&class.equations, V::visit_equation)?;
+        visitor.visit_each(&class.initial_equations, V::visit_equation)?;
+        for section in &class.algorithms {
+            visitor.visit_each(section, V::visit_statement)?;
+        }
+        for section in &class.initial_algorithms {
+            visitor.visit_each(section, V::visit_statement)?;
+        }
+        for annotation in &class.annotation {
+            visitor.visit_expression_ctx(annotation, ExpressionContext::ClassAnnotation)?;
+        }
+        if let Some(external) = &class.external {
+            visitor.visit_external_function(external)?;
+        }
+        Continue(())
+    })();
+    finish_scope(result, visitor.exit_scope(VisitScope::Class(class)))
+}
+
 /// Trait for visiting AST nodes without modification.
 ///
 /// All methods return `ControlFlow<()>`:
@@ -332,6 +447,94 @@ pub trait Visitor {
         Continue(())
     }
 
+    fn enter_class_def(&mut self, _class: &ClassDef) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_import(&mut self, _import: &Import) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_extend(&mut self, _ext: &Extend) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_component(&mut self, _comp: &Component) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_expression(&mut self, _expr: &Expression) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_component_reference(&mut self, _cr: &ComponentReference) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_expr_function_call(
+        &mut self,
+        _comp: &ComponentReference,
+        _args: &[Expression],
+        _ctx: FunctionCallContext,
+    ) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_simple_equation(&mut self, _lhs: &Expression, _rhs: &Expression) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_connect(
+        &mut self,
+        _lhs: &ComponentReference,
+        _rhs: &ComponentReference,
+    ) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_for_index(&mut self, _idx: &ForIndex) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_assignment(
+        &mut self,
+        _comp: &ComponentReference,
+        _value: &Expression,
+    ) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_statement_function_call(
+        &mut self,
+        _comp: &ComponentReference,
+        _args: &[Expression],
+        _outputs: &[Expression],
+    ) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_external_function(&mut self, _external: &ExternalFunction) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_equation_assert(
+        &mut self,
+        _condition: &Expression,
+        _message: &Expression,
+        _level: Option<&Expression>,
+    ) -> ControlFlow<()> {
+        Continue(())
+    }
+
+    fn enter_statement_assert(
+        &mut self,
+        _condition: &Expression,
+        _message: &Expression,
+        _level: Option<&Expression>,
+    ) -> ControlFlow<()> {
+        Continue(())
+    }
+
     // =========================================================================
     // Expression methods
     // =========================================================================
@@ -343,15 +546,7 @@ pub trait Visitor {
 
     /// Visit a component reference.
     fn visit_component_reference(&mut self, cr: &ComponentReference) -> ControlFlow<()> {
-        for part in &cr.parts {
-            let Some(subs) = &part.subs else {
-                continue;
-            };
-            for subscript in subs {
-                self.visit_subscript_ctx(subscript, SubscriptContext::ComponentReferencePart)?;
-            }
-        }
-        Continue(())
+        walk_component_reference_default(self, cr)
     }
 
     /// Visit a function call in expression context.
@@ -373,6 +568,7 @@ pub trait Visitor {
 
     /// Visit a for-loop index.
     fn visit_for_index(&mut self, idx: &ForIndex) -> ControlFlow<()> {
+        self.enter_for_index(idx)?;
         self.visit_expression(&idx.range)
     }
 
@@ -387,6 +583,7 @@ pub trait Visitor {
 
     /// Visit a simple equation: lhs = rhs
     fn visit_simple_equation(&mut self, lhs: &Expression, rhs: &Expression) -> ControlFlow<()> {
+        self.enter_simple_equation(lhs, rhs)?;
         self.visit_expression(lhs)?;
         self.visit_expression(rhs)
     }
@@ -397,6 +594,7 @@ pub trait Visitor {
         lhs: &ComponentReference,
         rhs: &ComponentReference,
     ) -> ControlFlow<()> {
+        self.enter_connect(lhs, rhs)?;
         self.visit_component_reference_ctx(lhs, ComponentReferenceContext::EquationConnectLhs)?;
         self.visit_component_reference_ctx(rhs, ComponentReferenceContext::EquationConnectRhs)
     }
@@ -451,6 +649,7 @@ pub trait Visitor {
         message: &Expression,
         level: Option<&Expression>,
     ) -> ControlFlow<()> {
+        self.enter_equation_assert(condition, message, level)?;
         self.visit_expression_ctx(condition, ExpressionContext::EquationAssertCondition)?;
         self.visit_expression_ctx(message, ExpressionContext::EquationAssertMessage)?;
         if let Some(lvl) = level {
@@ -480,6 +679,7 @@ pub trait Visitor {
         comp: &ComponentReference,
         value: &Expression,
     ) -> ControlFlow<()> {
+        self.enter_assignment(comp, value)?;
         self.visit_component_reference_ctx(comp, ComponentReferenceContext::AssignmentTarget)?;
         self.visit_expression(value)
     }
@@ -521,6 +721,7 @@ pub trait Visitor {
         args: &[Expression],
         outputs: &[Expression],
     ) -> ControlFlow<()> {
+        self.enter_statement_function_call(comp, args, outputs)?;
         self.visit_component_reference_ctx(
             comp,
             ComponentReferenceContext::StatementFunctionCallTarget,
@@ -549,6 +750,7 @@ pub trait Visitor {
         message: &Expression,
         level: Option<&Expression>,
     ) -> ControlFlow<()> {
+        self.enter_statement_assert(condition, message, level)?;
         self.visit_expression_ctx(condition, ExpressionContext::StatementAssertCondition)?;
         self.visit_expression_ctx(message, ExpressionContext::StatementAssertMessage)?;
         if let Some(lvl) = level {
@@ -580,89 +782,28 @@ pub trait Visitor {
 
     /// Visit a class definition.
     fn visit_class_def(&mut self, class: &ClassDef) -> ControlFlow<()> {
-        self.enter_scope(VisitScope::Class(class))?;
-        let result = (|| {
-            if let Some(constrainedby) = &class.constrainedby {
-                self.visit_type_name(constrainedby, TypeNameContext::ClassConstrainedBy)?;
-            }
-            for ext in &class.extends {
-                self.visit_extend(ext)?;
-            }
-            self.visit_each(&class.imports, Self::visit_import)?;
-            for subscript in &class.array_subscripts {
-                self.visit_subscript_ctx(subscript, SubscriptContext::ClassArraySubscript)?;
-            }
-            for (_, nested) in &class.classes {
-                self.visit_class_def(nested)?;
-            }
-            for (_, comp) in &class.components {
-                self.visit_component(comp)?;
-            }
-            self.visit_each(&class.equations, Self::visit_equation)?;
-            self.visit_each(&class.initial_equations, Self::visit_equation)?;
-            for section in &class.algorithms {
-                self.visit_each(section, Self::visit_statement)?;
-            }
-            for section in &class.initial_algorithms {
-                self.visit_each(section, Self::visit_statement)?;
-            }
-            for annotation in &class.annotation {
-                self.visit_expression_ctx(annotation, ExpressionContext::ClassAnnotation)?;
-            }
-            if let Some(external) = &class.external {
-                self.visit_external_function(external)?;
-            }
-            Continue(())
-        })();
-        finish_scope(result, self.exit_scope(VisitScope::Class(class)))
+        walk_class_def_default(self, class)
     }
 
     /// Visit an import clause.
     fn visit_import(&mut self, import: &Import) -> ControlFlow<()> {
+        self.enter_import(import)?;
         self.visit_name_ctx(import.base_path(), NameContext::ImportPath)
     }
 
     /// Visit an extends clause.
     fn visit_extend(&mut self, ext: &Extend) -> ControlFlow<()> {
-        self.visit_type_name(&ext.base_name, TypeNameContext::ExtendsBase)?;
-        for modification in &ext.modifications {
-            self.visit_expression_ctx(&modification.expr, ExpressionContext::ExtendModification)?;
-        }
-        for annotation in &ext.annotation {
-            self.visit_expression_ctx(annotation, ExpressionContext::ExtendAnnotation)?;
-        }
-        Continue(())
+        walk_extend_default(self, ext)
     }
 
     /// Visit a component declaration.
     fn visit_component(&mut self, comp: &Component) -> ControlFlow<()> {
-        self.visit_type_name(&comp.type_name, TypeNameContext::ComponentType)?;
-        if let Some(constrainedby) = &comp.constrainedby {
-            self.visit_type_name(constrainedby, TypeNameContext::ComponentConstrainedBy)?;
-        }
-        for subscript in &comp.shape_expr {
-            self.visit_subscript_ctx(subscript, SubscriptContext::ComponentShape)?;
-        }
-        if !matches!(comp.start, Expression::Empty { .. }) {
-            self.visit_expression_ctx(&comp.start, ExpressionContext::ComponentStart)?;
-        }
-        if let Some(binding) = &comp.binding {
-            self.visit_expression_ctx(binding, ExpressionContext::ComponentBinding)?;
-        }
-        for (_, mod_expr) in &comp.modifications {
-            self.visit_expression_ctx(mod_expr, ExpressionContext::ComponentModification)?;
-        }
-        if let Some(cond) = &comp.condition {
-            self.visit_expression_ctx(cond, ExpressionContext::ComponentCondition)?;
-        }
-        for annotation in &comp.annotation {
-            self.visit_expression_ctx(annotation, ExpressionContext::ComponentAnnotation)?;
-        }
-        Continue(())
+        walk_component_default(self, comp)
     }
 
     /// Visit an external function declaration.
     fn visit_external_function(&mut self, external: &ExternalFunction) -> ControlFlow<()> {
+        self.enter_external_function(external)?;
         if let Some(output) = &external.output {
             self.visit_component_reference_ctx(output, ComponentReferenceContext::ExternalOutput)?;
         }

--- a/crates/rumoca-ir-dae/src/lib.rs
+++ b/crates/rumoca-ir-dae/src/lib.rs
@@ -722,11 +722,26 @@ pub struct Variable {
     pub state_select: rumoca_core::StateSelect,
     /// Description string.
     pub description: Option<String>,
+    /// FMI-style causality metadata for downstream JSON consumers.
+    #[serde(default)]
+    pub causality: VariableCausality,
     /// True if this parameter is tunable at runtime (FMI 3.0 ConfigurationMode).
     /// Structural parameters (evaluate=true, Integer/Boolean used for sizing)
     /// remain fixed; all other parameters are tunable.
     #[serde(default)]
     pub is_tunable: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VariableCausality {
+    Input,
+    Output,
+    #[default]
+    Local,
+    Parameter,
+    CalculatedParameter,
+    Independent,
 }
 
 impl Serialize for Variable {
@@ -735,7 +750,7 @@ impl Serialize for Variable {
         S: serde::Serializer,
     {
         let include_component_ref = !serializer.is_human_readable() || self.component_ref.is_some();
-        let field_count = if include_component_ref { 18 } else { 17 };
+        let field_count = if include_component_ref { 19 } else { 18 };
         let mut state = serializer.serialize_struct("Variable", field_count)?;
         state.serialize_field("name", &self.name)?;
         if include_component_ref {
@@ -755,6 +770,7 @@ impl Serialize for Variable {
         state.serialize_field("unit", &self.unit)?;
         state.serialize_field("state_select", &self.state_select)?;
         state.serialize_field("description", &self.description)?;
+        state.serialize_field("causality", &self.causality)?;
         state.serialize_field("is_tunable", &self.is_tunable)?;
         state.end()
     }
@@ -1001,7 +1017,7 @@ fn default_scalar_count() -> usize {
 mod tests {
     use super::{
         Algorithm, ClockSchedule, DAE_SCHEMA_VERSION, Dae, Equation, VarName, Variable,
-        flat_index_to_subscripts, scalar_name_text_for_flat_index,
+        VariableCausality, flat_index_to_subscripts, scalar_name_text_for_flat_index,
     };
     use rumoca_core::{Expression, Literal, OpBinary, OpUnary, Reference, Span};
 
@@ -1057,6 +1073,7 @@ mod tests {
                 fixed: Some(true),
                 unit: Some("s".to_string()),
                 description: Some("Periodic Boolean sample interval".to_string()),
+                causality: VariableCausality::CalculatedParameter,
                 ..Default::default()
             },
         );
@@ -1181,6 +1198,18 @@ mod tests {
         ] {
             assert!(obj.contains_key(key), "expected MLS key `{key}`");
         }
+    }
+
+    #[test]
+    fn variable_json_surfaces_causality() {
+        let variable = Variable {
+            name: VarName::new("u"),
+            causality: VariableCausality::Input,
+            ..Default::default()
+        };
+        let value = serde_json::to_value(variable).expect("variable should serialize");
+
+        assert_eq!(value["causality"], serde_json::json!("input"));
     }
 
     #[test]

--- a/crates/rumoca-ir-dae/tests/golden/modelica_blocks_examples_logical_network1.dae.json
+++ b/crates/rumoca-ir-dae/tests/golden/modelica_blocks_examples_logical_network1.dae.json
@@ -36,6 +36,7 @@
       "unit": "s",
       "state_select": "Default",
       "description": "Periodic Boolean sample interval",
+      "causality": "calculatedParameter",
       "is_tunable": false
     }
   },
@@ -72,6 +73,7 @@
       "unit": null,
       "state_select": "Default",
       "description": "Latched numeric visualization of logical state",
+      "causality": "local",
       "is_tunable": false
     }
   },
@@ -107,6 +109,7 @@
       "unit": null,
       "state_select": "Default",
       "description": "Logical block output",
+      "causality": "local",
       "is_tunable": false
     },
     "not1.y": {
@@ -140,6 +143,7 @@
       "unit": null,
       "state_select": "Default",
       "description": "Logical inversion output",
+      "causality": "local",
       "is_tunable": false
     }
   },

--- a/crates/rumoca-phase-dae/src/condition_lowering.rs
+++ b/crates/rumoca-phase-dae/src/condition_lowering.rs
@@ -147,6 +147,7 @@ fn declare_condition_pre_parameter(dae_model: &mut dae::Dae, condition_name: &st
             unit: None,
             state_select: rumoca_core::StateSelect::Default,
             description: Some(format!("pre() of {condition_name}")),
+            causality: dae::VariableCausality::CalculatedParameter,
             is_tunable: false,
         });
 }

--- a/crates/rumoca-phase-dae/src/pre_lowering.rs
+++ b/crates/rumoca-phase-dae/src/pre_lowering.rs
@@ -82,6 +82,7 @@ pub(crate) fn lower_pre_operator(dae: &mut dae::Dae) -> Result<(), ToDaeError> {
             unit: None,
             state_select: rumoca_core::StateSelect::Default,
             description: Some(format!("pre() of {}", target.source_name.as_str())),
+            causality: dae::VariableCausality::CalculatedParameter,
             is_tunable: false,
         };
         pre_params.insert(pre_param_name, pre_var);

--- a/crates/rumoca-phase-dae/src/pre_lowering/tests.rs
+++ b/crates/rumoca-phase-dae/src/pre_lowering/tests.rs
@@ -84,6 +84,7 @@ fn discrete_valued_var(name: &str) -> dae::Variable {
         unit: None,
         state_select: rumoca_core::StateSelect::Default,
         description: None,
+        causality: dae::VariableCausality::Local,
         is_tunable: false,
     }
 }
@@ -382,6 +383,7 @@ fn test_lower_pre_creates_parameter() -> Result<(), ToDaeError> {
             unit: None,
             state_select: rumoca_core::StateSelect::Default,
             description: None,
+            causality: dae::VariableCausality::Local,
             is_tunable: false,
         },
     );
@@ -513,6 +515,7 @@ fn test_lower_pre_normalizes_encoded_integer_subscript_target() -> Result<(), To
             unit: None,
             state_select: rumoca_core::StateSelect::Default,
             description: None,
+            causality: dae::VariableCausality::Local,
             is_tunable: false,
         },
     );
@@ -671,6 +674,7 @@ fn test_lower_pre_keeps_existing_pre_parameter_metadata() -> Result<(), ToDaeErr
             unit: None,
             state_select: rumoca_core::StateSelect::Default,
             description: None,
+            causality: dae::VariableCausality::Local,
             is_tunable: false,
         },
     );
@@ -696,6 +700,7 @@ fn test_lower_pre_keeps_existing_pre_parameter_metadata() -> Result<(), ToDaeErr
             unit: None,
             state_select: rumoca_core::StateSelect::Default,
             description: Some("first pass metadata".to_string()),
+            causality: dae::VariableCausality::Local,
             is_tunable: false,
         },
     );
@@ -773,6 +778,7 @@ fn test_lower_pre_rewrites_expression_variables_to_pre_parameters() -> Result<()
                 unit: None,
                 state_select: rumoca_core::StateSelect::Default,
                 description: None,
+                causality: dae::VariableCausality::Local,
                 is_tunable: false,
             },
         );
@@ -916,6 +922,7 @@ fn test_lower_pre_preserves_index_subscripts() -> Result<(), ToDaeError> {
             unit: None,
             state_select: rumoca_core::StateSelect::Default,
             description: None,
+            causality: dae::VariableCausality::Local,
             is_tunable: false,
         },
     );
@@ -1082,6 +1089,7 @@ fn test_lower_pre_rewrites_record_field_target() -> Result<(), ToDaeError> {
             unit: None,
             state_select: rumoca_core::StateSelect::Default,
             description: None,
+            causality: dae::VariableCausality::Local,
             is_tunable: false,
         },
     );

--- a/crates/rumoca-phase-dae/src/scalar_inference/inference_and_bindings.rs
+++ b/crates/rumoca-phase-dae/src/scalar_inference/inference_and_bindings.rs
@@ -582,7 +582,24 @@ pub(crate) fn create_dae_variable(
         unit: var.unit.clone(),
         state_select: var.state_select,
         description: None,
+        causality: variable_causality(var, is_tunable),
         is_tunable,
+    }
+}
+
+fn variable_causality(var: &flat::Variable, is_tunable: bool) -> rumoca_ir_dae::VariableCausality {
+    match &var.causality {
+        rumoca_core::Causality::Input(_) => rumoca_ir_dae::VariableCausality::Input,
+        rumoca_core::Causality::Output(_) => rumoca_ir_dae::VariableCausality::Output,
+        rumoca_core::Causality::Empty => match var.variability {
+            Variability::Parameter(_) if is_tunable => rumoca_ir_dae::VariableCausality::Parameter,
+            Variability::Parameter(_) | Variability::Constant(_) => {
+                rumoca_ir_dae::VariableCausality::CalculatedParameter
+            }
+            Variability::Empty | Variability::Continuous(_) | Variability::Discrete(_) => {
+                rumoca_ir_dae::VariableCausality::Local
+            }
+        },
     }
 }
 
@@ -759,6 +776,41 @@ mod tests {
                 .as_ref()
                 .and_then(|reference| reference.def_id),
             Some(component_def_id)
+        );
+    }
+
+    #[test]
+    fn create_dae_variable_surfaces_source_causality() {
+        let name = VarName::new("u");
+        let flat_var = flat::Variable {
+            name: name.clone(),
+            causality: rumoca_core::Causality::Input(Default::default()),
+            is_primitive: true,
+            ..Default::default()
+        };
+        let known_var_names = HashSet::from([name.as_str().to_string()]);
+
+        let dae_var = create_dae_variable(&name, &flat_var, &known_var_names);
+
+        assert_eq!(dae_var.causality, rumoca_ir_dae::VariableCausality::Input);
+    }
+
+    #[test]
+    fn create_dae_variable_marks_parameter_causality() {
+        let name = VarName::new("p");
+        let flat_var = flat::Variable {
+            name: name.clone(),
+            variability: Variability::Parameter(Default::default()),
+            is_primitive: true,
+            ..Default::default()
+        };
+        let known_var_names = HashSet::from([name.as_str().to_string()]);
+
+        let dae_var = create_dae_variable(&name, &flat_var, &known_var_names);
+
+        assert_eq!(
+            dae_var.causality,
+            rumoca_ir_dae::VariableCausality::Parameter
         );
     }
 }

--- a/crates/rumoca-phase-parse/src/elements.rs
+++ b/crates/rumoca-phase-parse/src/elements.rs
@@ -537,6 +537,10 @@ fn process_single_component(
         shape_expr: ctx.type_level_shape_expr.clone(),
         shape_is_modification: false,
         annotation,
+        source_modifications: Vec::new(),
+        source_modification_each_flags: Vec::new(),
+        source_modification_final_flags: Vec::new(),
+        source_modification_redeclare_flags: Vec::new(),
         modifications: IndexMap::default(),
         location: comp_location,
         condition,
@@ -564,6 +568,7 @@ fn process_single_component(
 
     // Handle component modification
     if let Some(modif) = &c.declaration.declaration_opt0 {
+        preserve_component_source_modification(&mut value, modif);
         process_component_modification(&mut value, modif)?;
     }
 
@@ -1195,4 +1200,22 @@ fn process_component_modification(
         }
     }
     Ok(())
+}
+
+fn preserve_component_source_modification(
+    value: &mut rumoca_ir_ast::Component,
+    modif: &modelica_grammar_trait::DeclarationOpt0,
+) {
+    let modelica_grammar_trait::Modification::ClassModificationModificationOpt(class_mod) =
+        &modif.modification
+    else {
+        return;
+    };
+    let Some(opt) = &class_mod.class_modification.class_modification_opt else {
+        return;
+    };
+    value.source_modifications = opt.argument_list.args.clone();
+    value.source_modification_each_flags = opt.argument_list.each_flags.clone();
+    value.source_modification_final_flags = opt.argument_list.final_flags.clone();
+    value.source_modification_redeclare_flags = opt.argument_list.redeclare_flags.clone();
 }

--- a/crates/rumoca-phase-parse/src/expressions.rs
+++ b/crates/rumoca-phase-parse/src/expressions.rs
@@ -122,6 +122,17 @@ fn add_op_to_unary(op: &modelica_grammar_trait::AddOperator) -> rumoca_core::OpU
     }
 }
 
+fn add_op_span(op: &modelica_grammar_trait::AddOperator) -> Span {
+    match op {
+        modelica_grammar_trait::AddOperator::Minus(op) => token_span(&op.minus.clone().into()),
+        modelica_grammar_trait::AddOperator::Plus(op) => token_span(&op.plus.clone().into()),
+        modelica_grammar_trait::AddOperator::DotMinus(op) => {
+            token_span(&op.dot_minus.clone().into())
+        }
+        modelica_grammar_trait::AddOperator::DotPlus(op) => token_span(&op.dot_plus.clone().into()),
+    }
+}
+
 //-----------------------------------------------------------------------------
 #[derive(Debug, Default, Clone)]
 
@@ -1262,7 +1273,7 @@ impl TryFrom<&modelica_grammar_trait::ArithmeticExpression> for rumoca_ir_ast::E
         let mut lhs = match &ast.arithmetic_expression_opt {
             Some(opt) => rumoca_ir_ast::Expression::Unary {
                 op: add_op_to_unary(&opt.add_operator),
-                span: ast.term.span(),
+                span: merge_spans(add_op_span(&opt.add_operator), ast.term.span()),
                 rhs: Arc::new(ast.term.clone()),
             },
             None => ast.term.clone(),
@@ -1328,9 +1339,9 @@ impl TryFrom<&modelica_grammar_trait::LogicalFactor> for rumoca_ir_ast::Expressi
         ast: &modelica_grammar_trait::LogicalFactor,
     ) -> std::result::Result<Self, Self::Error> {
         match &ast.logical_factor_opt {
-            Some(_) => Ok(rumoca_ir_ast::Expression::Unary {
+            Some(opt) => Ok(rumoca_ir_ast::Expression::Unary {
                 op: rumoca_core::OpUnary::Not,
-                span: ast.relation.span(),
+                span: merge_spans(token_span(&opt.not.not.clone().into()), ast.relation.span()),
                 rhs: Arc::new(ast.relation.clone()),
             }),
             None => Ok(ast.relation.clone()),

--- a/crates/rumoca-phase-parse/src/lib.rs
+++ b/crates/rumoca-phase-parse/src/lib.rs
@@ -548,6 +548,12 @@ mod tests {
         parse_to_ast(&rendered, "roundtrip.mo").expect("round-trip parse should succeed")
     }
 
+    fn source_slice(source: &str, span: Span) -> &str {
+        source
+            .get(span.start.0..span.end.0)
+            .expect("span should slice source")
+    }
+
     #[test]
     fn test_parse_extends() {
         let source = r#"
@@ -670,6 +676,24 @@ end Ball;
     }
 
     #[test]
+    fn test_parse_unary_expression_span_includes_operator() {
+        let source = "model Test\n  parameter Real M[2,2] = [-d, not flag; d, flag];\nend Test;";
+        let ast = parse_to_ast(source, "test.mo").expect("Parse should succeed");
+        let model = ast.classes.get("Test").expect("Test should exist");
+        let component = model.components.get("M").expect("M should exist");
+        let binding = component.binding.as_ref().expect("binding should exist");
+        let ast::Expression::Array { elements, .. } = binding else {
+            panic!("expected matrix binding");
+        };
+        let ast::Expression::Array { elements, .. } = &elements[0] else {
+            panic!("expected first matrix row");
+        };
+
+        assert_eq!(source_slice(source, elements[0].span()), "-d");
+        assert_eq!(source_slice(source, elements[1].span()), "not flag");
+    }
+
+    #[test]
     fn test_parse_component_declarations() {
         let source = r#"
 model Test
@@ -683,6 +707,36 @@ end Test;
         let model = ast.classes.get("Test").expect("Test should exist");
         assert_eq!(&*model.name.text, "Test");
         assert_eq!(model.components.len(), 3, "Should have 3 components");
+    }
+
+    #[test]
+    fn test_component_declaration_preserves_source_modifications() {
+        let source = r#"
+model Test
+  Real x(start = 1, fixed = true);
+end Test;
+"#;
+        let ast = parse_to_ast(source, "test.mo").expect("Parse should succeed");
+        let model = ast.classes.get("Test").expect("Test should exist");
+        let x = model.components.get("x").expect("x should exist");
+
+        assert_eq!(x.source_modifications.len(), 2);
+        assert_eq!(x.source_modification_each_flags, vec![false, false]);
+        assert_eq!(x.source_modification_final_flags, vec![false, false]);
+        assert_eq!(x.source_modification_redeclare_flags, vec![false, false]);
+        assert!(x.start_is_modification);
+        assert!(x.modifications.contains_key("fixed"));
+
+        let first_name = match &x.source_modifications[0] {
+            ast::Expression::Modification { target, .. } => target.to_string(),
+            other => panic!("expected source modification, got {other:?}"),
+        };
+        let second_name = match &x.source_modifications[1] {
+            ast::Expression::Modification { target, .. } => target.to_string(),
+            other => panic!("expected source modification, got {other:?}"),
+        };
+        assert_eq!(first_name, "start");
+        assert_eq!(second_name, "fixed");
     }
 
     #[test]

--- a/crates/rumoca-tool-fmt/src/format_options.rs
+++ b/crates/rumoca-tool-fmt/src/format_options.rs
@@ -36,8 +36,14 @@ pub fn find_config(start_dir: &Path) -> Option<PathBuf> {
 
 /// Load configuration from a specific file path.
 pub fn load_config(path: &Path) -> Result<FormatOptions, ConfigError> {
+    let overrides = load_config_overrides(path)?;
+    Ok(FormatOptions::from_partial(overrides))
+}
+
+/// Load partial configuration overrides from a specific file path.
+pub fn load_config_overrides(path: &Path) -> Result<PartialFormatOptions, ConfigError> {
     let content = std::fs::read_to_string(path)?;
-    let options: FormatOptions = toml::from_str(&content)?;
+    let options: PartialFormatOptions = toml::from_str(&content)?;
     Ok(options)
 }
 
@@ -49,14 +55,36 @@ pub fn load_config_from_dir(dir: &Path) -> Result<Option<FormatOptions>, ConfigE
     }
 }
 
+/// Load partial configuration overrides from a directory, searching parent directories.
+pub fn load_config_overrides_from_dir(
+    dir: &Path,
+) -> Result<Option<PartialFormatOptions>, ConfigError> {
+    match find_config(dir) {
+        Some(path) => Ok(Some(load_config_overrides(&path)?)),
+        None => Ok(None),
+    }
+}
+
 /// Formatter behavior profile.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum FormatProfile {
-    /// Minimal churn profile for large codebases like MSL.
-    Msl,
-    /// Aggressive whitespace normalization profile.
+    /// Apply conservative Dymola/MSL-compatible whitespace rules.
+    Dymola,
+    /// Apply canonical whitespace rules that normalize more spacing.
     Canonical,
+}
+
+/// Output line-ending style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LineEnding {
+    /// Keep CRLF only when the input is predominantly CRLF; otherwise use LF.
+    Auto,
+    /// Use Unix line endings.
+    Lf,
+    /// Use Windows line endings.
+    Crlf,
 }
 
 /// Formatting options.
@@ -70,72 +98,103 @@ pub struct FormatOptions {
     #[serde(default = "default_indent_size")]
     pub indent_size: usize,
 
-    /// Use tabs instead of spaces.
+    /// Use tabs instead of spaces when normalizing indentation.
     #[serde(default)]
     pub use_tabs: bool,
 
-    /// Maximum line length before wrapping.
-    #[serde(default = "default_max_line_length")]
-    pub max_line_length: usize,
+    /// Normalize structural indentation. Off by default because MSL/Dymola
+    /// continuation indentation carries local alignment information.
+    #[serde(default)]
+    pub normalize_indentation: bool,
 
-    /// Align annotation modifiers.
+    /// Add missing structural indentation only to unindented lines.
     #[serde(default = "default_true")]
-    pub align_annotations: bool,
+    pub repair_missing_indentation: bool,
+
+    /// Normalize spaces around declaration bindings and equation/algorithm assignments.
+    #[serde(default)]
+    pub normalize_equation_spacing: bool,
+
+    /// Normalize spaces around binary expression operators.
+    #[serde(default)]
+    pub normalize_operator_spacing: bool,
+
+    /// Normalize named argument and modification assignments to compact `=`.
+    #[serde(default)]
+    pub normalize_argument_assignment_spacing: bool,
 
     /// Insert newline at end of file.
     #[serde(default = "default_true")]
     pub insert_final_newline: bool,
 
-    /// Trim trailing whitespace.
+    /// Trim trailing horizontal whitespace outside strings and block comments.
     #[serde(default = "default_true")]
     pub trim_trailing_whitespace: bool,
+
+    /// Output line endings.
+    #[serde(default = "default_line_ending")]
+    pub line_ending: LineEnding,
 }
 
 fn default_profile() -> FormatProfile {
-    FormatProfile::Msl
+    FormatProfile::Dymola
 }
 
 fn default_indent_size() -> usize {
     2
 }
 
-fn default_max_line_length() -> usize {
-    100
-}
-
 fn default_true() -> bool {
     true
 }
 
+fn default_line_ending() -> LineEnding {
+    LineEnding::Auto
+}
+
 impl Default for FormatOptions {
     fn default() -> Self {
-        Self {
-            profile: default_profile(),
-            indent_size: default_indent_size(),
-            use_tabs: false,
-            max_line_length: default_max_line_length(),
-            align_annotations: true,
-            insert_final_newline: true,
-            trim_trailing_whitespace: true,
-        }
+        Self::for_profile(default_profile())
     }
 }
 
 impl FormatOptions {
-    /// Create options with tab indentation.
-    pub fn with_tabs() -> Self {
-        Self {
-            use_tabs: true,
-            ..Default::default()
+    /// Default options for a formatter profile before user overrides.
+    pub fn for_profile(profile: FormatProfile) -> Self {
+        match profile {
+            FormatProfile::Dymola => Self {
+                profile,
+                indent_size: default_indent_size(),
+                use_tabs: false,
+                normalize_indentation: false,
+                repair_missing_indentation: true,
+                normalize_equation_spacing: false,
+                normalize_operator_spacing: false,
+                normalize_argument_assignment_spacing: false,
+                insert_final_newline: true,
+                trim_trailing_whitespace: true,
+                line_ending: default_line_ending(),
+            },
+            FormatProfile::Canonical => Self {
+                profile,
+                indent_size: default_indent_size(),
+                use_tabs: false,
+                normalize_indentation: true,
+                repair_missing_indentation: true,
+                normalize_equation_spacing: true,
+                normalize_operator_spacing: true,
+                normalize_argument_assignment_spacing: true,
+                insert_final_newline: true,
+                trim_trailing_whitespace: true,
+                line_ending: default_line_ending(),
+            },
         }
     }
 
-    /// Create options with specific indent size.
-    pub fn with_indent_size(size: usize) -> Self {
-        Self {
-            indent_size: size,
-            ..Default::default()
-        }
+    /// Resolve profile defaults and then apply partial overrides.
+    pub fn from_partial(overrides: PartialFormatOptions) -> Self {
+        let profile = overrides.profile.unwrap_or_else(default_profile);
+        Self::for_profile(profile).merge(overrides)
     }
 
     /// Merge with another set of options.
@@ -144,14 +203,57 @@ impl FormatOptions {
             profile: other.profile.unwrap_or(self.profile),
             indent_size: other.indent_size.unwrap_or(self.indent_size),
             use_tabs: other.use_tabs.unwrap_or(self.use_tabs),
-            max_line_length: other.max_line_length.unwrap_or(self.max_line_length),
-            align_annotations: other.align_annotations.unwrap_or(self.align_annotations),
+            normalize_indentation: other
+                .normalize_indentation
+                .unwrap_or(self.normalize_indentation),
+            repair_missing_indentation: other
+                .repair_missing_indentation
+                .unwrap_or(self.repair_missing_indentation),
+            normalize_equation_spacing: other
+                .normalize_equation_spacing
+                .unwrap_or(self.normalize_equation_spacing),
+            normalize_operator_spacing: other
+                .normalize_operator_spacing
+                .unwrap_or(self.normalize_operator_spacing),
+            normalize_argument_assignment_spacing: other
+                .normalize_argument_assignment_spacing
+                .unwrap_or(self.normalize_argument_assignment_spacing),
             insert_final_newline: other
                 .insert_final_newline
                 .unwrap_or(self.insert_final_newline),
             trim_trailing_whitespace: other
                 .trim_trailing_whitespace
                 .unwrap_or(self.trim_trailing_whitespace),
+            line_ending: other.line_ending.unwrap_or(self.line_ending),
+        }
+    }
+}
+
+impl PartialFormatOptions {
+    /// Overlay another partial option set, using `other` when a field is set.
+    pub fn overlay(self, other: PartialFormatOptions) -> Self {
+        Self {
+            profile: other.profile.or(self.profile),
+            indent_size: other.indent_size.or(self.indent_size),
+            use_tabs: other.use_tabs.or(self.use_tabs),
+            normalize_indentation: other.normalize_indentation.or(self.normalize_indentation),
+            repair_missing_indentation: other
+                .repair_missing_indentation
+                .or(self.repair_missing_indentation),
+            normalize_equation_spacing: other
+                .normalize_equation_spacing
+                .or(self.normalize_equation_spacing),
+            normalize_operator_spacing: other
+                .normalize_operator_spacing
+                .or(self.normalize_operator_spacing),
+            normalize_argument_assignment_spacing: other
+                .normalize_argument_assignment_spacing
+                .or(self.normalize_argument_assignment_spacing),
+            insert_final_newline: other.insert_final_newline.or(self.insert_final_newline),
+            trim_trailing_whitespace: other
+                .trim_trailing_whitespace
+                .or(self.trim_trailing_whitespace),
+            line_ending: other.line_ending.or(self.line_ending),
         }
     }
 }
@@ -163,16 +265,24 @@ pub struct PartialFormatOptions {
     pub profile: Option<FormatProfile>,
     /// Number of spaces per indentation level.
     pub indent_size: Option<usize>,
-    /// Use tabs instead of spaces.
+    /// Use tabs instead of spaces when normalizing indentation.
     pub use_tabs: Option<bool>,
-    /// Maximum line length before wrapping.
-    pub max_line_length: Option<usize>,
-    /// Align annotation modifiers.
-    pub align_annotations: Option<bool>,
+    /// Normalize structural indentation.
+    pub normalize_indentation: Option<bool>,
+    /// Add missing structural indentation only to unindented lines.
+    pub repair_missing_indentation: Option<bool>,
+    /// Normalize spaces around declaration bindings and equation/algorithm assignments.
+    pub normalize_equation_spacing: Option<bool>,
+    /// Normalize spaces around binary expression operators.
+    pub normalize_operator_spacing: Option<bool>,
+    /// Normalize named argument and modification assignments to compact `=`.
+    pub normalize_argument_assignment_spacing: Option<bool>,
     /// Insert newline at end of file.
     pub insert_final_newline: Option<bool>,
-    /// Trim trailing whitespace.
+    /// Trim trailing horizontal whitespace outside strings and block comments.
     pub trim_trailing_whitespace: Option<bool>,
+    /// Output line endings.
+    pub line_ending: Option<LineEnding>,
 }
 
 #[cfg(test)]
@@ -183,25 +293,95 @@ mod tests {
     #[test]
     fn test_default_options() {
         let opts = FormatOptions::default();
-        assert_eq!(opts.profile, FormatProfile::Msl);
+        assert_eq!(opts.profile, FormatProfile::Dymola);
         assert_eq!(opts.indent_size, 2);
         assert!(!opts.use_tabs);
-        assert_eq!(opts.max_line_length, 100);
+        assert!(!opts.normalize_indentation);
+        assert!(opts.repair_missing_indentation);
+        assert!(!opts.normalize_equation_spacing);
+        assert!(!opts.normalize_operator_spacing);
+        assert!(!opts.normalize_argument_assignment_spacing);
+        assert!(opts.insert_final_newline);
+        assert!(opts.trim_trailing_whitespace);
+        assert_eq!(opts.line_ending, LineEnding::Auto);
+    }
+
+    #[test]
+    fn test_canonical_profile_defaults() {
+        let opts = FormatOptions::for_profile(FormatProfile::Canonical);
+        assert_eq!(opts.profile, FormatProfile::Canonical);
+        assert_eq!(opts.indent_size, 2);
+        assert!(!opts.use_tabs);
+        assert!(opts.normalize_indentation);
+        assert!(opts.repair_missing_indentation);
+        assert!(opts.normalize_equation_spacing);
+        assert!(opts.normalize_operator_spacing);
+        assert!(opts.normalize_argument_assignment_spacing);
+        assert!(opts.insert_final_newline);
+        assert!(opts.trim_trailing_whitespace);
+        assert_eq!(opts.line_ending, LineEnding::Auto);
     }
 
     #[test]
     fn test_merge_options() {
         let base = FormatOptions::default();
         let overrides = PartialFormatOptions {
-            profile: Some(FormatProfile::Canonical),
+            profile: Some(FormatProfile::Dymola),
             indent_size: Some(4),
             use_tabs: Some(true),
-            ..Default::default()
+            normalize_indentation: Some(true),
+            repair_missing_indentation: Some(false),
+            normalize_equation_spacing: Some(false),
+            normalize_operator_spacing: Some(true),
+            normalize_argument_assignment_spacing: Some(true),
+            insert_final_newline: Some(false),
+            trim_trailing_whitespace: Some(false),
+            line_ending: Some(LineEnding::Crlf),
         };
         let merged = base.merge(overrides);
-        assert_eq!(merged.profile, FormatProfile::Canonical);
+        assert_eq!(merged.profile, FormatProfile::Dymola);
         assert_eq!(merged.indent_size, 4);
         assert!(merged.use_tabs);
+        assert!(merged.normalize_indentation);
+        assert!(!merged.repair_missing_indentation);
+        assert!(!merged.normalize_equation_spacing);
+        assert!(merged.normalize_operator_spacing);
+        assert!(merged.normalize_argument_assignment_spacing);
+        assert!(!merged.insert_final_newline);
+        assert!(!merged.trim_trailing_whitespace);
+        assert_eq!(merged.line_ending, LineEnding::Crlf);
+    }
+
+    #[test]
+    fn test_partial_options_resolve_profile_defaults_before_overrides() {
+        let opts = FormatOptions::from_partial(PartialFormatOptions {
+            profile: Some(FormatProfile::Canonical),
+            normalize_equation_spacing: Some(false),
+            ..PartialFormatOptions::default()
+        });
+        assert_eq!(opts.profile, FormatProfile::Canonical);
+        assert!(opts.normalize_indentation);
+        assert!(!opts.normalize_equation_spacing);
+        assert!(opts.normalize_operator_spacing);
+        assert!(opts.normalize_argument_assignment_spacing);
+    }
+
+    #[test]
+    fn test_partial_options_overlay() {
+        let config = PartialFormatOptions {
+            profile: Some(FormatProfile::Canonical),
+            normalize_indentation: Some(true),
+            normalize_equation_spacing: Some(true),
+            ..PartialFormatOptions::default()
+        };
+        let cli = PartialFormatOptions {
+            normalize_equation_spacing: Some(false),
+            ..PartialFormatOptions::default()
+        };
+        let merged = config.overlay(cli);
+        assert_eq!(merged.profile, Some(FormatProfile::Canonical));
+        assert_eq!(merged.normalize_indentation, Some(true));
+        assert_eq!(merged.normalize_equation_spacing, Some(false));
     }
 
     #[test]
@@ -209,13 +389,61 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let config_path = dir.path().join(".rumoca_fmt.toml");
         let mut file = std::fs::File::create(&config_path).expect("create config");
+        writeln!(file, "profile = \"dymola\"").expect("write profile");
         writeln!(file, "indent_size = 4").expect("write indent_size");
         writeln!(file, "use_tabs = true").expect("write use_tabs");
+        writeln!(file, "normalize_indentation = true").expect("write normalize_indentation");
+        writeln!(file, "repair_missing_indentation = false")
+            .expect("write repair_missing_indentation");
+        writeln!(file, "normalize_equation_spacing = false")
+            .expect("write normalize_equation_spacing");
+        writeln!(file, "normalize_operator_spacing = true")
+            .expect("write normalize_operator_spacing");
+        writeln!(file, "normalize_argument_assignment_spacing = true")
+            .expect("write normalize_argument_assignment_spacing");
+        writeln!(file, "insert_final_newline = false").expect("write insert_final_newline");
+        writeln!(file, "trim_trailing_whitespace = false").expect("write trim_trailing");
+        writeln!(file, "line_ending = \"crlf\"").expect("write line_ending");
+
+        let opts = load_config(&config_path).expect("load config");
+        assert_eq!(opts.profile, FormatProfile::Dymola);
+        assert_eq!(opts.indent_size, 4);
+        assert!(opts.use_tabs);
+        assert!(opts.normalize_indentation);
+        assert!(!opts.repair_missing_indentation);
+        assert!(!opts.normalize_equation_spacing);
+        assert!(opts.normalize_operator_spacing);
+        assert!(opts.normalize_argument_assignment_spacing);
+        assert!(!opts.insert_final_newline);
+        assert!(!opts.trim_trailing_whitespace);
+        assert_eq!(opts.line_ending, LineEnding::Crlf);
+    }
+
+    #[test]
+    fn test_load_dymola_profile_from_toml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join(".rumoca_fmt.toml");
+        let mut file = std::fs::File::create(&config_path).expect("create config");
+        writeln!(file, "profile = \"dymola\"").expect("write profile");
+
+        let opts = load_config(&config_path).expect("load config");
+        assert_eq!(opts.profile, FormatProfile::Dymola);
+    }
+
+    #[test]
+    fn test_load_canonical_profile_from_toml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join(".rumoca_fmt.toml");
+        let mut file = std::fs::File::create(&config_path).expect("create config");
         writeln!(file, "profile = \"canonical\"").expect("write profile");
+        writeln!(file, "normalize_equation_spacing = false")
+            .expect("write normalize_equation_spacing");
 
         let opts = load_config(&config_path).expect("load config");
         assert_eq!(opts.profile, FormatProfile::Canonical);
-        assert_eq!(opts.indent_size, 4);
-        assert!(opts.use_tabs);
+        assert!(opts.normalize_indentation);
+        assert!(!opts.normalize_equation_spacing);
+        assert!(opts.normalize_operator_spacing);
+        assert!(opts.normalize_argument_assignment_spacing);
     }
 }

--- a/crates/rumoca-tool-fmt/src/formatter.rs
+++ b/crates/rumoca-tool-fmt/src/formatter.rs
@@ -3,7 +3,23 @@
 use crate::format_errors::FormatError;
 use crate::format_options::{FormatOptions, FormatProfile};
 
-use rumoca_compile::parsing::validate_source_syntax;
+use rumoca_compile::parsing::{
+    Causality, OpBinary, Span, Token, Variability, ast, ir_core, parse_source_to_ast,
+};
+use std::ops::ControlFlow::{self, Continue};
+
+mod dymola;
+
+mod coverage;
+mod trivia;
+
+pub use coverage::{FormatCoverageCategory, FormatCoverageCategoryReport, FormatCoverageReport};
+
+use trivia::*;
+
+use dymola::{
+    DymolaFormatState, can_trim_trailing_whitespace, format_dymola_line, target_line_ending,
+};
 
 /// Format Modelica source code.
 pub fn format(source: &str, options: &FormatOptions) -> Result<String, FormatError> {
@@ -16,10 +32,9 @@ pub fn format_with_source_name(
     options: &FormatOptions,
     source_name: &str,
 ) -> Result<String, FormatError> {
-    if let Err(e) = validate_source_syntax(source, source_name) {
-        return Err(FormatError::SyntaxError(e.to_string()));
-    }
-    Ok(format_source(source, options))
+    let ast = parse_source_to_ast(source, source_name)
+        .map_err(|e| FormatError::SyntaxError(e.to_string()))?;
+    Ok(format_source(source, options, &ast))
 }
 
 /// Format source, returning original on syntax error.
@@ -36,346 +51,1665 @@ pub fn format_or_original_with_source_name(
     format_with_source_name(source, options, source_name).unwrap_or_else(|_| source.to_string())
 }
 
-fn format_source(source: &str, options: &FormatOptions) -> String {
-    let rules = style_rules(options.profile);
+/// Report formatter rule coverage over eligible AST trivia gaps.
+pub fn format_coverage_report(
+    source: &str,
+    options: &FormatOptions,
+) -> Result<FormatCoverageReport, FormatError> {
+    format_coverage_report_with_source_name(source, options, "<coverage>")
+}
+
+/// Report formatter rule coverage with an explicit source name.
+pub fn format_coverage_report_with_source_name(
+    source: &str,
+    options: &FormatOptions,
+    source_name: &str,
+) -> Result<FormatCoverageReport, FormatError> {
+    let ast = parse_source_to_ast(source, source_name)
+        .map_err(|e| FormatError::SyntaxError(e.to_string()))?;
+    let component_layout = ComponentDeclarationLayout::collect(&ast);
+    let mut collector = AstTriviaCoverageCollector::new(source, options, &component_layout);
+    let _ = ast::Visitor::visit_stored_definition(&mut collector, &ast);
+    Ok(collector.into_report())
+}
+
+fn format_source(source: &str, options: &FormatOptions, ast: &ast::StoredDefinition) -> String {
+    match options.profile {
+        FormatProfile::Dymola | FormatProfile::Canonical => {
+            format_dymola_source(source, options, ast)
+        }
+    }
+}
+
+fn format_dymola_source(
+    source: &str,
+    options: &FormatOptions,
+    ast: &ast::StoredDefinition,
+) -> String {
+    let source = apply_ast_trivia_rules(source, options, ast);
+    let mut line_options = options.clone();
+    line_options.normalize_equation_spacing = false;
+
+    let line_ending = target_line_ending(&source, options.line_ending);
     let mut result = String::with_capacity(source.len());
-    let indent_str = if options.use_tabs {
-        "\t".to_string()
-    } else {
-        " ".repeat(options.indent_size)
-    };
+    let mut indent_level = 0usize;
+    let mut state = DymolaFormatState::default();
+    let mut wrote_line = false;
 
-    let mut indent_level: usize = 0;
-    let mut in_string = false;
-    let mut prev_char = '\0';
-
-    for line in source.lines() {
-        let line_no_trailing = if options.trim_trailing_whitespace {
+    for raw_line in source.lines() {
+        let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
+        let line = if line_options.trim_trailing_whitespace
+            && can_trim_trailing_whitespace(line, &state)
+        {
             line.trim_end_matches([' ', '\t'])
         } else {
             line
         };
-        let trimmed = line_no_trailing.trim();
-
-        if trimmed.is_empty() {
-            result.push('\n');
-            continue;
-        }
-
-        let lower = if in_string {
-            String::new()
-        } else {
-            trimmed.to_ascii_lowercase()
-        };
-
-        if !in_string
-            && rules.normalize_indentation
-            && (is_end_keyword(&lower)
-                || is_branch_keyword(&lower)
-                || (rules.dedent_section_headers && is_section_header_keyword(&lower)))
-        {
-            indent_level = indent_level.saturating_sub(1);
-        }
-
-        if rules.normalize_indentation {
-            for _ in 0..indent_level {
-                result.push_str(&indent_str);
-            }
-        } else {
-            let leading_len = line_no_trailing.len() - line_no_trailing.trim_start().len();
-            result.push_str(&line_no_trailing[..leading_len]);
-        }
-
-        let line_content = if rules.normalize_indentation {
-            trimmed
-        } else {
-            line_no_trailing.trim_start()
-        };
-        let (formatted_line, next_in_string, next_prev_char) =
-            format_line(line_content, rules, in_string, prev_char);
+        let formatted_line = format_dymola_line(line, &line_options, &mut indent_level, &mut state);
         result.push_str(&formatted_line);
-        result.push('\n');
-        in_string = next_in_string;
-        prev_char = next_prev_char;
-
-        if !in_string
-            && rules.normalize_indentation
-            && (is_block_header_keyword(&lower)
-                || is_branch_keyword(&lower)
-                || is_section_header_keyword(&lower))
-        {
-            indent_level += 1;
-        }
+        result.push_str(line_ending);
+        wrote_line = true;
     }
 
-    if !options.insert_final_newline && !source.ends_with('\n') {
-        let _ = result.pop();
+    if !line_options.insert_final_newline && wrote_line {
+        for _ in 0..line_ending.len() {
+            let _ = result.pop();
+        }
     }
 
     result
 }
 
-#[derive(Clone, Copy)]
-struct StyleRules {
-    normalize_indentation: bool,
-    dedent_section_headers: bool,
-    normalize_operator_spacing: bool,
-    tighten_unary_sign_spacing: bool,
+struct AstTriviaReplacementCollector<'source, 'options> {
+    trivia: SourceTrivia<'source>,
+    options: &'options FormatOptions,
+    component_layout: &'options ComponentDeclarationLayout,
+    replacements: Vec<TextReplacement>,
+    token_spans: Vec<Span>,
 }
 
-fn style_rules(profile: FormatProfile) -> StyleRules {
-    match profile {
-        // MSL profile: close to existing MSL whitespace while using full formatting path.
-        FormatProfile::Msl => StyleRules {
-            normalize_indentation: false,
-            dedent_section_headers: false,
-            normalize_operator_spacing: true,
-            tighten_unary_sign_spacing: false,
-        },
-        // Canonical profile: fully normalize indentation and operator spacing.
-        FormatProfile::Canonical => StyleRules {
-            normalize_indentation: true,
-            dedent_section_headers: true,
-            normalize_operator_spacing: true,
-            tighten_unary_sign_spacing: true,
-        },
+impl<'source, 'options> AstTriviaReplacementCollector<'source, 'options> {
+    fn new(
+        source: &'source str,
+        options: &'options FormatOptions,
+        component_layout: &'options ComponentDeclarationLayout,
+    ) -> Self {
+        Self {
+            trivia: SourceTrivia::new(source),
+            options,
+            component_layout,
+            replacements: Vec::new(),
+            token_spans: Vec::new(),
+        }
+    }
+
+    fn into_replacements(mut self) -> Vec<TextReplacement> {
+        self.collect_token_gap_replacements();
+        self.replacements
+    }
+
+    fn remember_token(&mut self, token: &Token) {
+        let span = token_span(token);
+        if !span.is_dummy() {
+            self.token_spans.push(span);
+        }
+    }
+
+    fn remember_component_reference_tokens(&mut self, reference: &ast::ComponentReference) {
+        for part in &reference.parts {
+            self.remember_token(&part.ident);
+        }
+    }
+
+    fn collect_token_gap_replacements(&mut self) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        self.token_spans
+            .sort_by_key(|span| (span.start.0, span.end.0));
+        self.token_spans
+            .dedup_by_key(|span| (span.start.0, span.end.0));
+        let spans = self.token_spans.clone();
+        for adjacent in spans.windows(2) {
+            let Some(gap) = self.trivia.gap_between_spans(adjacent[0], adjacent[1]) else {
+                continue;
+            };
+            if let Some(replacement) = gap.closing_expression_separator_replacement() {
+                self.replacements.push(replacement);
+            }
+            if let Some(replacement) = gap.opening_parenthesis_replacement() {
+                self.replacements.push(replacement);
+            }
+            if let Some(replacement) = gap.opening_delimiter_padding_replacement() {
+                self.replacements.push(replacement);
+            }
+            if let Some(replacement) = gap.closing_delimiter_binary_operator_replacement() {
+                self.replacements.push(replacement);
+            }
+            if let Some(replacement) = gap.closing_delimiter_opening_parenthesis_replacement() {
+                self.replacements.push(replacement);
+            }
+            if let Some(replacement) = gap.statement_separator_replacement() {
+                self.replacements.push(replacement);
+            }
+        }
+    }
+
+    fn collect_class_keyword_spacing(&mut self, class: &ast::ClassDef) {
+        let Some(replacement) = self
+            .trivia
+            .gap_between_tokens(&class.class_type_token, &class.name)
+            .and_then(|gap| gap.single_horizontal_space_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_class_prefix_spacing(&mut self, class: &ast::ClassDef) {
+        let Some(line) = self.trivia.line_before_token(&class.class_type_token) else {
+            return;
+        };
+        let allowed = class_prefix_keywords(class);
+        for gap in declaration_prefix_gaps_before_token(line, &allowed) {
+            let Some(replacement) = gap.single_horizontal_space_replacement() else {
+                continue;
+            };
+            self.replacements.push(replacement);
+        }
+    }
+
+    fn collect_class_end_name_spacing(&mut self, class: &ast::ClassDef) {
+        let Some(replacement) = class
+            .end_name_token
+            .as_ref()
+            .and_then(|end_name| self.trivia.gap_after_keyword_before_token("end", end_name))
+            .and_then(|gap| gap.single_horizontal_space_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_type_alias_assignment_spacing(&mut self, class: &ast::ClassDef) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        let Some(base) = type_alias_base_name(class) else {
+            return;
+        };
+        let Some(replacement) = self
+            .trivia
+            .gap_between_token_and_name(&class.name, base)
+            .and_then(|gap| gap.assignment_operator_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_keyword_name_spacing(&mut self, keyword: &str, name: &ast::Name) {
+        let Some(replacement) = self
+            .trivia
+            .gap_after_keyword_before_name(keyword, name)
+            .and_then(|gap| gap.single_horizontal_space_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_name_separators(&mut self, name: &ast::Name) {
+        for tokens in name.name.windows(2) {
+            self.collect_dot_separator_between_tokens(&tokens[0], &tokens[1]);
+        }
+    }
+
+    fn collect_component_reference_separators(&mut self, reference: &ast::ComponentReference) {
+        self.remember_component_reference_tokens(reference);
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        for parts in reference.parts.windows(2) {
+            self.collect_dot_separator_between_tokens(&parts[0].ident, &parts[1].ident);
+        }
+    }
+
+    fn collect_import_spacing(&mut self, import: &ast::Import) {
+        match import {
+            ast::Import::Renamed { alias, path, .. } => {
+                self.collect_renamed_import_assignment_spacing(alias, path);
+            }
+            ast::Import::Selective { names, .. } => {
+                self.collect_selective_import_name_separators(names);
+            }
+            ast::Import::Qualified { .. } | ast::Import::Unqualified { .. } => {}
+        }
+    }
+
+    fn collect_renamed_import_assignment_spacing(&mut self, alias: &Token, path: &ast::Name) {
+        let Some(replacement) = self
+            .trivia
+            .gap_between_token_and_name(alias, path)
+            .and_then(|gap| gap.assignment_operator_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_selective_import_name_separators(&mut self, names: &[Token]) {
+        for adjacent in names.windows(2) {
+            let Some(replacement) = self
+                .trivia
+                .gap_between_tokens(&adjacent[0], &adjacent[1])
+                .and_then(|gap| gap.comma_separator_replacement())
+            else {
+                continue;
+            };
+            self.replacements.push(replacement);
+        }
+    }
+
+    fn collect_expression_list_commas(&mut self, expressions: &[ast::Expression]) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        for adjacent in expressions.windows(2) {
+            let Some(replacement) = self
+                .trivia
+                .gap_between_expression_list_items(&adjacent[0], &adjacent[1])
+                .and_then(|gap| gap.comma_separator_replacement())
+            else {
+                continue;
+            };
+            self.replacements.push(replacement);
+        }
+    }
+
+    fn collect_opening_parenthesis_padding(
+        &mut self,
+        target: &ast::ComponentReference,
+        args: &[ast::Expression],
+    ) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        let Some(first_arg) = args.first() else {
+            return;
+        };
+        let Some(replacement) = self
+            .trivia
+            .gap_after_call_open_paren(target, first_arg)
+            .and_then(|gap| gap.opening_parenthesis_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_assert_opening_parenthesis_padding(&mut self, condition: &ast::Expression) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        let Some(replacement) = self
+            .trivia
+            .gap_after_keyword_open_paren_before_expression("assert", condition)
+            .and_then(|gap| gap.opening_parenthesis_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_component_modifier_opening_parenthesis_padding(
+        &mut self,
+        component: &ast::Component,
+    ) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        let Some(first_modification) = component.source_modifications.first() else {
+            return;
+        };
+        let Some(replacement) = self
+            .trivia
+            .gap_after_token_open_paren(&component.name_token, first_modification)
+            .and_then(|gap| gap.opening_parenthesis_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_subscript_commas(&mut self, subscripts: &[ast::Subscript]) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        for adjacent in subscripts.windows(2) {
+            let Some(replacement) = self
+                .trivia
+                .gap_between_subscripts(&adjacent[0], &adjacent[1])
+                .and_then(|gap| gap.comma_separator_replacement())
+            else {
+                continue;
+            };
+            self.replacements.push(replacement);
+        }
+    }
+
+    fn collect_extend_modification_commas(&mut self, modifications: &[ast::ExtendModification]) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        for adjacent in modifications.windows(2) {
+            let Some(replacement) = self
+                .trivia
+                .gap_between_extend_modifications(&adjacent[0], &adjacent[1])
+                .and_then(|gap| gap.comma_separator_replacement())
+            else {
+                continue;
+            };
+            self.replacements.push(replacement);
+        }
+    }
+
+    fn collect_argument_assignment_spacing(&mut self, expr: &ast::Expression) {
+        if !self.options.normalize_argument_assignment_spacing {
+            return;
+        }
+        let replacement = match expr {
+            ast::Expression::NamedArgument { name, value, .. } => self
+                .trivia
+                .gap_between_token_and_expression(name, value)
+                .and_then(|gap| gap.compact_assignment_operator_replacement()),
+            ast::Expression::Modification { target, value, .. } => self
+                .trivia
+                .gap_between_component_reference_and_expression(target, value)
+                .and_then(|gap| gap.compact_assignment_operator_replacement()),
+            ast::Expression::Binary {
+                op: OpBinary::Assign,
+                lhs,
+                rhs,
+                ..
+            } => self
+                .trivia
+                .gap_between_expressions(lhs, rhs)
+                .and_then(|gap| gap.compact_assignment_operator_replacement()),
+            _ => None,
+        };
+        if let Some(replacement) = replacement {
+            self.replacements.push(replacement);
+        }
+    }
+
+    fn collect_dot_separator_between_tokens(&mut self, left: &Token, right: &Token) {
+        let Some(replacement) = self
+            .trivia
+            .gap_between_tokens(left, right)
+            .and_then(|gap| gap.dot_separator_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_component_prefix_spacing(&mut self, component: &ast::Component) {
+        let Some(first_type_part) = component.type_name.name.first() else {
+            return;
+        };
+        let Some(line) = self.trivia.line_before_token(first_type_part) else {
+            return;
+        };
+        let allowed = component_prefix_keywords(component);
+        for gap in declaration_prefix_gaps_before_token(line, &allowed) {
+            let Some(replacement) = gap.single_horizontal_space_replacement() else {
+                continue;
+            };
+            self.replacements.push(replacement);
+        }
+    }
+
+    fn collect_component_type_name_spacing(&mut self, component: &ast::Component) {
+        let Some(gap) = self.component_type_name_gap(component) else {
+            return;
+        };
+        if self.should_preserve_component_alignment(component, &gap) {
+            return;
+        }
+        let replacement = if component.shape_expr.is_empty() {
+            gap.single_horizontal_space_replacement()
+        } else {
+            gap.closing_delimiter_name_replacement()
+        };
+        let Some(replacement) = replacement else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn component_type_name_gap(&self, component: &ast::Component) -> Option<TriviaGap<'source>> {
+        if let Some(last_shape) = component.shape_expr.last()
+            && let Some(shape_span) = subscript_span(last_shape)
+            && shape_span.end.0 <= token_span(&component.name_token).start.0
+        {
+            return self
+                .trivia
+                .gap_between_spans(shape_span, token_span(&component.name_token));
+        }
+        self.trivia
+            .gap_between_name_and_token(&component.type_name, &component.name_token)
+    }
+
+    fn collect_redeclare_modification_type_name_spacing(&mut self, expr: &ast::Expression) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        let Some(replacement) = self
+            .redeclare_modification_type_name_gap(expr)
+            .and_then(|gap| gap.single_horizontal_space_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_redeclare_modification_opening_parenthesis_padding(
+        &mut self,
+        expr: &ast::Expression,
+    ) {
+        let Some((target, modifications)) = redeclare_modification_class_target(expr) else {
+            return;
+        };
+        self.collect_opening_parenthesis_padding(target, modifications);
+    }
+
+    fn collect_class_modification_redeclare_spacing(
+        &mut self,
+        modifications: &[ast::Expression],
+        redeclare_flags: &[bool],
+    ) {
+        for (modification, redeclare) in modifications.iter().zip(redeclare_flags) {
+            if !*redeclare {
+                continue;
+            }
+            self.collect_redeclare_modification_type_name_spacing(modification);
+            self.collect_redeclare_modification_opening_parenthesis_padding(modification);
+        }
+    }
+
+    fn redeclare_modification_type_name_gap(
+        &self,
+        expr: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        let ast::Expression::Modification { target, value, .. } = expr else {
+            return None;
+        };
+        let ast::Expression::ClassModification {
+            target: replacement_type,
+            ..
+        } = value.as_ref()
+        else {
+            return None;
+        };
+        self.trivia.gap_between_tokens(
+            &replacement_type.parts.last()?.ident,
+            &target.parts.first()?.ident,
+        )
+    }
+
+    fn collect_component_binding_assignment(&mut self, component: &ast::Component) {
+        if !self.options.normalize_equation_spacing {
+            return;
+        }
+        let Some(binding) = &component.binding else {
+            return;
+        };
+        let gap = component
+            .source_modifications
+            .last()
+            .and_then(|last| {
+                self.trivia
+                    .gap_between_expression_list_item_and_expression(last, binding)
+            })
+            .or_else(|| {
+                self.trivia
+                    .gap_between_token_and_expression(&component.name_token, binding)
+            });
+        let Some(replacement) = gap.and_then(|gap| gap.assignment_operator_replacement()) else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_external_function_spacing(&mut self, external: &ast::ExternalFunction) {
+        if let Some(function_name) = &external.function_name {
+            self.collect_external_opening_parenthesis_padding(function_name, &external.args);
+        }
+        self.collect_expression_list_commas(&external.args);
+    }
+
+    fn collect_external_opening_parenthesis_padding(
+        &mut self,
+        function_name: &Token,
+        args: &[ast::Expression],
+    ) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        let Some(first_arg) = args.first() else {
+            return;
+        };
+        let Some(replacement) = self
+            .trivia
+            .gap_after_token_open_paren(function_name, first_arg)
+            .and_then(|gap| gap.opening_parenthesis_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn should_preserve_component_alignment(
+        &self,
+        component: &ast::Component,
+        gap: &TriviaGap<'_>,
+    ) -> bool {
+        gap.is_multiple_spaces()
+            && (!is_builtin_scalar_type_name(&component.type_name)
+                || self
+                    .component_layout
+                    .has_nearby_declaration_line(component.name_token.location.start_line))
+    }
+
+    fn collect_simple_equation_assignment(&mut self, lhs: &ast::Expression, rhs: &ast::Expression) {
+        if !self.options.normalize_equation_spacing {
+            return;
+        }
+        let Some(replacement) = self
+            .trivia
+            .gap_between_expressions(lhs, rhs)
+            .and_then(|gap| gap.assignment_operator_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_statement_assignment(
+        &mut self,
+        target: &ast::ComponentReference,
+        value: &ast::Expression,
+    ) {
+        if !self.options.normalize_equation_spacing {
+            return;
+        }
+        let Some(replacement) = self
+            .trivia
+            .gap_between_component_reference_and_expression(target, value)
+            .and_then(|gap| gap.statement_assignment_operator_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_connect_comma(
+        &mut self,
+        lhs: &ast::ComponentReference,
+        rhs: &ast::ComponentReference,
+    ) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        let Some(replacement) = self
+            .trivia
+            .gap_between_component_references(lhs, rhs)
+            .and_then(|gap| gap.comma_separator_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_statement_call_output_assignment(
+        &mut self,
+        outputs: &[ast::Expression],
+        target: &ast::ComponentReference,
+    ) {
+        if !self.options.normalize_equation_spacing {
+            return;
+        }
+        let Some(last_output) = outputs.last() else {
+            return;
+        };
+        let Some(replacement) = self
+            .trivia
+            .gap_between_expression_and_component_reference(last_output, target)
+            .and_then(|gap| gap.statement_assignment_operator_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_binary_operator_spacing(
+        &mut self,
+        op: &OpBinary,
+        lhs: &ast::Expression,
+        rhs: &ast::Expression,
+    ) {
+        if !self.options.normalize_operator_spacing || matches!(op, OpBinary::Assign) {
+            return;
+        }
+        let Some(replacement) = self
+            .trivia
+            .gap_between_expressions(lhs, rhs)
+            .and_then(|gap| gap.binary_operator_replacement(op))
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_extends_base_spacing(&mut self, ext: &ast::Extend) {
+        self.collect_keyword_name_spacing("extends", &ext.base_name);
+    }
+
+    fn collect_extends_opening_parenthesis_padding(&mut self, ext: &ast::Extend) {
+        if !matches!(self.options.profile, FormatProfile::Canonical) {
+            return;
+        }
+        let Some(first_modification) = ext.modifications.first() else {
+            return;
+        };
+        let Some(replacement) = self
+            .trivia
+            .gap_after_name_open_paren(&ext.base_name, &first_modification.expr)
+            .and_then(|gap| gap.opening_parenthesis_replacement())
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
+    }
+
+    fn collect_constrainedby_spacing(&mut self, name: &ast::Name) {
+        self.collect_keyword_name_spacing("constrainedby", name);
+    }
+
+    fn collect_for_index_spacing(&mut self, index: &ast::ForIndex) {
+        let Some(replacement) = self
+            .trivia
+            .gap_between_token_and_expression(&index.ident, &index.range)
+            .and_then(|gap| gap.keyword_separator_replacement("in"))
+        else {
+            return;
+        };
+        self.replacements.push(replacement);
     }
 }
 
-fn needs_space_before_eq(prev_char: char, result: &str) -> bool {
-    !matches!(prev_char, ':' | '=' | '<' | '>') && !result.ends_with(' ') && !result.is_empty()
+struct AstTriviaCoverageCollector<'source, 'options> {
+    trivia: SourceTrivia<'source>,
+    options: &'options FormatOptions,
+    component_layout: &'options ComponentDeclarationLayout,
+    report: FormatCoverageReport,
+    recorded_ranges: Vec<(usize, usize)>,
+    token_spans: Vec<Span>,
 }
 
-fn needs_space_after_eq(next: Option<&char>) -> bool {
-    matches!(next, Some(&c) if c != '=' && c != ' ')
-}
-
-fn needs_space_before_arith(prev_char: char, result: &str) -> bool {
-    !matches!(prev_char, 'e' | 'E' | '(') && !result.ends_with(' ') && !result.is_empty()
-}
-
-fn needs_space_after_arith(next: Option<&char>) -> bool {
-    matches!(next, Some(&c) if !matches!(c, ' ' | ')' | ';' | ','))
-}
-
-fn needs_space_after_comma(next: Option<&char>) -> bool {
-    matches!(next, Some(&c) if c != ' ')
-}
-
-fn format_line(
-    line: &str,
-    rules: StyleRules,
-    mut in_string: bool,
-    mut prev_char: char,
-) -> (String, bool, char) {
-    let mut result = String::with_capacity(line.len());
-    let mut chars = line.chars().peekable();
-    let mut in_quoted_identifier = false;
-
-    while let Some(c) = chars.next() {
-        if !in_quoted_identifier && c == '"' && prev_char != '\\' {
-            in_string = !in_string;
-            result.push(c);
-            prev_char = c;
-            continue;
+impl<'source, 'options> AstTriviaCoverageCollector<'source, 'options> {
+    fn new(
+        source: &'source str,
+        options: &'options FormatOptions,
+        component_layout: &'options ComponentDeclarationLayout,
+    ) -> Self {
+        Self {
+            trivia: SourceTrivia::new(source),
+            options,
+            component_layout,
+            report: FormatCoverageReport::new(),
+            recorded_ranges: Vec::new(),
+            token_spans: Vec::new(),
         }
+    }
 
-        if !in_string && c == '\'' {
-            in_quoted_identifier = !in_quoted_identifier;
-            result.push(c);
-            prev_char = c;
-            continue;
+    fn into_report(mut self) -> FormatCoverageReport {
+        self.record_unclassified_token_gaps();
+        self.report
+    }
+
+    fn record_gap(&mut self, category: FormatCoverageCategory, gap: Option<TriviaGap<'source>>) {
+        let Some(gap) = gap else {
+            return;
+        };
+        if gap.text.contains(['\n', '\r']) {
+            return;
         }
+        self.recorded_ranges
+            .push((gap.start, gap.start + gap.text.len()));
+        self.report
+            .record(category, self.category_is_covered(category));
+    }
 
-        if in_string || in_quoted_identifier {
-            result.push(c);
-            prev_char = c;
-            continue;
+    fn category_is_covered(&self, category: FormatCoverageCategory) -> bool {
+        match category {
+            FormatCoverageCategory::SimpleEquationAssignment
+            | FormatCoverageCategory::StatementAssignment
+            | FormatCoverageCategory::StatementCallAssignment
+            | FormatCoverageCategory::ComponentBindingAssignment => {
+                self.options.normalize_equation_spacing
+            }
+            FormatCoverageCategory::ArgumentAssignment => {
+                self.options.normalize_argument_assignment_spacing
+            }
+            FormatCoverageCategory::BinaryOperator => self.options.normalize_operator_spacing,
+            FormatCoverageCategory::ExpressionListComma
+            | FormatCoverageCategory::ConnectComma
+            | FormatCoverageCategory::OpeningParenthesisPadding
+            | FormatCoverageCategory::ArraySubscriptComma
+            | FormatCoverageCategory::StatementSeparator => {
+                matches!(self.options.profile, FormatProfile::Canonical)
+            }
+            FormatCoverageCategory::Unclassified => false,
+            FormatCoverageCategory::ClassPrefix
+            | FormatCoverageCategory::ClassKeywordName
+            | FormatCoverageCategory::ClassEndName
+            | FormatCoverageCategory::QualifiedNameDot
+            | FormatCoverageCategory::RenamedImportAssignment
+            | FormatCoverageCategory::SelectiveImportComma
+            | FormatCoverageCategory::ComponentPrefix
+            | FormatCoverageCategory::ComponentTypeName
+            | FormatCoverageCategory::ComponentDeclarationAlignment
+            | FormatCoverageCategory::ExtendsBase
+            | FormatCoverageCategory::ConstrainedBy
+            | FormatCoverageCategory::ForIndexIn => true,
+            FormatCoverageCategory::TypeAliasAssignment => {
+                matches!(self.options.profile, FormatProfile::Canonical)
+            }
         }
+    }
 
-        if !rules.normalize_operator_spacing {
-            result.push(c);
-            prev_char = c;
-            continue;
+    fn remember_token(&mut self, token: &Token) {
+        let span = token_span(token);
+        if !span.is_dummy() {
+            self.token_spans.push(span);
         }
+    }
 
-        match c {
-            '=' => {
-                if needs_space_before_eq(prev_char, &result) {
-                    result.push(' ');
+    fn remember_name_tokens(&mut self, name: &ast::Name) {
+        for token in &name.name {
+            self.remember_token(token);
+        }
+    }
+
+    fn remember_component_reference_tokens(&mut self, reference: &ast::ComponentReference) {
+        for part in &reference.parts {
+            self.remember_token(&part.ident);
+        }
+    }
+
+    fn record_unclassified_token_gaps(&mut self) {
+        self.token_spans
+            .sort_by_key(|span| (span.start.0, span.end.0));
+        self.token_spans
+            .dedup_by_key(|span| (span.start.0, span.end.0));
+        self.recorded_ranges.sort_unstable();
+        self.recorded_ranges.dedup();
+
+        let spans = self.token_spans.clone();
+        for adjacent in spans.windows(2) {
+            let left = adjacent[0];
+            let right = adjacent[1];
+            let Some(gap) = self.trivia.gap_between_spans(left, right) else {
+                continue;
+            };
+            if !is_unclassified_gap_candidate(gap.text) {
+                continue;
+            }
+            let range = (gap.start, gap.start + gap.text.len());
+            if self.recorded_ranges_overlap(range) {
+                continue;
+            }
+            if is_closing_expression_separator_gap(gap.text) {
+                self.report.record(
+                    FormatCoverageCategory::ExpressionListComma,
+                    self.category_is_covered(FormatCoverageCategory::ExpressionListComma),
+                );
+                continue;
+            }
+            if opening_parenthesis_padding_gap(TriviaGap {
+                start: gap.start,
+                text: gap.text,
+            })
+            .is_some()
+            {
+                self.report.record(
+                    FormatCoverageCategory::OpeningParenthesisPadding,
+                    self.category_is_covered(FormatCoverageCategory::OpeningParenthesisPadding),
+                );
+                continue;
+            }
+            if opening_delimiter_padding_gap(&gap) {
+                self.report.record(
+                    FormatCoverageCategory::OpeningParenthesisPadding,
+                    self.category_is_covered(FormatCoverageCategory::OpeningParenthesisPadding),
+                );
+                continue;
+            }
+            if closing_delimiter_binary_operator(gap.text).is_some() {
+                self.report.record(
+                    FormatCoverageCategory::BinaryOperator,
+                    self.category_is_covered(FormatCoverageCategory::BinaryOperator),
+                );
+                continue;
+            }
+            if is_closing_delimiter_opening_parenthesis_gap(gap.text) {
+                self.report.record(
+                    FormatCoverageCategory::OpeningParenthesisPadding,
+                    self.category_is_covered(FormatCoverageCategory::OpeningParenthesisPadding),
+                );
+                continue;
+            }
+            if is_statement_separator_gap(gap.text) {
+                self.report.record(
+                    FormatCoverageCategory::StatementSeparator,
+                    self.category_is_covered(FormatCoverageCategory::StatementSeparator),
+                );
+                continue;
+            }
+            self.report
+                .record(FormatCoverageCategory::Unclassified, false);
+            self.report
+                .record_unclassified_example(self.unclassified_gap_example(left, &gap, right));
+        }
+    }
+
+    fn recorded_ranges_overlap(&self, range: (usize, usize)) -> bool {
+        self.recorded_ranges
+            .iter()
+            .any(|recorded| recorded.0 < range.1 && range.0 < recorded.1)
+    }
+
+    fn unclassified_gap_example(&self, left: Span, gap: &TriviaGap<'_>, right: Span) -> String {
+        let left_text = self.source_span_text(left).unwrap_or("<left>");
+        let right_text = self.source_span_text(right).unwrap_or("<right>");
+        format!(
+            "{}{}{}",
+            truncate_example(left_text),
+            escape_example_gap(gap.text),
+            truncate_example(right_text)
+        )
+    }
+
+    fn source_span_text(&self, span: Span) -> Option<&'source str> {
+        self.trivia.source.get(span.start.0..span.end.0)
+    }
+
+    fn record_class_gaps(&mut self, class: &ast::ClassDef) {
+        self.remember_token(&class.class_type_token);
+        self.remember_token(&class.name);
+        if let Some(end_name) = &class.end_name_token {
+            self.remember_token(end_name);
+        }
+        self.record_gap(
+            FormatCoverageCategory::ClassKeywordName,
+            self.trivia
+                .gap_between_tokens(&class.class_type_token, &class.name),
+        );
+        if let Some(end_name) = &class.end_name_token {
+            self.record_gap(
+                FormatCoverageCategory::ClassEndName,
+                self.trivia.gap_after_keyword_before_token("end", end_name),
+            );
+        }
+        if let Some(base) = type_alias_base_name(class) {
+            self.record_gap(
+                FormatCoverageCategory::TypeAliasAssignment,
+                self.trivia.gap_between_token_and_name(&class.name, base),
+            );
+        }
+        let Some(line) = self.trivia.line_before_token(&class.class_type_token) else {
+            return;
+        };
+        for gap in declaration_prefix_gaps_before_token(line, &class_prefix_keywords(class)) {
+            self.record_gap(FormatCoverageCategory::ClassPrefix, Some(gap));
+        }
+    }
+
+    fn record_name_separators(&mut self, name: &ast::Name) {
+        self.remember_name_tokens(name);
+        for tokens in name.name.windows(2) {
+            self.record_gap(
+                FormatCoverageCategory::QualifiedNameDot,
+                self.trivia.gap_between_tokens(&tokens[0], &tokens[1]),
+            );
+        }
+    }
+
+    fn record_component_reference_separators(&mut self, reference: &ast::ComponentReference) {
+        self.remember_component_reference_tokens(reference);
+        for parts in reference.parts.windows(2) {
+            self.record_gap(
+                FormatCoverageCategory::QualifiedNameDot,
+                self.trivia
+                    .gap_between_tokens(&parts[0].ident, &parts[1].ident),
+            );
+        }
+    }
+
+    fn record_import_gaps(&mut self, import: &ast::Import) {
+        match import {
+            ast::Import::Renamed { alias, path, .. } => {
+                self.remember_token(alias);
+                self.record_gap(
+                    FormatCoverageCategory::RenamedImportAssignment,
+                    self.trivia.gap_between_token_and_name(alias, path),
+                );
+            }
+            ast::Import::Selective { names, .. } => {
+                for name in names {
+                    self.remember_token(name);
                 }
-                result.push(c);
-                if needs_space_after_eq(chars.peek()) {
-                    result.push(' ');
+                for adjacent in names.windows(2) {
+                    self.record_gap(
+                        FormatCoverageCategory::SelectiveImportComma,
+                        self.trivia.gap_between_tokens(&adjacent[0], &adjacent[1]),
+                    );
                 }
             }
-            '+' | '-' | '*' | '/' => {
-                let unary_sign = is_unary_sign(c, prev_char, prev_non_space_char(&result));
-                if !unary_sign && needs_space_before_arith(prev_char, &result) {
-                    result.push(' ');
-                }
-                result.push(c);
-                if !unary_sign && needs_space_after_arith(chars.peek()) {
-                    result.push(' ');
-                } else if unary_sign && rules.tighten_unary_sign_spacing {
-                    skip_horizontal_whitespace(&mut chars);
-                }
-            }
-            ',' => {
-                result.push(c);
-                if needs_space_after_comma(chars.peek()) {
-                    result.push(' ');
-                }
-            }
-            _ => result.push(c),
+            ast::Import::Qualified { .. } | ast::Import::Unqualified { .. } => {}
         }
-
-        prev_char = c;
     }
 
-    (result, in_string, prev_char)
-}
-
-fn is_end_keyword(lower: &str) -> bool {
-    lower.starts_with("end ") || lower == "end;"
-}
-
-fn is_branch_keyword(lower: &str) -> bool {
-    lower.starts_with("else") || lower.starts_with("elseif")
-}
-
-fn is_section_header_keyword(lower: &str) -> bool {
-    lower.starts_with("equation")
-        || lower.starts_with("algorithm")
-        || lower.starts_with("initial equation")
-        || lower.starts_with("initial algorithm")
-        || lower.starts_with("public")
-        || lower.starts_with("protected")
-}
-
-fn is_block_header_keyword(lower: &str) -> bool {
-    lower.starts_with("model ")
-        || lower.starts_with("class ")
-        || lower.starts_with("block ")
-        || lower.starts_with("connector ")
-        || lower.starts_with("record ")
-        || lower.starts_with("type ")
-        || lower.starts_with("package ")
-        || lower.starts_with("function ")
-        || lower.starts_with("if ")
-        || lower.starts_with("for ")
-        || lower.starts_with("while ")
-        || lower.starts_with("when ")
-}
-
-fn prev_non_space_char(result: &str) -> Option<char> {
-    result.chars().rev().find(|c| !c.is_whitespace())
-}
-
-fn is_unary_sign(current: char, prev_char: char, prev_non_space: Option<char>) -> bool {
-    if !matches!(current, '+' | '-') {
-        return false;
+    fn record_expression_list_commas(&mut self, expressions: &[ast::Expression]) {
+        for adjacent in expressions.windows(2) {
+            self.record_gap(
+                FormatCoverageCategory::ExpressionListComma,
+                self.trivia
+                    .gap_between_expression_list_items(&adjacent[0], &adjacent[1]),
+            );
+        }
     }
-    if matches!(prev_char, 'e' | 'E') {
-        return true;
+
+    fn record_opening_parenthesis_padding(
+        &mut self,
+        target: &ast::ComponentReference,
+        args: &[ast::Expression],
+    ) {
+        let Some(first_arg) = args.first() else {
+            return;
+        };
+        self.record_gap(
+            FormatCoverageCategory::OpeningParenthesisPadding,
+            self.trivia.gap_after_call_open_paren(target, first_arg),
+        );
     }
-    matches!(
-        prev_non_space,
-        None | Some('(' | '[' | '{' | ',' | '=' | ':' | '+' | '-' | '*' | '/' | '^' | '<' | '>')
-    )
+
+    fn record_assert_opening_parenthesis_padding(&mut self, condition: &ast::Expression) {
+        self.record_gap(
+            FormatCoverageCategory::OpeningParenthesisPadding,
+            self.trivia
+                .gap_after_keyword_open_paren_before_expression("assert", condition),
+        );
+    }
+
+    fn record_component_modifier_opening_parenthesis_padding(
+        &mut self,
+        component: &ast::Component,
+    ) {
+        let Some(first_modification) = component.source_modifications.first() else {
+            return;
+        };
+        self.record_gap(
+            FormatCoverageCategory::OpeningParenthesisPadding,
+            self.trivia
+                .gap_after_token_open_paren(&component.name_token, first_modification),
+        );
+    }
+
+    fn record_subscript_commas(&mut self, subscripts: &[ast::Subscript]) {
+        for adjacent in subscripts.windows(2) {
+            self.record_gap(
+                FormatCoverageCategory::ArraySubscriptComma,
+                self.trivia
+                    .gap_between_subscripts(&adjacent[0], &adjacent[1]),
+            );
+        }
+    }
+
+    fn record_extend_modification_commas(&mut self, modifications: &[ast::ExtendModification]) {
+        for adjacent in modifications.windows(2) {
+            self.record_gap(
+                FormatCoverageCategory::ExpressionListComma,
+                self.trivia
+                    .gap_between_extend_modifications(&adjacent[0], &adjacent[1]),
+            );
+        }
+    }
+
+    fn record_component_gaps(&mut self, component: &ast::Component) {
+        self.remember_token(&component.name_token);
+        if let Some(first_type_part) = component.type_name.name.first()
+            && let Some(line) = self.trivia.line_before_token(first_type_part)
+        {
+            for gap in
+                declaration_prefix_gaps_before_token(line, &component_prefix_keywords(component))
+            {
+                self.record_gap(FormatCoverageCategory::ComponentPrefix, Some(gap));
+            }
+        }
+        let Some(gap) = self.component_type_name_gap(component) else {
+            return;
+        };
+        if self.should_preserve_component_alignment(component, &gap) {
+            self.record_gap(
+                FormatCoverageCategory::ComponentDeclarationAlignment,
+                Some(gap),
+            );
+        } else {
+            self.record_gap(FormatCoverageCategory::ComponentTypeName, Some(gap));
+        }
+        if let Some(binding) = &component.binding {
+            let gap = component
+                .source_modifications
+                .last()
+                .and_then(|last| {
+                    self.trivia
+                        .gap_between_expression_list_item_and_expression(last, binding)
+                })
+                .or_else(|| {
+                    self.trivia
+                        .gap_between_token_and_expression(&component.name_token, binding)
+                });
+            self.record_gap(FormatCoverageCategory::ComponentBindingAssignment, gap);
+        }
+    }
+
+    fn component_type_name_gap(&self, component: &ast::Component) -> Option<TriviaGap<'source>> {
+        if let Some(last_shape) = component.shape_expr.last()
+            && let Some(shape_span) = subscript_span(last_shape)
+            && shape_span.end.0 <= token_span(&component.name_token).start.0
+        {
+            return self
+                .trivia
+                .gap_between_spans(shape_span, token_span(&component.name_token));
+        }
+        self.trivia
+            .gap_between_name_and_token(&component.type_name, &component.name_token)
+    }
+
+    fn record_redeclare_modification_type_name_spacing(&mut self, expr: &ast::Expression) {
+        self.record_gap(
+            FormatCoverageCategory::ComponentTypeName,
+            self.redeclare_modification_type_name_gap(expr),
+        );
+    }
+
+    fn record_redeclare_modification_opening_parenthesis_padding(
+        &mut self,
+        expr: &ast::Expression,
+    ) {
+        let Some((target, modifications)) = redeclare_modification_class_target(expr) else {
+            return;
+        };
+        self.record_opening_parenthesis_padding(target, modifications);
+    }
+
+    fn record_class_modification_redeclare_gaps(
+        &mut self,
+        modifications: &[ast::Expression],
+        redeclare_flags: &[bool],
+    ) {
+        for (modification, redeclare) in modifications.iter().zip(redeclare_flags) {
+            if !*redeclare {
+                continue;
+            }
+            self.record_redeclare_modification_type_name_spacing(modification);
+            self.record_redeclare_modification_opening_parenthesis_padding(modification);
+        }
+    }
+
+    fn redeclare_modification_type_name_gap(
+        &self,
+        expr: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        let ast::Expression::Modification { target, value, .. } = expr else {
+            return None;
+        };
+        let ast::Expression::ClassModification {
+            target: replacement_type,
+            ..
+        } = value.as_ref()
+        else {
+            return None;
+        };
+        self.trivia.gap_between_tokens(
+            &replacement_type.parts.last()?.ident,
+            &target.parts.first()?.ident,
+        )
+    }
+
+    fn record_external_function_spacing(&mut self, external: &ast::ExternalFunction) {
+        if let Some(function_name) = &external.function_name
+            && let Some(first_arg) = external.args.first()
+        {
+            self.record_gap(
+                FormatCoverageCategory::OpeningParenthesisPadding,
+                self.trivia
+                    .gap_after_token_open_paren(function_name, first_arg),
+            );
+        }
+        self.record_expression_list_commas(&external.args);
+    }
+
+    fn record_extends_opening_parenthesis_padding(&mut self, ext: &ast::Extend) {
+        let Some(first_modification) = ext.modifications.first() else {
+            return;
+        };
+        self.record_gap(
+            FormatCoverageCategory::OpeningParenthesisPadding,
+            self.trivia
+                .gap_after_name_open_paren(&ext.base_name, &first_modification.expr),
+        );
+    }
+
+    fn should_preserve_component_alignment(
+        &self,
+        component: &ast::Component,
+        gap: &TriviaGap<'_>,
+    ) -> bool {
+        gap.is_multiple_spaces()
+            && (!is_builtin_scalar_type_name(&component.type_name)
+                || self
+                    .component_layout
+                    .has_nearby_declaration_line(component.name_token.location.start_line))
+    }
+
+    fn record_binary_operator(
+        &mut self,
+        op: &OpBinary,
+        lhs: &ast::Expression,
+        rhs: &ast::Expression,
+    ) {
+        if matches!(op, OpBinary::Assign | OpBinary::Empty) {
+            return;
+        }
+        self.record_gap(
+            FormatCoverageCategory::BinaryOperator,
+            self.trivia.gap_between_expressions(lhs, rhs),
+        );
+    }
+
+    fn record_argument_assignment(&mut self, expr: &ast::Expression) {
+        match expr {
+            ast::Expression::NamedArgument { name, value, .. } => {
+                self.record_gap(
+                    FormatCoverageCategory::ArgumentAssignment,
+                    self.trivia.gap_between_token_and_expression(name, value),
+                );
+            }
+            ast::Expression::Modification { target, value, .. } => {
+                self.record_gap(
+                    FormatCoverageCategory::ArgumentAssignment,
+                    self.trivia
+                        .gap_between_component_reference_and_expression(target, value),
+                );
+            }
+            ast::Expression::Binary {
+                op: OpBinary::Assign,
+                lhs,
+                rhs,
+                ..
+            } => {
+                self.record_gap(
+                    FormatCoverageCategory::ArgumentAssignment,
+                    self.trivia.gap_between_expressions(lhs, rhs),
+                );
+            }
+            _ => {}
+        }
+    }
 }
 
-fn skip_horizontal_whitespace(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
-    while matches!(chars.peek(), Some(' ' | '\t')) {
-        let _ = chars.next();
+impl ast::Visitor for AstTriviaCoverageCollector<'_, '_> {
+    fn enter_class_def(&mut self, class: &ast::ClassDef) -> ControlFlow<()> {
+        self.record_subscript_commas(&class.array_subscripts);
+        self.record_expression_list_commas(&class.annotation);
+        Continue(())
+    }
+
+    fn enter_scope(&mut self, scope: ast::VisitScope<'_>) -> ControlFlow<()> {
+        if let ast::VisitScope::Class(class) = scope {
+            self.record_class_gaps(class);
+        }
+        Continue(())
+    }
+
+    fn visit_type_name(&mut self, name: &ast::Name, ctx: ast::TypeNameContext) -> ControlFlow<()> {
+        if matches!(
+            ctx,
+            ast::TypeNameContext::ClassConstrainedBy | ast::TypeNameContext::ComponentConstrainedBy
+        ) {
+            self.record_gap(
+                FormatCoverageCategory::ConstrainedBy,
+                self.trivia
+                    .gap_after_keyword_before_name("constrainedby", name),
+            );
+        }
+        self.record_name_separators(name);
+        Continue(())
+    }
+
+    fn visit_name_ctx(&mut self, name: &ast::Name, _ctx: ast::NameContext) -> ControlFlow<()> {
+        self.record_name_separators(name);
+        Continue(())
+    }
+
+    fn enter_expression(&mut self, expr: &ast::Expression) -> ControlFlow<()> {
+        match expr {
+            ast::Expression::Terminal { token, .. } => {
+                self.remember_token(token);
+            }
+            ast::Expression::ComponentReference(_) | ast::Expression::FunctionCall { .. } => {}
+            ast::Expression::ClassModification {
+                target,
+                modifications,
+                redeclare_flags,
+                ..
+            } => {
+                self.record_opening_parenthesis_padding(target, modifications);
+                self.record_expression_list_commas(modifications);
+                self.record_class_modification_redeclare_gaps(modifications, redeclare_flags);
+            }
+            ast::Expression::NamedArgument { name, .. } => {
+                self.remember_token(name);
+                self.record_argument_assignment(expr);
+            }
+            ast::Expression::Modification { .. } => {
+                self.record_argument_assignment(expr);
+            }
+            ast::Expression::Binary { op, lhs, rhs, .. } => {
+                self.record_binary_operator(op, lhs, rhs);
+                if matches!(op, OpBinary::Assign) {
+                    self.record_argument_assignment(expr);
+                }
+            }
+            ast::Expression::Array { elements, .. } | ast::Expression::Tuple { elements, .. } => {
+                self.record_expression_list_commas(elements);
+            }
+            ast::Expression::ArrayIndex { subscripts, .. } => {
+                self.record_subscript_commas(subscripts);
+            }
+            _ => {}
+        }
+        Continue(())
+    }
+
+    fn enter_component_reference(
+        &mut self,
+        reference: &ast::ComponentReference,
+    ) -> ControlFlow<()> {
+        self.record_component_reference_separators(reference);
+        for part in &reference.parts {
+            if let Some(subscripts) = &part.subs {
+                self.record_subscript_commas(subscripts);
+            }
+        }
+        Continue(())
+    }
+
+    fn enter_expr_function_call(
+        &mut self,
+        target: &ast::ComponentReference,
+        args: &[ast::Expression],
+        _ctx: ast::FunctionCallContext,
+    ) -> ControlFlow<()> {
+        self.record_opening_parenthesis_padding(target, args);
+        self.record_expression_list_commas(args);
+        Continue(())
+    }
+
+    fn enter_equation_assert(
+        &mut self,
+        condition: &ast::Expression,
+        _message: &ast::Expression,
+        _level: Option<&ast::Expression>,
+    ) -> ControlFlow<()> {
+        self.record_assert_opening_parenthesis_padding(condition);
+        Continue(())
+    }
+
+    fn enter_statement_assert(
+        &mut self,
+        condition: &ast::Expression,
+        _message: &ast::Expression,
+        _level: Option<&ast::Expression>,
+    ) -> ControlFlow<()> {
+        self.record_assert_opening_parenthesis_padding(condition);
+        Continue(())
+    }
+
+    fn enter_external_function(&mut self, external: &ast::ExternalFunction) -> ControlFlow<()> {
+        self.record_external_function_spacing(external);
+        Continue(())
+    }
+
+    fn enter_import(&mut self, import: &ast::Import) -> ControlFlow<()> {
+        self.record_import_gaps(import);
+        Continue(())
+    }
+
+    fn enter_extend(&mut self, ext: &ast::Extend) -> ControlFlow<()> {
+        self.record_extend_modification_commas(&ext.modifications);
+        self.record_expression_list_commas(&ext.annotation);
+        self.record_extends_opening_parenthesis_padding(ext);
+        for modification in &ext.modifications {
+            if modification.redeclare {
+                self.record_redeclare_modification_type_name_spacing(&modification.expr);
+                self.record_redeclare_modification_opening_parenthesis_padding(&modification.expr);
+            }
+        }
+        self.record_gap(
+            FormatCoverageCategory::ExtendsBase,
+            self.trivia
+                .gap_after_keyword_before_name("extends", &ext.base_name),
+        );
+        Continue(())
+    }
+
+    fn enter_component(&mut self, component: &ast::Component) -> ControlFlow<()> {
+        self.record_subscript_commas(&component.shape_expr);
+        self.record_component_modifier_opening_parenthesis_padding(component);
+        self.record_expression_list_commas(&component.annotation);
+        self.record_expression_list_commas(&component.source_modifications);
+        for (modification, redeclare) in component
+            .source_modifications
+            .iter()
+            .zip(&component.source_modification_redeclare_flags)
+        {
+            if *redeclare {
+                self.record_redeclare_modification_type_name_spacing(modification);
+                self.record_redeclare_modification_opening_parenthesis_padding(modification);
+            }
+        }
+        self.record_component_gaps(component);
+        Continue(())
+    }
+
+    fn enter_simple_equation(
+        &mut self,
+        lhs: &ast::Expression,
+        rhs: &ast::Expression,
+    ) -> ControlFlow<()> {
+        self.record_gap(
+            FormatCoverageCategory::SimpleEquationAssignment,
+            self.trivia.gap_between_expressions(lhs, rhs),
+        );
+        Continue(())
+    }
+
+    fn enter_connect(
+        &mut self,
+        lhs: &ast::ComponentReference,
+        rhs: &ast::ComponentReference,
+    ) -> ControlFlow<()> {
+        self.remember_component_reference_tokens(lhs);
+        self.remember_component_reference_tokens(rhs);
+        self.record_gap(
+            FormatCoverageCategory::ConnectComma,
+            self.trivia.gap_between_component_references(lhs, rhs),
+        );
+        Continue(())
+    }
+
+    fn enter_for_index(&mut self, index: &ast::ForIndex) -> ControlFlow<()> {
+        self.remember_token(&index.ident);
+        self.record_gap(
+            FormatCoverageCategory::ForIndexIn,
+            self.trivia
+                .gap_between_token_and_expression(&index.ident, &index.range),
+        );
+        Continue(())
+    }
+
+    fn enter_assignment(
+        &mut self,
+        target: &ast::ComponentReference,
+        value: &ast::Expression,
+    ) -> ControlFlow<()> {
+        self.remember_component_reference_tokens(target);
+        self.record_gap(
+            FormatCoverageCategory::StatementAssignment,
+            self.trivia
+                .gap_between_component_reference_and_expression(target, value),
+        );
+        Continue(())
+    }
+
+    fn enter_statement_function_call(
+        &mut self,
+        target: &ast::ComponentReference,
+        _args: &[ast::Expression],
+        outputs: &[ast::Expression],
+    ) -> ControlFlow<()> {
+        self.remember_component_reference_tokens(target);
+        if let Some(last_output) = outputs.last() {
+            self.record_gap(
+                FormatCoverageCategory::StatementCallAssignment,
+                self.trivia
+                    .gap_between_expression_and_component_reference(last_output, target),
+            );
+        }
+        self.record_expression_list_commas(outputs);
+        Continue(())
+    }
+}
+
+impl ast::Visitor for AstTriviaReplacementCollector<'_, '_> {
+    fn enter_class_def(&mut self, class: &ast::ClassDef) -> ControlFlow<()> {
+        self.collect_subscript_commas(&class.array_subscripts);
+        self.collect_expression_list_commas(&class.annotation);
+        Continue(())
+    }
+
+    fn enter_scope(&mut self, scope: ast::VisitScope<'_>) -> ControlFlow<()> {
+        if let ast::VisitScope::Class(class) = scope {
+            self.collect_class_prefix_spacing(class);
+            self.collect_class_keyword_spacing(class);
+            self.collect_class_end_name_spacing(class);
+            self.collect_type_alias_assignment_spacing(class);
+        }
+        Continue(())
+    }
+
+    fn visit_type_name(&mut self, name: &ast::Name, ctx: ast::TypeNameContext) -> ControlFlow<()> {
+        if matches!(
+            ctx,
+            ast::TypeNameContext::ClassConstrainedBy | ast::TypeNameContext::ComponentConstrainedBy
+        ) {
+            self.collect_constrainedby_spacing(name);
+        }
+        self.collect_name_separators(name);
+        Continue(())
+    }
+
+    fn visit_name_ctx(&mut self, name: &ast::Name, _ctx: ast::NameContext) -> ControlFlow<()> {
+        self.collect_name_separators(name);
+        Continue(())
+    }
+
+    fn enter_expression(&mut self, expr: &ast::Expression) -> ControlFlow<()> {
+        match expr {
+            ast::Expression::Terminal { token, .. } => {
+                self.remember_token(token);
+            }
+            ast::Expression::Binary { op, lhs, rhs, .. } => {
+                self.collect_binary_operator_spacing(op, lhs, rhs);
+                if matches!(op, OpBinary::Assign) {
+                    self.collect_argument_assignment_spacing(expr);
+                }
+            }
+            ast::Expression::NamedArgument { name, .. } => {
+                self.remember_token(name);
+                self.collect_argument_assignment_spacing(expr);
+            }
+            ast::Expression::Modification { .. } => {
+                self.collect_argument_assignment_spacing(expr);
+            }
+            ast::Expression::Array { elements, .. } | ast::Expression::Tuple { elements, .. } => {
+                self.collect_expression_list_commas(elements);
+            }
+            ast::Expression::ArrayIndex { subscripts, .. } => {
+                self.collect_subscript_commas(subscripts);
+            }
+            ast::Expression::ClassModification {
+                target,
+                modifications,
+                redeclare_flags,
+                ..
+            } => {
+                self.collect_opening_parenthesis_padding(target, modifications);
+                self.collect_expression_list_commas(modifications);
+                self.collect_class_modification_redeclare_spacing(modifications, redeclare_flags);
+            }
+            _ => {}
+        }
+        Continue(())
+    }
+
+    fn enter_component_reference(
+        &mut self,
+        reference: &ast::ComponentReference,
+    ) -> ControlFlow<()> {
+        self.collect_component_reference_separators(reference);
+        for part in &reference.parts {
+            if let Some(subscripts) = &part.subs {
+                self.collect_subscript_commas(subscripts);
+            }
+        }
+        Continue(())
+    }
+
+    fn enter_expr_function_call(
+        &mut self,
+        target: &ast::ComponentReference,
+        args: &[ast::Expression],
+        _ctx: ast::FunctionCallContext,
+    ) -> ControlFlow<()> {
+        self.collect_opening_parenthesis_padding(target, args);
+        self.collect_expression_list_commas(args);
+        Continue(())
+    }
+
+    fn enter_equation_assert(
+        &mut self,
+        condition: &ast::Expression,
+        _message: &ast::Expression,
+        _level: Option<&ast::Expression>,
+    ) -> ControlFlow<()> {
+        self.collect_assert_opening_parenthesis_padding(condition);
+        Continue(())
+    }
+
+    fn enter_statement_assert(
+        &mut self,
+        condition: &ast::Expression,
+        _message: &ast::Expression,
+        _level: Option<&ast::Expression>,
+    ) -> ControlFlow<()> {
+        self.collect_assert_opening_parenthesis_padding(condition);
+        Continue(())
+    }
+
+    fn enter_external_function(&mut self, external: &ast::ExternalFunction) -> ControlFlow<()> {
+        self.collect_external_function_spacing(external);
+        Continue(())
+    }
+
+    fn enter_import(&mut self, import: &ast::Import) -> ControlFlow<()> {
+        self.collect_import_spacing(import);
+        Continue(())
+    }
+
+    fn enter_extend(&mut self, ext: &ast::Extend) -> ControlFlow<()> {
+        self.collect_extend_modification_commas(&ext.modifications);
+        self.collect_expression_list_commas(&ext.annotation);
+        self.collect_extends_opening_parenthesis_padding(ext);
+        for modification in &ext.modifications {
+            if modification.redeclare {
+                self.collect_redeclare_modification_type_name_spacing(&modification.expr);
+                self.collect_redeclare_modification_opening_parenthesis_padding(&modification.expr);
+            }
+        }
+        self.collect_extends_base_spacing(ext);
+        Continue(())
+    }
+
+    fn enter_component(&mut self, component: &ast::Component) -> ControlFlow<()> {
+        self.collect_subscript_commas(&component.shape_expr);
+        self.collect_component_modifier_opening_parenthesis_padding(component);
+        self.collect_expression_list_commas(&component.annotation);
+        self.collect_expression_list_commas(&component.source_modifications);
+        for (modification, redeclare) in component
+            .source_modifications
+            .iter()
+            .zip(&component.source_modification_redeclare_flags)
+        {
+            if *redeclare {
+                self.collect_redeclare_modification_type_name_spacing(modification);
+                self.collect_redeclare_modification_opening_parenthesis_padding(modification);
+            }
+        }
+        self.collect_component_prefix_spacing(component);
+        self.collect_component_type_name_spacing(component);
+        self.collect_component_binding_assignment(component);
+        Continue(())
+    }
+
+    fn enter_simple_equation(
+        &mut self,
+        lhs: &ast::Expression,
+        rhs: &ast::Expression,
+    ) -> ControlFlow<()> {
+        self.collect_simple_equation_assignment(lhs, rhs);
+        Continue(())
+    }
+
+    fn enter_connect(
+        &mut self,
+        lhs: &ast::ComponentReference,
+        rhs: &ast::ComponentReference,
+    ) -> ControlFlow<()> {
+        self.collect_connect_comma(lhs, rhs);
+        Continue(())
+    }
+
+    fn enter_for_index(&mut self, index: &ast::ForIndex) -> ControlFlow<()> {
+        self.collect_for_index_spacing(index);
+        Continue(())
+    }
+
+    fn enter_assignment(
+        &mut self,
+        target: &ast::ComponentReference,
+        value: &ast::Expression,
+    ) -> ControlFlow<()> {
+        self.collect_statement_assignment(target, value);
+        Continue(())
+    }
+
+    fn enter_statement_function_call(
+        &mut self,
+        target: &ast::ComponentReference,
+        _args: &[ast::Expression],
+        outputs: &[ast::Expression],
+    ) -> ControlFlow<()> {
+        self.collect_statement_call_output_assignment(outputs, target);
+        self.collect_expression_list_commas(outputs);
+        Continue(())
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_format_error_uses_explicit_source_name() {
-        let source = "model M Real x end M;";
-        let err = format_with_source_name(source, &FormatOptions::default(), "test_input.mo")
-            .expect_err("expected syntax error");
-        let rendered = err.to_string();
-        assert!(rendered.contains("test_input.mo"));
-    }
-
-    #[test]
-    fn test_format_ball_model_canonical_profile() {
-        let source = r#"model Ball
-  Real x(start = 10);
-  Real v;
-  equation
-    der(x) = 2 * v;
-    der(v) = - 9.8;
-    when (x < 0) then
-      reinit(v, - 0.8 * pre(v));
-    end when;
-  end Ball;
-"#;
-        let expected = r#"model Ball
-  Real x(start = 10);
-  Real v;
-equation
-  der(x) = 2 * v;
-  der(v) = -9.8;
-  when (x < 0) then
-    reinit(v, -0.8 * pre(v));
-  end when;
-end Ball;
-"#;
-        let formatted = format(
-            source,
-            &FormatOptions {
-                profile: FormatProfile::Canonical,
-                ..FormatOptions::default()
-            },
-        )
-        .expect("format");
-        assert_eq!(formatted, expected);
-    }
-
-    #[test]
-    fn test_format_ball_model_msl_profile_preserves_section_indent_and_unary_spacing() {
-        let source = r#"model Ball
-  Real x(start = 10);
-  Real v;
-  equation
-    der(x) = 2 * v;
-    der(v) = - 9.8;
-    when (x < 0) then
-      reinit(v, - 0.8 * pre(v));
-    end when;
-  end Ball;
-"#;
-        let formatted = format(source, &FormatOptions::default()).expect("format");
-        assert_eq!(formatted, source);
-    }
-
-    #[test]
-    fn test_multiline_string_is_preserved() {
-        let source = r#"model C
-  annotation(Documentation(info="<html>
-<p>This function returns <em>re</em> and <em>im</em>.</p>
-</html>"));
-end C;
-"#;
-        let formatted = format(source, &FormatOptions::default()).expect("format");
-        assert!(formatted.contains("info = \"<html>"));
-        assert!(formatted.contains("<p>This function returns <em>re</em> and <em>im</em>.</p>"));
-        assert!(formatted.contains("</html>"));
-    }
-
-    #[test]
-    fn test_quoted_operator_identifier_is_preserved() {
-        let source = r#"operator '-'
-end '-';
-"#;
-        let formatted = format(source, &FormatOptions::default()).expect("format");
-        assert_eq!(formatted, source);
-    }
-}
+mod tests;

--- a/crates/rumoca-tool-fmt/src/formatter/coverage.rs
+++ b/crates/rumoca-tool-fmt/src/formatter/coverage.rs
@@ -1,0 +1,139 @@
+/// Per-category formatter coverage over classified AST trivia gaps.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FormatCoverageReport {
+    /// Total eligible single-line trivia gaps.
+    pub eligible_gaps: usize,
+    /// Eligible gaps controlled by the active formatter options.
+    pub covered_gaps: usize,
+    /// Coverage split by whitespace category.
+    pub categories: Vec<FormatCoverageCategoryReport>,
+    /// First few unclassified gap examples for diagnosis.
+    pub unclassified_examples: Vec<String>,
+}
+
+impl FormatCoverageReport {
+    pub(super) fn new() -> Self {
+        Self {
+            eligible_gaps: 0,
+            covered_gaps: 0,
+            categories: Vec::new(),
+            unclassified_examples: Vec::new(),
+        }
+    }
+
+    pub(super) fn record(&mut self, category: FormatCoverageCategory, covered: bool) {
+        self.eligible_gaps += 1;
+        if covered {
+            self.covered_gaps += 1;
+        }
+        if let Some(entry) = self
+            .categories
+            .iter_mut()
+            .find(|entry| entry.category == category)
+        {
+            entry.eligible_gaps += 1;
+            if covered {
+                entry.covered_gaps += 1;
+            }
+            return;
+        }
+        self.categories.push(FormatCoverageCategoryReport {
+            category,
+            eligible_gaps: 1,
+            covered_gaps: usize::from(covered),
+        });
+    }
+
+    pub(super) fn record_unclassified_example(&mut self, example: String) {
+        if self.unclassified_examples.len() < 8
+            && !self
+                .unclassified_examples
+                .iter()
+                .any(|existing| existing == &example)
+        {
+            self.unclassified_examples.push(example);
+        }
+    }
+
+    /// Coverage as a percentage, where an empty report is considered complete.
+    pub fn coverage_percent(&self) -> f64 {
+        if self.eligible_gaps == 0 {
+            return 100.0;
+        }
+        self.covered_gaps as f64 * 100.0 / self.eligible_gaps as f64
+    }
+}
+
+/// Coverage for one formatter whitespace category.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormatCoverageCategoryReport {
+    /// Whitespace category.
+    pub category: FormatCoverageCategory,
+    /// Eligible single-line trivia gaps in this category.
+    pub eligible_gaps: usize,
+    /// Gaps controlled by the active formatter options.
+    pub covered_gaps: usize,
+}
+
+/// Formatter-controlled AST trivia category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FormatCoverageCategory {
+    ClassPrefix,
+    ClassKeywordName,
+    ClassEndName,
+    TypeAliasAssignment,
+    QualifiedNameDot,
+    RenamedImportAssignment,
+    SelectiveImportComma,
+    ComponentPrefix,
+    ComponentTypeName,
+    ComponentDeclarationAlignment,
+    ComponentBindingAssignment,
+    ArraySubscriptComma,
+    SimpleEquationAssignment,
+    StatementAssignment,
+    StatementCallAssignment,
+    StatementSeparator,
+    ArgumentAssignment,
+    OpeningParenthesisPadding,
+    ExpressionListComma,
+    ConnectComma,
+    ExtendsBase,
+    ConstrainedBy,
+    ForIndexIn,
+    BinaryOperator,
+    Unclassified,
+}
+
+impl FormatCoverageCategory {
+    /// Stable label used in coverage reports.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::ClassPrefix => "class-prefix",
+            Self::ClassKeywordName => "class-keyword-name",
+            Self::ClassEndName => "class-end-name",
+            Self::TypeAliasAssignment => "type-alias-assignment",
+            Self::QualifiedNameDot => "qualified-name-dot",
+            Self::RenamedImportAssignment => "renamed-import-assignment",
+            Self::SelectiveImportComma => "selective-import-comma",
+            Self::ComponentPrefix => "component-prefix",
+            Self::ComponentTypeName => "component-type-name",
+            Self::ComponentDeclarationAlignment => "component-declaration-alignment",
+            Self::ComponentBindingAssignment => "component-binding-assignment",
+            Self::ArraySubscriptComma => "array-subscript-comma",
+            Self::SimpleEquationAssignment => "simple-equation-assignment",
+            Self::StatementAssignment => "statement-assignment",
+            Self::StatementCallAssignment => "statement-call-assignment",
+            Self::StatementSeparator => "statement-separator",
+            Self::ArgumentAssignment => "argument-assignment",
+            Self::OpeningParenthesisPadding => "opening-parenthesis-padding",
+            Self::ExpressionListComma => "expression-list-comma",
+            Self::ConnectComma => "connect-comma",
+            Self::ExtendsBase => "extends-base",
+            Self::ConstrainedBy => "constrainedby",
+            Self::ForIndexIn => "for-index-in",
+            Self::BinaryOperator => "binary-operator",
+            Self::Unclassified => "unclassified",
+        }
+    }
+}

--- a/crates/rumoca-tool-fmt/src/formatter/dymola.rs
+++ b/crates/rumoca-tool-fmt/src/formatter/dymola.rs
@@ -1,0 +1,500 @@
+use crate::format_options::{FormatOptions, LineEnding};
+
+pub(super) fn can_trim_trailing_whitespace(line: &str, state: &DymolaFormatState) -> bool {
+    if state.in_string || state.in_quoted_identifier || state.in_block_comment {
+        return false;
+    }
+
+    let mut probe = state.clone();
+    update_format_state(line, &mut probe);
+    !probe.in_string && !probe.in_quoted_identifier && !probe.in_block_comment
+}
+
+#[derive(Clone, Default)]
+pub(super) struct DymolaFormatState {
+    section: FormatSection,
+    in_string: bool,
+    in_quoted_identifier: bool,
+    in_block_comment: bool,
+    previous_line_continues: bool,
+    paren_depth: usize,
+    brace_depth: usize,
+    bracket_depth: usize,
+    prev_char: char,
+    statement_continuation: bool,
+    comment_anchored_layout: bool,
+}
+
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+enum FormatSection {
+    #[default]
+    Declaration,
+    Equation,
+    Algorithm,
+}
+
+pub(super) fn target_line_ending(source: &str, setting: LineEnding) -> &'static str {
+    match setting {
+        LineEnding::Lf => "\n",
+        LineEnding::Crlf => "\r\n",
+        LineEnding::Auto => {
+            let crlf_count = source
+                .as_bytes()
+                .windows(2)
+                .filter(|w| *w == b"\r\n")
+                .count();
+            let lf_count = source.as_bytes().iter().filter(|&&b| b == b'\n').count();
+            if crlf_count > lf_count.saturating_sub(crlf_count) {
+                "\r\n"
+            } else {
+                "\n"
+            }
+        }
+    }
+}
+
+pub(super) fn format_dymola_line(
+    line: &str,
+    options: &FormatOptions,
+    indent_level: &mut usize,
+    state: &mut DymolaFormatState,
+) -> String {
+    if line.trim().is_empty() {
+        if state.in_string || state.in_quoted_identifier || state.in_block_comment {
+            update_format_state(line, state);
+            return line.to_string();
+        }
+        state.previous_line_continues = false;
+        state.comment_anchored_layout = false;
+        return String::new();
+    }
+
+    let line = if options.normalize_indentation {
+        normalized_indented_line(line, options, indent_level, state)
+    } else if options.repair_missing_indentation {
+        repair_missing_indented_line(line, options, indent_level, state)
+    } else {
+        line.to_string()
+    };
+
+    update_format_state(&line, state);
+    line
+}
+
+fn normalized_indented_line(
+    line: &str,
+    options: &FormatOptions,
+    indent_level: &mut usize,
+    state: &DymolaFormatState,
+) -> String {
+    let trimmed = line.trim_start_matches([' ', '\t']);
+
+    if should_preserve_leading_whitespace(trimmed, state) {
+        return line.to_string();
+    }
+
+    if should_preserve_comment_anchored_layout(trimmed, state) {
+        let _ = update_indent_level_for_line(trimmed, indent_level);
+        return line.to_string();
+    }
+
+    let visual_indent = update_indent_level_for_line(trimmed, indent_level);
+    indented_line(trimmed, options, visual_indent)
+}
+
+fn repair_missing_indented_line(
+    line: &str,
+    options: &FormatOptions,
+    indent_level: &mut usize,
+    state: &DymolaFormatState,
+) -> String {
+    let trimmed = line.trim_start_matches([' ', '\t']);
+
+    if should_preserve_leading_whitespace(trimmed, state) {
+        return line.to_string();
+    }
+
+    let visual_indent = update_indent_level_for_line(trimmed, indent_level);
+    let has_existing_indent = trimmed.len() != line.len();
+    if has_existing_indent
+        || visual_indent == 0
+        || should_preserve_unindented_layout_line(trimmed)
+        || !should_repair_missing_indentation_line(trimmed, state)
+    {
+        return line.to_string();
+    }
+
+    indented_line(trimmed, options, visual_indent)
+}
+
+fn should_repair_missing_indentation_line(trimmed: &str, state: &DymolaFormatState) -> bool {
+    match state.section {
+        FormatSection::Equation => false,
+        FormatSection::Declaration => is_builtin_scalar_declaration(trimmed),
+        FormatSection::Algorithm => false,
+    }
+}
+
+fn is_builtin_scalar_declaration(trimmed: &str) -> bool {
+    let mut rest = trimmed;
+    loop {
+        let Some((word, tail)) = split_first_word(rest) else {
+            return false;
+        };
+        if matches!(
+            word,
+            "final"
+                | "parameter"
+                | "constant"
+                | "discrete"
+                | "input"
+                | "output"
+                | "flow"
+                | "stream"
+        ) {
+            rest = tail.trim_start();
+            continue;
+        }
+        return matches!(word, "Real" | "Integer" | "Boolean" | "String");
+    }
+}
+
+fn split_first_word(input: &str) -> Option<(&str, &str)> {
+    let trimmed = input.trim_start();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let end = trimmed
+        .char_indices()
+        .find_map(|(index, c)| {
+            if c.is_whitespace() || matches!(c, '(' | '[' | ';') {
+                Some(index)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(trimmed.len());
+    Some((&trimmed[..end], &trimmed[end..]))
+}
+
+fn should_preserve_unindented_layout_line(trimmed: &str) -> bool {
+    let lower = trimmed.to_ascii_lowercase();
+    is_class_open_keyword(&lower)
+        || is_dedent_keyword(&lower)
+        || is_section_keyword(&lower)
+        || lower.starts_with("extends ")
+        || lower.starts_with("import ")
+        || lower.starts_with("within ")
+        || lower.starts_with("annotation")
+        || lower.starts_with("connect(")
+        || lower.starts_with("public")
+        || lower.starts_with("protected")
+}
+
+fn indented_line(trimmed: &str, options: &FormatOptions, visual_indent: usize) -> String {
+    let mut normalized = String::new();
+    let unit = if options.use_tabs {
+        "\t".to_string()
+    } else {
+        " ".repeat(options.indent_size)
+    };
+    for _ in 0..visual_indent {
+        normalized.push_str(&unit);
+    }
+    normalized.push_str(trimmed);
+    normalized
+}
+
+fn update_indent_level_for_line(trimmed: &str, indent_level: &mut usize) -> usize {
+    let lower = trimmed.to_ascii_lowercase();
+    let section = is_section_keyword(&lower);
+    let branch = is_branch_keyword(&lower);
+    if is_dedent_keyword(&lower) || branch {
+        *indent_level = indent_level.saturating_sub(1);
+    }
+
+    let visual_indent = if section {
+        indent_level.saturating_sub(1)
+    } else {
+        *indent_level
+    };
+
+    if is_indent_keyword(&lower) || branch {
+        *indent_level += 1;
+    }
+    visual_indent
+}
+
+fn should_preserve_leading_whitespace(trimmed: &str, state: &DymolaFormatState) -> bool {
+    state.in_string
+        || state.in_quoted_identifier
+        || state.in_block_comment
+        || state.previous_line_continues
+        || state.paren_depth > 0
+        || state.brace_depth > 0
+        || state.bracket_depth > 0
+        || trimmed.starts_with('"')
+        || trimmed.starts_with("annotation")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with("//")
+}
+
+fn should_preserve_comment_anchored_layout(trimmed: &str, state: &DymolaFormatState) -> bool {
+    state.comment_anchored_layout && !is_comment_anchor_boundary(trimmed)
+}
+
+fn is_comment_anchor_boundary(trimmed: &str) -> bool {
+    let lower = trimmed.to_ascii_lowercase();
+    trimmed.is_empty()
+        || is_section_keyword(&lower)
+        || is_class_open_keyword(&lower)
+        || is_branch_keyword(&lower)
+        || lower.starts_with("end if")
+        || lower.starts_with("end when")
+        || lower.starts_with("annotation")
+}
+
+fn update_format_state(line: &str, state: &mut DymolaFormatState) {
+    let was_in_block_comment = state.in_block_comment;
+    update_format_section(line, state);
+    let started_as_layout_comment = is_layout_comment_line(line, state);
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        if state.in_block_comment {
+            if c == '*' && matches!(chars.peek(), Some('/')) {
+                let _ = chars.next();
+                state.in_block_comment = false;
+                state.prev_char = '/';
+            } else {
+                state.prev_char = c;
+            }
+            continue;
+        }
+        if !state.in_quoted_identifier && c == '"' && state.prev_char != '\\' {
+            state.in_string = !state.in_string;
+            state.prev_char = c;
+            continue;
+        }
+        if !state.in_string && c == '\'' {
+            state.in_quoted_identifier = !state.in_quoted_identifier;
+            state.prev_char = c;
+            continue;
+        }
+        if !state.in_string && !state.in_quoted_identifier {
+            if c == '/' && matches!(chars.peek(), Some('/')) {
+                state.prev_char = '/';
+                break;
+            }
+            if c == '/' && matches!(chars.peek(), Some('*')) {
+                let _ = chars.next();
+                state.in_block_comment = true;
+                state.prev_char = '*';
+                continue;
+            }
+            match c {
+                '(' => state.paren_depth += 1,
+                ')' => state.paren_depth = state.paren_depth.saturating_sub(1),
+                '{' => state.brace_depth += 1,
+                '}' => state.brace_depth = state.brace_depth.saturating_sub(1),
+                '[' => state.bracket_depth += 1,
+                ']' => state.bracket_depth = state.bracket_depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+        state.prev_char = c;
+    }
+    finish_line_state(line, state);
+    update_comment_anchored_layout(line, state, was_in_block_comment, started_as_layout_comment);
+}
+
+fn finish_line_state(line: &str, state: &mut DymolaFormatState) {
+    let was_statement_continuation = state.statement_continuation;
+    let continues = line_continues(line, state);
+    let lower = line.trim().to_ascii_lowercase();
+    state.statement_continuation =
+        continues && (was_statement_continuation || starts_statement_continuation(&lower));
+    state.previous_line_continues = continues;
+}
+
+fn update_format_section(line: &str, state: &mut DymolaFormatState) {
+    if state.in_string || state.in_quoted_identifier {
+        return;
+    }
+    let lower = line.trim_start().to_ascii_lowercase();
+    if lower.starts_with("initial equation") || lower.starts_with("equation") {
+        state.section = FormatSection::Equation;
+    } else if lower.starts_with("initial algorithm") || lower.starts_with("algorithm") {
+        state.section = FormatSection::Algorithm;
+    } else if lower.starts_with("public")
+        || lower.starts_with("protected")
+        || is_class_end_keyword(&lower)
+    {
+        state.section = FormatSection::Declaration;
+    }
+}
+
+fn is_class_end_keyword(lower: &str) -> bool {
+    (lower.starts_with("end ") || lower == "end;") && !is_control_end_keyword(lower)
+}
+
+fn is_control_end_keyword(lower: &str) -> bool {
+    lower.starts_with("end if")
+        || lower.starts_with("end for")
+        || lower.starts_with("end while")
+        || lower.starts_with("end when")
+}
+
+fn is_layout_comment_line(line: &str, state: &DymolaFormatState) -> bool {
+    if !matches!(
+        state.section,
+        FormatSection::Equation | FormatSection::Algorithm
+    ) {
+        return false;
+    }
+    let trimmed = line.trim_start();
+    trimmed.starts_with("//") || trimmed.starts_with("/*")
+}
+
+fn update_comment_anchored_layout(
+    line: &str,
+    state: &mut DymolaFormatState,
+    was_in_block_comment: bool,
+    started_as_layout_comment: bool,
+) {
+    if state.in_string || state.in_quoted_identifier {
+        return;
+    }
+
+    let trimmed = line.trim_start();
+    if is_comment_anchor_boundary(trimmed) {
+        state.comment_anchored_layout = false;
+        return;
+    }
+
+    if started_as_layout_comment && !state.in_block_comment {
+        state.comment_anchored_layout = true;
+        return;
+    }
+
+    if was_in_block_comment && !state.in_block_comment {
+        state.comment_anchored_layout = true;
+    }
+}
+
+fn line_continues(line: &str, state: &DymolaFormatState) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if state.in_string || state.in_block_comment {
+        return true;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if is_section_keyword(&lower)
+        || is_class_open_keyword(&lower)
+        || is_dedent_keyword(&lower)
+        || is_statement_branch(&lower, state)
+        || lower.ends_with(';')
+        || is_statement_then(&lower, state)
+        || is_statement_loop(&lower, state)
+        || is_statement_else(&lower, state)
+        || lower.starts_with("/*")
+        || lower.starts_with('*')
+        || lower.ends_with("*/")
+        || lower.starts_with("//")
+    {
+        return false;
+    }
+
+    true
+}
+
+fn is_dedent_keyword(lower: &str) -> bool {
+    lower.starts_with("end ") || lower == "end;"
+}
+
+fn is_indent_keyword(lower: &str) -> bool {
+    is_class_open_keyword(lower)
+        || lower.starts_with("if ")
+        || lower.starts_with("for ")
+        || lower.starts_with("while ")
+        || lower.starts_with("when ")
+}
+
+fn is_class_open_keyword(lower: &str) -> bool {
+    let mut lowered = lower;
+    if lowered.starts_with("operator ") {
+        return true;
+    }
+    for prefix in [
+        "encapsulated ",
+        "partial ",
+        "operator ",
+        "expandable ",
+        "pure ",
+        "impure ",
+    ] {
+        if let Some(stripped) = lowered.strip_prefix(prefix) {
+            lowered = stripped;
+            if lowered.starts_with("operator ") {
+                return true;
+            }
+        }
+    }
+    lowered.starts_with("model ")
+        || lowered.starts_with("class ")
+        || lowered.starts_with("block ")
+        || lowered.starts_with("connector ")
+        || lowered.starts_with("record ")
+        || lowered.starts_with("type ")
+        || lowered.starts_with("package ")
+        || lowered.starts_with("function ")
+}
+
+fn is_section_keyword(lower: &str) -> bool {
+    matches!(
+        lower,
+        "equation"
+            | "algorithm"
+            | "initial equation"
+            | "initial algorithm"
+            | "public"
+            | "protected"
+    )
+}
+
+fn is_branch_keyword(lower: &str) -> bool {
+    lower.starts_with("else") || lower.starts_with("elseif ")
+}
+
+fn is_statement_branch(lower: &str, state: &DymolaFormatState) -> bool {
+    !state.previous_line_continues
+        && (lower.starts_with("else") && !lower.starts_with("elseif ")
+            || lower.starts_with("elseif ") && lower.ends_with(" then"))
+}
+
+fn is_statement_then(lower: &str, state: &DymolaFormatState) -> bool {
+    (!state.previous_line_continues || state.statement_continuation)
+        && lower.ends_with(" then")
+        && (state.statement_continuation
+            || lower.starts_with("if ")
+            || lower.starts_with("elseif "))
+}
+
+fn is_statement_loop(lower: &str, state: &DymolaFormatState) -> bool {
+    (!state.previous_line_continues || state.statement_continuation)
+        && lower.ends_with(" loop")
+        && (state.statement_continuation
+            || lower.starts_with("for ")
+            || lower.starts_with("while "))
+}
+
+fn is_statement_else(lower: &str, state: &DymolaFormatState) -> bool {
+    !state.previous_line_continues && lower.ends_with(" else")
+}
+
+fn starts_statement_continuation(lower: &str) -> bool {
+    ((lower.starts_with("if ") || lower.starts_with("elseif ")) && !lower.ends_with(" then"))
+        || ((lower.starts_with("for ") || lower.starts_with("while ")) && !lower.ends_with(" loop"))
+}

--- a/crates/rumoca-tool-fmt/src/formatter/tests.rs
+++ b/crates/rumoca-tool-fmt/src/formatter/tests.rs
@@ -1,0 +1,766 @@
+use super::*;
+use crate::format_options::{FormatProfile, LineEnding};
+
+#[test]
+fn test_format_error_uses_explicit_source_name() {
+    let source = "model M Real x end M;";
+    let err = format_with_source_name(source, &FormatOptions::default(), "test_input.mo")
+        .expect_err("expected syntax error");
+    let rendered = err.to_string();
+    assert!(rendered.contains("test_input.mo"));
+}
+
+#[test]
+fn test_default_dymola_format_preserves_compact_equation_spacing() {
+    let source = "model Ball\n  Real x(start=10);\nequation\n  x=1;\n  y = 2;\nend Ball;";
+    let expected = "model Ball\n  Real x(start=10);\nequation\n  x=1;\n  y = 2;\nend Ball;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_default_dymola_format_preserves_compact_statement_assignment_spacing() {
+    let source = "function f\noutput Real y;\nalgorithm\ny:=1;\nend f;";
+    let expected = "function f\n  output Real y;\nalgorithm\ny:=1;\nend f;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_default_dymola_format_preserves_compact_statement_call_output_spacing() {
+    let source = "function f\noutput Real a;\noutput Real b;\nalgorithm\n(a,b):=g();\nend f;";
+    let expected =
+        "function f\n  output Real a;\n  output Real b;\nalgorithm\n(a,b):=g();\nend f;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_default_dymola_format_preserves_compact_expression_list_commas() {
+    let source = "model C\n  Real x = f(1,2, 3, a=4, b =5);\n  Real y[3] = {1,2, 3};\nend C;";
+    let expected = "model C\n  Real x = f(1,2, 3, a=4, b =5);\n  Real y[3] = {1,2, 3};\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_default_dymola_format_preserves_argument_assignment_spacing() {
+    let source = "model C\n  Real x(start = 1);\nequation\n  y = f(a = 1, b=2);\nend C;";
+    let expected = "model C\n  Real x(start = 1);\nequation\n  y = f(a = 1, b=2);\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_default_dymola_format_preserves_component_binding_spacing() {
+    let source = "model C\n  parameter Real k=1;\n  Real x = k;\nend C;";
+    let expected = "model C\n  parameter Real k=1;\n  Real x = k;\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_default_dymola_format_preserves_compact_binary_operator_spacing() {
+    let source = "model C\n  Real x;\nequation\n  x=1+2*3;\nend C;";
+    let expected = "model C\n  Real x;\nequation\n  x=1+2*3;\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_default_dymola_format_preserves_compact_connect_commas() {
+    let source = "connector Pin\n  Real v;\n  flow Real i;\nend Pin;\nmodel C\n  Pin a;\n  Pin b;\nequation\n  connect(a,b);\nend C;";
+    let expected = "connector Pin\n  Real v;\n  flow Real i;\nend Pin;\nmodel C\n  Pin a;\n  Pin b;\nequation\n  connect(a,b);\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_normalizes_class_keyword_name_spacing_from_ast() {
+    let source = "package P\nmodel   C\nReal x;\nend C;\nend P;";
+    let expected = "package P\nmodel C\n    Real x;\nend C;\nend P;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_normalizes_class_prefix_spacing_from_ast() {
+    let source = "package P\npartial   model   C\nend C;\nimpure   function   f\nend f;\noperator   record   R\nend R;\nexpandable   connector   Bus\nend Bus;\nreplaceable   model   Medium\nend Medium;\nfinal   model   Fixed\nend Fixed;\nend P;";
+    let expected = "package P\npartial model C\nend C;\nimpure function f\nend f;\noperator record R\nend R;\nexpandable connector Bus\nend Bus;\nreplaceable model Medium\nend Medium;\nfinal model Fixed\nend Fixed;\nend P;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_normalizes_class_end_name_spacing_from_ast() {
+    let source = "model C\nReal x;\nend   C;";
+    let expected = "model C\n  Real x;\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_preserves_type_alias_assignment_spacing() {
+    let source = "type Voltage=Real;";
+    let expected = "type Voltage=Real;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_format_normalizes_type_alias_assignment_from_ast() {
+    let source =
+        "type   Voltage=   Real;\npackage Medium= Modelica.Media.Interfaces.PartialMedium;";
+    let expected =
+        "type Voltage = Real;\n  package Medium = Modelica.Media.Interfaces.PartialMedium;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_normalizes_type_alias_array_modifier_spacing() {
+    let source = "type RotationSequence = Modelica.Icons.TypeInteger[3] (min={1,1,1});";
+    let expected = "type RotationSequence = Modelica.Icons.TypeInteger[3](min={1, 1, 1});\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_normalizes_component_type_name_spacing_from_ast() {
+    let source = "model C\nReal   x;\nend C;";
+    let expected = "model C\n  Real x;\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_normalizes_component_prefix_spacing_from_ast() {
+    let source = "model C\ninput   Real   u;\nparameter   Real   k;\nfinal   constant   Real c;\n  replaceable   Real r;\n  inner   outer   StateGraphRoot root;\nend C;";
+    let expected = "model C\n  input Real   u;\n  parameter Real   k;\n  final constant Real c;\n  replaceable Real r;\n  inner outer StateGraphRoot root;\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_preserves_aligned_component_declarations() {
+    let source = "model C\n  SI.Velocity v;\n  SI.Length   l;\nend C;";
+    let expected = "model C\n  SI.Velocity v;\n  SI.Length   l;\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_normalizes_qualified_name_separators_from_ast() {
+    let source = "within Modelica . Blocks;\nmodel C\n  Modelica . Units . SI . Angle phi;\nend C;";
+    let expected = "within Modelica.Blocks;\nmodel C\n  Modelica.Units.SI.Angle phi;\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_normalizes_import_spacing_from_ast() {
+    let source = "model C\nimport SI   =   Modelica . Units . SI;\nimport Modelica.Utilities.{Streams,  Files};\nend C;";
+    let expected = "model C\nimport SI = Modelica.Units.SI;\nimport Modelica.Utilities.{Streams, Files};\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_normalizes_extends_and_constrainedby_spacing_from_ast() {
+    let source =
+        "model C\n  extends   Base;\n  replaceable Real r constrainedby   PartialReal;\nend C;";
+    let expected =
+        "model C\n  extends Base;\n  replaceable Real r constrainedby PartialReal;\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_normalizes_for_index_spacing_from_ast() {
+    let source = "model C\nalgorithm\nfor i   in   1:3 loop\nend for;\nend C;";
+    let expected = "model C\nalgorithm\nfor i in 1:3 loop\nend for;\nend C;\n";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_can_normalize_equation_spacing() {
+    let source = "model Ball\n  Real x(start=10);\nequation\n  x=1;\n  y =2;\nend Ball;";
+    let expected = "model Ball\n  Real x(start=10);\nequation\n  x = 1;\n  y = 2;\nend Ball;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_equation_spacing: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_can_normalize_component_binding_spacing() {
+    let source = "model C\nparameter Real k=1;\nReal y(start= 1)=k;\nend C;";
+    let expected = "model C\n  parameter Real k = 1;\n  Real y(start= 1) = k;\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_equation_spacing: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_can_normalize_statement_assignment_spacing() {
+    let source = "function f\noutput Real y;\nalgorithm\ny:=1;\nz :=2;\nend f;";
+    let expected = "function f\n  output Real y;\nalgorithm\ny := 1;\nz := 2;\nend f;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_equation_spacing: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_format_can_normalize_statement_call_output_spacing() {
+    let source =
+        "function f\noutput Real a;\noutput Real b;\nalgorithm\n(a,b):=g();\n(c, d) :=h();\nend f;";
+    let expected = "function f\n  output Real a;\n  output Real b;\nalgorithm\n(a,b) := g();\n(c, d) := h();\nend f;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_equation_spacing: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_format_dymola_profile_preserves_modifier_spacing_and_normalizes_equations() {
+    let source = "model DymolaStyle\r\n  Real x(start=1);  \r\n  Real y;\r\n\r\nequation\r\n  der(x)=y;\r\n  y=-9.8;\r\nend DymolaStyle;";
+    let expected = "model DymolaStyle\r\n  Real x(start=1);\r\n  Real y;\r\n\r\nequation\r\n  der(x) = y;\r\n  y = -9.8;\r\nend DymolaStyle;\r\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            profile: FormatProfile::Dymola,
+            normalize_equation_spacing: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_normalizes_spacing_and_indentation_defaults() {
+    let source = "model C\nReal x;\nequation\nx=1;\nend C;";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(
+        formatted,
+        "model C\n  Real x;\nequation\n  x = 1;\nend C;\n"
+    );
+}
+
+#[test]
+fn test_canonical_profile_normalizes_expression_list_commas() {
+    let source = "function f\noutput Real a;\noutput Real b;\nalgorithm\n(a,b):=g(1,2, 3);\nx := h(a=1,b=2);\ny := {1,2, 3};\nend f;";
+    let expected = "function f\n  output Real a;\n  output Real b;\nalgorithm\n  (a, b) := g(1, 2, 3);\n  x := h(a=1, b=2);\n  y := {1, 2, 3};\nend f;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_compacts_argument_assignment_spacing() {
+    let source = "model C\n  extends Base(use_reset = false, k= 2, u(unit = \"K\"),y(unit = \"s\"));\nReal y(start = 1, fixed= true) = 3;\nequation\ny = f(a = 1,b = 2);\nend C;";
+    let expected = "model C\n  extends Base(use_reset=false, k=2, u(unit=\"K\"), y(unit=\"s\"));\n  Real y(start=1, fixed=true) = 3;\nequation\n  y = f(a=1, b=2);\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_removes_call_opening_parenthesis_padding() {
+    let source = "model C\n  extends Base ( k = 1);\n  Real x(        fixed = false);\nequation\n  assert( x > 0, \"positive\");\n  x = f( x);\nend C;";
+    let expected = "model C\n  extends Base(k=1);\n  Real x(fixed=false);\nequation\n  assert(x > 0, \"positive\");\n  x = f(x);\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_removes_padding_before_parenthesized_first_argument() {
+    let source = "model C\n  Real x;\nequation\n  x = integer( (superSample(x)) + 0.5);\nend C;";
+    let expected = "model C\n  Real x;\nequation\n  x = integer((superSample(x)) + 0.5);\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_removes_opening_delimiter_padding() {
+    let source = "model C\n  Real x;\n  Real Q1;\n  Real Q2;\nequation\n  x = exp(( 1)) + sum({ Q1,Q2});\nend C;";
+    let expected = "model C\n  Real x;\n  Real Q1;\n  Real Q2;\nequation\n  x = exp((1)) + sum({Q1, Q2});\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_normalizes_type_level_array_component_spacing() {
+    let source = "model C\n  Real[3]    x;\nend C;";
+    let expected = "model C\n  Real[3] x;\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_normalizes_binding_after_multiline_component_modifiers() {
+    let source = "block Pulse\n  parameter Real width(\n    final min=0,\n    final max=100)=50;\nend Pulse;";
+    let expected = "block Pulse\n  parameter Real width(\n    final min=0,\n    final max=100) = 50;\nend Pulse;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_normalizes_redeclare_type_name_spacing() {
+    let source = "model C\n  extends Base(redeclare P.T     x, redeclare model HeatTransfer = P.Ideal (k=1));\nend C;";
+    let expected = "model C\n  extends Base(redeclare P.T x, redeclare model HeatTransfer=P.Ideal(k=1));\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_profile_preserves_redeclare_type_name_spacing() {
+    let source = "model C\n  extends Base(redeclare P.T     x);\nend C;";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, format!("{source}\n"));
+}
+
+#[test]
+fn test_canonical_profile_normalizes_external_function_argument_commas() {
+    let source = "function f\n  input Real tableID;\n  input Integer icol;\n  input Real timeIn;\n  output Real y;\n  external \"C\" y = getValue(tableID,icol, timeIn);\nend f;";
+    let expected = "function f\n  input Real tableID;\n  input Integer icol;\n  input Real timeIn;\n  output Real y;\n  external \"C\" y = getValue(tableID, icol, timeIn);\nend f;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_profile_preserves_call_opening_parenthesis_padding() {
+    let source = "model C\n  Real x(        fixed = false);\nequation\n  assert( x > 0, \"positive\");\n  x = f( x);\nend C;";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, format!("{source}\n"));
+}
+
+#[test]
+fn test_canonical_profile_normalizes_binary_operator_spacing() {
+    let source = "model C\nReal x;\nReal y[3];\nReal Q1;\nBoolean b;\nequation\nx=1+2*3 + y[3]-Q1 + (y[1]+y[2])+0.5;\nb=x<4 and  y[1]>=5;\nend C;";
+    let expected = "model C\n  Real x;\n  Real y[3];\n  Real Q1;\n  Boolean b;\nequation\n  x = 1 + 2 * 3 + y[3] - Q1 + (y[1] + y[2]) + 0.5;\n  b = x < 4 and y[1] >= 5;\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_normalizes_same_line_statement_separator() {
+    let source = "function f\noutput Real x;\nalgorithm\nassert(true, \"ok\");x:=1;\nend f;";
+    let expected =
+        "function f\n  output Real x;\nalgorithm\n  assert(true, \"ok\"); x := 1;\nend f;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_normalizes_component_reference_dot_spacing() {
+    let source = "model C\n  Real x;\nequation\n  x = sub. u2 + step. y;\nend C;";
+    let expected = "model C\n  Real x;\nequation\n  x = sub.u2 + step.y;\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_dymola_profile_preserves_component_reference_dot_spacing() {
+    let source = "model C\n  Real x;\nequation\n  x = sub. u2 + step. y;\nend C;";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, format!("{source}\n"));
+}
+
+#[test]
+fn test_canonical_profile_normalizes_connect_commas() {
+    let source = "connector Pin\nReal v;\nflow Real i;\nend Pin;\nmodel C\nPin a;\nPin b;\nequation\nconnect(a,b);\nend C;";
+    let expected = "connector Pin\n  Real v;\n  flow Real i;\nend Pin;\nmodel C\n  Pin a;\n  Pin b;\nequation\n  connect(a, b);\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_normalizes_array_subscript_commas() {
+    let source = "model C\nReal x[3,3];\nequation\nx[1,2]=x[2, 1];\nend C;";
+    let expected = "model C\n  Real x[3, 3];\nequation\n  x[1, 2] = x[2, 1];\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format");
+    assert_eq!(formatted, expected);
+}
+
+#[test]
+fn test_canonical_profile_normalizes_matrix_row_commas_but_dymola_preserves_alignment() {
+    let source =
+        "model C\n  parameter Real M[2, 3] = [\n    -d,   d,  -d;\n    Cm, -Cm,  Cm\n  ];\nend C;";
+    let dymola = format(source, &FormatOptions::default()).expect("format dymola");
+    assert_eq!(dymola, format!("{source}\n"));
+
+    let canonical = format(
+        source,
+        &FormatOptions::for_profile(FormatProfile::Canonical),
+    )
+    .expect("format canonical");
+    assert_eq!(
+        canonical,
+        "model C\n  parameter Real M[2, 3] = [\n    -d, d, -d;\n    Cm, -Cm, Cm\n  ];\nend C;\n"
+    );
+}
+
+#[test]
+fn test_canonical_profile_reports_full_classified_gap_coverage() {
+    let options = FormatOptions::for_profile(FormatProfile::Canonical);
+    let source = "within Modelica . Blocks;\ntype Voltage=Real;\nmodel C\nparameter Real k=1;\nReal x[3,3];\nBoolean b;\nequation\nx[1,2]=1+2*3;\nb=x[2, 1]<4 and  y>=5;\nconnect(a,b);\nassert( b, \"ok\");\nalgorithm\n(a,b):=g(1,2);\nend C;";
+    let report = format_coverage_report(source, &options).expect("coverage");
+    assert!(report.eligible_gaps > 0, "coverage report should see gaps");
+    assert_eq!(report.covered_gaps, report.eligible_gaps);
+    assert_eq!(report.coverage_percent(), 100.0);
+    assert!(
+        report
+            .categories
+            .iter()
+            .any(|entry| entry.category == FormatCoverageCategory::BinaryOperator)
+    );
+    assert!(
+        report
+            .categories
+            .iter()
+            .any(|entry| entry.category == FormatCoverageCategory::ComponentBindingAssignment)
+    );
+    assert!(
+        report
+            .categories
+            .iter()
+            .any(|entry| entry.category == FormatCoverageCategory::ArraySubscriptComma)
+    );
+    assert!(
+        report
+            .categories
+            .iter()
+            .any(|entry| entry.category == FormatCoverageCategory::TypeAliasAssignment)
+    );
+    assert!(
+        report
+            .categories
+            .iter()
+            .any(|entry| entry.category == FormatCoverageCategory::OpeningParenthesisPadding)
+    );
+}
+
+#[test]
+fn test_format_dymola_profile_preserves_dymola_annotation_style() {
+    // Patterns taken from Dymola-authored ModelicaServices/Physiolibrary-style
+    // sources: compact modifiers, `annotation (` spacing, graphic extents,
+    // experiment metadata, and `__Dymola_*` annotations.
+    let source = r#"model DymolaStyle
+  parameter Boolean LimitBackflow=false;
+  Real passableVariable(start=0, final unit="1")
+  "Auxiliary variable" annotation(HideResult = not LimitBackflow);
+  Boolean open(start = true) annotation(HideResult = true);
+equation
+  open = passableVariable > Modelica.Constants.eps;
+  annotation (Placement(transformation(extent={{10,-10},{30,10}}),
+  iconTransformation(extent={{30,-10},{50,10}})),
+  experiment(
+  StopTime=3,
+  Interval=0.001,
+  Tolerance=1e-05,
+  __Dymola_Algorithm="Cvode"));
+end DymolaStyle;
+"#;
+    let formatted = format(
+        source,
+        &FormatOptions {
+            profile: FormatProfile::Dymola,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert!(formatted.contains("LimitBackflow=false"));
+    assert!(formatted.contains("annotation(HideResult = not LimitBackflow)"));
+    assert!(formatted.contains("Boolean open(start = true) annotation(HideResult = true);"));
+    assert!(formatted.contains("open = passableVariable > Modelica.Constants.eps;"));
+}
+
+#[test]
+fn test_multiline_string_is_preserved() {
+    let source = r#"model C
+  annotation(Documentation(info="<html>
+<p>This function returns <em>re</em> and <em>im</em>.</p>
+</html>"));
+end C;
+"#;
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, source);
+}
+
+#[test]
+fn test_trim_trailing_whitespace_preserves_multiline_string_text() {
+    let source = "model C\n  Real x;  \n  annotation(Documentation(info=\"<html>\n<p>literal trailing space </p> \n</html>\"));\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            trim_trailing_whitespace: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(
+        formatted,
+        "model C\n  Real x;\n  annotation(Documentation(info=\"<html>\n<p>literal trailing space </p> \n</html>\"));\nend C;\n"
+    );
+}
+
+#[test]
+fn test_trim_trailing_whitespace_preserves_multiline_block_comment() {
+    let source = "model C\n  /* keep aligned comment text  \n     and its blank spacer   \n  */\n  Real x;  \nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            trim_trailing_whitespace: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(
+        formatted,
+        "model C\n  /* keep aligned comment text  \n     and its blank spacer   \n  */\n  Real x;\nend C;\n"
+    );
+}
+
+#[test]
+fn test_quoted_operator_identifier_is_preserved() {
+    let source = r#"operator '-'
+end '-';
+"#;
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, source);
+}
+
+#[test]
+fn test_common_options_can_preserve_trailing_final_newline_and_crlf() {
+    let source = "model C\r\n  Real x(start=1);  \r\nequation\r\n  x=1;\r\nend C;";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_equation_spacing: false,
+            trim_trailing_whitespace: false,
+            insert_final_newline: false,
+            line_ending: LineEnding::Crlf,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(formatted, source);
+}
+
+#[test]
+fn test_common_options_normalize_indentation_with_tabs() {
+    let source = "model C\nReal x;\nequation\nx=1;\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_indentation: true,
+            normalize_equation_spacing: true,
+            use_tabs: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(
+        formatted,
+        "model C\n\tReal x;\nequation\n\tx = 1;\nend C;\n"
+    );
+}
+
+#[test]
+fn test_default_repairs_missing_structural_indentation() {
+    let source = "model C\nReal x;\nequation\nx=1;\nend C;";
+    let formatted = format(source, &FormatOptions::default()).expect("format");
+    assert_eq!(formatted, "model C\n  Real x;\nequation\nx=1;\nend C;\n");
+}
+
+#[test]
+fn test_repair_missing_indentation_can_be_disabled() {
+    let source = "model C\nReal x;\nequation\nx=1;\nend C;";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            repair_missing_indentation: false,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(formatted, "model C\nReal x;\nequation\nx=1;\nend C;\n");
+}
+
+#[test]
+fn test_normalize_indentation_preserves_continuation_alignment() {
+    let source = "model C\nparameter Real x=1\n  annotation(Evaluate=true);\nequation\nif x > 0 or\n       x < 2 then\nx=1;\nend if;\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_indentation: true,
+            normalize_equation_spacing: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(
+        formatted,
+        "model C\n  parameter Real x = 1\n  annotation(Evaluate=true);\nequation\n  if x > 0 or\n       x < 2 then\n    x = 1;\n  end if;\nend C;\n"
+    );
+}
+
+#[test]
+fn test_normalize_indentation_preserves_conditional_expression_alignment() {
+    let source = "model C\nparameter Integer nx = if filterType == LowPass or\n                          filterType == HighPass then\n                          order else 2*order;\nparameter Real y;\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_indentation: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(
+        formatted,
+        "model C\n  parameter Integer nx = if filterType == LowPass or\n                          filterType == HighPass then\n                          order else 2*order;\n  parameter Real y;\nend C;\n"
+    );
+}
+
+#[test]
+fn test_normalize_indentation_closes_multiline_statement_condition() {
+    let source =
+        "model C\nReal x;\nequation\nif x > 0 or\n       x < 2 then\nx=1;\nend if;\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_indentation: true,
+            normalize_equation_spacing: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(
+        formatted,
+        "model C\n  Real x;\nequation\n  if x > 0 or\n       x < 2 then\n    x = 1;\n  end if;\nend C;\n"
+    );
+}
+
+#[test]
+fn test_normalize_indentation_preserves_comment_anchored_equation_layout() {
+    let source = "model C\nReal x;\nReal y;\nequation\nif x > 0 then\n     /* Dense filter equations keep local alignment:\n        real poles and complex poles are documented here. */\n     for i in 1:2 loop\n        y = y + i;\n     end for;\nelseif x < 0 then\n     // Alternative branch keeps generated alignment.\n       y = -x;\nend if;\nend C;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_indentation: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(
+        formatted,
+        "model C\n  Real x;\n  Real y;\nequation\n  if x > 0 then\n     /* Dense filter equations keep local alignment:\n        real poles and complex poles are documented here. */\n     for i in 1:2 loop\n        y = y + i;\n     end for;\n  elseif x < 0 then\n     // Alternative branch keeps generated alignment.\n       y = -x;\n  end if;\nend C;\n"
+    );
+}
+
+#[test]
+fn test_normalize_indentation_handles_operator_classes() {
+    let source = "record Complex\nencapsulated operator '-'\nfunction negate\ninput Real x;\nalgorithm\nx := -x;\nend negate;\nend '-';\nend Complex;\n";
+    let formatted = format(
+        source,
+        &FormatOptions {
+            normalize_indentation: true,
+            ..FormatOptions::default()
+        },
+    )
+    .expect("format");
+    assert_eq!(
+        formatted,
+        "record Complex\n  encapsulated operator '-'\n    function negate\n      input Real x;\n    algorithm\n      x := -x;\n    end negate;\n  end '-';\nend Complex;\n"
+    );
+}

--- a/crates/rumoca-tool-fmt/src/formatter/trivia.rs
+++ b/crates/rumoca-tool-fmt/src/formatter/trivia.rs
@@ -1,0 +1,1150 @@
+//! AST trivia helpers for the Modelica formatter.
+
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct TextReplacement {
+    pub(super) start: usize,
+    pub(super) end: usize,
+    pub(super) text: &'static str,
+}
+
+pub(super) fn apply_ast_trivia_rules(
+    source: &str,
+    options: &FormatOptions,
+    ast: &ast::StoredDefinition,
+) -> String {
+    let component_layout = ComponentDeclarationLayout::collect(ast);
+    let mut collector = AstTriviaReplacementCollector::new(source, options, &component_layout);
+    let _ = ast::Visitor::visit_stored_definition(&mut collector, ast);
+    let mut replacements = collector.into_replacements();
+    if replacements.is_empty() {
+        return source.to_string();
+    }
+
+    replacements.sort_by_key(|replacement| replacement.start);
+    replacements.dedup();
+
+    let mut formatted = source.to_string();
+    let mut previous_start = source.len() + 1;
+    for replacement in replacements.into_iter().rev() {
+        if replacement.end > previous_start {
+            continue;
+        }
+        formatted.replace_range(replacement.start..replacement.end, replacement.text);
+        previous_start = replacement.start;
+    }
+    formatted
+}
+
+pub(super) struct SourceTrivia<'source> {
+    pub(super) source: &'source str,
+}
+
+impl<'source> SourceTrivia<'source> {
+    pub(super) fn new(source: &'source str) -> Self {
+        Self { source }
+    }
+
+    pub(super) fn gap_between_spans(&self, left: Span, right: Span) -> Option<TriviaGap<'source>> {
+        if left.is_dummy() || right.is_dummy() || left.source != right.source {
+            return None;
+        }
+        let start = left.end.0;
+        let end = right.start.0;
+        if start > end {
+            return None;
+        }
+        self.source
+            .get(start..end)
+            .map(|text| TriviaGap { start, text })
+    }
+
+    pub(super) fn gap_between_expressions(
+        &self,
+        left: &ast::Expression,
+        right: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(left.span(), right.span())
+    }
+
+    pub(super) fn gap_between_expression_list_items(
+        &self,
+        left: &ast::Expression,
+        right: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        let gap = self.gap_between_spans(
+            expression_list_item_span(left),
+            expression_list_item_span(right),
+        )?;
+        Some(adjust_expression_list_separator_gap(gap))
+    }
+
+    pub(super) fn gap_after_call_open_paren(
+        &self,
+        target: &ast::ComponentReference,
+        first_arg: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(target.span, first_arg.span())
+            .and_then(opening_parenthesis_padding_gap)
+    }
+
+    pub(super) fn gap_after_token_open_paren(
+        &self,
+        target: &Token,
+        first_arg: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(token_span(target), first_arg.span())
+            .and_then(opening_parenthesis_padding_gap)
+    }
+
+    pub(super) fn gap_after_name_open_paren(
+        &self,
+        target: &ast::Name,
+        first_arg: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(token_span(target.name.last()?), first_arg.span())
+            .and_then(opening_parenthesis_padding_gap)
+    }
+
+    pub(super) fn gap_after_keyword_open_paren_before_expression(
+        &self,
+        keyword: &str,
+        expr: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        let span = expr.span();
+        if span.is_dummy() {
+            return None;
+        }
+        let expr_start = span.start.0;
+        let line_start = self
+            .source
+            .get(..expr_start)?
+            .rfind('\n')
+            .map_or(0, |index| index + '\n'.len_utf8());
+        let before_expr = self.source.get(line_start..expr_start)?;
+        let keyword_start = before_expr.find(keyword)?;
+        let keyword_end = keyword_start + keyword.len();
+        if keyword_start > 0
+            && before_expr[..keyword_start]
+                .chars()
+                .next_back()
+                .is_some_and(is_identifier_char)
+        {
+            return None;
+        }
+        if before_expr[keyword_end..]
+            .chars()
+            .next()
+            .is_some_and(is_identifier_char)
+        {
+            return None;
+        }
+        opening_parenthesis_padding_gap(TriviaGap {
+            start: line_start + keyword_end,
+            text: before_expr.get(keyword_end..)?,
+        })
+    }
+
+    pub(super) fn gap_between_tokens(
+        &self,
+        left: &Token,
+        right: &Token,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(token_span(left), token_span(right))
+    }
+
+    pub(super) fn gap_between_name_and_token(
+        &self,
+        left: &ast::Name,
+        right: &Token,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_tokens(left.name.last()?, right)
+    }
+
+    pub(super) fn gap_between_token_and_expression(
+        &self,
+        left: &Token,
+        right: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(token_span(left), right.span())
+    }
+
+    pub(super) fn gap_between_expression_list_item_and_expression(
+        &self,
+        left: &ast::Expression,
+        right: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(expression_list_item_span(left), right.span())
+    }
+
+    pub(super) fn gap_between_component_reference_and_expression(
+        &self,
+        left: &ast::ComponentReference,
+        right: &ast::Expression,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(left.span, right.span())
+    }
+
+    pub(super) fn gap_between_component_references(
+        &self,
+        left: &ast::ComponentReference,
+        right: &ast::ComponentReference,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(left.span, right.span)
+    }
+
+    pub(super) fn gap_between_expression_and_component_reference(
+        &self,
+        left: &ast::Expression,
+        right: &ast::ComponentReference,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(left.span(), right.span)
+    }
+
+    pub(super) fn gap_between_subscripts(
+        &self,
+        left: &ast::Subscript,
+        right: &ast::Subscript,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_spans(subscript_span(left)?, subscript_span(right)?)
+    }
+
+    pub(super) fn gap_between_extend_modifications(
+        &self,
+        left: &ast::ExtendModification,
+        right: &ast::ExtendModification,
+    ) -> Option<TriviaGap<'source>> {
+        let gap = self.gap_between_spans(
+            expression_list_item_span(&left.expr),
+            expression_list_item_span(&right.expr),
+        )?;
+        Some(adjust_expression_list_separator_gap(gap))
+    }
+
+    pub(super) fn gap_between_token_and_name(
+        &self,
+        left: &Token,
+        right: &ast::Name,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_between_tokens(left, right.name.first()?)
+    }
+
+    pub(super) fn gap_after_keyword_before_name(
+        &self,
+        keyword: &str,
+        name: &ast::Name,
+    ) -> Option<TriviaGap<'source>> {
+        self.gap_after_keyword_before_token(keyword, name.name.first()?)
+    }
+
+    pub(super) fn gap_after_keyword_before_token(
+        &self,
+        keyword: &str,
+        token: &Token,
+    ) -> Option<TriviaGap<'source>> {
+        let span = token_span(token);
+        if span.is_dummy() {
+            return None;
+        }
+        let token_start = span.start.0;
+        let line_start = self
+            .source
+            .get(..token_start)?
+            .rfind('\n')
+            .map_or(0, |index| index + '\n'.len_utf8());
+        let before_token = self.source.get(line_start..token_start)?;
+        let keyword_end = before_token.trim_end_matches([' ', '\t']).len();
+        let keyword_start = keyword_end.checked_sub(keyword.len())?;
+        if before_token.get(keyword_start..keyword_end)? != keyword {
+            return None;
+        }
+        if keyword_start > 0
+            && before_token[..keyword_start]
+                .chars()
+                .next_back()
+                .is_some_and(is_identifier_char)
+        {
+            return None;
+        }
+        Some(TriviaGap {
+            start: line_start + keyword_end,
+            text: before_token.get(keyword_end..)?,
+        })
+    }
+
+    pub(super) fn line_before_token(&self, token: &Token) -> Option<LineBeforeToken<'source>> {
+        let span = token_span(token);
+        if span.is_dummy() {
+            return None;
+        }
+        let token_start = span.start.0;
+        let line_start = self
+            .source
+            .get(..token_start)?
+            .rfind('\n')
+            .map_or(0, |index| index + '\n'.len_utf8());
+        let text = self.source.get(line_start..token_start)?;
+        Some(LineBeforeToken {
+            start: line_start,
+            text,
+        })
+    }
+}
+
+pub(super) struct LineBeforeToken<'source> {
+    pub(super) start: usize,
+    text: &'source str,
+}
+
+pub(super) struct TriviaGap<'source> {
+    pub(super) start: usize,
+    pub(super) text: &'source str,
+}
+
+impl TriviaGap<'_> {
+    pub(super) fn single_horizontal_space_replacement(&self) -> Option<TextReplacement> {
+        if self.text == " " || self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        self.text
+            .chars()
+            .all(|c| matches!(c, ' ' | '\t'))
+            .then_some(TextReplacement {
+                start: self.start,
+                end: self.start + self.text.len(),
+                text: " ",
+            })
+    }
+
+    pub(super) fn is_multiple_spaces(&self) -> bool {
+        self.text.len() > 1 && self.text.chars().all(|c| c == ' ')
+    }
+
+    pub(super) fn dot_separator_replacement(&self) -> Option<TextReplacement> {
+        if self.text == "." || self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let dot_count = self.text.chars().filter(|&c| c == '.').count();
+        (dot_count == 1 && self.text.chars().all(|c| matches!(c, '.' | ' ' | '\t'))).then_some(
+            TextReplacement {
+                start: self.start,
+                end: self.start + self.text.len(),
+                text: ".",
+            },
+        )
+    }
+
+    pub(super) fn assignment_operator_replacement(&self) -> Option<TextReplacement> {
+        if self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let assignment_offset = self.text.rfind('=')?;
+        let start = self.start + trim_horizontal_whitespace_before(self.text, assignment_offset);
+        let end = self.start
+            + trim_horizontal_whitespace_after(self.text, assignment_offset + '='.len_utf8());
+        Some(TextReplacement {
+            start,
+            end,
+            text: " = ",
+        })
+    }
+
+    pub(super) fn compact_assignment_operator_replacement(&self) -> Option<TextReplacement> {
+        if self.text == "=" || self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let assignment_offset = self.text.rfind('=')?;
+        let start = self.start + trim_horizontal_whitespace_before(self.text, assignment_offset);
+        let end = self.start
+            + trim_horizontal_whitespace_after(self.text, assignment_offset + '='.len_utf8());
+        Some(TextReplacement {
+            start,
+            end,
+            text: "=",
+        })
+    }
+
+    pub(super) fn statement_assignment_operator_replacement(&self) -> Option<TextReplacement> {
+        if self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let assignment_offset = self.text.rfind(":=")?;
+        let start = self.start + trim_horizontal_whitespace_before(self.text, assignment_offset);
+        let end = self.start
+            + trim_horizontal_whitespace_after(self.text, assignment_offset + ":=".len());
+        Some(TextReplacement {
+            start,
+            end,
+            text: " := ",
+        })
+    }
+
+    pub(super) fn keyword_separator_replacement(
+        &self,
+        keyword: &'static str,
+    ) -> Option<TextReplacement> {
+        if self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        (self.text.trim_matches([' ', '\t']) == keyword).then_some(TextReplacement {
+            start: self.start,
+            end: self.start + self.text.len(),
+            text: match keyword {
+                "in" => " in ",
+                _ => return None,
+            },
+        })
+    }
+
+    pub(super) fn comma_separator_replacement(&self) -> Option<TextReplacement> {
+        if self.text == ", " || self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let comma_count = self.text.chars().filter(|&c| c == ',').count();
+        (comma_count == 1 && self.text.chars().all(|c| matches!(c, ',' | ' ' | '\t'))).then_some(
+            TextReplacement {
+                start: self.start,
+                end: self.start + self.text.len(),
+                text: ", ",
+            },
+        )
+    }
+
+    pub(super) fn opening_parenthesis_replacement(&self) -> Option<TextReplacement> {
+        if self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let paren_offset = self.text.find('(')?;
+        if !self.text[..paren_offset]
+            .chars()
+            .all(|c| matches!(c, ' ' | '\t'))
+        {
+            return None;
+        }
+        let after_paren = paren_offset + '('.len_utf8();
+        let padding_len = self.text[after_paren..]
+            .chars()
+            .take_while(|c| matches!(c, ' ' | '\t'))
+            .map(char::len_utf8)
+            .sum::<usize>();
+        if paren_offset == 0 && padding_len == 0 {
+            return None;
+        }
+        Some(TextReplacement {
+            start: self.start,
+            end: self.start + after_paren + padding_len,
+            text: "(",
+        })
+    }
+
+    pub(super) fn opening_delimiter_padding_replacement(&self) -> Option<TextReplacement> {
+        if self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let delimiter_len = self
+            .text
+            .chars()
+            .take_while(|c| matches!(c, '(' | '[' | '{'))
+            .map(char::len_utf8)
+            .sum::<usize>();
+        if delimiter_len == 0 {
+            return None;
+        }
+        let padding = self.text.get(delimiter_len..)?;
+        if padding.is_empty() || !padding.chars().all(|c| matches!(c, ' ' | '\t')) {
+            return None;
+        }
+        Some(TextReplacement {
+            start: self.start + delimiter_len,
+            end: self.start + self.text.len(),
+            text: "",
+        })
+    }
+
+    pub(super) fn closing_expression_separator_replacement(&self) -> Option<TextReplacement> {
+        if self.text == ", " || self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let comma_offset = self.text.find(',')?;
+        if !self.text[..comma_offset]
+            .chars()
+            .all(|c| matches!(c, ')' | '}' | ']' | ' ' | '\t'))
+            || !self.text[comma_offset + ','.len_utf8()..]
+                .chars()
+                .all(|c| matches!(c, ' ' | '\t'))
+        {
+            return None;
+        }
+        Some(TextReplacement {
+            start: self.start + comma_offset,
+            end: self.start + self.text.len(),
+            text: ", ",
+        })
+    }
+
+    pub(super) fn binary_operator_replacement(&self, op: &OpBinary) -> Option<TextReplacement> {
+        if self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let operator = binary_operator_text(op)?;
+        (self.text.trim_matches([' ', '\t']) == operator).then_some(TextReplacement {
+            start: self.start,
+            end: self.start + self.text.len(),
+            text: spaced_binary_operator_text(op)?,
+        })
+    }
+
+    pub(super) fn closing_delimiter_name_replacement(&self) -> Option<TextReplacement> {
+        if self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let delimiter_len = self
+            .text
+            .chars()
+            .take_while(|c| matches!(c, ')' | ']' | '}'))
+            .map(char::len_utf8)
+            .sum::<usize>();
+        if delimiter_len == 0 {
+            return None;
+        }
+        let padding = self.text.get(delimiter_len..)?;
+        if padding == " " || !padding.chars().all(|c| matches!(c, ' ' | '\t')) {
+            return None;
+        }
+        Some(TextReplacement {
+            start: self.start + delimiter_len,
+            end: self.start + self.text.len(),
+            text: " ",
+        })
+    }
+
+    pub(super) fn closing_delimiter_binary_operator_replacement(&self) -> Option<TextReplacement> {
+        let operator = closing_delimiter_binary_operator(self.text)?;
+        let delimiter_len = closing_delimiter_prefix_len(self.text);
+        let replacement_text = spaced_token_operator_text(operator);
+        if self.text.get(delimiter_len..) == Some(replacement_text) {
+            return None;
+        }
+        Some(TextReplacement {
+            start: self.start + delimiter_len,
+            end: self.start + self.text.len(),
+            text: replacement_text,
+        })
+    }
+
+    pub(super) fn closing_delimiter_opening_parenthesis_replacement(
+        &self,
+    ) -> Option<TextReplacement> {
+        let delimiter_len = closing_delimiter_prefix_len(self.text);
+        if delimiter_len == 0 || self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let after_delimiters = self.text.get(delimiter_len..)?;
+        let paren_offset = after_delimiters.find('(')?;
+        if !after_delimiters[..paren_offset]
+            .chars()
+            .all(|c| matches!(c, ' ' | '\t'))
+        {
+            return None;
+        }
+        let after_paren = paren_offset + '('.len_utf8();
+        let padding_len = after_delimiters[after_paren..]
+            .chars()
+            .take_while(|c| matches!(c, ' ' | '\t'))
+            .map(char::len_utf8)
+            .sum::<usize>();
+        if paren_offset == 0 && padding_len == 0 {
+            return None;
+        }
+        Some(TextReplacement {
+            start: self.start + delimiter_len,
+            end: self.start + delimiter_len + after_paren + padding_len,
+            text: "(",
+        })
+    }
+
+    pub(super) fn statement_separator_replacement(&self) -> Option<TextReplacement> {
+        if self.text.contains(['\n', '\r']) {
+            return None;
+        }
+        let semicolon_offset = self.text.find(';')?;
+        if !self.text[..semicolon_offset]
+            .chars()
+            .all(|c| matches!(c, ')' | ']' | '}' | ' ' | '\t'))
+            || !self.text[semicolon_offset + ';'.len_utf8()..]
+                .chars()
+                .all(|c| matches!(c, ' ' | '\t'))
+            || self.text.matches(';').count() != 1
+        {
+            return None;
+        }
+        (self.text.get(semicolon_offset..) != Some("; ")).then_some(TextReplacement {
+            start: self.start + semicolon_offset,
+            end: self.start + self.text.len(),
+            text: "; ",
+        })
+    }
+}
+
+pub(super) fn adjust_expression_list_separator_gap(gap: TriviaGap<'_>) -> TriviaGap<'_> {
+    let Some(comma_offset) = gap.text.find(',') else {
+        return gap;
+    };
+    if !gap.text[..comma_offset]
+        .chars()
+        .all(|c| matches!(c, ')' | '}' | ']' | ' ' | '\t'))
+    {
+        return gap;
+    }
+    TriviaGap {
+        start: gap.start + comma_offset,
+        text: &gap.text[comma_offset..],
+    }
+}
+
+pub(super) fn opening_parenthesis_padding_gap(gap: TriviaGap<'_>) -> Option<TriviaGap<'_>> {
+    let paren_offset = gap.text.find('(')?;
+    if !gap.text[..paren_offset]
+        .chars()
+        .all(|c| matches!(c, ' ' | '\t'))
+    {
+        return None;
+    }
+    let padding_start = paren_offset + '('.len_utf8();
+    let padding_len = gap
+        .text
+        .get(padding_start..)?
+        .chars()
+        .take_while(|c| matches!(c, ' ' | '\t'))
+        .map(char::len_utf8)
+        .sum::<usize>();
+    let text = gap.text.get(..padding_start + padding_len)?;
+    (paren_offset > 0 || padding_len > 0).then_some(TriviaGap {
+        start: gap.start,
+        text,
+    })
+}
+
+pub(super) fn opening_delimiter_padding_gap(gap: &TriviaGap<'_>) -> bool {
+    let delimiter_len = gap
+        .text
+        .chars()
+        .take_while(|c| matches!(c, '(' | '[' | '{'))
+        .map(char::len_utf8)
+        .sum::<usize>();
+    delimiter_len > 0
+        && gap.text.get(delimiter_len..).is_some_and(|padding| {
+            !padding.is_empty() && padding.chars().all(|c| matches!(c, ' ' | '\t'))
+        })
+}
+
+pub(super) fn closing_delimiter_prefix_len(text: &str) -> usize {
+    text.chars()
+        .take_while(|c| matches!(c, ')' | ']' | '}'))
+        .map(char::len_utf8)
+        .sum()
+}
+
+pub(super) fn closing_delimiter_binary_operator(text: &str) -> Option<&'static str> {
+    if text.contains(['\n', '\r']) {
+        return None;
+    }
+    let delimiter_len = closing_delimiter_prefix_len(text);
+    if delimiter_len == 0 {
+        return None;
+    }
+    let after_delimiters = text.get(delimiter_len..)?;
+    let trimmed = after_delimiters.trim_matches([' ', '\t']);
+    let operator = match trimmed {
+        "+" => "+",
+        "-" => "-",
+        "*" => "*",
+        "/" => "/",
+        "<" => "<",
+        "<=" => "<=",
+        ">" => ">",
+        ">=" => ">=",
+        "==" => "==",
+        "<>" => "<>",
+        _ => return None,
+    };
+    if !after_delimiters
+        .chars()
+        .all(|c| matches!(c, ' ' | '\t' | '+' | '-' | '*' | '/' | '<' | '>' | '='))
+    {
+        return None;
+    }
+    Some(operator)
+}
+
+pub(super) fn is_closing_delimiter_opening_parenthesis_gap(text: &str) -> bool {
+    let delimiter_len = closing_delimiter_prefix_len(text);
+    if delimiter_len == 0 || text.contains(['\n', '\r']) {
+        return false;
+    }
+    let Some(after_delimiters) = text.get(delimiter_len..) else {
+        return false;
+    };
+    let Some(paren_offset) = after_delimiters.find('(') else {
+        return false;
+    };
+    after_delimiters[..paren_offset]
+        .chars()
+        .all(|c| matches!(c, ' ' | '\t'))
+        && after_delimiters[paren_offset + '('.len_utf8()..]
+            .chars()
+            .all(|c| matches!(c, ' ' | '\t'))
+}
+
+pub(super) fn is_statement_separator_gap(text: &str) -> bool {
+    let Some(semicolon_offset) = text.find(';') else {
+        return false;
+    };
+    !text.contains(['\n', '\r'])
+        && text.matches(';').count() == 1
+        && text[..semicolon_offset]
+            .chars()
+            .all(|c| matches!(c, ')' | ']' | '}' | ' ' | '\t'))
+        && text[semicolon_offset + ';'.len_utf8()..]
+            .chars()
+            .all(|c| matches!(c, ' ' | '\t'))
+}
+
+pub(super) fn spaced_token_operator_text(operator: &str) -> &'static str {
+    match operator {
+        "+" => " + ",
+        "-" => " - ",
+        "*" => " * ",
+        "/" => " / ",
+        "<" => " < ",
+        "<=" => " <= ",
+        ">" => " > ",
+        ">=" => " >= ",
+        "==" => " == ",
+        "<>" => " <> ",
+        _ => unreachable!("operator filtered by closing_delimiter_binary_operator"),
+    }
+}
+
+pub(super) fn token_span(token: &Token) -> Span {
+    Span::from_offsets(
+        ir_core::SourceId::from_source_name(&token.location.file_name),
+        token.location.start as usize,
+        token.location.end as usize,
+    )
+}
+
+pub(super) fn expression_list_item_span(expr: &ast::Expression) -> Span {
+    match expr {
+        ast::Expression::NamedArgument { name, value, span } => {
+            span_from_start_to_end(token_span(name), value.span()).unwrap_or(*span)
+        }
+        ast::Expression::Modification {
+            target,
+            value,
+            span,
+        } => span_from_start_to_end(target.span, value.span()).unwrap_or(*span),
+        _ => expr.span(),
+    }
+}
+
+pub(super) fn subscript_span(subscript: &ast::Subscript) -> Option<Span> {
+    match subscript {
+        ast::Subscript::Expression(expr) => Some(expr.span()),
+        ast::Subscript::Range { token } => Some(token_span(token)),
+        ast::Subscript::Empty => None,
+    }
+}
+
+pub(super) fn span_from_start_to_end(start: Span, end: Span) -> Option<Span> {
+    if start.is_dummy() || end.is_dummy() || start.source != end.source {
+        return None;
+    }
+    Some(Span::from_offsets(start.source, start.start.0, end.end.0))
+}
+
+#[derive(Default)]
+pub(super) struct ComponentDeclarationLayout {
+    declaration_lines: Vec<u32>,
+}
+
+impl ComponentDeclarationLayout {
+    pub(super) fn collect(ast: &ast::StoredDefinition) -> Self {
+        let mut collector = ComponentDeclarationLayoutCollector::default();
+        let _ = ast::Visitor::visit_stored_definition(&mut collector, ast);
+        collector.into_layout()
+    }
+
+    pub(super) fn has_nearby_declaration_line(&self, line: u32) -> bool {
+        self.declaration_lines
+            .iter()
+            .copied()
+            .any(|other| other != line && other.abs_diff(line) <= 2)
+    }
+}
+
+#[derive(Default)]
+pub(super) struct ComponentDeclarationLayoutCollector {
+    declaration_lines: Vec<u32>,
+}
+
+impl ComponentDeclarationLayoutCollector {
+    pub(super) fn into_layout(mut self) -> ComponentDeclarationLayout {
+        self.declaration_lines.sort_unstable();
+        self.declaration_lines.dedup();
+        ComponentDeclarationLayout {
+            declaration_lines: self.declaration_lines,
+        }
+    }
+}
+
+impl ast::Visitor for ComponentDeclarationLayoutCollector {
+    fn enter_component(&mut self, component: &ast::Component) -> ControlFlow<()> {
+        self.declaration_lines
+            .push(component.name_token.location.start_line);
+        Continue(())
+    }
+}
+
+pub(super) fn is_builtin_scalar_type_name(name: &ast::Name) -> bool {
+    let [token] = name.name.as_slice() else {
+        return false;
+    };
+    matches!(
+        token.text.as_ref(),
+        "Real" | "Integer" | "Boolean" | "String"
+    )
+}
+
+pub(super) fn type_alias_base_name(class: &ast::ClassDef) -> Option<&ast::Name> {
+    if class.extends.len() != 1 || class.end_name_token.is_some() {
+        return None;
+    }
+    Some(&class.extends[0].base_name)
+}
+
+pub(super) fn redeclare_modification_class_target(
+    expr: &ast::Expression,
+) -> Option<(&ast::ComponentReference, &[ast::Expression])> {
+    let ast::Expression::Modification { value, .. } = expr else {
+        return None;
+    };
+    let ast::Expression::ClassModification {
+        target,
+        modifications,
+        ..
+    } = value.as_ref()
+    else {
+        return None;
+    };
+    Some((target, modifications))
+}
+
+pub(super) fn is_identifier_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+pub(super) fn component_prefix_keywords(component: &ast::Component) -> Vec<&'static str> {
+    let mut keywords = Vec::new();
+    if component.is_redeclare {
+        keywords.push("redeclare");
+    }
+    if component.is_final {
+        keywords.push("final");
+    }
+    if component.inner {
+        keywords.push("inner");
+    }
+    if component.outer {
+        keywords.push("outer");
+    }
+    if component.is_replaceable {
+        keywords.push("replaceable");
+    }
+    if let Some(keyword) = component_connection_keyword(component) {
+        keywords.push(keyword);
+    }
+    if let Some(keyword) = component_variability_keyword(component) {
+        keywords.push(keyword);
+    }
+    if let Some(keyword) = component_causality_keyword(component) {
+        keywords.push(keyword);
+    }
+    keywords
+}
+
+pub(super) fn component_connection_keyword(component: &ast::Component) -> Option<&'static str> {
+    match &component.connection {
+        ast::Connection::Flow(_) => Some("flow"),
+        ast::Connection::Stream(_) => Some("stream"),
+        ast::Connection::Empty => None,
+    }
+}
+
+pub(super) fn component_variability_keyword(component: &ast::Component) -> Option<&'static str> {
+    match &component.variability {
+        Variability::Constant(_) => Some("constant"),
+        Variability::Parameter(_) => Some("parameter"),
+        Variability::Discrete(_) => Some("discrete"),
+        Variability::Continuous(_) => Some("continuous"),
+        Variability::Empty => None,
+    }
+}
+
+pub(super) fn component_causality_keyword(component: &ast::Component) -> Option<&'static str> {
+    match &component.causality {
+        Causality::Input(_) => Some("input"),
+        Causality::Output(_) => Some("output"),
+        Causality::Empty => None,
+    }
+}
+
+pub(super) fn class_prefix_keywords(class: &ast::ClassDef) -> Vec<&'static str> {
+    let mut keywords = Vec::new();
+    if class.is_redeclare {
+        keywords.push("redeclare");
+    }
+    if class.is_final {
+        keywords.push("final");
+    }
+    if class.is_inner {
+        keywords.push("inner");
+    }
+    if class.is_outer {
+        keywords.push("outer");
+    }
+    if class.is_replaceable {
+        keywords.push("replaceable");
+    }
+    if class.encapsulated {
+        keywords.push("encapsulated");
+    }
+    if class.partial {
+        keywords.push("partial");
+    }
+    if class.expandable {
+        keywords.push("expandable");
+    }
+    if class.operator_record {
+        keywords.push("operator");
+    }
+    if is_function_class_type_token(&class.class_type_token) {
+        if class.pure {
+            keywords.push("pure");
+        } else {
+            keywords.push("impure");
+        }
+    }
+    keywords
+}
+
+pub(super) fn declaration_prefix_gaps_before_token<'source>(
+    line: LineBeforeToken<'source>,
+    allowed_keywords: &[&str],
+) -> Vec<TriviaGap<'source>> {
+    let words = declaration_prefix_words_before_token(line.text, allowed_keywords);
+    words
+        .windows(2)
+        .filter_map(|adjacent| {
+            let left = &adjacent[0];
+            let right = &adjacent[1];
+            let text = line.text.get(left.end..right.start)?;
+            Some(TriviaGap {
+                start: line.start + left.end,
+                text,
+            })
+        })
+        .collect()
+}
+
+fn declaration_prefix_words_before_token<'source>(
+    text_before_declaration_token: &'source str,
+    allowed_keywords: &[&str],
+) -> Vec<WordSpan<'source>> {
+    let mut words = leading_words(text_before_declaration_token);
+    let mut selected = vec![WordSpan {
+        text: "",
+        start: text_before_declaration_token.len(),
+        end: text_before_declaration_token.len(),
+    }];
+    while let Some(word) = words.pop() {
+        if !allowed_keywords.contains(&word.text) {
+            break;
+        }
+        selected.push(word);
+    }
+    selected.reverse();
+    selected
+}
+
+#[derive(Debug)]
+struct WordSpan<'source> {
+    text: &'source str,
+    start: usize,
+    end: usize,
+}
+
+fn leading_words(text: &str) -> Vec<WordSpan<'_>> {
+    let mut words = Vec::new();
+    let mut cursor = 0usize;
+    while let Some((start, end)) = next_word_span(text, cursor) {
+        words.push(WordSpan {
+            text: &text[start..end],
+            start,
+            end,
+        });
+        cursor = end;
+    }
+    words
+}
+
+pub(super) fn next_word_span(text: &str, cursor: usize) -> Option<(usize, usize)> {
+    let start = text
+        .get(cursor..)?
+        .char_indices()
+        .find_map(|(offset, c)| is_identifier_char(c).then_some(cursor + offset))?;
+    let end = text
+        .get(start..)?
+        .char_indices()
+        .find_map(|(offset, c)| (!is_identifier_char(c)).then_some(start + offset))
+        .unwrap_or(text.len());
+    Some((start, end))
+}
+
+pub(super) fn is_function_class_type_token(token: &Token) -> bool {
+    token.text.as_ref() == "function"
+}
+
+pub(super) fn binary_operator_text(op: &OpBinary) -> Option<&'static str> {
+    match op {
+        OpBinary::Add => Some("+"),
+        OpBinary::Sub => Some("-"),
+        OpBinary::Mul => Some("*"),
+        OpBinary::Div => Some("/"),
+        OpBinary::Eq => Some("=="),
+        OpBinary::Neq => Some("<>"),
+        OpBinary::Lt => Some("<"),
+        OpBinary::Le => Some("<="),
+        OpBinary::Gt => Some(">"),
+        OpBinary::Ge => Some(">="),
+        OpBinary::And => Some("and"),
+        OpBinary::Or => Some("or"),
+        OpBinary::Exp => Some("^"),
+        OpBinary::ExpElem => Some(".^"),
+        OpBinary::AddElem => Some(".+"),
+        OpBinary::SubElem => Some(".-"),
+        OpBinary::MulElem => Some(".*"),
+        OpBinary::DivElem => Some("./"),
+        OpBinary::Assign | OpBinary::Empty => None,
+    }
+}
+
+pub(super) fn spaced_binary_operator_text(op: &OpBinary) -> Option<&'static str> {
+    match op {
+        OpBinary::Add => Some(" + "),
+        OpBinary::Sub => Some(" - "),
+        OpBinary::Mul => Some(" * "),
+        OpBinary::Div => Some(" / "),
+        OpBinary::Eq => Some(" == "),
+        OpBinary::Neq => Some(" <> "),
+        OpBinary::Lt => Some(" < "),
+        OpBinary::Le => Some(" <= "),
+        OpBinary::Gt => Some(" > "),
+        OpBinary::Ge => Some(" >= "),
+        OpBinary::And => Some(" and "),
+        OpBinary::Or => Some(" or "),
+        OpBinary::Exp => Some(" ^ "),
+        OpBinary::ExpElem => Some(" .^ "),
+        OpBinary::AddElem => Some(" .+ "),
+        OpBinary::SubElem => Some(" .- "),
+        OpBinary::MulElem => Some(" .* "),
+        OpBinary::DivElem => Some(" ./ "),
+        OpBinary::Assign | OpBinary::Empty => None,
+    }
+}
+
+pub(super) fn escape_example_gap(text: &str) -> String {
+    text.replace('\t', "\\t").replace(' ', "·")
+}
+
+pub(super) fn truncate_example(text: &str) -> String {
+    const MAX_CHARS: usize = 32;
+    let mut chars = text.chars();
+    let truncated: String = chars.by_ref().take(MAX_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}
+
+pub(super) fn is_unclassified_gap_candidate(text: &str) -> bool {
+    text.contains([' ', '\t'])
+        && !text.contains(['\n', '\r'])
+        && text.chars().all(|c| {
+            matches!(
+                c,
+                ' ' | '\t'
+                    | '('
+                    | ')'
+                    | '['
+                    | ']'
+                    | '{'
+                    | '}'
+                    | ','
+                    | ';'
+                    | ':'
+                    | '='
+                    | '+'
+                    | '-'
+                    | '*'
+                    | '/'
+                    | '^'
+                    | '<'
+                    | '>'
+                    | '.'
+            )
+        })
+}
+
+pub(super) fn is_closing_expression_separator_gap(text: &str) -> bool {
+    let Some(comma_offset) = text.find(',') else {
+        return false;
+    };
+    text[..comma_offset]
+        .chars()
+        .all(|c| matches!(c, ')' | '}' | ']' | ' ' | '\t'))
+        && text[comma_offset + ','.len_utf8()..]
+            .chars()
+            .all(|c| matches!(c, ' ' | '\t'))
+}
+
+pub(super) fn trim_horizontal_whitespace_before(text: &str, offset: usize) -> usize {
+    let mut start = offset;
+    while start > 0 {
+        let Some((previous_offset, previous_char)) = text[..start].char_indices().next_back()
+        else {
+            break;
+        };
+        if !matches!(previous_char, ' ' | '\t') {
+            break;
+        }
+        start = previous_offset;
+    }
+    start
+}
+
+pub(super) fn trim_horizontal_whitespace_after(text: &str, offset: usize) -> usize {
+    let mut end = offset;
+    while end < text.len() {
+        let Some(next_char) = text[end..].chars().next() else {
+            break;
+        };
+        if !matches!(next_char, ' ' | '\t') {
+            break;
+        }
+        end += next_char.len_utf8();
+    }
+    end
+}

--- a/crates/rumoca-tool-fmt/src/lib.rs
+++ b/crates/rumoca-tool-fmt/src/lib.rs
@@ -6,11 +6,14 @@ mod formatter;
 
 pub use format_errors::FormatError;
 pub use format_options::{
-    CONFIG_FILE_NAMES, ConfigError, FormatOptions, FormatProfile, PartialFormatOptions,
-    find_config, load_config, load_config_from_dir,
+    CONFIG_FILE_NAMES, ConfigError, FormatOptions, FormatProfile, LineEnding, PartialFormatOptions,
+    find_config, load_config, load_config_from_dir, load_config_overrides,
+    load_config_overrides_from_dir,
 };
 pub use formatter::{
-    format, format_or_original, format_or_original_with_source_name, format_with_source_name,
+    FormatCoverageCategory, FormatCoverageCategoryReport, FormatCoverageReport, format,
+    format_coverage_report, format_coverage_report_with_source_name, format_or_original,
+    format_or_original_with_source_name, format_with_source_name,
 };
 
 /// Check if source code is valid Modelica syntax.

--- a/crates/rumoca-tool-lsp/src/server/tests/editor_surface_tests.rs
+++ b/crates/rumoca-tool-lsp/src/server/tests/editor_surface_tests.rs
@@ -18,8 +18,8 @@ pub(super) async fn assert_formatting_wraps_handler(
         .expect("formatting should return an edit");
     assert_eq!(formatting.len(), 1);
     assert!(
-        formatting[0].new_text.contains("x = 1;"),
-        "formatting should rewrite the document into the formatter's normalized form"
+        formatting[0].new_text.ends_with("end F;\n"),
+        "formatting should insert the default final newline"
     );
 }
 

--- a/crates/rumoca-tool-lsp/src/server/tests/workspace_query_tests.rs
+++ b/crates/rumoca-tool-lsp/src/server/tests/workspace_query_tests.rs
@@ -913,7 +913,7 @@ fn formatting_code_actions_inlay_hints_and_document_links_wrap_handler_results()
             let mut session = server.session.write().await;
             session.update_document(
                 &session_document_uri_key(&formatting_uri),
-                "model F\nReal x;\nequation\nx=1;\nend F;\n",
+                "model F\nReal x;\nequation\nx=1;\nend F;",
             );
         }
         assert_formatting_wraps_handler(server, &formatting_uri).await;

--- a/crates/rumoca/src/fmt_cli.rs
+++ b/crates/rumoca/src/fmt_cli.rs
@@ -1,0 +1,311 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use clap::{Args, ValueEnum};
+use rumoca_tool_fmt::PartialFormatOptions;
+
+use crate::{collect_modelica_files, normalize_target_paths, validate_explicit_target_paths};
+
+#[derive(Args, Debug)]
+pub(crate) struct FmtArgs {
+    /// Files or directories to format. If empty, formats current directory.
+    #[arg()]
+    pub(crate) paths: Vec<PathBuf>,
+    /// Check formatting without writing changes.
+    #[arg(long, default_value_t = false)]
+    pub(crate) check: bool,
+    /// Report formatter rule coverage over eligible AST trivia gaps without
+    /// writing changes.
+    #[arg(long, default_value_t = false)]
+    pub(crate) coverage: bool,
+    /// Formatting profile. `dymola` preserves MSL/Dymola-compatible local
+    /// whitespace; `canonical` enables stricter spacing and indentation
+    /// defaults that can still be overridden by the flags below.
+    #[arg(long, value_enum)]
+    pub(crate) profile: Option<FmtProfileArg>,
+    /// Number of spaces per indentation level when indentation normalization is enabled.
+    #[arg(long)]
+    pub(crate) indent_size: Option<usize>,
+    /// Use tabs instead of spaces when indentation normalization is enabled.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
+    pub(crate) use_tabs: Option<bool>,
+    /// Normalize structural indentation; enabled by the canonical profile.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
+    pub(crate) normalize_indentation: Option<bool>,
+    /// Add missing structural indentation only to unindented lines.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
+    pub(crate) repair_missing_indentation: Option<bool>,
+    /// Normalize spaces around declaration bindings and equation/algorithm
+    /// assignments; enabled by the canonical profile.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
+    pub(crate) normalize_equation_spacing: Option<bool>,
+    /// Normalize spaces around binary expression operators; enabled by the
+    /// canonical profile.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
+    pub(crate) normalize_operator_spacing: Option<bool>,
+    /// Normalize named argument and modification assignments to compact `=`;
+    /// enabled by the canonical profile.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
+    pub(crate) normalize_argument_assignment_spacing: Option<bool>,
+    /// Insert a final newline.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
+    pub(crate) insert_final_newline: Option<bool>,
+    /// Trim trailing horizontal whitespace.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
+    pub(crate) trim_trailing_whitespace: Option<bool>,
+    /// Output line-ending style.
+    #[arg(long, value_enum)]
+    pub(crate) line_ending: Option<FmtLineEndingArg>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum FmtProfileArg {
+    Dymola,
+    Canonical,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum FmtLineEndingArg {
+    Auto,
+    Lf,
+    Crlf,
+}
+
+impl From<FmtProfileArg> for rumoca_tool_fmt::FormatProfile {
+    fn from(value: FmtProfileArg) -> Self {
+        match value {
+            FmtProfileArg::Dymola => rumoca_tool_fmt::FormatProfile::Dymola,
+            FmtProfileArg::Canonical => rumoca_tool_fmt::FormatProfile::Canonical,
+        }
+    }
+}
+
+impl From<FmtLineEndingArg> for rumoca_tool_fmt::LineEnding {
+    fn from(value: FmtLineEndingArg) -> Self {
+        match value {
+            FmtLineEndingArg::Auto => rumoca_tool_fmt::LineEnding::Auto,
+            FmtLineEndingArg::Lf => rumoca_tool_fmt::LineEnding::Lf,
+            FmtLineEndingArg::Crlf => rumoca_tool_fmt::LineEnding::Crlf,
+        }
+    }
+}
+pub(crate) fn run_fmt(args: FmtArgs) -> Result<()> {
+    validate_explicit_target_paths(&args.paths)?;
+    let paths = normalize_target_paths(&args.paths);
+    let cli_overrides = PartialFormatOptions {
+        profile: args.profile.map(Into::into),
+        indent_size: args.indent_size,
+        use_tabs: args.use_tabs,
+        normalize_indentation: args.normalize_indentation,
+        repair_missing_indentation: args.repair_missing_indentation,
+        normalize_equation_spacing: args.normalize_equation_spacing,
+        normalize_operator_spacing: args.normalize_operator_spacing,
+        normalize_argument_assignment_spacing: args.normalize_argument_assignment_spacing,
+        insert_final_newline: args.insert_final_newline,
+        trim_trailing_whitespace: args.trim_trailing_whitespace,
+        line_ending: args.line_ending.map(Into::into),
+    };
+
+    let files = collect_modelica_files(&paths);
+    if files.is_empty() {
+        eprintln!("No .mo files found");
+        return Ok(());
+    }
+
+    let mut needs_formatting = 0usize;
+    let mut errors = 0usize;
+    let mut coverage = FmtCoverageSummary::default();
+    for file in &files {
+        let source = match std::fs::read_to_string(file) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Error reading {}: {e}", file.display());
+                errors += 1;
+                continue;
+            }
+        };
+
+        let source_name = file.display().to_string();
+        let options = fmt_options_for_file(file, &cli_overrides)?;
+        if args.coverage {
+            match rumoca_tool_fmt::format_coverage_report_with_source_name(
+                &source,
+                &options,
+                &source_name,
+            ) {
+                Ok(report) => coverage.record(report),
+                Err(e) => {
+                    eprintln!(
+                        "Error measuring formatter coverage for {}: {e}",
+                        file.display()
+                    );
+                    errors += 1;
+                }
+            }
+            continue;
+        }
+
+        let formatted =
+            match rumoca_tool_fmt::format_with_source_name(&source, &options, &source_name) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("Error formatting {}: {e}", file.display());
+                    errors += 1;
+                    continue;
+                }
+            };
+        if formatted == source {
+            continue;
+        }
+        needs_formatting += 1;
+        if args.check {
+            // The changed-file list is the result data → stdout (matches `lint`,
+            // so `rumoca fmt --check . > changes.txt` captures it).
+            println!("Would reformat: {}", file.display());
+        } else if let Err(e) = std::fs::write(file, formatted) {
+            eprintln!("Error writing {}: {e}", file.display());
+            errors += 1;
+        } else {
+            println!("Formatted: {}", file.display());
+        }
+    }
+
+    let total = files.len();
+    let unchanged = total.saturating_sub(needs_formatting + errors);
+    if args.coverage {
+        coverage.print(total, errors);
+        if errors > 0 {
+            std::process::exit(1);
+        }
+    } else if args.check {
+        eprintln!(
+            "{total} files checked: {unchanged} ok, {needs_formatting} need formatting, {errors} errors"
+        );
+        if needs_formatting > 0 || errors > 0 {
+            std::process::exit(1);
+        }
+    } else {
+        eprintln!(
+            "{total} files processed: {unchanged} unchanged, {needs_formatting} formatted, {errors} errors"
+        );
+        if errors > 0 {
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct FmtCoverageSummary {
+    eligible_gaps: usize,
+    covered_gaps: usize,
+    categories: Vec<FmtCoverageCategorySummary>,
+    unclassified_examples: Vec<String>,
+}
+
+impl FmtCoverageSummary {
+    fn record(&mut self, report: rumoca_tool_fmt::FormatCoverageReport) {
+        self.eligible_gaps += report.eligible_gaps;
+        self.covered_gaps += report.covered_gaps;
+        for example in report.unclassified_examples {
+            self.record_unclassified_example(example);
+        }
+        for category in report.categories {
+            self.record_category(category);
+        }
+    }
+
+    fn record_unclassified_example(&mut self, example: String) {
+        if self.unclassified_examples.len() < 8
+            && !self
+                .unclassified_examples
+                .iter()
+                .any(|existing| existing == &example)
+        {
+            self.unclassified_examples.push(example);
+        }
+    }
+
+    fn record_category(&mut self, category: rumoca_tool_fmt::FormatCoverageCategoryReport) {
+        if let Some(entry) = self
+            .categories
+            .iter_mut()
+            .find(|entry| entry.category == category.category)
+        {
+            entry.eligible_gaps += category.eligible_gaps;
+            entry.covered_gaps += category.covered_gaps;
+            return;
+        }
+        self.categories.push(FmtCoverageCategorySummary {
+            category: category.category,
+            eligible_gaps: category.eligible_gaps,
+            covered_gaps: category.covered_gaps,
+        });
+    }
+
+    fn print(&mut self, total_files: usize, errors: usize) {
+        self.categories.sort_by_key(|entry| entry.category.label());
+        eprintln!(
+            "{total_files} files measured: {} eligible gaps, {} covered, {:.2}% coverage, {errors} errors",
+            self.eligible_gaps,
+            self.covered_gaps,
+            self.coverage_percent(),
+        );
+        if self.categories.is_empty() {
+            return;
+        }
+        eprintln!("category,eligible,covered,coverage");
+        for category in &self.categories {
+            eprintln!(
+                "{},{},{},{:.2}%",
+                category.category.label(),
+                category.eligible_gaps,
+                category.covered_gaps,
+                category.coverage_percent(),
+            );
+        }
+        if !self.unclassified_examples.is_empty() {
+            eprintln!("unclassified examples:");
+            for example in &self.unclassified_examples {
+                eprintln!("  {example}");
+            }
+        }
+    }
+
+    fn coverage_percent(&self) -> f64 {
+        coverage_percent(self.covered_gaps, self.eligible_gaps)
+    }
+}
+
+struct FmtCoverageCategorySummary {
+    category: rumoca_tool_fmt::FormatCoverageCategory,
+    eligible_gaps: usize,
+    covered_gaps: usize,
+}
+
+impl FmtCoverageCategorySummary {
+    fn coverage_percent(&self) -> f64 {
+        coverage_percent(self.covered_gaps, self.eligible_gaps)
+    }
+}
+
+fn coverage_percent(covered_gaps: usize, eligible_gaps: usize) -> f64 {
+    if eligible_gaps == 0 {
+        return 100.0;
+    }
+    covered_gaps as f64 * 100.0 / eligible_gaps as f64
+}
+
+fn fmt_options_for_file(
+    file: &Path,
+    cli_overrides: &PartialFormatOptions,
+) -> Result<rumoca_tool_fmt::FormatOptions> {
+    let config_dir = file.parent().unwrap_or(Path::new("."));
+    let config_overrides = rumoca_tool_fmt::load_config_overrides_from_dir(config_dir)
+        .map_err(|e| anyhow::anyhow!("Failed to load formatter config: {e}"))?
+        .unwrap_or_default();
+    Ok(rumoca_tool_fmt::FormatOptions::from_partial(
+        config_overrides.overlay(cli_overrides.clone()),
+    ))
+}

--- a/crates/rumoca/src/main.rs
+++ b/crates/rumoca/src/main.rs
@@ -25,6 +25,7 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 mod cache_cmd;
+mod fmt_cli;
 mod fmu;
 mod sim_bench;
 mod sim_inspect;
@@ -42,6 +43,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::{Result, bail};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+use fmt_cli::FmtArgs;
 use miette::{
     GraphicalTheme, LabeledSpan, MietteDiagnostic, MietteHandlerOpts, NamedSource, Report, Severity,
 };
@@ -533,46 +535,6 @@ impl SimulateSolverMode {
 }
 
 #[derive(Args, Debug)]
-struct FmtArgs {
-    /// Files or directories to format. If empty, formats current directory.
-    #[arg()]
-    paths: Vec<PathBuf>,
-    /// Check formatting without writing changes.
-    #[arg(long, default_value_t = false)]
-    check: bool,
-    /// Number of spaces per indentation level.
-    #[arg(long)]
-    indent_size: Option<usize>,
-    /// Use tabs instead of spaces (bare `--use-tabs` means true; or
-    /// `--use-tabs false`).
-    #[arg(
-        long,
-        num_args = 0..=1,
-        default_missing_value = "true",
-        value_parser = clap::builder::BoolishValueParser::new()
-    )]
-    use_tabs: Option<bool>,
-    /// Formatting profile.
-    #[arg(long, value_enum)]
-    profile: Option<FmtProfileArg>,
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum FmtProfileArg {
-    Msl,
-    Canonical,
-}
-
-impl From<FmtProfileArg> for rumoca_tool_fmt::FormatProfile {
-    fn from(value: FmtProfileArg) -> Self {
-        match value {
-            FmtProfileArg::Msl => rumoca_tool_fmt::FormatProfile::Msl,
-            FmtProfileArg::Canonical => rumoca_tool_fmt::FormatProfile::Canonical,
-        }
-    }
-}
-
-#[derive(Args, Debug)]
 struct LintArgs {
     /// Files or directories to lint. If empty, lints current directory.
     #[arg()]
@@ -654,7 +616,7 @@ fn try_main() -> Result<()> {
     match cli.command {
         Commands::Compile(args) => run_compile(args),
         Commands::Sim(args) => run_sim(*args),
-        Commands::Fmt(args) => run_fmt(args),
+        Commands::Fmt(args) => fmt_cli::run_fmt(args),
         Commands::Lint(args) => run_lint(args),
         Commands::Completions { shell } => {
             print!("{}", completion_script(shell));
@@ -1217,88 +1179,6 @@ fn run_direct_simulation(args: SimCommandArgs) -> Result<()> {
         output: args.output.as_deref(),
         workspace_root: workspace_root.as_deref(),
     })
-}
-
-fn run_fmt(args: FmtArgs) -> Result<()> {
-    validate_explicit_target_paths(&args.paths)?;
-    let paths = normalize_target_paths(&args.paths);
-    let config_dir = first_path_config_dir(&paths);
-    let mut options = rumoca_tool_fmt::load_config_from_dir(&config_dir)
-        .map_err(|e| anyhow::anyhow!("Failed to load formatter config: {e}"))?
-        .unwrap_or_default();
-    if let Some(indent_size) = args.indent_size {
-        options.indent_size = indent_size;
-    }
-    if let Some(use_tabs) = args.use_tabs {
-        options.use_tabs = use_tabs;
-    }
-    if let Some(profile) = args.profile {
-        options.profile = profile.into();
-    }
-
-    let files = collect_modelica_files(&paths);
-    if files.is_empty() {
-        eprintln!("No .mo files found");
-        return Ok(());
-    }
-
-    let mut needs_formatting = 0usize;
-    let mut errors = 0usize;
-    for file in &files {
-        let source = match std::fs::read_to_string(file) {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("Error reading {}: {e}", file.display());
-                errors += 1;
-                continue;
-            }
-        };
-
-        let source_name = file.display().to_string();
-        let formatted =
-            match rumoca_tool_fmt::format_with_source_name(&source, &options, &source_name) {
-                Ok(v) => v,
-                Err(e) => {
-                    eprintln!("Error formatting {}: {e}", file.display());
-                    errors += 1;
-                    continue;
-                }
-            };
-        if formatted == source {
-            continue;
-        }
-        needs_formatting += 1;
-        if args.check {
-            // The changed-file list is the result data → stdout (matches `lint`,
-            // so `rumoca fmt --check . > changes.txt` captures it).
-            println!("Would reformat: {}", file.display());
-        } else if let Err(e) = std::fs::write(file, formatted) {
-            eprintln!("Error writing {}: {e}", file.display());
-            errors += 1;
-        } else {
-            println!("Formatted: {}", file.display());
-        }
-    }
-
-    let total = files.len();
-    let unchanged = total.saturating_sub(needs_formatting + errors);
-    if args.check {
-        eprintln!(
-            "{total} files checked: {unchanged} ok, {needs_formatting} need formatting, {errors} errors"
-        );
-        if needs_formatting > 0 || errors > 0 {
-            std::process::exit(1);
-        }
-    } else {
-        eprintln!(
-            "{total} files processed: {unchanged} unchanged, {needs_formatting} formatted, {errors} errors"
-        );
-        if errors > 0 {
-            std::process::exit(1);
-        }
-    }
-
-    Ok(())
 }
 
 fn run_lint(args: LintArgs) -> Result<()> {

--- a/crates/rumoca/tests/cli_fmt_lint.rs
+++ b/crates/rumoca/tests/cli_fmt_lint.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use tempfile::tempdir;
@@ -8,29 +8,98 @@ fn write_model(path: &Path, source: &str) {
     fs::write(path, source).expect("write model file");
 }
 
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("create destination directory");
+    for entry in fs::read_dir(src).expect("read source directory") {
+        let entry = entry.expect("read directory entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).expect("copy file");
+        }
+    }
+}
+
+fn assert_dir_tree_bytes_equal(expected_root: &Path, actual_root: &Path) {
+    for entry in fs::read_dir(expected_root).expect("read expected directory") {
+        let entry = entry.expect("read expected directory entry");
+        let expected_path = entry.path();
+        let actual_path = actual_root.join(entry.file_name());
+        if expected_path.is_dir() {
+            assert!(
+                actual_path.is_dir(),
+                "missing formatted directory {}",
+                actual_path.display()
+            );
+            assert_dir_tree_bytes_equal(&expected_path, &actual_path);
+        } else {
+            assert!(
+                actual_path.is_file(),
+                "missing formatted file {}",
+                actual_path.display()
+            );
+            assert_eq!(
+                fs::read(&actual_path).expect("read formatted file"),
+                fs::read(&expected_path).expect("read expected file"),
+                "formatted MSL file drifted: {}",
+                expected_path.display()
+            );
+        }
+    }
+
+    for entry in fs::read_dir(actual_root).expect("read actual directory") {
+        let entry = entry.expect("read actual directory entry");
+        let actual_path = entry.path();
+        let expected_path = expected_root.join(entry.file_name());
+        assert!(
+            expected_path.exists(),
+            "formatter created unexpected MSL path {}",
+            actual_path.display()
+        );
+    }
+}
+
+fn cached_msl_root() -> Option<PathBuf> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let roots = std::env::current_dir()
+        .ok()
+        .into_iter()
+        .chain(manifest_dir.ancestors().map(Path::to_path_buf));
+    for root in roots {
+        let candidate = root
+            .join("target")
+            .join("msl")
+            .join("ModelicaStandardLibrary-4.1.0");
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 #[test]
-fn fmt_check_fails_when_file_needs_formatting() {
+fn fmt_check_reports_compact_equation_assignment_with_normalization_enabled() {
     let dir = tempdir().expect("tempdir");
-    let file = dir.path().join("needs_fmt.mo");
-    write_model(&file, "model NeedsFmt\n  Real x(start=1);\nend NeedsFmt;\n");
+    let file = dir.path().join("dymola_style.mo");
+    let source =
+        "model DymolaStyle\n  Real x(start=1);  \nequation\n  der(x)= -9.8;\nend DymolaStyle;";
+    write_model(&file, source);
 
     let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
         .arg("fmt")
         .arg("--check")
+        .arg("--normalize-equation-spacing=true")
         .arg(&file)
         .output()
         .expect("run rumoca fmt --check");
 
-    assert!(
-        !output.status.success(),
-        "fmt --check should fail when file needs formatting"
-    );
-    // The changed-file list is result data → stdout (matches `lint`); the
-    // summary stays on stderr.
+    assert!(!output.status.success(), "fmt --check should report drift");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stdout.contains("Would reformat"));
-    assert!(stderr.contains("need formatting"));
+    assert!(stderr.contains("1 need formatting"));
 }
 
 #[test]
@@ -56,6 +125,413 @@ fn fmt_check_succeeds_for_already_formatted_file() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("files checked"));
     assert!(stderr.contains("0 need formatting"));
+}
+
+#[test]
+fn fmt_check_fails_on_syntax_error() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("bad.mo");
+    write_model(&file, "model Bad\n  Real x =\nend Bad;\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg("--check")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt --check");
+
+    assert!(
+        !output.status.success(),
+        "fmt --check should fail on syntax errors"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error formatting"));
+    assert!(stderr.contains("1 errors"));
+}
+
+#[test]
+fn fmt_respects_dymola_profile_config_without_rewriting_source() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("dymola_style.mo");
+    let source = "model DymolaStyle\r\n  Real x(start=1);  \r\n  Real y;\r\n\r\nequation\r\n  der(x)=y;\r\n  y=-9.8;\r\nend DymolaStyle;";
+    write_model(&file, source);
+    fs::write(
+        dir.path().join(".rumoca_fmt.toml"),
+        concat!(
+            "profile = \"dymola\"\n",
+            "normalize_equation_spacing = false\n",
+            "trim_trailing_whitespace = false\n",
+            "insert_final_newline = false\n",
+            "line_ending = \"auto\"\n",
+        ),
+    )
+    .expect("write fmt config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt");
+
+    assert!(
+        output.status.success(),
+        "Dymola profile config should preserve source bytes"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stdout.contains("Formatted"));
+    assert!(stderr.contains("1 unchanged"));
+    assert_eq!(
+        fs::read(&file).expect("read formatted file"),
+        source.as_bytes()
+    );
+}
+
+#[test]
+fn fmt_dymola_equation_spacing_option_preserves_modifiers() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("rewrite.mo");
+    write_model(
+        &file,
+        "model Rewrite\n  Real x(start=1);  \nequation\n  x=1;\nend Rewrite;",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg("--normalize-equation-spacing=true")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt");
+
+    assert!(output.status.success(), "fmt should succeed");
+    let formatted = fs::read_to_string(&file).expect("read formatted");
+    assert_eq!(
+        formatted,
+        "model Rewrite\n  Real x(start=1);\nequation\n  x = 1;\nend Rewrite;\n"
+    );
+}
+
+#[test]
+fn fmt_canonical_profile_normalizes_spacing_and_indentation() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("canonical.mo");
+    write_model(
+        &file,
+        "model Canonical\nReal x;\nequation\nx=1;\nend Canonical;",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg("--profile")
+        .arg("canonical")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt --profile canonical");
+
+    assert!(output.status.success(), "fmt should succeed");
+    let formatted = fs::read_to_string(&file).expect("read formatted");
+    assert_eq!(
+        formatted,
+        "model Canonical\n  Real x;\nequation\n  x = 1;\nend Canonical;\n"
+    );
+}
+
+#[test]
+fn fmt_canonical_profile_config_can_override_individual_knobs() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("canonical_override.mo");
+    write_model(
+        &file,
+        "model CanonicalOverride\nReal x(start = 1);\nequation\nx=1+2;\nend CanonicalOverride;",
+    );
+    fs::write(
+        dir.path().join(".rumoca_fmt.toml"),
+        concat!(
+            "profile = \"canonical\"\n",
+            "normalize_equation_spacing = false\n",
+            "normalize_operator_spacing = false\n",
+            "normalize_argument_assignment_spacing = false\n",
+        ),
+    )
+    .expect("write fmt config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt");
+
+    assert!(output.status.success(), "fmt should succeed");
+    let formatted = fs::read_to_string(&file).expect("read formatted");
+    assert_eq!(
+        formatted,
+        "model CanonicalOverride\n  Real x(start = 1);\nequation\n  x=1+2;\nend CanonicalOverride;\n"
+    );
+}
+
+#[test]
+fn fmt_operator_spacing_can_be_enabled_by_cli() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("operators.mo");
+    write_model(
+        &file,
+        "model Operators\n  Real x;\nequation\n  x=1+2*3;\nend Operators;",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg("--normalize-operator-spacing")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt --normalize-operator-spacing");
+
+    assert!(output.status.success(), "fmt should succeed");
+    let formatted = fs::read_to_string(&file).expect("read formatted");
+    assert_eq!(
+        formatted,
+        "model Operators\n  Real x;\nequation\n  x=1 + 2 * 3;\nend Operators;\n"
+    );
+}
+
+#[test]
+fn fmt_coverage_reports_canonical_classified_gap_percentage() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("coverage.mo");
+    write_model(
+        &file,
+        "model Coverage\nReal x;\nequation\nx=1+2*3;\nconnect(a,b);\nend Coverage;",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg("--coverage")
+        .arg("--profile")
+        .arg("canonical")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt --coverage --profile canonical");
+
+    assert!(output.status.success(), "fmt coverage should succeed");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).is_empty(),
+        "coverage mode should not emit changed-file stdout"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("coverage"));
+    assert!(stderr.contains("100.00% coverage"));
+    assert!(stderr.contains("binary-operator"));
+    assert!(stderr.contains("connect-comma"));
+    assert_eq!(
+        fs::read_to_string(&file).expect("read source"),
+        "model Coverage\nReal x;\nequation\nx=1+2*3;\nconnect(a,b);\nend Coverage;"
+    );
+}
+
+#[test]
+fn fmt_default_trims_trailing_whitespace_outside_literals() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("trailing.mo");
+    write_model(
+        &file,
+        "model Trailing\n  Real x;  \n  annotation(Documentation(info=\"<html>\n<p>keep this literal space </p> \n</html>\"));\nend Trailing;",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt");
+
+    assert!(output.status.success(), "fmt should succeed");
+    let formatted = fs::read_to_string(&file).expect("read formatted");
+    assert_eq!(
+        formatted,
+        "model Trailing\n  Real x;\n  annotation(Documentation(info=\"<html>\n<p>keep this literal space </p> \n</html>\"));\nend Trailing;\n"
+    );
+}
+
+#[test]
+fn fmt_repair_missing_indentation_can_be_disabled_by_cli() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("missing_indent.mo");
+    let source = "model MissingIndent\nReal x;\nequation\nx=1;\nend MissingIndent;";
+    write_model(&file, source);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg("--repair-missing-indentation=false")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt");
+
+    assert!(output.status.success(), "fmt should succeed");
+    assert_eq!(
+        fs::read_to_string(&file).expect("read formatted"),
+        "model MissingIndent\nReal x;\nequation\nx=1;\nend MissingIndent;\n"
+    );
+}
+
+#[test]
+fn fmt_common_cli_options_control_rewrites() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("options.mo");
+    let source = "model Options\r\nReal x(start=1);  \r\nequation\r\nx=1;\r\nend Options;";
+    write_model(&file, source);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg("--normalize-indentation")
+        .arg("--use-tabs")
+        .arg("--normalize-equation-spacing=false")
+        .arg("--trim-trailing-whitespace=false")
+        .arg("--insert-final-newline=false")
+        .arg("--line-ending")
+        .arg("crlf")
+        .arg(&file)
+        .output()
+        .expect("run rumoca fmt");
+
+    assert!(output.status.success(), "fmt should succeed");
+    let formatted = fs::read_to_string(&file).expect("read formatted");
+    assert_eq!(
+        formatted,
+        "model Options\r\n\tReal x(start=1);  \r\nequation\r\n\tx=1;\r\nend Options;"
+    );
+}
+
+#[test]
+fn fmt_msl_copy_has_no_drift_and_bad_file_is_rewritten() {
+    let Some(msl_root) = cached_msl_root() else {
+        let message = "cached MSL not found under target/msl; skipping MSL formatter drift test";
+        if std::env::var_os("REQUIRE_MSL_FMT_DRIFT").is_some() {
+            panic!("{message}");
+        }
+        eprintln!("{message}");
+        return;
+    };
+    let dir = tempdir().expect("tempdir");
+    let copy_root = dir.path().join("msl-copy");
+    copy_dir_recursive(&msl_root, &copy_root);
+
+    let msl_fmt_output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg(&copy_root)
+        .output()
+        .expect("run rumoca fmt on MSL copy");
+    assert!(
+        msl_fmt_output.status.success(),
+        "MSL copy formatting should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&msl_fmt_output.stdout),
+        String::from_utf8_lossy(&msl_fmt_output.stderr)
+    );
+    assert_dir_tree_bytes_equal(&msl_root, &copy_root);
+
+    let canonical_coverage_output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg("--coverage")
+        .arg("--profile")
+        .arg("canonical")
+        .arg(&copy_root)
+        .output()
+        .expect("measure canonical formatter coverage on MSL copy");
+    assert!(
+        canonical_coverage_output.status.success(),
+        "canonical MSL formatter coverage should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&canonical_coverage_output.stdout),
+        String::from_utf8_lossy(&canonical_coverage_output.stderr)
+    );
+    let canonical_coverage = String::from_utf8_lossy(&canonical_coverage_output.stderr);
+    let summary_line = canonical_coverage
+        .lines()
+        .find(|line| line.contains("files measured"))
+        .expect("canonical coverage should print a summary line");
+    assert!(
+        summary_line.contains("100.00% coverage"),
+        "canonical MSL formatter coverage should be complete, got: {summary_line}"
+    );
+
+    let missing_indent_file = copy_root.join("MissingDymolaIndent.mo");
+    write_model(
+        &missing_indent_file,
+        "model MissingDymolaIndent\nReal x(start=1);\nequation\nx=1;\nend MissingDymolaIndent;",
+    );
+    let default_fmt_output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg(&missing_indent_file)
+        .output()
+        .expect("run rumoca fmt on missing-indent Dymola file");
+    assert!(
+        default_fmt_output.status.success(),
+        "missing-indent file formatting should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&default_fmt_output.stdout),
+        String::from_utf8_lossy(&default_fmt_output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&missing_indent_file)
+            .expect("read missing-indent file after formatting"),
+        "model MissingDymolaIndent\n  Real x(start=1);\nequation\nx=1;\nend MissingDymolaIndent;\n"
+    );
+
+    let bad_file = copy_root.join("BadDymolaFormat.mo");
+    write_model(
+        &bad_file,
+        "model BadDymolaFormat\nReal x(start=1);\nequation\nx=1;\nend BadDymolaFormat;",
+    );
+    let fmt_output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg("--normalize-indentation")
+        .arg("--normalize-equation-spacing")
+        .arg(&bad_file)
+        .output()
+        .expect("run rumoca fmt on bad Dymola file");
+    assert!(
+        fmt_output.status.success(),
+        "bad file formatting should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&fmt_output.stdout),
+        String::from_utf8_lossy(&fmt_output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&bad_file).expect("read bad file after formatting"),
+        "model BadDymolaFormat\n  Real x(start=1);\nequation\n  x = 1;\nend BadDymolaFormat;\n"
+    );
+}
+
+#[test]
+fn fmt_loads_config_from_each_file_directory() {
+    let dir = tempdir().expect("tempdir");
+    let dymola_dir = dir.path().join("dymola");
+    let default_dir = dir.path().join("default");
+    fs::create_dir_all(&dymola_dir).expect("create dymola dir");
+    fs::create_dir_all(&default_dir).expect("create default dir");
+
+    let dymola_file = dymola_dir.join("dymola.mo");
+    let default_file = default_dir.join("default.mo");
+    let compact_source = "model Compact\n  Real x(start=1);\nend Compact;\n";
+    write_model(&dymola_file, compact_source);
+    write_model(&default_file, compact_source);
+    fs::write(
+        dymola_dir.join(".rumoca_fmt.toml"),
+        "profile = \"dymola\"\n",
+    )
+    .expect("write dymola fmt config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rumoca"))
+        .arg("fmt")
+        .arg(dir.path())
+        .output()
+        .expect("run rumoca fmt");
+
+    assert!(output.status.success(), "fmt should succeed");
+    assert_eq!(
+        fs::read(&dymola_file).expect("read dymola file"),
+        compact_source.as_bytes(),
+        "Dymola config should apply to files under that directory"
+    );
+    assert_eq!(
+        fs::read(&default_file).expect("read default file"),
+        compact_source.as_bytes(),
+        "default Dymola profile should keep declaration modifier spacing"
+    );
 }
 
 #[test]

--- a/crates/rumoca/tests/pipeline_cases/flat_output_regressions.rs
+++ b/crates/rumoca/tests/pipeline_cases/flat_output_regressions.rs
@@ -1,6 +1,46 @@
 use super::*;
 
 #[test]
+fn test_dae_json_surfaces_variable_causality() {
+    let source = r#"
+model Base
+  input Real inherited_u;
+  output Real inherited_y;
+equation
+  inherited_y = inherited_u;
+end Base;
+
+model Plant
+  extends Base;
+  parameter Real R = 1.0;
+  Real x(start = 0);
+  input Real u;
+  output Real y;
+equation
+  der(x) = -R*x + u + inherited_u;
+  y = x;
+end Plant;
+"#;
+
+    let mut session = Session::new(SessionConfig::default());
+    session
+        .add_document("test.mo", source)
+        .expect("parse/resolve/typecheck failed");
+
+    let result = session
+        .compile_model("Plant")
+        .expect("compile should succeed");
+    let json = serde_json::to_value(&result.dae).expect("DAE should serialize");
+
+    assert_eq!(json["u"]["u"]["causality"], "input");
+    assert_eq!(json["u"]["inherited_u"]["causality"], "input");
+    assert_eq!(json["w"]["y"]["causality"], "output");
+    assert_eq!(json["w"]["inherited_y"]["causality"], "output");
+    assert_eq!(json["p"]["R"]["causality"], "parameter");
+    assert_eq!(json["x"]["x"]["causality"], "local");
+}
+
+#[test]
 fn test_flat_output_preserves_symbolic_modifier_binding_for_subcomponent_parameter() {
     let source = r#"
 model Parent

--- a/crates/xtask/src/lsp_benchmark_cmd.rs
+++ b/crates/xtask/src/lsp_benchmark_cmd.rs
@@ -62,7 +62,7 @@ end M;
 "#;
 
 const VALIDATION_CHANGED_SOURCE: &str = "model Shifted\n  Real x;\nend Shifted;\n";
-const VALIDATION_FORMATTING_SOURCE: &str = "model F\nReal x;\nequation\nx=1;\nend F;\n";
+const VALIDATION_FORMATTING_SOURCE: &str = "model F\nReal x;\nequation\nx=1;\nend F;";
 const VALIDATION_SAVE_SOURCE: &str =
     "model Active\n  Real x;\nequation\n  der(x) = -x;\nend Active;\n";
 const VALIDATION_CODE_ACTION_SOURCE: &str = r#"model Broken

--- a/crates/xtask/src/lsp_benchmark_cmd/runtime.rs
+++ b/crates/xtask/src/lsp_benchmark_cmd/runtime.rs
@@ -781,9 +781,16 @@ fn validate_mutation_rewrites(
         }),
         VALIDATION_TIMEOUT,
     )?;
+    let format_result = response_result(&format_response);
+    let format_edits = format_result
+        .as_array()
+        .context("formatting should return edit list")?;
     ensure!(
-        json_array_len(&response_result(&format_response)) >= 1,
-        "formatting should return a rewrite edit"
+        format_edits.iter().any(|edit| edit
+            .get("newText")
+            .and_then(|text| text.as_str())
+            .is_some_and(|text| text.ends_with("end F;\n"))),
+        "formatting should return default final-newline edit"
     );
 
     client.did_open(&workspace.broken_uri, VALIDATION_CODE_ACTION_SOURCE)?;
@@ -812,7 +819,7 @@ fn validate_mutation_rewrites(
     client.did_close(&workspace.broken_uri)?;
 
     Ok(vec![
-        ok_validation("formatting", "req", Some(format_ms), "synthetic rewrite"),
+        ok_validation("formatting", "req", Some(format_ms), "synthetic preserved"),
         ok_validation("codeAction", "req", Some(action_ms), "synthetic EP001"),
     ])
 }

--- a/editors/vscode/tests/msl_extension_suite.cjs
+++ b/editors/vscode/tests/msl_extension_suite.cjs
@@ -20,6 +20,17 @@ function requiredBenchmarkSetting(vscode, key) {
   return value;
 }
 
+function optionalPositiveNumberBenchmarkSetting(vscode, key, fallback) {
+  const value = vscode.workspace.getConfiguration("rumoca").get(key);
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  throw new Error(`expected positive numeric workspace setting: rumoca.${key}`);
+}
+
 function labelText(label) {
   if (typeof label === "string") {
     return label;
@@ -58,7 +69,11 @@ exports.run = async function run() {
 
   const documentPath = requiredBenchmarkSetting(vscode, "benchmark.smoke.document");
   const resultPath = requiredBenchmarkSetting(vscode, "benchmark.smoke.result");
-  const activateMaxMs = ACTIVATE_MAX_MS;
+  const activateMaxMs = optionalPositiveNumberBenchmarkSetting(
+    vscode,
+    "benchmark.smoke.activateMaxMs",
+    ACTIVATE_MAX_MS,
+  );
   const codeLensMaxMs = CODELENS_MAX_MS;
   const completionMaxMs = COMPLETION_MAX_MS;
   const hoverMaxMs = HOVER_MAX_MS;

--- a/editors/vscode/tests/run_msl_extension_smoke.mjs
+++ b/editors/vscode/tests/run_msl_extension_smoke.mjs
@@ -61,6 +61,7 @@ async function createWorkspaceFile(rootDir, { completionTimingPath, documentPath
           // Document/result are consumed by the extension-host test suite.
           "rumoca.benchmark.smoke.document": documentPath,
           "rumoca.benchmark.smoke.result": resultPath,
+          "rumoca.benchmark.smoke.activateMaxMs": 60000,
           // The extension forwards this to rumoca-lsp as `--completion-timing-file`.
           "rumoca.benchmark.completionTimingFile": completionTimingPath,
         },

--- a/spec/SPEC_0018_TOOL_CONFIG.md
+++ b/spec/SPEC_0018_TOOL_CONFIG.md
@@ -238,28 +238,39 @@ CLI arguments override file configuration using partial option types:
 ```rust
 /// Full options (all fields required)
 pub struct FormatOptions {
+    pub profile: FormatProfile,
     pub indent_size: usize,
     pub use_tabs: bool,
-    pub max_line_length: usize,
-    // ...
+    pub normalize_indentation: bool,
+    pub repair_missing_indentation: bool,
+    pub normalize_equation_spacing: bool,
+    pub normalize_operator_spacing: bool,
+    pub normalize_argument_assignment_spacing: bool,
+    pub insert_final_newline: bool,
+    pub trim_trailing_whitespace: bool,
+    pub line_ending: LineEnding,
 }
 
 /// Partial options for CLI overrides (all fields optional)
 pub struct PartialFormatOptions {
+    pub profile: Option<FormatProfile>,
     pub indent_size: Option<usize>,
     pub use_tabs: Option<bool>,
-    pub max_line_length: Option<usize>,
-    // ...
+    pub normalize_indentation: Option<bool>,
+    pub repair_missing_indentation: Option<bool>,
+    pub normalize_equation_spacing: Option<bool>,
+    pub normalize_operator_spacing: Option<bool>,
+    pub normalize_argument_assignment_spacing: Option<bool>,
+    pub insert_final_newline: Option<bool>,
+    pub trim_trailing_whitespace: Option<bool>,
+    pub line_ending: Option<LineEnding>,
 }
 
 impl FormatOptions {
     /// Merge with partial options. CLI values override file values.
     pub fn merge(self, cli: PartialFormatOptions) -> Self {
         FormatOptions {
-            indent_size: cli.indent_size.unwrap_or(self.indent_size),
-            use_tabs: cli.use_tabs.unwrap_or(self.use_tabs),
-            max_line_length: cli.max_line_length.unwrap_or(self.max_line_length),
-            // ...
+            profile: cli.profile.unwrap_or(self.profile),
         }
     }
 }
@@ -282,17 +293,38 @@ let formatted = format(&source, &options)?;
 ### TOML Format
 
 ```toml
-# .rumoca_fmt.toml
-indent_size = 4
+profile = "dymola"
+indent_size = 2
 use_tabs = false
-max_line_length = 120
-align_annotations = true
+normalize_indentation = false
+repair_missing_indentation = true
+normalize_equation_spacing = false
+normalize_operator_spacing = false
+normalize_argument_assignment_spacing = false
 insert_final_newline = true
 trim_trailing_whitespace = true
+line_ending = "auto" # "auto", "lf", or "crlf"
 ```
 
+`normalize_indentation = true` normalizes clear structural indentation for
+class/package bodies, section headers, and control blocks. Continuation lines,
+annotation alignment, comments, quoted identifiers, and multi-line strings keep
+local MSL/Dymola alignment rather than a single global indentation rule.
+
+`repair_missing_indentation = true` is the Dymola default. It only adds
+structural indentation to otherwise unindented built-in scalar declaration
+lines; existing nonzero indentation and local alignment are preserved.
+
+`normalize_equation_spacing` covers declaration bindings and equation/algorithm
+assignments. `normalize_operator_spacing` covers binary operators.
+`normalize_argument_assignment_spacing` compacts call/modification assignments
+such as `Real x(start=10)` and `h(a=1, b=2)`. Canonical enables it; Dymola
+disables it to preserve MSL modifier whitespace.
+
+`trim_trailing_whitespace = true` is the Dymola default. It trims only outside
+strings, quoted identifiers, and block comments.
+
 ```toml
-# .rumoca_lint.toml
 min_level = "warning"  # "help", "note", "warning", "error"
 disabled_rules = ["magic-number", "naming-convention"]
 warnings_as_errors = false


### PR DESCRIPTION
## Summary

- Convert `rumoca fmt` into an AST/span-backed Modelica formatter with a Dymola-compatible default profile and a canonical profile for full whitespace normalization coverage.
- Preserve MSL/Dymola source whitespace where a stable rule is not yet justified, while normalizing covered whitespace through explicit formatter rules and configurable knobs.
- Preserve source component modifications in the AST so formatter and navigation visitors can use original modifier spans without double-walking normalized modifier data.
- Add CI/local regression coverage for MSL no-drift formatting, canonical 100% classified-gap coverage, malformed-file rewrites, and AST modifier/navigation behavior.

Refs #157.

## Spec / MLS Alignment

- Relevant active spec(s) checked: `SPEC_0018_TOOL_CONFIG.md`, `SPEC_0021_CODE_COMPLEXITY.md`, `SPEC_0029_CRATE_BOUNDARIES.md`, `SPEC_0007_IR_PIPELINE.md`
- Relevant MLS section(s), if semantics changed: MLS lexical/source formatting only; no semantic Modelica change intended.
- Crate/phase owner: `rumoca-tool-fmt`, `rumoca` CLI, `rumoca-ir-ast`, `rumoca-phase-parse`.

## Risk and Design Notes

- Main correctness risk: formatting broad Modelica syntax could drift MSL/Dymola source. The default `dymola` profile is guarded by an MSL copy no-drift test and preserves ambiguous trivia.
- Main maintenance risk: the formatter now depends on AST spans and source trivia classification. The rule split (`dymola`, `trivia`, `coverage`) keeps traversal, whitespace lookup, and reporting separate.
- Why the change belongs in these crate(s): parse owns source modifier spans; AST owns visitors; tool-fmt owns formatting rules; CLI owns flag/config merge behavior.
- Any new abstraction, public API, or migration path: adds formatter coverage reporting, source-trivia lookup helpers, source modification preservation, and documented formatter knobs for profile/indent/spacing/newline/line-ending behavior.

## Testing

- Key command(s) run: `cargo test -p rumoca-tool-fmt -- --nocapture`; `cargo test -p rumoca-phase-parse -- --nocapture`; `cargo test -p rumoca-ir-ast -- --nocapture`; `REQUIRE_MSL_FMT_DRIFT=1 cargo test -p rumoca --test cli_fmt_lint fmt_msl_copy_has_no_drift_and_bad_file_is_rewritten -- --nocapture`; `cargo run --bin rumoca -- fmt --check --profile dymola /home/jgoppert/git/rumoca/target/editor-msl-smoke/Modelica`; `cargo run --bin rumoca -- fmt --coverage --check --profile canonical /home/jgoppert/git/rumoca/target/editor-msl-smoke/Modelica`; `cargo xtask verify quick`; `cargo xtask verify full`.
- Behavior or regression covered: MSL Dymola-profile no-drift; canonical classified whitespace coverage at 100%; bad formatting is rewritten; formatter CLI/config knobs merge correctly; component modifier spans are preserved and not double-visited.
- Commands NOT run and why: none.
- MSL gate: `cargo xtask verify full` passed locally. MSL quality gate passed vs `msl_quality_baseline.json`: parse 566/566, flatten 562/566, DAE 477/566, solve 388/566, IC 224/566, sim 152/566, trace 109/566, no-severe 131/566.

## Code Size Budget (required)

- production_lines_added: 4429
- production_lines_deleted: 549
- test_lines_added: 1329
- test_lines_deleted: 15
- public_items_added: formatter coverage reports, source-trivia helpers, source modification AST fields, formatter CLI/config knobs
- public_items_removed: none
- files_touched: 34
- net_added_lines: 5230

Positive net growth is required because this replaces the earlier partial/source-text formatter with AST/span-backed formatting, source-trivia coverage measurement, profile-specific rules, and MSL-backed regressions. The compression pass split formatter logic into focused modules and moved CLI formatting code out of `main.rs`; line-count and traversal policy checks passed in `verify quick` and `verify full`. Follow-up cleanup should focus on reducing formatter rule/test volume after the AST coverage surface stabilizes.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.