### PR TITLE
Deduplicate verify full filesize gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1057,7 +1057,22 @@ jobs:
 
       - name: Install Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
+          export PATH="$HOME/.cargo/bin:$PATH"
+          toolchain="$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
+          if ! command -v rustup >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+          fi
+          rustup set profile minimal
+          if ! rustup toolchain list | grep -Eq "^${toolchain}"; then
+            rustup toolchain install "$toolchain"
+          fi
+          if ! rustup component list --toolchain "$toolchain" --installed | grep -qx 'rust-src'; then
+            rustup component add rust-src --toolchain "$toolchain"
+          fi
+          if ! rustup target list --toolchain "$toolchain" --installed | grep -qx 'wasm32-unknown-unknown'; then
+            rustup target add wasm32-unknown-unknown --toolchain "$toolchain"
+          fi
+          rustup default "$toolchain"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install maturin

--- a/crates/xtask/src/verify_cmd.rs
+++ b/crates/xtask/src/verify_cmd.rs
@@ -14,9 +14,8 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use crate::{
-    CheckRustFileLinesArgs, cmd_check_rust_file_lines, command_exists, exe_name, lsp_benchmark_cmd,
-    modelica_dependency_cache, msl_flamegraph_cmd, run_status, run_status_quiet, test_cmd,
-    vscode_cmd,
+    command_exists, exe_name, lsp_benchmark_cmd, modelica_dependency_cache, msl_flamegraph_cmd,
+    run_status, run_status_quiet, test_cmd, vscode_cmd,
 };
 
 const MSL_VERSION: &str = "4.1.0";
@@ -182,7 +181,7 @@ fn write_parity_config(root: &Path, args: &VerifyMslParityArgs) -> Result<()> {
 pub(crate) enum VerifyCommand {
     /// Architecture-hardening gates (env-var registry, file-size, layering)
     Architecture,
-    /// Rust formatting, line-count policy, traversal policy, and clippy
+    /// Rust formatting, traversal policy, and clippy
     Lint,
     /// Workspace tests that mirror the main test matrix
     Workspace,
@@ -1078,13 +1077,7 @@ impl Drop for ChildGuard {
 fn run_lint_policy_checks(root: &Path) -> Result<()> {
     let fmt_root = root.to_path_buf();
     let fmt_check = thread::spawn(move || test_cmd::run_workspace_fmt_check(&fmt_root));
-    let policy_checks = thread::spawn(|| {
-        cmd_check_rust_file_lines(CheckRustFileLinesArgs {
-            max_lines: 2000,
-            all_files: true,
-        })?;
-        xtask::run_traversal_policy_check()
-    });
+    let policy_checks = thread::spawn(xtask::run_traversal_policy_check);
 
     join_lint_policy_check("rustfmt", fmt_check)?;
     join_lint_policy_check("policy checks", policy_checks)


### PR DESCRIPTION
## Summary

- `cargo xtask verify lint` no longer runs the all-files Rust line-count check directly.
- `cargo xtask verify full` and `verify quick` still cover filesize policy through the Cargo-native workspace policy tests, avoiding duplicate filesize validation in the composed suites.
- Hardened the Python sdist CI Rust setup after the draft PR exposed a `rust-src` runner conflict before `maturin sdist` could run.
- Addresses issue #170 without formally closing it.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0021, SPEC_0025.
- Relevant MLS section(s), if semantics changed: none; this is repo verification/CI tooling only.
- Crate/phase owner: `crates/xtask` verification orchestration and `.github/workflows/ci.yml` packaging CI.

## Risk and Design Notes

- Main correctness risk: removing the lint-level line-count check could reduce standalone `verify lint` coverage; this is intentional because filesize policy is already owned by `code_size_budget_test` in workspace policy tests.
- Main maintenance risk: CI Rust setup snippets can drift between jobs; this PR limits the CI setup change to the failing sdist job instead of broadening unrelated jobs.
- Why the change belongs in these crate(s): `crates/xtask` owns `verify full`/`verify quick` composition, and the workflow owns Python sdist packaging setup.
- Any new abstraction, public API, or migration path: none.

## Testing

- Key command(s) run:
  - `cargo fmt --all -- --check`
  - `cargo test -p xtask verify_cmd::tests -- --nocapture`
  - `cargo test -p xtask main_tests::cli_parses_verify_full_job -- --nocapture`
  - `bash -n` on the new Python sdist Rust setup block
  - `git diff --check`
- Behavior or regression covered: focused xtask tests still confirm `verify full` and `verify quick` suite composition, including the workspace test step that carries the filesize policy test. The shell syntax check covers the updated sdist setup block.
- Commands NOT run and why: full `cargo xtask verify full` was not run because it includes long MSL/editor/browser/coverage gates outside this narrow tooling fix. `actionlint` was not run because it is not installed in the local environment.
- For compiler/simulator changes: not applicable; no compiler or simulator behavior changed.

## Code Size Budget (required)

- production_lines_added: 20
- production_lines_deleted: 12
- test_lines_added: 0
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 2
- net_added_lines: 8

Positive net growth justification:

- Required to make the Python sdist CI job install the pinned Rust toolchain, `rust-src`, and `wasm32-unknown-unknown` target explicitly before `maturin` invokes Cargo metadata.
- Compression pass removed the duplicate xtask line-count invocation from `verify lint`, so the verification behavior change itself is net-negative.
- Remaining growth is CI setup hardening for the observed runner/toolchain conflict.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.
