### PR TITLE
implemented steering fix on rover interactive simulation

### DIFF
--- a/crates/rumoca-phase-structural/src/dae_prepare/dae_prepare_demotion_tests.rs
+++ b/crates/rumoca-phase-structural/src/dae_prepare/dae_prepare_demotion_tests.rs
@@ -355,6 +355,40 @@ fn test_demote_direct_assigned_states_keeps_state_defined_by_non_state_alias() {
 }
 
 #[test]
+fn test_constrained_dummy_reduction_keeps_state_with_direct_output_alias() {
+    let mut dae = Dae::new();
+    dae.variables
+        .states
+        .insert(VarName::new("delta"), Variable::new(VarName::new("delta")));
+    dae.variables.outputs.insert(
+        VarName::new("front_wheel_yaw"),
+        Variable::new(VarName::new("front_wheel_yaw")),
+    );
+    dae.variables
+        .parameters
+        .insert(VarName::new("u"), Variable::new(VarName::new("u")));
+
+    dae.continuous
+        .equations
+        .push(eq(sub(der("delta"), var("u"))));
+    dae.continuous
+        .equations
+        .push(eq(sub(var("front_wheel_yaw"), var("delta"))));
+
+    let demoted = reduce_constrained_dummy_derivatives(&mut dae);
+    assert_eq!(
+        demoted, 0,
+        "a plain output alias must not make the source state a dummy derivative"
+    );
+    assert!(dae.variables.states.contains_key(&VarName::new("delta")));
+    assert!(
+        !dae.variables
+            .algebraics
+            .contains_key(&VarName::new("delta"))
+    );
+}
+
+#[test]
 fn test_demote_direct_assigned_states_keeps_state_with_other_state_in_alias_closure() {
     let mut dae = Dae::new();
     dae.variables

--- a/crates/rumoca-phase-structural/src/dae_prepare/dummy_state_metadata.rs
+++ b/crates/rumoca-phase-structural/src/dae_prepare/dummy_state_metadata.rs
@@ -98,26 +98,41 @@ fn direct_dummy_state_candidate(
     let references_other_state = state_names
         .iter()
         .any(|other| other != &state_name && expr_contains_var(&defining_expr, other))
-        || defining_expr_references_output(dae, &defining_expr);
+        || defining_expr_references_non_alias_output(dae, &defining_expr, &state_name);
     references_other_state.then_some(state_name)
 }
 
-/// True if `defining_expr` references a model output variable. A state defined
-/// by `S = E` where `E` depends on an output is over-determined: outputs are
-/// causally computed by their own block equations, so a differentiated input
-/// bound to one (e.g. a `Modelica.Blocks.Continuous.Der` chain `der1.u =
-/// Bessel.y`, or successive `derN.u = der(N-1).y`) is not a free state but a
-/// dummy derivative to be deselected (Mattsson & Söderlind dummy derivatives, as
-/// in OpenModelica's `IndexReduction.mo`). The direct [`expr_contains_var`]
-/// state check and the linear [`linear_constraint_dummy_state_definitions`] path
-/// both miss this when the binding runs through a nonlinear output such as a
-/// filter result. The differentiation guard in `constrained_dummy_derivative_plan`
-/// still rejects the demotion if `d/dt(E)` cannot be expressed over the states.
-fn defining_expr_references_output(dae: &Dae, defining_expr: &Expression) -> bool {
+/// True if `defining_expr` references a model output variable that is not just a
+/// direct alias of `state_name`. A state defined by `S = E` where `E` depends on
+/// a computed output is over-determined: outputs are causally computed by their
+/// own block equations, so a differentiated input bound to one can be a dummy
+/// derivative to deselect. Plain visualization aliases (`output = state`) must
+/// not trigger demotion, or the state loses its ODE row.
+fn defining_expr_references_non_alias_output(
+    dae: &Dae,
+    defining_expr: &Expression,
+    state_name: &VarName,
+) -> bool {
     let mut refs: Vec<VarName> = Vec::new();
     defining_expr.collect_var_refs(&mut refs);
-    refs.iter()
-        .any(|name| dae.variables.outputs.contains_key(name))
+    refs.iter().any(|name| {
+        dae.variables.outputs.contains_key(name)
+            && !output_is_direct_alias_of_state(dae, name, state_name)
+    })
+}
+
+fn output_is_direct_alias_of_state(dae: &Dae, output_name: &VarName, state_name: &VarName) -> bool {
+    super::find_defining_expr_candidates(dae, output_name)
+        .into_iter()
+        .any(|expr| expression_is_plain_var_ref(&expr, state_name))
+}
+
+fn expression_is_plain_var_ref(expr: &Expression, expected: &VarName) -> bool {
+    matches!(
+        expr,
+        Expression::VarRef { name, subscripts, .. }
+            if subscripts.is_empty() && name.var_name() == expected
+    )
 }
 
 fn numeric_constant(expr: &Expression) -> Option<f64> {

--- a/crates/rumoca/tests/examples_smoke.rs
+++ b/crates/rumoca/tests/examples_smoke.rs
@@ -530,6 +530,49 @@ fn quadrotor_acro_solve_preserves_tensor_structure_when_cmm_available() {
 
 #[cfg(feature = "runner")]
 #[test]
+fn rover_config_steering_input_changes_delta_and_heading() {
+    let config_path = example_root().join("interactive/rover/rum.toml");
+    let result = compile_toml_model_if_source_roots_exist(&config_path)
+        .expect("rover rum.toml should compile without extra source roots");
+    let mut stepper = SimStepper::new_with_diagnostics(
+        &result.dae,
+        SimOptions {
+            rtol: 1e-5,
+            atol: 1e-7,
+            dt: Some(0.01),
+            solver_mode: SimSolverMode::RkLike,
+            pacing_mode: SimPacingMode::AsFastAsPossible,
+            ..Default::default()
+        },
+    )
+    .expect("rover rum.toml should create an RK-like simulation stepper");
+
+    assert!(
+        stepper.input_names().iter().any(|name| name == "steering"),
+        "rover solve input layout should expose steering"
+    );
+    stepper
+        .set_inputs(&[("throttle", 1.0), ("steering", 1.0)])
+        .expect("rover should accept throttle and steering inputs");
+    for _ in 0..100 {
+        stepper.step(0.01).expect("rover should advance");
+    }
+
+    let state = stepper.state();
+    let delta = state_value(&state.values, "delta");
+    let theta = state_value(&state.values, "theta");
+    assert!(
+        delta > 0.3,
+        "full steering should move the steering state; delta={delta}"
+    );
+    assert!(
+        theta > 0.1,
+        "full steering while moving should change heading; theta={theta}"
+    );
+}
+
+#[cfg(feature = "runner")]
+#[test]
 fn quadrotor_acro_config_creates_rk_stepper_when_cmm_available() {
     let Some(result) = compile_quadrotor_acro_config_if_cmm_available() else {
         eprintln!(


### PR DESCRIPTION
# Rumoca PR Review 

<!--
Mirrors SPEC_0025. Section names here must match SPEC_0025 §"PR Template
Alignment". Update both files together if you change either one.
-->

## Summary

The steering was not working properly on the rover simuilation

## Risk and Design Notes

What was happening was that the delta state was being demoted unintentionally (going from dynamic to algebraic state), so then the der(delta) was being dropped, therefore making delta not a dynamic variable, thus no change.

Also added test-case for this issue to prevent it from happening with future changes. 

## Testing

Tested by using `cargo rumoca sim -c examples/interactive/rover/rum.toml` and inputted rover controls to verify accurate steering.

## Reviewer Checklist

- [ ] Relevant active specs were checked.
- [ ] MLS-sensitive changes cite the right MLS section.
- [ ] Crate boundaries and phase ownership preserved (SPEC_0029).
- [ ] Tests prove behavior or explain the remaining gap.
- [ ] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [ ] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [ ] Size-budget section completed.
- [ ] Positive net diff has explicit compression justification.
- [ ] New APIs are required and minimal.
- [ ] Old/new parallel paths removed unless explicitly migrating.
- [ ] No `#[allow(clippy::...)]` added outside generated code.
- [ ] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [ ] External material (if any) attributed and Apache-2.0 compatible.
