### PR TITLE
Fix Modelica mod and rem solve semantics

### DIFF
--- a/crates/rumoca-phase-solve/src/dynamic_events.rs
+++ b/crates/rumoca-phase-solve/src/dynamic_events.rs
@@ -129,10 +129,19 @@ fn next_period_event_expr(args: &[rumoca_core::Expression]) -> Option<rumoca_cor
         return None;
     }
     let period = abs_expr(period.clone());
+    let advance = sub_expr(period.clone(), mod_expr(time_ref_expr(), period.clone()));
     Some(add_expr(
         time_ref_expr(),
-        sub_expr(period.clone(), mod_expr(time_ref_expr(), period)),
+        max_expr(advance, dynamic_time_event_min_advance_expr(period)),
     ))
+}
+
+fn dynamic_time_event_min_advance_expr(period: rumoca_core::Expression) -> rumoca_core::Expression {
+    let scale = max_expr(
+        period,
+        add_expr(literal_expr(1.0), abs_expr(time_ref_expr())),
+    );
+    mul_expr(scale, literal_expr(1.0e-12))
 }
 
 fn time_ref_expr() -> rumoca_core::Expression {
@@ -159,9 +168,33 @@ fn mod_expr(lhs: rumoca_core::Expression, rhs: rumoca_core::Expression) -> rumoc
     }
 }
 
+fn max_expr(lhs: rumoca_core::Expression, rhs: rumoca_core::Expression) -> rumoca_core::Expression {
+    rumoca_core::Expression::BuiltinCall {
+        function: rumoca_core::BuiltinFunction::Max,
+        args: vec![lhs, rhs],
+        span: rumoca_core::Span::DUMMY,
+    }
+}
+
+fn literal_expr(value: f64) -> rumoca_core::Expression {
+    rumoca_core::Expression::Literal {
+        value: rumoca_core::Literal::Real(value),
+        span: rumoca_core::Span::DUMMY,
+    }
+}
+
 fn add_expr(lhs: rumoca_core::Expression, rhs: rumoca_core::Expression) -> rumoca_core::Expression {
     rumoca_core::Expression::Binary {
         op: OpBinary::Add,
+        lhs: Box::new(lhs),
+        rhs: Box::new(rhs),
+        span: rumoca_core::Span::DUMMY,
+    }
+}
+
+fn mul_expr(lhs: rumoca_core::Expression, rhs: rumoca_core::Expression) -> rumoca_core::Expression {
+    rumoca_core::Expression::Binary {
+        op: OpBinary::Mul,
         lhs: Box::new(lhs),
         rhs: Box::new(rhs),
         span: rumoca_core::Span::DUMMY,
@@ -252,6 +285,10 @@ pub(crate) fn collect_dynamic_time_event_exprs(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn scalar_var(name: &str) -> dae::Variable {
+        dae::Variable::new(rumoca_core::VarName::new(name))
+    }
 
     fn time_ref() -> rumoca_core::Expression {
         rumoca_core::Expression::VarRef {
@@ -444,5 +481,57 @@ mod tests {
             ));
 
         assert!(collect_dynamic_time_event_exprs(&dae_model).is_empty());
+    }
+
+    #[test]
+    fn lowered_mod_time_event_row_advances_past_current_time() {
+        let mut dae_model = dae::Dae::default();
+        dae_model
+            .variables
+            .parameters
+            .insert(rumoca_core::VarName::new("period"), scalar_var("period"));
+        dae_model
+            .variables
+            .parameters
+            .insert(rumoca_core::VarName::new("width"), scalar_var("width"));
+        dae_model
+            .discrete
+            .valued_updates
+            .push(dae::Equation::explicit(
+                rumoca_core::VarName::new("turn"),
+                rumoca_core::Expression::Binary {
+                    op: OpBinary::Lt,
+                    lhs: Box::new(builtin_call(
+                        rumoca_core::BuiltinFunction::Mod,
+                        vec![time_ref(), var_ref("period")],
+                    )),
+                    rhs: Box::new(var_ref("width")),
+                    span: rumoca_core::Span::DUMMY,
+                },
+                rumoca_core::Span::DUMMY,
+                "periodic turn guard",
+            ));
+
+        let exprs = collect_dynamic_time_event_exprs(&dae_model);
+        let layout = crate::layout::build_var_layout(&dae_model);
+        let rows = crate::lower::lower_dynamic_time_event_rhs(&dae_model, &layout, &exprs)
+            .expect("dynamic modulo event row should lower");
+        let block = rumoca_ir_solve::ScalarProgramBlock::new(rows);
+        let mut p = vec![0.0; layout.p_scalars()];
+        let Some(rumoca_ir_solve::ScalarSlot::P { index, .. }) = layout.binding("period") else {
+            panic!("period should be a parameter slot");
+        };
+        p[index] = 0.1;
+        let current_t = 0.6;
+        let mut out = vec![0.0; block.programs.len()];
+
+        rumoca_eval_solve::eval_scalar_program_block(&block, &[], &p, current_t, None, &mut out)
+            .expect("dynamic event row should evaluate");
+
+        assert!(
+            out[0] > current_t,
+            "dynamic modulo event row must advance past current_t; got {} at current_t {current_t}",
+            out[0]
+        );
     }
 }

--- a/crates/rumoca-phase-solve/src/dynamic_events.rs
+++ b/crates/rumoca-phase-solve/src/dynamic_events.rs
@@ -64,15 +64,41 @@ fn collect_dynamic_time_event_exprs_from_expr(
     expr: &rumoca_core::Expression,
     exprs: &mut Vec<rumoca_core::Expression>,
 ) {
-    let mut collector = DynamicTimeEventExprCollector { exprs };
+    let mut collector = DynamicTimeEventExprCollector {
+        exprs,
+        no_event_depth: 0,
+    };
     collector.visit_expression(expr);
 }
 
 struct DynamicTimeEventExprCollector<'a> {
     exprs: &'a mut Vec<rumoca_core::Expression>,
+    no_event_depth: usize,
 }
 
 impl ExpressionVisitor for DynamicTimeEventExprCollector<'_> {
+    fn visit_builtin_call(
+        &mut self,
+        function: &rumoca_core::BuiltinFunction,
+        args: &[rumoca_core::Expression],
+    ) {
+        if matches!(function, rumoca_core::BuiltinFunction::NoEvent) {
+            self.no_event_depth += 1;
+            self.walk_builtin_call(function, args);
+            self.no_event_depth -= 1;
+            return;
+        }
+        if matches!(
+            function,
+            rumoca_core::BuiltinFunction::Mod | rumoca_core::BuiltinFunction::Rem
+        ) && self.no_event_depth == 0
+            && let Some(next_event) = next_period_event_expr(args)
+        {
+            self.exprs.push(next_event);
+        }
+        self.walk_builtin_call(function, args);
+    }
+
     fn visit_binary(
         &mut self,
         op: &OpBinary,
@@ -82,7 +108,8 @@ impl ExpressionVisitor for DynamicTimeEventExprCollector<'_> {
         if matches!(
             op,
             OpBinary::Ge | OpBinary::Gt | OpBinary::Le | OpBinary::Lt
-        ) && let Some(threshold) = comparison_time_threshold_expr(lhs, rhs)
+        ) && self.no_event_depth == 0
+            && let Some(threshold) = comparison_time_threshold_expr(lhs, rhs)
         {
             // MLS §3.7.3 / Appendix B: relations involving `time` are time
             // event generating expressions. Solve-IR records the threshold
@@ -91,6 +118,62 @@ impl ExpressionVisitor for DynamicTimeEventExprCollector<'_> {
         }
         self.visit_expression(lhs);
         self.visit_expression(rhs);
+    }
+}
+
+fn next_period_event_expr(args: &[rumoca_core::Expression]) -> Option<rumoca_core::Expression> {
+    let [time, period] = args else {
+        return None;
+    };
+    if !expr_is_time_var(time) {
+        return None;
+    }
+    let period = abs_expr(period.clone());
+    Some(add_expr(
+        time_ref_expr(),
+        sub_expr(period.clone(), mod_expr(time_ref_expr(), period)),
+    ))
+}
+
+fn time_ref_expr() -> rumoca_core::Expression {
+    rumoca_core::Expression::VarRef {
+        name: rumoca_core::VarName::new("time").into(),
+        subscripts: vec![],
+        span: rumoca_core::Span::DUMMY,
+    }
+}
+
+fn abs_expr(expr: rumoca_core::Expression) -> rumoca_core::Expression {
+    rumoca_core::Expression::BuiltinCall {
+        function: rumoca_core::BuiltinFunction::Abs,
+        args: vec![expr],
+        span: rumoca_core::Span::DUMMY,
+    }
+}
+
+fn mod_expr(lhs: rumoca_core::Expression, rhs: rumoca_core::Expression) -> rumoca_core::Expression {
+    rumoca_core::Expression::BuiltinCall {
+        function: rumoca_core::BuiltinFunction::Mod,
+        args: vec![lhs, rhs],
+        span: rumoca_core::Span::DUMMY,
+    }
+}
+
+fn add_expr(lhs: rumoca_core::Expression, rhs: rumoca_core::Expression) -> rumoca_core::Expression {
+    rumoca_core::Expression::Binary {
+        op: OpBinary::Add,
+        lhs: Box::new(lhs),
+        rhs: Box::new(rhs),
+        span: rumoca_core::Span::DUMMY,
+    }
+}
+
+fn sub_expr(lhs: rumoca_core::Expression, rhs: rumoca_core::Expression) -> rumoca_core::Expression {
+    rumoca_core::Expression::Binary {
+        op: OpBinary::Sub,
+        lhs: Box::new(lhs),
+        rhs: Box::new(rhs),
+        span: rumoca_core::Span::DUMMY,
     }
 }
 
@@ -194,6 +277,17 @@ mod tests {
         }
     }
 
+    fn builtin_call(
+        function: rumoca_core::BuiltinFunction,
+        args: Vec<rumoca_core::Expression>,
+    ) -> rumoca_core::Expression {
+        rumoca_core::Expression::BuiltinCall {
+            function,
+            args,
+            span: rumoca_core::Span::DUMMY,
+        }
+    }
+
     #[test]
     fn collect_dynamic_time_event_names_finds_pre_time_guards() {
         let mut dae_model = dae::Dae::default();
@@ -292,5 +386,63 @@ mod tests {
             ));
 
         assert_eq!(collect_dynamic_time_event_exprs(&dae_model).len(), 1);
+    }
+
+    #[test]
+    fn collect_dynamic_time_event_exprs_finds_mod_and_rem_time_discontinuities() {
+        for function in [
+            rumoca_core::BuiltinFunction::Mod,
+            rumoca_core::BuiltinFunction::Rem,
+        ] {
+            let mut dae_model = dae::Dae::default();
+            dae_model
+                .discrete
+                .valued_updates
+                .push(dae::Equation::explicit(
+                    rumoca_core::VarName::new("turn"),
+                    rumoca_core::Expression::Binary {
+                        op: OpBinary::Lt,
+                        lhs: Box::new(builtin_call(function, vec![time_ref(), var_ref("period")])),
+                        rhs: Box::new(var_ref("width")),
+                        span: rumoca_core::Span::DUMMY,
+                    },
+                    rumoca_core::Span::DUMMY,
+                    "periodic turn guard",
+                ));
+
+            assert_eq!(
+                collect_dynamic_time_event_exprs(&dae_model).len(),
+                1,
+                "{}(time, period) should expose its discontinuity as a dynamic time event",
+                function.name()
+            );
+        }
+    }
+
+    #[test]
+    fn collect_dynamic_time_event_exprs_respects_no_event() {
+        let mut dae_model = dae::Dae::default();
+        dae_model
+            .discrete
+            .valued_updates
+            .push(dae::Equation::explicit(
+                rumoca_core::VarName::new("turn"),
+                builtin_call(
+                    rumoca_core::BuiltinFunction::NoEvent,
+                    vec![rumoca_core::Expression::Binary {
+                        op: OpBinary::Lt,
+                        lhs: Box::new(builtin_call(
+                            rumoca_core::BuiltinFunction::Mod,
+                            vec![time_ref(), var_ref("period")],
+                        )),
+                        rhs: Box::new(var_ref("width")),
+                        span: rumoca_core::Span::DUMMY,
+                    }],
+                ),
+                rumoca_core::Span::DUMMY,
+                "noEvent periodic guard",
+            ));
+
+        assert!(collect_dynamic_time_event_exprs(&dae_model).is_empty());
     }
 }

--- a/crates/rumoca-phase-solve/src/layout.rs
+++ b/crates/rumoca-phase-solve/src/layout.rs
@@ -517,6 +517,11 @@ fn eval_const_builtin(
         let rhs = eval_const_scalar(args.get(1)?, enum_literal_ordinals)?;
         Some(vec![f(lhs, rhs)])
     };
+    let binary_builtin = |function| {
+        let lhs = eval_const_scalar(args.first()?, enum_literal_ordinals)?;
+        let rhs = eval_const_scalar(args.get(1)?, enum_literal_ordinals)?;
+        rumoca_core::apply_scalar_binary_math(function, lhs, rhs).map(|value| vec![value])
+    };
 
     match function {
         Builtin::Abs => unary(f64::abs),
@@ -540,9 +545,9 @@ fn eval_const_builtin(
         Builtin::Atan2 => binary(f64::atan2),
         Builtin::Min => binary(f64::min),
         Builtin::Max => binary(f64::max),
-        Builtin::Div => binary(|lhs, rhs| (lhs / rhs).floor()),
-        Builtin::Mod => binary(f64::rem_euclid),
-        Builtin::Rem => binary(f64::rem_euclid),
+        Builtin::Div => binary_builtin(Builtin::Div),
+        Builtin::Mod => binary_builtin(Builtin::Mod),
+        Builtin::Rem => binary_builtin(Builtin::Rem),
         Builtin::NoEvent => eval_const_values(args.first()?, enum_literal_ordinals),
         Builtin::Smooth => eval_const_values(args.get(1)?, enum_literal_ordinals),
         Builtin::Homotopy => eval_const_values(args.first()?, enum_literal_ordinals),
@@ -586,4 +591,41 @@ fn expand_values_to_size(raw_values: Vec<f64>, size: usize) -> Vec<f64> {
         expanded.push(raw_values.get(idx).copied().unwrap_or(last));
     }
     expanded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn real(value: f64) -> rumoca_core::Expression {
+        rumoca_core::Expression::Literal {
+            value: rumoca_core::Literal::Real(value),
+            span: Span::DUMMY,
+        }
+    }
+
+    fn builtin(function: rumoca_core::BuiltinFunction) -> rumoca_core::Expression {
+        rumoca_core::Expression::BuiltinCall {
+            function,
+            args: vec![real(-5.5), real(2.0)],
+            span: Span::DUMMY,
+        }
+    }
+
+    #[test]
+    fn const_builtin_div_mod_and_rem_follow_modelica_rounding() {
+        let ordinals = IndexMap::new();
+        assert_eq!(
+            eval_const_values(&builtin(rumoca_core::BuiltinFunction::Div), &ordinals),
+            Some(vec![-2.0])
+        );
+        assert_eq!(
+            eval_const_values(&builtin(rumoca_core::BuiltinFunction::Mod), &ordinals),
+            Some(vec![0.5])
+        );
+        assert_eq!(
+            eval_const_values(&builtin(rumoca_core::BuiltinFunction::Rem), &ordinals),
+            Some(vec![-1.5])
+        );
+    }
 }

--- a/crates/rumoca-phase-solve/src/lower.rs
+++ b/crates/rumoca-phase-solve/src/lower.rs
@@ -1566,8 +1566,11 @@ impl<'a> LowerBuilder<'a> {
             rumoca_core::BuiltinFunction::Log10 => unary(self, UnaryOp::Log10),
             rumoca_core::BuiltinFunction::Atan2 => binary(self, BinaryOp::Atan2),
             rumoca_core::BuiltinFunction::Div => self.lower_div_builtin(args, scope, call_depth),
-            rumoca_core::BuiltinFunction::Mod | rumoca_core::BuiltinFunction::Rem => {
-                self.lower_truncating_remainder_builtin(args, scope, call_depth)
+            rumoca_core::BuiltinFunction::Mod => {
+                self.lower_remainder_builtin(args, scope, call_depth, UnaryOp::Floor, "mod")
+            }
+            rumoca_core::BuiltinFunction::Rem => {
+                self.lower_remainder_builtin(args, scope, call_depth, UnaryOp::Trunc, "rem")
             }
             rumoca_core::BuiltinFunction::NoEvent => arg(self, 0),
             rumoca_core::BuiltinFunction::Homotopy => {
@@ -1610,7 +1613,7 @@ impl<'a> LowerBuilder<'a> {
         scope: &Scope,
         call_depth: usize,
     ) -> Result<Reg, LowerError> {
-        if args.len() < 2 {
+        if args.len() != 2 {
             return Err(LowerError::ContractViolation {
                 reason: format!("div() requires exactly 2 arguments, got {}", args.len()),
                 span: rumoca_core::Span::DUMMY,
@@ -1622,23 +1625,28 @@ impl<'a> LowerBuilder<'a> {
         Ok(self.emit_unary(UnaryOp::Trunc, q))
     }
 
-    fn lower_truncating_remainder_builtin(
+    fn lower_remainder_builtin(
         &mut self,
         args: &[rumoca_core::Expression],
         scope: &Scope,
         call_depth: usize,
+        quotient_rounding: UnaryOp,
+        function_name: &str,
     ) -> Result<Reg, LowerError> {
-        if args.len() < 2 {
+        if args.len() != 2 {
             return Err(LowerError::ContractViolation {
-                reason: format!("mod/rem requires exactly 2 arguments, got {}", args.len()),
+                reason: format!(
+                    "{function_name}() requires exactly 2 arguments, got {}",
+                    args.len()
+                ),
                 span: rumoca_core::Span::DUMMY,
             });
         }
         let x = self.lower_expr(&args[0], scope, call_depth)?;
         let y = self.lower_expr(&args[1], scope, call_depth)?;
         let q = self.emit_binary(BinaryOp::Div, x, y);
-        let q_trunc = self.emit_unary(UnaryOp::Trunc, q);
-        let product = self.emit_binary(BinaryOp::Mul, q_trunc, y);
+        let q_rounded = self.emit_unary(quotient_rounding, q);
+        let product = self.emit_binary(BinaryOp::Mul, q_rounded, y);
         Ok(self.emit_binary(BinaryOp::Sub, x, product))
     }
 

--- a/crates/rumoca-phase-solve/src/lower/tests/intrinsics/clocked_initial_tests.rs
+++ b/crates/rumoca-phase-solve/src/lower/tests/intrinsics/clocked_initial_tests.rs
@@ -672,9 +672,9 @@ fn lower_expression_supports_scalar_array_builtins() {
 #[test]
 fn lower_expression_supports_mod_and_rem_builtins() {
     let layout = VarLayout::default();
-    for function in [
-        rumoca_core::BuiltinFunction::Mod,
-        rumoca_core::BuiltinFunction::Rem,
+    for (function, expected) in [
+        (rumoca_core::BuiltinFunction::Mod, 0.5),
+        (rumoca_core::BuiltinFunction::Rem, -1.5),
     ] {
         let expr = rumoca_core::Expression::BuiltinCall {
             function,
@@ -694,7 +694,6 @@ fn lower_expression_supports_mod_and_rem_builtins() {
             lower_expression(&expr, &layout, &IndexMap::new()).expect("mod/rem should lower");
         let (regs, _) = eval_linear_ops(&lowered.ops, &[], &[], 0.0);
         let compiled = read_reg(&regs, lowered.result);
-        let expected = -1.5;
         assert!(
             (compiled - expected).abs() < 1e-12,
             "builtin {} mismatch: compiled={compiled}, expected={expected}",


### PR DESCRIPTION
## Summary

- Separates Solve-IR runtime lowering for `mod` and `rem`: `mod` now uses floor-based quotient semantics, while `rem` keeps truncating quotient semantics.
- Aligns Solve layout constant evaluation for `div`/`mod`/`rem` with the shared Modelica builtin helper.
- Adds dynamic time-event discovery for `mod(time, period)` / `rem(time, period)` discontinuities and keeps `noEvent(...)` suppressing those generated events.
- Related to issue #138; this PR does not close it without review.

## Spec / MLS Alignment

- Relevant specs checked: SPEC_0007, SPEC_0022, SPEC_0029, SPEC_0021, SPEC_0025.
- MLS-sensitive behavior: Modelica `mod(x, y) = x - floor(x / y) * y`; `rem(x, y) = x - div(x, y) * y`; `div` truncates toward zero.
- Crate/phase owner: `rumoca-phase-solve` Solve-IR lowering and dynamic time-event extraction.

## Testing

- `cargo test -p rumoca-phase-solve mod_and_rem -- --nocapture`
- `cargo test -p rumoca-phase-solve dynamic_time_event_exprs -- --nocapture`
- `cargo test -p rumoca-phase-solve -- --nocapture`
- `cargo test -p rumoca-exec-cranelift -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p rumoca-phase-solve --all-targets -- -D warnings`

Full `cargo xtask verify full` was not run; this is a focused Solve-IR semantics fix with targeted package coverage.

## Code Size Budget (required)

- production_lines_added: 110
- production_lines_deleted: 13
- test_lines_added: 108
- test_lines_deleted: 4
- public_items_added: 0
- public_items_removed: 0
- files_touched: 4
- net_added_lines: 201

Positive net growth justification: tests cover the spec-distinguishing negative-operand case, constant-layout evaluation, generated dynamic events for periodic `mod/rem(time, period)`, and `noEvent` suppression.