### PR TITLE
fix(rumoca): stop constant-eval integer overflows from panicking

### DIFF
--- a/crates/rumoca-bind-wasm/src/source_root_api.rs
+++ b/crates/rumoca-bind-wasm/src/source_root_api.rs
@@ -389,11 +389,26 @@ pub fn compile_check_with_source_roots_with_options(
                 .map_err(|message| JsValue::from_str(&message))?;
             let check_ms = wasm_elapsed_ms(check_started);
             let total_ms = wasm_elapsed_ms(total_started);
+            let warning_diagnostics = session
+                .compile_model_diagnostics(&requested_model)
+                .diagnostics
+                .into_iter()
+                .filter(|diag| matches!(diag.severity, rumoca_core::DiagnosticSeverity::Warning))
+                .map(|diag| {
+                    serde_json::json!({
+                        "code": diag.code,
+                        "message": diag.message,
+                        "labels": diag.labels,
+                        "notes": diag.notes,
+                    })
+                })
+                .collect::<Vec<_>>();
 
             let timing = compile_phase_timing_stats();
             Ok(serde_json::json!({
                 "status": "compiled",
                 "model_name": requested_model,
+                "__compile_warnings": warning_diagnostics,
                 "__compile_check_timing": {
                     "load_source_roots_ms": load_ms,
                     "update_document_ms": update_ms,

--- a/crates/rumoca-core/src/integer_binary.rs
+++ b/crates/rumoca-core/src/integer_binary.rs
@@ -18,9 +18,9 @@ pub enum IntegerBinaryOperator {
 /// Evaluate an integer binary operation.
 pub fn eval_integer_binary(op: IntegerBinaryOperator, lhs: i64, rhs: i64) -> Option<i64> {
     match op {
-        IntegerBinaryOperator::Add => Some(lhs + rhs),
-        IntegerBinaryOperator::Sub => Some(lhs - rhs),
-        IntegerBinaryOperator::Mul => Some(lhs * rhs),
+        IntegerBinaryOperator::Add => lhs.checked_add(rhs),
+        IntegerBinaryOperator::Sub => lhs.checked_sub(rhs),
+        IntegerBinaryOperator::Mul => lhs.checked_mul(rhs),
         IntegerBinaryOperator::Div => eval_integer_slash(lhs, rhs),
         IntegerBinaryOperator::Exp => {
             let exponent = u32::try_from(rhs).ok()?;
@@ -86,6 +86,22 @@ mod tests {
     #[test]
     fn exp_overflow_returns_none() {
         assert_eq!(eval_integer_binary(IntegerBinaryOperator::Exp, 2, 63), None);
+    }
+
+    #[test]
+    fn add_sub_mul_overflow_returns_none() {
+        assert_eq!(
+            eval_integer_binary(IntegerBinaryOperator::Add, i64::MAX, 1),
+            None
+        );
+        assert_eq!(
+            eval_integer_binary(IntegerBinaryOperator::Sub, i64::MIN, 1),
+            None
+        );
+        assert_eq!(
+            eval_integer_binary(IntegerBinaryOperator::Mul, i64::MAX, 2),
+            None
+        );
     }
 
     #[test]

--- a/crates/rumoca-eval-ast/src/eval/mod.rs
+++ b/crates/rumoca-eval-ast/src/eval/mod.rs
@@ -7,12 +7,15 @@
 
 use rumoca_core::{Causality, ClassType, OpBinary, OpUnary};
 use rumoca_core::{
-    IntegerBinaryOperator, eval_integer_binary as eval_common_integer_binary,
-    eval_integer_div_builtin, find_last_top_level_dot,
+    Diagnostic as CommonDiagnostic, IntegerBinaryOperator, PrimaryLabel, Span,
+    eval_integer_binary as eval_common_integer_binary, eval_integer_div_builtin,
+    find_last_top_level_dot,
 };
 use rumoca_ir_ast::{ClassDef, Expression, Statement, StatementBlock, Subscript, TerminalType};
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 pub use dimension_inference::{
@@ -96,6 +99,8 @@ pub struct TypeCheckEvalContext {
     pub func_eval_depth: usize,
     pub enum_sizes: FxHashMap<String, usize>,
     pub enum_ordinals: FxHashMap<String, i64>,
+    warning_keys: RefCell<HashSet<(String, Span)>>,
+    warnings: RefCell<Vec<CommonDiagnostic>>,
 }
 
 impl Default for TypeCheckEvalContext {
@@ -116,6 +121,8 @@ impl TypeCheckEvalContext {
             func_eval_depth: 0,
             enum_sizes: FxHashMap::default(),
             enum_ordinals: FxHashMap::default(),
+            warning_keys: RefCell::new(HashSet::default()),
+            warnings: RefCell::new(Vec::new()),
         }
     }
 
@@ -138,6 +145,149 @@ impl TypeCheckEvalContext {
     pub fn get_dimensions(&self, name: &str) -> Option<&Vec<usize>> {
         self.dimensions.get(name)
     }
+
+    pub fn emit_warning(&self, code: &str, message: impl Into<String>, span: Span, label: &str) {
+        let key = (code.to_string(), span);
+        if !self.warning_keys.borrow_mut().insert(key) {
+            return;
+        }
+        let message = message.into();
+        let diagnostic = if span.is_dummy() {
+            CommonDiagnostic::global_warning(code, message)
+        } else {
+            CommonDiagnostic::warning(code, message, PrimaryLabel::new(span).with_message(label))
+        };
+        self.warnings.borrow_mut().push(diagnostic);
+    }
+
+    pub fn take_warnings(&self) -> Vec<CommonDiagnostic> {
+        std::mem::take(&mut *self.warnings.borrow_mut())
+    }
+}
+
+const ET006_INVALID_INT_COERCION: &str = "ET006";
+const ET007_INT_FOLD_OVERFLOW: &str = "ET007";
+
+fn checked_real_to_i64(
+    value: f64,
+    ctx: &TypeCheckEvalContext,
+    span: Span,
+    context: &str,
+) -> Option<i64> {
+    if !value.is_finite() {
+        ctx.emit_warning(
+            ET006_INVALID_INT_COERCION,
+            format!(
+                "non-finite real value {value} cannot be used as a compile-time integer while evaluating {context}; skipping constant fold"
+            ),
+            span,
+            "invalid compile-time integer coercion",
+        );
+        return None;
+    }
+    if value < i64::MIN as f64 || value > i64::MAX as f64 {
+        ctx.emit_warning(
+            ET006_INVALID_INT_COERCION,
+            format!(
+                "real value {value} is outside i64 range while evaluating {context}; skipping constant fold"
+            ),
+            span,
+            "out-of-range compile-time integer coercion",
+        );
+        return None;
+    }
+    Some(value as i64)
+}
+
+fn checked_integral_real_to_i64(
+    value: f64,
+    ctx: &TypeCheckEvalContext,
+    span: Span,
+    context: &str,
+) -> Option<i64> {
+    let rounded = value.round();
+    ((value - rounded).abs() < REAL_COMPARISON_EPSILON)
+        .then_some(rounded)
+        .and_then(|integral| checked_real_to_i64(integral, ctx, span, context))
+}
+
+fn emit_integer_overflow_warning(ctx: &TypeCheckEvalContext, span: Span, context: &str) {
+    ctx.emit_warning(
+        ET007_INT_FOLD_OVERFLOW,
+        format!("compile-time integer overflow while evaluating {context}; skipping constant fold"),
+        span,
+        "integer overflow during constant evaluation",
+    );
+}
+
+fn checked_abs_with_warning(
+    value: i64,
+    ctx: &TypeCheckEvalContext,
+    span: Span,
+    context: &str,
+) -> Option<i64> {
+    let result = value.checked_abs();
+    if result.is_none() {
+        emit_integer_overflow_warning(ctx, span, context);
+    }
+    result
+}
+
+fn try_fold_integers_with_warning<I>(
+    values: I,
+    init: i64,
+    ctx: &TypeCheckEvalContext,
+    span: Span,
+    context: &str,
+    combine: impl Fn(i64, i64) -> Option<i64>,
+) -> Option<i64>
+where
+    I: IntoIterator<Item = i64>,
+{
+    values.into_iter().try_fold(init, |acc, value| {
+        let result = combine(acc, value);
+        if result.is_none() {
+            emit_integer_overflow_warning(ctx, span, context);
+        }
+        result
+    })
+}
+
+fn eval_integer_binary_with_warning(
+    op: &OpBinary,
+    lhs: i64,
+    rhs: i64,
+    ctx: &TypeCheckEvalContext,
+    span: Span,
+) -> Option<i64> {
+    let operator = match op {
+        OpBinary::Add | OpBinary::AddElem => IntegerBinaryOperator::Add,
+        OpBinary::Sub | OpBinary::SubElem => IntegerBinaryOperator::Sub,
+        OpBinary::Mul | OpBinary::MulElem => IntegerBinaryOperator::Mul,
+        OpBinary::Div | OpBinary::DivElem => IntegerBinaryOperator::Div,
+        OpBinary::Exp | OpBinary::ExpElem => IntegerBinaryOperator::Exp,
+        _ => return None,
+    };
+    let value = eval_common_integer_binary(operator, lhs, rhs);
+    if value.is_none()
+        && matches!(
+            operator,
+            IntegerBinaryOperator::Add
+                | IntegerBinaryOperator::Sub
+                | IntegerBinaryOperator::Mul
+                | IntegerBinaryOperator::Exp
+        )
+    {
+        ctx.emit_warning(
+            ET007_INT_FOLD_OVERFLOW,
+            format!(
+                "compile-time integer overflow while evaluating {lhs} {op:?} {rhs}; skipping constant fold"
+            ),
+            span,
+            "integer overflow during constant evaluation",
+        );
+    }
+    value
 }
 
 /// Scope-aware evaluation for integer builtins and pure functions.
@@ -146,10 +296,27 @@ fn eval_integer_func_with_scope(
     args: &[Expression],
     ctx: &TypeCheckEvalContext,
     scope: &str,
+    call_span: Span,
+) -> Option<i64> {
+    if let Some(value) =
+        eval_builtin_integer_func_with_scope(func_name, args, ctx, scope, call_span)
+    {
+        return Some(value);
+    }
+
+    eval_user_func_integer(func_name, args, ctx, scope)
+}
+
+fn eval_builtin_integer_func_with_scope(
+    func_name: &str,
+    args: &[Expression],
+    ctx: &TypeCheckEvalContext,
+    scope: &str,
+    call_span: Span,
 ) -> Option<i64> {
     match func_name {
         "integer" if args.len() == 1 => eval_real_with_scope(&args[0], ctx, scope)
-            .map(|r| r.floor() as i64)
+            .and_then(|r| checked_real_to_i64(r.floor(), ctx, call_span, "integer(...)"))
             .or_else(|| eval_integer_with_scope(&args[0], ctx, scope)),
         "size" if args.len() == 2 => {
             let dim_idx = eval_integer_with_scope(&args[1], ctx, scope)? as usize;
@@ -167,7 +334,8 @@ fn eval_integer_func_with_scope(
             let dims = infer_dimensions_from_binding_with_scope(&args[0], ctx, scope)?;
             (dim_idx <= dims.len()).then(|| dims[dim_idx - 1] as i64)
         }
-        "abs" if args.len() == 1 => eval_integer_with_scope(&args[0], ctx, scope).map(|v| v.abs()),
+        "abs" if args.len() == 1 => eval_integer_with_scope(&args[0], ctx, scope)
+            .and_then(|value| checked_abs_with_warning(value, ctx, call_span, "abs(...)")),
         "max" if args.len() == 2 => {
             let a = eval_integer_with_scope(&args[0], ctx, scope)?;
             let b = eval_integer_with_scope(&args[1], ctx, scope)?;
@@ -198,18 +366,33 @@ fn eval_integer_func_with_scope(
             let b = eval_integer_with_scope(&args[1], ctx, scope)?;
             (b != 0).then(|| a % b)
         }
-        "floor" if args.len() == 1 => {
-            eval_real_with_scope(&args[0], ctx, scope).map(|r| r.floor() as i64)
-        }
-        "ceil" if args.len() == 1 => {
-            eval_real_with_scope(&args[0], ctx, scope).map(|r| r.ceil() as i64)
-        }
+        "floor" if args.len() == 1 => eval_real_with_scope(&args[0], ctx, scope)
+            .and_then(|r| checked_real_to_i64(r.floor(), ctx, call_span, "floor(...)")),
+        "ceil" if args.len() == 1 => eval_real_with_scope(&args[0], ctx, scope)
+            .and_then(|r| checked_real_to_i64(r.ceil(), ctx, call_span, "ceil(...)")),
         "sum" if args.len() == 1 => {
-            eval_integer_array_with_scope(&args[0], ctx, scope).map(|vals| vals.iter().sum())
+            eval_integer_array_with_scope(&args[0], ctx, scope).and_then(|vals| {
+                try_fold_integers_with_warning(
+                    vals,
+                    0_i64,
+                    ctx,
+                    call_span,
+                    "sum(...)",
+                    i64::checked_add,
+                )
+            })
         }
-        "product" if args.len() == 1 => {
-            eval_integer_array_with_scope(&args[0], ctx, scope).map(|vals| vals.iter().product())
-        }
+        "product" if args.len() == 1 => eval_integer_array_with_scope(&args[0], ctx, scope)
+            .and_then(|vals| {
+                try_fold_integers_with_warning(
+                    vals,
+                    1_i64,
+                    ctx,
+                    call_span,
+                    "product(...)",
+                    i64::checked_mul,
+                )
+            }),
         "rem" if args.len() == 2 => {
             let a = eval_integer_with_scope(&args[0], ctx, scope)?;
             let b = eval_integer_with_scope(&args[1], ctx, scope)?;
@@ -228,8 +411,7 @@ fn eval_integer_func_with_scope(
             infer_dimensions_from_binding_with_scope(&args[0], ctx, scope)
                 .map(|dims| dims.len() as i64)
         }
-        // Fallback: try interpreting user-defined pure functions (MLS §12.4)
-        _ => eval_user_func_integer(func_name, args, ctx, scope),
+        _ => None,
     }
 }
 
@@ -247,9 +429,13 @@ fn find_func_output_name(func_def: &ClassDef) -> Option<String> {
         .map(|(name, _)| name.clone())
 }
 
-fn integral_real_to_i64(value: f64) -> Option<i64> {
-    let rounded = value.round();
-    ((value - rounded).abs() < REAL_COMPARISON_EPSILON).then_some(rounded as i64)
+fn integral_real_to_i64(
+    value: f64,
+    ctx: &TypeCheckEvalContext,
+    span: Span,
+    context: &str,
+) -> Option<i64> {
+    checked_integral_real_to_i64(value, ctx, span, context)
 }
 
 fn local_has_scalar(local: &TypeCheckEvalContext, name: &str) -> bool {
@@ -272,7 +458,7 @@ fn bind_local_scalar_value(
     }
     if let Some(v) = eval_real_with_scope(expr, ctx, scope) {
         local.reals.insert(name.to_string(), v);
-        if let Some(i) = integral_real_to_i64(v) {
+        if let Some(i) = integral_real_to_i64(v, ctx, expr.span(), "local scalar binding") {
             local.integers.insert(name.to_string(), i);
         }
         return;
@@ -373,7 +559,7 @@ fn eval_user_func_integer(
         local_ctx
             .reals
             .get(&output_name)
-            .and_then(|v| integral_real_to_i64(*v))
+            .and_then(|v| integral_real_to_i64(*v, &local_ctx, Span::DUMMY, "function return"))
     })
 }
 
@@ -413,7 +599,9 @@ fn interpret_stmt(stmt: &Statement, ctx: &mut TypeCheckEvalContext) -> Option<Fu
             }
             if let Some(val) = eval_real_with_scope(value, ctx, "") {
                 ctx.reals.insert(var_name.clone(), val);
-                if let Some(i) = integral_real_to_i64(val) {
+                if let Some(i) =
+                    integral_real_to_i64(val, ctx, value.span(), "algorithm assignment")
+                {
                     ctx.integers.insert(var_name, i);
                 }
                 return Some(FunctionStmtFlow::Continue);
@@ -580,19 +768,6 @@ fn eval_integer_array_with_scope(
         Expression::Parenthesized { inner, .. } => eval_integer_array_with_scope(inner, ctx, scope),
         _ => None,
     }
-}
-
-/// Evaluate integer binary operations.
-fn eval_integer_binary(op: &OpBinary, l: i64, r: i64) -> Option<i64> {
-    let operator = match op {
-        OpBinary::Add | OpBinary::AddElem => IntegerBinaryOperator::Add,
-        OpBinary::Sub | OpBinary::SubElem => IntegerBinaryOperator::Sub,
-        OpBinary::Mul | OpBinary::MulElem => IntegerBinaryOperator::Mul,
-        OpBinary::Div | OpBinary::DivElem => IntegerBinaryOperator::Div,
-        OpBinary::Exp | OpBinary::ExpElem => IntegerBinaryOperator::Exp,
-        _ => return None,
-    };
-    eval_common_integer_binary(operator, l, r)
 }
 
 /// Try to evaluate an AST expression to an integer.
@@ -1046,7 +1221,9 @@ pub fn eval_integer_with_scope(
             ..
         } => {
             let f: f64 = token.text.parse().ok()?;
-            (f.fract() == 0.0).then_some(f as i64)
+            (f.fract() == 0.0).then_some(f).and_then(|integral| {
+                checked_real_to_i64(integral, ctx, expr.span(), "real literal")
+            })
         }
         Expression::Terminal { .. } => None,
 
@@ -1064,14 +1241,25 @@ pub fn eval_integer_with_scope(
             match op {
                 OpUnary::Not => None,
                 OpUnary::Plus | OpUnary::DotPlus | OpUnary::Empty => Some(val),
-                OpUnary::Minus | OpUnary::DotMinus => Some(-val),
+                OpUnary::Minus | OpUnary::DotMinus => {
+                    let value = val.checked_neg();
+                    if value.is_none() {
+                        ctx.emit_warning(
+                            ET007_INT_FOLD_OVERFLOW,
+                            "compile-time integer overflow while evaluating unary minus; skipping constant fold",
+                            expr.span(),
+                            "integer overflow during constant evaluation",
+                        );
+                    }
+                    value
+                }
             }
         }
 
         Expression::Binary { op, lhs, rhs, .. } => {
             let l = eval_integer_with_scope(lhs, ctx, scope)?;
             let r = eval_integer_with_scope(rhs, ctx, scope)?;
-            eval_integer_binary(op, l, r)
+            eval_integer_binary_with_warning(op, l, r, ctx, expr.span())
         }
 
         Expression::Parenthesized { inner, .. } => eval_integer_with_scope(inner, ctx, scope),
@@ -1083,7 +1271,7 @@ pub fn eval_integer_with_scope(
                 .map(|p| p.ident.text.as_ref())
                 .collect::<Vec<_>>()
                 .join(".");
-            eval_integer_func_with_scope(&func_name, args, ctx, scope)
+            eval_integer_func_with_scope(&func_name, args, ctx, scope, expr.span())
         }
 
         Expression::If {

--- a/crates/rumoca-eval-ast/src/eval_instantiate/function_eval.rs
+++ b/crates/rumoca-eval-ast/src/eval_instantiate/function_eval.rs
@@ -824,7 +824,7 @@ fn try_eval_integer_shape_expr_with_depth(
         ast::Expression::Unary { op, rhs, .. } => {
             let value = recurse(rhs)?;
             match op {
-                rumoca_core::OpUnary::Minus => Some(-value),
+                rumoca_core::OpUnary::Minus => value.checked_neg(),
                 rumoca_core::OpUnary::Plus => Some(value),
                 _ => None,
             }

--- a/crates/rumoca-eval-ast/src/eval_instantiate/mod.rs
+++ b/crates/rumoca-eval-ast/src/eval_instantiate/mod.rs
@@ -983,7 +983,7 @@ fn try_eval_integer_expr_with_depth_and_locals(
         ast::Expression::Unary { op, rhs, .. } => {
             let r = recurse(rhs)?;
             match op {
-                rumoca_core::OpUnary::Minus => Some(-r),
+                rumoca_core::OpUnary::Minus => r.checked_neg(),
                 rumoca_core::OpUnary::Plus => Some(r),
                 _ => None,
             }

--- a/crates/rumoca-eval-flat/src/constant/builtins.rs
+++ b/crates/rumoca-eval-flat/src/constant/builtins.rs
@@ -146,7 +146,10 @@ fn eval_abs(args: &[Value], span: Span) -> Result<Value, EvalError> {
     check_arg_count(args, 1, span)?;
     match &args[0] {
         Value::Real(x) => Ok(Value::Real(x.abs())),
-        Value::Integer(x) => Ok(Value::Integer(x.abs())),
+        Value::Integer(x) => x
+            .checked_abs()
+            .map(Value::Integer)
+            .ok_or_else(|| integer_overflow_error("abs(...)", span)),
         other => Err(EvalError::type_mismatch(
             "Real or Integer",
             other.type_name(),
@@ -191,7 +194,7 @@ fn eval_sign(args: &[Value], span: Span) -> Result<Value, EvalError> {
 fn eval_floor(args: &[Value], span: Span) -> Result<Value, EvalError> {
     check_arg_count(args, 1, span)?;
     match &args[0] {
-        Value::Real(x) => Ok(Value::Integer(x.floor() as i64)),
+        Value::Real(x) => checked_real_to_i64(x.floor(), span, "floor(...)").map(Value::Integer),
         Value::Integer(x) => Ok(Value::Integer(*x)),
         other => Err(EvalError::type_mismatch(
             "Real or Integer",
@@ -205,7 +208,7 @@ fn eval_floor(args: &[Value], span: Span) -> Result<Value, EvalError> {
 fn eval_ceil(args: &[Value], span: Span) -> Result<Value, EvalError> {
     check_arg_count(args, 1, span)?;
     match &args[0] {
-        Value::Real(x) => Ok(Value::Integer(x.ceil() as i64)),
+        Value::Real(x) => checked_real_to_i64(x.ceil(), span, "ceil(...)").map(Value::Integer),
         Value::Integer(x) => Ok(Value::Integer(*x)),
         other => Err(EvalError::type_mismatch(
             "Real or Integer",
@@ -330,7 +333,7 @@ fn eval_div(args: &[Value], span: Span) -> Result<Value, EvalError> {
             if y == 0.0 {
                 return Err(EvalError::DivisionByZero { span });
             }
-            Ok(Value::Integer((x / y).trunc() as i64))
+            checked_real_to_i64((x / y).trunc(), span, "div(...)").map(Value::Integer)
         }
     }
 }
@@ -340,7 +343,7 @@ fn eval_integer(args: &[Value], span: Span) -> Result<Value, EvalError> {
     check_arg_count(args, 1, span)?;
     match &args[0] {
         Value::Integer(x) => Ok(Value::Integer(*x)),
-        Value::Real(x) => Ok(Value::Integer(x.floor() as i64)),
+        Value::Real(x) => checked_real_to_i64(x.floor(), span, "integer(...)").map(Value::Integer),
         other => Err(EvalError::type_mismatch(
             "Real or Integer",
             other.type_name(),
@@ -411,7 +414,9 @@ fn eval_sum(args: &[Value], span: Span) -> Result<Value, EvalError> {
     let all_int = arr.iter().all(|v| matches!(v, Value::Integer(_)));
     if all_int {
         let sum = arr.iter().try_fold(0_i64, |acc, value| {
-            integer_value(value, span).map(|value| acc + value)
+            let value = integer_value(value, span)?;
+            acc.checked_add(value)
+                .ok_or_else(|| integer_overflow_error("sum(...)", span))
         })?;
         return Ok(Value::Integer(sum));
     }
@@ -434,7 +439,9 @@ fn eval_product(args: &[Value], span: Span) -> Result<Value, EvalError> {
     let all_int = arr.iter().all(|v| matches!(v, Value::Integer(_)));
     if all_int {
         let prod = arr.iter().try_fold(1_i64, |acc, value| {
-            integer_value(value, span).map(|value| acc * value)
+            let value = integer_value(value, span)?;
+            acc.checked_mul(value)
+                .ok_or_else(|| integer_overflow_error("product(...)", span))
         })?;
         return Ok(Value::Integer(prod));
     }
@@ -695,6 +702,23 @@ fn integer_value(v: &Value, span: Span) -> Result<i64, EvalError> {
         .ok_or_else(|| EvalError::type_mismatch("Integer", v.type_name(), span))
 }
 
+fn checked_real_to_i64(value: f64, span: Span, context: &str) -> Result<i64, EvalError> {
+    if !value.is_finite() || value < i64::MIN as f64 || value > i64::MAX as f64 {
+        return Err(EvalError::function_error(
+            format!("real value {value} is outside i64 range while evaluating {context}"),
+            span,
+        ));
+    }
+    Ok(value as i64)
+}
+
+fn integer_overflow_error(context: &str, span: Span) -> EvalError {
+    EvalError::function_error(
+        format!("compile-time integer overflow while evaluating {context}"),
+        span,
+    )
+}
+
 // Helper: get nested array dimension size (reduces nesting in eval_size)
 fn get_nested_dim_size(arr: &[Value], dim: i64, span: Span) -> Result<Value, EvalError> {
     let Some(first) = arr.first() else {
@@ -853,6 +877,34 @@ mod tests {
 
         let ceil_result = eval_builtin("ceil", &[Value::Real(3.2)], Span::DUMMY).unwrap();
         assert_eq!(ceil_result.as_integer(), Some(4));
+    }
+
+    #[test]
+    fn test_integer_out_of_range_real_returns_error() {
+        let err = eval_builtin("integer", &[Value::Real(-1e40)], Span::DUMMY).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("outside i64 range while evaluating integer(...)")
+        );
+    }
+
+    #[test]
+    fn test_sum_integer_overflow_returns_error() {
+        let arr = Value::Array(vec![Value::Integer(i64::MAX), Value::Integer(1)]);
+        let err = eval_builtin("sum", &[arr], Span::DUMMY).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("compile-time integer overflow while evaluating sum(...)")
+        );
+    }
+
+    #[test]
+    fn test_abs_integer_overflow_returns_error() {
+        let err = eval_builtin("abs", &[Value::Integer(i64::MIN)], Span::DUMMY).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("compile-time integer overflow while evaluating abs(...)")
+        );
     }
 
     #[test]

--- a/crates/rumoca-eval-flat/src/constant/mod.rs
+++ b/crates/rumoca-eval-flat/src/constant/mod.rs
@@ -539,9 +539,19 @@ fn eval_unary_op(op: &OpUnary, rhs: &Value, span: Span) -> Result<Value, EvalErr
 
 // Arithmetic operations
 
+fn integer_overflow_error(op: &str, span: Span) -> EvalError {
+    EvalError::function_error(
+        format!("compile-time integer overflow while evaluating {op}"),
+        span,
+    )
+}
+
 fn eval_add(lhs: &Value, rhs: &Value, span: Span) -> Result<Value, EvalError> {
     match (lhs, rhs) {
-        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a + b)),
+        (Value::Integer(a), Value::Integer(b)) => a
+            .checked_add(*b)
+            .map(Value::Integer)
+            .ok_or_else(|| integer_overflow_error("integer addition", span)),
         (Value::Real(a), Value::Real(b)) => Ok(Value::Real(a + b)),
         (Value::Integer(a), Value::Real(b)) => Ok(Value::Real(*a as f64 + b)),
         (Value::Real(a), Value::Integer(b)) => Ok(Value::Real(a + *b as f64)),
@@ -570,7 +580,10 @@ fn eval_add(lhs: &Value, rhs: &Value, span: Span) -> Result<Value, EvalError> {
 
 fn eval_sub(lhs: &Value, rhs: &Value, span: Span) -> Result<Value, EvalError> {
     match (lhs, rhs) {
-        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a - b)),
+        (Value::Integer(a), Value::Integer(b)) => a
+            .checked_sub(*b)
+            .map(Value::Integer)
+            .ok_or_else(|| integer_overflow_error("integer subtraction", span)),
         (Value::Real(a), Value::Real(b)) => Ok(Value::Real(a - b)),
         (Value::Integer(a), Value::Real(b)) => Ok(Value::Real(*a as f64 - b)),
         (Value::Real(a), Value::Integer(b)) => Ok(Value::Real(a - *b as f64)),
@@ -598,7 +611,10 @@ fn eval_sub(lhs: &Value, rhs: &Value, span: Span) -> Result<Value, EvalError> {
 
 fn eval_mul(lhs: &Value, rhs: &Value, span: Span) -> Result<Value, EvalError> {
     match (lhs, rhs) {
-        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a * b)),
+        (Value::Integer(a), Value::Integer(b)) => a
+            .checked_mul(*b)
+            .map(Value::Integer)
+            .ok_or_else(|| integer_overflow_error("integer multiplication", span)),
         (Value::Real(a), Value::Real(b)) => Ok(Value::Real(a * b)),
         (Value::Integer(a), Value::Real(b)) => Ok(Value::Real(*a as f64 * b)),
         (Value::Real(a), Value::Integer(b)) => Ok(Value::Real(a * *b as f64)),
@@ -617,7 +633,10 @@ fn eval_mul(lhs: &Value, rhs: &Value, span: Span) -> Result<Value, EvalError> {
 
 fn eval_mul_elem(lhs: &Value, rhs: &Value, span: Span) -> Result<Value, EvalError> {
     match (lhs, rhs) {
-        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a * b)),
+        (Value::Integer(a), Value::Integer(b)) => a
+            .checked_mul(*b)
+            .map(Value::Integer)
+            .ok_or_else(|| integer_overflow_error("integer multiplication", span)),
         (Value::Real(a), Value::Real(b)) => Ok(Value::Real(a * b)),
         (Value::Integer(a), Value::Real(b)) => Ok(Value::Real(*a as f64 * b)),
         (Value::Real(a), Value::Integer(b)) => Ok(Value::Real(a * *b as f64)),
@@ -919,7 +938,9 @@ fn eval_exp(lhs: &Value, rhs: &Value, span: Span) -> Result<Value, EvalError> {
     match (lhs, rhs) {
         (Value::Integer(a), Value::Integer(b)) => {
             if *b >= 0 {
-                Ok(Value::Integer(a.pow(*b as u32)))
+                a.checked_pow(*b as u32)
+                    .map(Value::Integer)
+                    .ok_or_else(|| integer_overflow_error("integer exponentiation", span))
             } else {
                 Ok(Value::Real((*a as f64).powf(*b as f64)))
             }
@@ -937,7 +958,10 @@ fn eval_exp(lhs: &Value, rhs: &Value, span: Span) -> Result<Value, EvalError> {
 
 fn eval_negate(v: &Value, span: Span) -> Result<Value, EvalError> {
     match v {
-        Value::Integer(x) => Ok(Value::Integer(-x)),
+        Value::Integer(x) => x
+            .checked_neg()
+            .map(Value::Integer)
+            .ok_or_else(|| integer_overflow_error("integer negation", span)),
         Value::Real(x) => Ok(Value::Real(-x)),
         Value::Array(arr) => {
             let result: Vec<Value> = arr
@@ -1120,7 +1144,7 @@ fn eval_builtin_function(
             .first()
             .cloned()
             .ok_or_else(|| EvalError::not_constant("delay requires 1 argument".to_string(), span)),
-        BuiltinFunction::Integer => eval_builtin("floor", args, span),
+        BuiltinFunction::Integer => eval_builtin("integer", args, span),
         BuiltinFunction::SemiLinear => eval_builtin("semiLinear", args, span),
 
         // These are runtime-only functions
@@ -1339,6 +1363,22 @@ mod tests {
         };
         let result = eval_expr(&expr, &ctx).unwrap();
         assert!((result.as_real().unwrap() - 2.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_eval_binary_integer_overflow_returns_error() {
+        let ctx = EvalContext::new();
+        let expr = Expression::Binary {
+            op: OpBinary::Add,
+            lhs: Box::new(make_int(i64::MAX)),
+            rhs: Box::new(make_int(1)),
+            span: rumoca_core::Span::DUMMY,
+        };
+        let err = eval_expr(&expr, &ctx).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("compile-time integer overflow while evaluating integer addition")
+        );
     }
 
     #[test]
@@ -1577,6 +1617,21 @@ mod tests {
         };
         let result = eval_expr(&expr, &ctx).unwrap();
         assert!((result.as_real().unwrap() - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_eval_builtin_integer_overflow_returns_error() {
+        let ctx = EvalContext::new();
+        let expr = Expression::BuiltinCall {
+            function: BuiltinFunction::Integer,
+            args: vec![make_real(-1e40)],
+            span: rumoca_core::Span::DUMMY,
+        };
+        let err = eval_expr(&expr, &ctx).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("outside i64 range while evaluating integer(...)")
+        );
     }
 
     #[test]

--- a/crates/rumoca-phase-typecheck/src/instanced.rs
+++ b/crates/rumoca-phase-typecheck/src/instanced.rs
@@ -25,6 +25,7 @@ impl TypeChecker {
         self.validate_dimensions(overlay);
         self.check_instanced_component_modifiers(tree, model_name, &type_table);
         self.check_instanced_equations(tree, overlay, model_name, &type_table);
+        self.flush_eval_warnings();
     }
 
     fn initialize_instanced_context(&mut self, tree: &ClassTree) -> TypeTable {

--- a/crates/rumoca-phase-typecheck/src/lib.rs
+++ b/crates/rumoca-phase-typecheck/src/lib.rs
@@ -298,6 +298,7 @@ impl TypeChecker {
                 &self.type_suffix_index,
             );
         self.check_stored_definition(&mut tree.definitions, &mut tree.type_table);
+        self.flush_eval_warnings();
     }
 
     /// Collect constants from instance-level class/package redeclare overrides.
@@ -334,6 +335,12 @@ impl TypeChecker {
             if new == prev {
                 break;
             }
+        }
+    }
+
+    fn flush_eval_warnings(&mut self) {
+        for diagnostic in self.eval_ctx.take_warnings() {
+            self.diagnostics.emit(diagnostic);
         }
     }
 

--- a/crates/rumoca-phase-typecheck/src/tests.rs
+++ b/crates/rumoca-phase-typecheck/src/tests.rs
@@ -17,6 +17,15 @@ fn parse(source: &str) -> ParsedTree {
     ParsedTree::new(tree)
 }
 
+fn typecheck_diagnostics(source: &str) -> rumoca_core::Diagnostics {
+    let parsed = parse(source);
+    let resolved = resolve(parsed).expect("resolve should succeed");
+    let mut tree = resolved.into_inner();
+    let mut checker = TypeChecker::new();
+    checker.check(&mut tree);
+    checker.take_diagnostics()
+}
+
 #[test]
 fn test_empty_typecheck() {
     let tree = ClassTree::new();
@@ -24,6 +33,62 @@ fn test_empty_typecheck() {
     let resolved = resolve(parsed).expect("resolve should succeed");
     let result = typecheck(resolved);
     assert!(result.is_ok());
+}
+
+#[test]
+fn legitimate_integer_conversion_emits_no_warning() {
+    let diagnostics = typecheck_diagnostics(
+        r#"
+        model Test
+          parameter Integer n = integer(4.0);
+          Real x[n];
+        end Test;
+        "#,
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diag| diag.code.as_deref() != Some("ET006")
+                && diag.code.as_deref() != Some("ET007")),
+        "expected no integer-coercion warnings, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn out_of_range_integer_coercion_emits_warning() {
+    let diagnostics = typecheck_diagnostics(
+        r#"
+        model Test
+          parameter Integer n = integer(-1e40);
+        end Test;
+        "#,
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diag| diag.code.as_deref() == Some("ET006")),
+        "expected ET006 warning, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn integer_fold_overflow_emits_warning() {
+    let diagnostics = typecheck_diagnostics(
+        r#"
+        model Test
+          parameter Integer n = integer(9e18) + integer(9e18);
+        end Test;
+        "#,
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diag| diag.code.as_deref() == Some("ET007")),
+        "expected ET007 warning, got: {diagnostics:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
  Fix two related compile-time evaluation bugs that surfaced in MSL
  comparison runs as `unreachable` crashes.

  Root cause:
  - compile-time integer folding used unchecked Rust arithmetic in shared integer helpers and in rumoca-eval-flat
  - compile-time real->integer coercion accepted out-of-range values via raw `f64 -> i64` casts
  - large sentinel-style values such as `-1e40` could enter integer evaluation and trigger later overflow

  Changes:
  - use checked integer add/sub/mul/neg/abs/pow in constant evaluation
  - reject invalid real->integer coercions unless values are finite and within `i64` range
  - keep legitimate conversions such as `integer(4.0)` working
  - emit structured warnings/diagnostics for skipped integer folds and invalid coercions instead of panicking
  - surface compile warnings through the WASM compile-check path
  - add focused regressions for overflow and out-of-range coercion cases

  Effect:
  - former `unreachable` crashes now become normal compile diagnostics
  - broad MSL regression surface improves, especially in Spice3 and other models hitting constant-fold overflow paths

 Rumoca PR Review Template

<!--
Mirrors SPEC_0025. Section names here must match SPEC_0025 §"PR Template
Alignment". Update both files together if you change either one.
-->

## Summary

- What user-facing behavior changes?
- What issue, spec, or design rule does this address?

## Spec / MLS Alignment

- Relevant active spec(s) checked:
- Relevant MLS section(s), if semantics changed:
- Crate/phase owner:

## Risk and Design Notes

- Main correctness risk:
- Main maintenance risk:
- Why the change belongs in these crate(s):
- Any new abstraction, public API, or migration path:

## Testing

- Key command(s) run (fmt, clippy, workspace test, doc):
- Behavior or regression covered:
- Commands NOT run and why:
- For compiler/simulator changes: did you run the MSL gate
  (`cargo test --release --package rumoca-test-msl --features msl-full-test --test msl_tests
  balance_pipeline::balance_pipeline_core::test_msl_all -- --nocapture`) and
  confirm no regression vs `msl_quality_baseline.json`?

## Code Size Budget (required)

- production_lines_added:
- production_lines_deleted:
- test_lines_added:
- test_lines_deleted:
- public_items_added:
- public_items_removed:
- files_touched:
- net_added_lines:

If `net_added_lines` is positive, add:

- Why this net growth is required.
- Which code was removed/merged as part of the first compression pass.
- Follow-up cleanup ticket/commit for remaining growth (if any).

## Reviewer Checklist

- [ ] Relevant active specs were checked.
- [ ] MLS-sensitive changes cite the right MLS section.
- [ ] Crate boundaries and phase ownership preserved (SPEC_0029).
- [ ] Tests prove behavior or explain the remaining gap.
- [ ] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [ ] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [ ] Size-budget section completed.
- [ ] Positive net diff has explicit compression justification.
- [ ] New APIs are required and minimal.
- [ ] Old/new parallel paths removed unless explicitly migrating.
- [ ] No `#[allow(clippy::...)]` added outside generated code.
- [ ] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [ ] External material (if any) attributed and Apache-2.0 compatible.
