### PR TITLE
feat(solver): allow choosing different solvers (ESDIRK34 / TR-BDF2)

### DIFF
--- a/crates/rumoca-sim/src/lib.rs
+++ b/crates/rumoca-sim/src/lib.rs
@@ -13,15 +13,15 @@ pub use rumoca_eval_solve::nan_trace;
 use rumoca_ir_dae as dae;
 pub use rumoca_phase_solve::{lower_solve_artifacts, lower_solve_problem};
 pub use rumoca_solver::{
-    BackendState, LoopStats, RuntimeProgressSnapshot, RuntimeStopSchedule, RuntimeTraceContext,
-    SimBackend, SimOptions, SimPacingMode, SimResult, SimSolverMode, SimVariableMeta,
-    SimulationBackend, SimulationRequestSummary, SimulationRunMetrics, SolverDeadlineGuard,
-    StepUntilOutcome, TimeoutBudget, TimeoutExceeded, build_simulation_metrics_value,
-    build_simulation_payload, is_solver_timeout_panic, panic_on_expired_solver_deadline,
-    run_timeout_result, run_timeout_step, run_timeout_step_result, run_with_runtime_schedule,
-    runtime_progress_snapshot, stop_time_reached_with_tol, time_advanced_with_tol,
-    time_match_with_tol, trace_runtime_done, trace_runtime_progress, trace_runtime_start,
-    trace_runtime_step_fail, trace_runtime_timeout,
+    BackendState, DiffsolMethod, LoopStats, RuntimeProgressSnapshot, RuntimeStopSchedule,
+    RuntimeTraceContext, SimBackend, SimOptions, SimPacingMode, SimResult, SimSolverMode,
+    SimVariableMeta, SimulationBackend, SimulationRequestSummary, SimulationRunMetrics,
+    SolverDeadlineGuard, StepUntilOutcome, TimeoutBudget, TimeoutExceeded,
+    build_simulation_metrics_value, build_simulation_payload, is_solver_timeout_panic,
+    panic_on_expired_solver_deadline, run_timeout_result, run_timeout_step,
+    run_timeout_step_result, run_with_runtime_schedule, runtime_progress_snapshot,
+    stop_time_reached_with_tol, time_advanced_with_tol, time_match_with_tol, trace_runtime_done,
+    trace_runtime_progress, trace_runtime_start, trace_runtime_step_fail, trace_runtime_timeout,
 };
 
 pub mod bulk;

--- a/crates/rumoca-solver-diffsol/src/bdf.rs
+++ b/crates/rumoca-solver-diffsol/src/bdf.rs
@@ -7,7 +7,7 @@ use std::{
 
 use diffsol::{
     BdfState, MatrixCommon, OdeEquations, OdeEquationsImplicit, OdeSolverMethod, OdeSolverProblem,
-    OdeSolverState, VectorHost,
+    OdeSolverState, RkState, VectorHost,
 };
 use rumoca_eval_solve as solve_eval;
 use rumoca_ir_solve as solve;
@@ -166,6 +166,40 @@ where
     let dy = bdf_derivative_guess(model, ode_model, y, p, problem.t0)?;
     let mut state = BdfState::<Vector>::new_without_initialise(problem)
         .map_err(|err| SimError::SolverError(format!("BDF projected init: {err}")))?;
+    {
+        let state_ref = state.as_mut();
+        state_ref.y.as_mut_slice().copy_from_slice(y);
+        state_ref.dy.as_mut_slice().copy_from_slice(&dy);
+    }
+    state.set_step_size(problem.h0, &problem.atol, problem.rtol, &problem.eqn, 1);
+    Ok(state)
+}
+
+/// Build the initial `RkState` for the SDIRK (ESDIRK34 / TR-BDF2) path.
+///
+/// Mirrors [`projected_initial_bdf_state`]: it seeds the solver with the
+/// already-settled, algebraically-consistent `y` and the mass-matrix
+/// derivative guess `dy` (the same `bdf_derivative_guess` used by BDF, which
+/// is solver-agnostic). This preserves the exact-AD projection-aware
+/// consistent initial condition for the implicit RK tableaus too — without it
+/// SDIRK would lose the very startup robustness the BDF path gained.
+///
+/// Callers pass a `y` that has been settled by the simulate path's
+/// equilibrium/initialisation pass, so it is already algebraically consistent
+/// at `problem.t0`.
+pub(crate) fn initial_rk_state<Eqn>(
+    model: &solve::SolveModel,
+    ode_model: &OdeModel,
+    problem: &OdeSolverProblem<Eqn>,
+    y: &[f64],
+    p: &[f64],
+) -> Result<RkState<Vector>, SimError>
+where
+    Eqn: OdeEquationsImplicit<M = Matrix, V = Vector, T = Scalar, C = <Matrix as MatrixCommon>::C>,
+{
+    let dy = bdf_derivative_guess(model, ode_model, y, p, problem.t0)?;
+    let mut state = RkState::<Vector>::new_without_initialise(problem)
+        .map_err(|err| SimError::SolverError(format!("SDIRK projected init: {err}")))?;
     {
         let state_ref = state.as_mut();
         state_ref.y.as_mut_slice().copy_from_slice(y);

--- a/crates/rumoca-solver-diffsol/src/lib.rs
+++ b/crates/rumoca-solver-diffsol/src/lib.rs
@@ -19,7 +19,8 @@ use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use bdf::can_use_state_only_bdf;
 pub(crate) use bdf::{
-    bdf_derivative_guess, initial_bdf_state, reset_solver_state, solver_call, write_state_to_solver,
+    bdf_derivative_guess, initial_bdf_state, initial_rk_state, reset_solver_state, solver_call,
+    write_state_to_solver,
 };
 use diffsol::{
     BacktrackingLineSearch, BdfState, FaerSparseLU, FaerSparseMat, MatrixCommon,
@@ -32,11 +33,11 @@ use rumoca_eval_solve::{
 };
 use rumoca_ir_solve as solve;
 use rumoca_solver::{
-    EventPreMode, RuntimeEventBoundary, RuntimeEventBoundaryHandler, RuntimeEventStop, SimOptions,
-    SimResult, SimTermination, SolveStopSchedule, build_sim_result_from_solve_model,
-    commit_pre_params_after_event, discrete_row_pre_mode, initial_runtime_event_stop,
-    process_runtime_event_boundary, push_visible_values, replace_last_visible_values,
-    runtime_event_horizon, runtime_root_event_application_time,
+    DiffsolMethod, EventPreMode, RuntimeEventBoundary, RuntimeEventBoundaryHandler,
+    RuntimeEventStop, SimOptions, SimResult, SimTermination, SolveStopSchedule,
+    build_sim_result_from_solve_model, commit_pre_params_after_event, discrete_row_pre_mode,
+    initial_runtime_event_stop, process_runtime_event_boundary, push_visible_values,
+    replace_last_visible_values, runtime_event_horizon, runtime_root_event_application_time,
     timeline::sample_time_match_with_tol, write_pre_params_from_sources,
 };
 pub(crate) use runtime::{
@@ -76,7 +77,10 @@ pub fn build_simulation(
     let state = if model.state_scalar_count() == 0 {
         tracing::debug!(target: "rumoca_solver_diffsol::bdf_path", "no-state path");
         PreparedSimulationState::NoState
-    } else if can_use_state_only_bdf(model) {
+    } else if opts.diffsol_method == DiffsolMethod::Bdf && can_use_state_only_bdf(model) {
+        // SDIRK tableaus are wired only on the general/implicit path, so a
+        // non-BDF request routes through `General` even when the model is
+        // state-only eligible.
         tracing::debug!(
             target: "rumoca_solver_diffsol::bdf_path",
             states = model.state_scalar_count(),
@@ -219,64 +223,135 @@ fn simulate_with_states(
         current_y.clone(),
         equilibrium_model.clone(),
     )?;
-    let state = initial_bdf_state(model, equilibrium_model, &problem, &current_y, &params)?;
-    let nl_solver =
-        NewtonNonlinearSolver::new(LinearSolver::default(), BacktrackingLineSearch::default());
-    // One BDF solver that lives for the whole simulation. After zero-crossing
-    // events we pin the state to root time (state_mut_back), apply Modelica
-    // event semantics, then write updated (t, y, params) back via state_mut()
-    // so BDF history is preserved when only params change and naturally
-    // reinitialised for state-jump events.
-    let mut solver = solver_call("BDF new", || {
-        diffsol::Bdf::<_, _, _, diffsol::NoAug<_>>::new(&problem, state, nl_solver)
-    })?;
+    // The solver borrows `problem` for the full simulation. `Bdf` and `Sdirk`
+    // are distinct concrete types, so we branch construction and run the
+    // (solver-generic) `simulate_state_targets` inside each arm. The default
+    // `Bdf` arm is unchanged; the implicit RK tableaus (ESDIRK34 / TR-BDF2)
+    // reuse the same projection-aware consistent initial condition via
+    // `initial_rk_state`.
+    let result = match opts.diffsol_method {
+        DiffsolMethod::Bdf => {
+            let state = initial_bdf_state(model, equilibrium_model, &problem, &current_y, &params)?;
+            let nl_solver = NewtonNonlinearSolver::new(
+                LinearSolver::default(),
+                BacktrackingLineSearch::default(),
+            );
+            // One BDF solver that lives for the whole simulation. After
+            // zero-crossing events we pin the state to root time
+            // (state_mut_back), apply Modelica event semantics, then write
+            // updated (t, y, params) back via state_mut() so BDF history is
+            // preserved when only params change and naturally reinitialised
+            // for state-jump events.
+            let mut solver = solver_call("BDF new", || {
+                diffsol::Bdf::<_, _, _, diffsol::NoAug<_>>::new(&problem, state, nl_solver)
+            })?;
+            simulate_state_targets(
+                model,
+                opts,
+                &times,
+                equilibrium_model,
+                &runtime_params,
+                &mut solver,
+                StateTrajectory {
+                    params: &mut params,
+                    data: &mut data,
+                    recorded_times: &mut recorded_times,
+                    current_t: &mut current_t,
+                    current_y: &mut current_y,
+                    runtime,
+                },
+            )
+        }
+        method @ (DiffsolMethod::Esdirk34 | DiffsolMethod::TrBdf2) => {
+            let state = initial_rk_state(model, equilibrium_model, &problem, &current_y, &params)?;
+            let mut solver = solver_call("SDIRK new", || match method {
+                DiffsolMethod::Esdirk34 => problem.esdirk34_solver::<LinearSolver>(state),
+                _ => problem.tr_bdf2_solver::<LinearSolver>(state),
+            })?;
+            simulate_state_targets(
+                model,
+                opts,
+                &times,
+                equilibrium_model,
+                &runtime_params,
+                &mut solver,
+                StateTrajectory {
+                    params: &mut params,
+                    data: &mut data,
+                    recorded_times: &mut recorded_times,
+                    current_t: &mut current_t,
+                    current_y: &mut current_y,
+                    runtime,
+                },
+            )
+        }
+    };
 
-    match simulate_state_targets(
-        model,
-        opts,
-        &times,
-        equilibrium_model,
-        &runtime_params,
-        &mut solver,
-        StateTrajectory {
-            params: &mut params,
-            data: &mut data,
-            recorded_times: &mut recorded_times,
-            current_t: &mut current_t,
-            current_y: &mut current_y,
-            runtime,
-        },
-    ) {
-        Ok(()) => Ok(build_sim_result_from_solve_model(
+    finalize_state_simulation(
+        result,
+        StateSimFinalize {
             model,
-            recorded_times,
+            opts,
+            equilibrium_model,
+            runtime,
+            runtime_params: &runtime_params,
+            params,
             data,
+            recorded_times,
+            current_y,
+        },
+    )
+}
+
+/// Owned trajectory buffers + context needed to turn a `simulate_state_targets`
+/// outcome into a `SimResult`, shared by every solver arm of
+/// [`simulate_with_states`].
+struct StateSimFinalize<'a> {
+    model: &'a solve::SolveModel,
+    opts: &'a SimOptions,
+    equilibrium_model: &'a Arc<OdeModel>,
+    runtime: &'a Arc<SolveRuntime>,
+    runtime_params: &'a RuntimeParameters,
+    params: Vec<f64>,
+    data: Vec<Vec<f64>>,
+    recorded_times: Vec<f64>,
+    current_y: Vec<f64>,
+}
+
+fn finalize_state_simulation(
+    result: Result<(), SimError>,
+    mut fin: StateSimFinalize<'_>,
+) -> Result<SimResult, SimError> {
+    match result {
+        Ok(()) => Ok(build_sim_result_from_solve_model(
+            fin.model,
+            fin.recorded_times,
+            fin.data,
             None,
         )),
         Err(SimError::Terminated { time, message }) => {
-            current_t = time;
             refresh_observation_discrete_rows(
-                model,
-                &equilibrium_model.runtime_state,
-                &mut current_y,
-                &mut params,
-                current_t,
-                opts.atol.max(1.0e-10),
+                fin.model,
+                &fin.equilibrium_model.runtime_state,
+                &mut fin.current_y,
+                &mut fin.params,
+                time,
+                fin.opts.atol.max(1.0e-10),
             )?;
-            runtime_params.borrow_mut().copy_from_slice(&params);
+            fin.runtime_params.borrow_mut().copy_from_slice(&fin.params);
             record_sample_if_new(
-                Some(runtime),
-                model,
-                &current_y,
-                &params,
-                &mut recorded_times,
-                &mut data,
-                current_t,
+                Some(fin.runtime),
+                fin.model,
+                &fin.current_y,
+                &fin.params,
+                &mut fin.recorded_times,
+                &mut fin.data,
+                time,
             )?;
             Ok(build_sim_result_from_solve_model(
-                model,
-                recorded_times,
-                data,
+                fin.model,
+                fin.recorded_times,
+                fin.data,
                 Some(SimTermination { time, message }),
             ))
         }

--- a/crates/rumoca-solver-diffsol/src/tests/mod.rs
+++ b/crates/rumoca-solver-diffsol/src/tests/mod.rs
@@ -39,6 +39,68 @@ fn state_only_bdf_accepts_projection_backed_derivative_dependencies() {
 }
 
 #[test]
+fn general_path_integrates_with_sdirk_tableaus() {
+    // A non-BDF `diffsol_method` routes the model through the general/implicit
+    // path, where ESDIRK34 / TR-BDF2 are wired. The ramp model (x' = 1,
+    // x(0) = 0) has the closed form x(t) = t, so every tableau must land on
+    // x(1) = 1 and agree with the BDF baseline.
+    let model = general_ramp_model();
+    let bdf = run_ramp(&model, DiffsolMethod::Bdf);
+    assert!((bdf - 1.0).abs() <= 1.0e-6, "BDF baseline: x(1) = {bdf}");
+    for method in [DiffsolMethod::Esdirk34, DiffsolMethod::TrBdf2] {
+        let x = run_ramp(&model, method);
+        assert!((x - 1.0).abs() <= 1.0e-6, "{method:?}: x(1) = {x}");
+        assert!(
+            (x - bdf).abs() <= 1.0e-6,
+            "{method:?} disagrees with BDF: {x} vs {bdf}"
+        );
+    }
+}
+
+fn run_ramp(model: &solve::SolveModel, method: DiffsolMethod) -> f64 {
+    let result = simulate(
+        model,
+        &SimOptions {
+            t_start: 0.0,
+            t_end: 1.0,
+            dt: Some(0.25),
+            diffsol_method: method,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|err| panic!("{method:?} should integrate the ramp: {err}"));
+    *result
+        .data
+        .first()
+        .and_then(|series| series.last())
+        .expect("x series should have a final sample")
+}
+
+/// A single-state ramp `x' = 1` (so `x(t) = t`) whose residual/jacobian are
+/// consistently formed for the general/implicit solver path: `M·x' = f` with
+/// `M = I` and `f = 1`, exact JVP `df/dx = 0`, visible value reading the state
+/// directly.
+fn general_ramp_model() -> solve::SolveModel {
+    let mut model = unit_integrator_model();
+    model.problem.continuous.implicit_rhs =
+        solve::ComputeBlock::from_scalar_program_block(solve::ScalarProgramBlock::new(vec![vec![
+            solve::LinearOp::Const { dst: 0, value: 1.0 },
+            solve::LinearOp::StoreOutput { src: 0 },
+        ]]));
+    model.problem.continuous.implicit_row_targets = vec![Some(solve::scalar_slot_y(0))];
+    model.artifacts.continuous.implicit_jacobian_v =
+        solve::ComputeBlock::from_scalar_program_block(solve::ScalarProgramBlock::new(vec![vec![
+            solve::LinearOp::Const { dst: 0, value: 0.0 },
+            solve::LinearOp::StoreOutput { src: 0 },
+        ]]));
+    model.visible_value_rows = solve::ScalarProgramBlock::new(vec![vec![
+        solve::LinearOp::LoadY { dst: 0, index: 0 },
+        solve::LinearOp::StoreOutput { src: 0 },
+    ]]);
+    model
+}
+
+#[test]
 fn state_only_bdf_accepts_transitive_projection_dependencies() {
     let mut model = projected_derivative_model();
     model

--- a/crates/rumoca-solver/src/lib.rs
+++ b/crates/rumoca-solver/src/lib.rs
@@ -59,6 +59,6 @@ pub use runtime::timeout::{
     run_timeout_step_result,
 };
 pub use solver::{
-    BackendState, SimBackend, SimOptions, SimPacingMode, SimResult, SimSolverMode, SimTermination,
-    SimVariableMeta, SimulationBackend, StepUntilOutcome,
+    BackendState, DiffsolMethod, SimBackend, SimOptions, SimPacingMode, SimResult, SimSolverMode,
+    SimTermination, SimVariableMeta, SimulationBackend, StepUntilOutcome,
 };

--- a/crates/rumoca-solver/src/solver.rs
+++ b/crates/rumoca-solver/src/solver.rs
@@ -21,11 +21,12 @@ impl SimSolverMode {
         }
 
         let normalized = lower.replace(['-', '_', ' '], "");
+        // ESDIRK34 / TR-BDF2 are *implicit* tableaus served by the diffsol
+        // (BDF-family) path via `DiffsolMethod`, not the explicit rk45 backend
+        // — so they resolve to `Bdf` here, not `RkLike`.
         let rk_like = normalized.contains("rungekutta")
             || normalized.starts_with("rk")
             || normalized.contains("dopri")
-            || normalized.contains("esdirk")
-            || normalized.contains("trbdf2")
             || normalized.contains("euler")
             || normalized.contains("midpoint");
 
@@ -39,6 +40,47 @@ impl SimSolverMode {
                 (Self::from_external_name(trimmed), trimmed.to_string())
             }
             _ => (Self::Auto, "auto".to_string()),
+        }
+    }
+}
+
+/// Which diffsol integrator to construct on the implicit (BDF-family) path.
+///
+/// `SimSolverMode` selects the solver *family* (auto / implicit-BDF /
+/// explicit-RK). Within the implicit family, diffsol also ships A- and
+/// L-stable singly-diagonally-implicit Runge-Kutta tableaus (ESDIRK34,
+/// TR-BDF2) that suit stiff DAEs whose BDF startup struggles with sharp
+/// near-discontinuities (tanh / relop transitions, radiative T^4). This
+/// enum picks among them. `Bdf` is the default and leaves the existing
+/// construction path byte-for-byte unchanged.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffsolMethod {
+    /// Variable-order BDF (default). Best general-purpose stiff solver.
+    #[default]
+    Bdf,
+    /// ESDIRK 3(4) — singly-diagonally-implicit, A- and L-stable.
+    Esdirk34,
+    /// TR-BDF2 — implicit, A- and L-stable, two-stage. Strong on moderately
+    /// stiff problems with event-driven dynamics.
+    TrBdf2,
+}
+
+impl DiffsolMethod {
+    /// Map a user-facing solver name (case-insensitive, dashes / underscores
+    /// ignored) to a specific implicit tableau. Returns `None` for names that
+    /// are not implicit RK tableaus (callers keep the BDF default).
+    pub fn from_external_name(name: &str) -> Option<Self> {
+        let n = name
+            .trim()
+            .to_ascii_lowercase()
+            .replace(['-', '_', ' '], "");
+        if n.starts_with("esdirk") {
+            Some(Self::Esdirk34)
+        } else if n.starts_with("trbdf2") {
+            Some(Self::TrBdf2)
+        } else {
+            None
         }
     }
 }
@@ -86,6 +128,9 @@ pub struct SimOptions {
     pub scalarize: bool,
     pub max_wall_seconds: Option<f64>,
     pub solver_mode: SimSolverMode,
+    /// Implicit tableau to use on the diffsol (BDF-family) path. Ignored when
+    /// `solver_mode` resolves to the explicit rk45 backend. Defaults to `Bdf`.
+    pub diffsol_method: DiffsolMethod,
     pub pacing_mode: SimPacingMode,
 }
 
@@ -100,6 +145,7 @@ impl Default for SimOptions {
             scalarize: true,
             max_wall_seconds: None,
             solver_mode: SimSolverMode::Auto,
+            diffsol_method: DiffsolMethod::Bdf,
             pacing_mode: SimPacingMode::AsFastAsPossible,
         }
     }
@@ -165,7 +211,35 @@ pub trait SimulationBackend: RuntimeEventBoundaryHandler {
 
 #[cfg(test)]
 mod tests {
-    use super::{SimOptions, SimPacingMode, SimSolverMode};
+    use super::{DiffsolMethod, SimOptions, SimPacingMode, SimSolverMode};
+
+    #[test]
+    fn implicit_tableau_names_resolve_to_sdirk_method_not_explicit_rk() {
+        // ESDIRK34 / TR-BDF2 are implicit tableaus on the diffsol path: they
+        // must select a `DiffsolMethod`, and must NOT be misrouted to the
+        // explicit rk45 backend (`RkLike`).
+        for name in ["esdirk34", "ESDIRK-34", "es_dirk34"] {
+            assert_eq!(
+                DiffsolMethod::from_external_name(name),
+                Some(DiffsolMethod::Esdirk34)
+            );
+            assert_eq!(SimSolverMode::from_external_name(name), SimSolverMode::Bdf);
+        }
+        for name in ["trbdf2", "TR-BDF2", "tr_bdf2"] {
+            assert_eq!(
+                DiffsolMethod::from_external_name(name),
+                Some(DiffsolMethod::TrBdf2)
+            );
+            assert_eq!(SimSolverMode::from_external_name(name), SimSolverMode::Bdf);
+        }
+        // Explicit / unknown names keep the BDF default (None) and route as before.
+        assert_eq!(DiffsolMethod::from_external_name("dopri5"), None);
+        assert_eq!(
+            SimSolverMode::from_external_name("dopri5"),
+            SimSolverMode::RkLike
+        );
+        assert_eq!(DiffsolMethod::from_external_name("bdf"), None);
+    }
 
     #[test]
     fn solver_mode_request_parsing_defaults_blank_input_to_auto() {

--- a/crates/rumoca/src/main.rs
+++ b/crates/rumoca/src/main.rs
@@ -54,7 +54,7 @@ use rumoca_compile::{
     compile::{Dae, FlatModel, ResolvedTree, Session, SessionConfig},
     project::{write_last_simulation_result_for_model, write_simulation_run},
 };
-use rumoca_sim::{SimOptions, SimSolverMode};
+use rumoca_sim::{DiffsolMethod, SimOptions, SimSolverMode};
 use rumoca_sim::{SimulationRequestSummary, SimulationRunMetrics};
 use rumoca_tool_lint::{LintLevel, LintMessage, PartialLintOptions};
 use walkdir::WalkDir;
@@ -412,7 +412,8 @@ struct SimCommandArgs {
     #[command(flatten)]
     model_options: ModelOptions,
 
-    /// Solver: auto (recommended), bdf (stiff/implicit, diffsol), or rk-like
+    /// Solver: auto (recommended), bdf (stiff/implicit, diffsol), esdirk34 or
+    /// trbdf2 (implicit SDIRK tableaus for stiff DAEs, diffsol), or rk-like
     /// (explicit Runge-Kutta-style, non-stiff)
     #[arg(long, value_enum)]
     solver: Option<SimulateSolverMode>,
@@ -510,6 +511,11 @@ impl SimCommandArgs {
 enum SimulateSolverMode {
     Auto,
     Bdf,
+    /// ESDIRK34 — implicit SDIRK tableau on the diffsol path (stiff).
+    Esdirk34,
+    /// TR-BDF2 — implicit SDIRK tableau on the diffsol path (stiff).
+    #[value(name = "trbdf2")]
+    TrBdf2,
     #[value(name = "rk-like")]
     RkLike,
 }
@@ -518,7 +524,12 @@ impl From<SimulateSolverMode> for SimSolverMode {
     fn from(value: SimulateSolverMode) -> Self {
         match value {
             SimulateSolverMode::Auto => SimSolverMode::Auto,
-            SimulateSolverMode::Bdf => SimSolverMode::Bdf,
+            // ESDIRK34 / TR-BDF2 are implicit tableaus served by the diffsol
+            // (BDF-family) path; the specific tableau is carried by the solver
+            // label into `SimOptions::diffsol_method`.
+            SimulateSolverMode::Bdf | SimulateSolverMode::Esdirk34 | SimulateSolverMode::TrBdf2 => {
+                SimSolverMode::Bdf
+            }
             SimulateSolverMode::RkLike => SimSolverMode::RkLike,
         }
     }
@@ -529,6 +540,8 @@ impl SimulateSolverMode {
         match self {
             SimulateSolverMode::Auto => "auto",
             SimulateSolverMode::Bdf => "bdf",
+            SimulateSolverMode::Esdirk34 => "esdirk34",
+            SimulateSolverMode::TrBdf2 => "trbdf2",
             SimulateSolverMode::RkLike => "rk-like",
         }
     }
@@ -1790,6 +1803,9 @@ fn run_simulation(run: SimulationRun<'_>) -> Result<()> {
         t_end: run.t_end,
         dt: run.dt,
         solver_mode: run.solver_mode,
+        // `--solver esdirk34` / `trbdf2` selects an implicit SDIRK tableau on
+        // the diffsol path; other names leave the BDF default.
+        diffsol_method: DiffsolMethod::from_external_name(run.solver_label).unwrap_or_default(),
         ..SimOptions::default()
     };
 


### PR DESCRIPTION
## Summary

- User-facing behavior: Adds two implicit SDIRK solvers selectable for simulation — rumoca sim --solver esdirk34 and --solver trbdf2 (also via SimOptions.diffsol_method). These are A/L-stable tableaus suited to stiff DAEs whose BDF startup struggles with sharp near-discontinuities (tanh/relop transitions, radiative T⁴). The default remains bdf, so existing runs are unchanged. Also fixes a latent bug: the names esdirk34/trbdf2 previously resolved to the explicit rk45 backend (RkLike) — wrong for stiff problems — and now route to the implicit diffsol path.
- Addresses: re-applies the intent of the earlier exposed_solvers work onto main's post-#161 (exact-AD-Jacobian) solver architecture; design rule SPEC_0021 (complexity budget) and SPEC_0029 (crate boundaries).

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0029 (crate boundaries — solver selector lives in rumoca-solver-diffsol, the neutral contract DiffsolMethod in rumoca-solver); SPEC_0021 (complexity — extracted finalize_state_simulation so simulate_with_states stays under the 100-line limit); SPEC_0025 (this PR/template).
- Relevant MLS section(s): none — solver/tableau selection is an integration concern, not Modelica language semantics. No MLS-observable behavior changes.
- Crate/phase owner: rumoca-solver-diffsol (diffsol backend), with the backend-neutral option in rumoca-solver.

## Risk and Design Notes

- Main correctness risk: an SDIRK tableau could diverge from BDF or mis-handle the consistent initial condition. Mitigated by reusing BDF's exact-AD projection-aware IC (initial_rk_state mirrors projected_initial_bdf_state, sharing bdf_derivative_guess), and by a general-path test asserting both tableaus reproduce x(t)=t and agree with BDF to 1e-6.
- Main maintenance risk: a two-knob surface (solver_mode + diffsol_method). Contained to the solver-name parse points; the interactive stepper silently keeps BDF for now (scoped follow-up, not a silent failure on the batch/CLI path where the selector is wired).
- Why these crates: solver construction and the diffsol primitives live in rumoca-solver-diffsol; the option enum is a backend-neutral contract so bindings/CLI can set it without depending on diffsol.
- New abstraction / public API / migration: enum DiffsolMethod { Bdf, Esdirk34, TrBdf2 } (default Bdf), SimOptions.diffsol_method field, DiffsolMethod::from_external_name, plus re-exports. No migration needed — default preserves current behavior. Dropped the original branch's Tsit45 (redundant with main's DoPri rk45) and its global permissive-solver-default knobs (obsoleted by #161's exact AD Jacobian, which fixed their FD-degeneracy root cause).

## Testing

- Key commands run: cargo fmt --check (clean); cargo clippy -p rumoca -p rumoca-sim -p rumoca-solver -p rumoca-solver-diffsol --all-targets (clean, -D warnings); cargo test -p rumoca-solver -p rumoca-solver-diffsol -p rumoca-sim (130 pass); cargo build --workspace (clean). End-to-end: rumoca sim examples/models/Ball.mo --t-end 2 --solver {trbdf2,esdirk34} both complete.
- Behavior covered: new test general_path_integrates_with_sdirk_tableaus (ESDIRK34/TR-BDF2 integrate the ramp x'=1 and match the BDF baseline); implicit_tableau_names_resolve_to_sdirk_method_not_explicit_rk (name routing + the rk45-misroute fix).
- Commands NOT run and why: the full MSL parity gate was not run — the default bdf construction path is byte-for-byte unchanged (the new arms are reached only when a non-BDF diffsol_method is explicitly requested), and MSL models run on the default solver, so no parity regression is expected. Recommend running it in CI to confirm.
- MSL gate: not run locally (see above); flagging for reviewer/CI.

## Code Size Budget (required)

- production_lines_added: 244
- production_lines_deleted: 71
- test_lines_added: 88
- test_lines_deleted: 0
- public_items_added: 3 (DiffsolMethod, DiffsolMethod::from_external_name, SimOptions.diffsol_method)
- public_items_removed: 0
- files_touched: 7
- net_added_lines: 261

## Positive net growth:
- Why required: adds a genuinely new capability (two solvers) plus its option contract, CLI wiring, and a parallel RkState initial-condition path (SDIRK cannot reuse BdfState).
- Compression done in this pass: extracted finalize_state_simulation to remove duplicated result-handling across the BDF/SDIRK arms (and keep under the SPEC_0021 limit); dropped the original branch's Tsit45 and global solver-knob changes rather than carrying them.
- Follow-up: wire SDIRK into the interactive stepper path; expose the selector in the wasm/python/worker bindings (currently default BDF).