### PR TITLE
Preserve start values

### DIFF
--- a/crates/rumoca-compile/src/session/compile_support.rs
+++ b/crates/rumoca-compile/src/session/compile_support.rs
@@ -130,6 +130,11 @@ fn summarize_typecheck_error_code(diags: &CommonDiagnostics) -> Option<String> {
 pub(super) fn todae_options_for_target_model() -> ToDaeOptions {
     ToDaeOptions {
         error_on_unbalanced: true,
+        // Keep computed parameter start expressions symbolic so an interactive
+        // host can override a base parameter between runs and have the
+        // dependents recompute without recompiling from source. Set false to
+        // restore the historical literal-folding behaviour.
+        preserve_overridable_param_starts: true,
     }
 }
 
@@ -234,6 +239,7 @@ pub(super) fn compile_model_internal_allow_unbalanced_for_diagnostics(
         InstantiateOptions::default(),
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     );
     compile_phase_result_from_dae(tree, model_name, dae_outcome)
@@ -267,6 +273,7 @@ pub(super) fn compile_model_dae_internal_allow_unbalanced_for_diagnostics(
         InstantiateOptions::default(),
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     );
     dae_phase_result_from_dae(tree, model_name, dae_outcome)

--- a/crates/rumoca-phase-dae/src/fold_start_values.rs
+++ b/crates/rumoca-phase-dae/src/fold_start_values.rs
@@ -15,10 +15,37 @@ use std::collections::HashMap;
 
 /// Evaluate all parameter/state/constant start expressions to typed literals
 /// where possible. Modifies the DAE in place.
-pub(crate) fn fold_start_values_to_literals(dae: &mut Dae) {
+///
+/// When `preserve_overridable_param_starts` is set, a *parameter* whose `start`
+/// expression references one or more other parameters is left symbolic instead
+/// of being folded to a literal. This keeps the dependency live so that a
+/// runtime override of a base parameter (e.g. `Isp`) propagates to its computed
+/// dependents (e.g. `massRatio = exp(dv_hop/(Isp*g0))`) when the interpreter
+/// re-evaluates start expressions, without recompiling from source. The
+/// parameter chain is already ordered for forward evaluation earlier in the
+/// pipeline. Defaults to the historical behaviour (`false`) so codegen backends
+/// keep getting literals.
+pub(crate) fn fold_start_values_to_literals(
+    dae: &mut Dae,
+    preserve_overridable_param_starts: bool,
+) {
     // Phase 1: build a name→value map from constants, enum ordinals, and
     // parameter start expressions (fixed-point iteration).
     let mut values: HashMap<String, ConstValue> = HashMap::new();
+
+    // Set of all parameter names — used by the override-preservation carve-out
+    // to detect parameter→parameter dependencies in a start expression. Only
+    // needed when preservation is on, so the default (codegen) path pays
+    // nothing.
+    let param_names: std::collections::HashSet<String> = if preserve_overridable_param_starts {
+        dae.variables
+            .parameters
+            .keys()
+            .map(|k| k.as_str().to_string())
+            .collect()
+    } else {
+        std::collections::HashSet::new()
+    };
 
     // Seed with enum literal ordinals
     for (name, ordinal) in &dae.symbols.enum_literal_ordinals {
@@ -55,7 +82,7 @@ pub(crate) fn fold_start_values_to_literals(dae: &mut Dae) {
 
     // Phase 2: rewrite start expressions to literals where we found values.
     // Also clear self-referencing defaults (start = VarRef(self_name)).
-    let rewrite = |var: &mut Variable| {
+    let rewrite = |var: &mut Variable, is_param: bool| {
         if let Some(ref start) = var.start {
             // Check for self-reference: start = VarRef(own_name)
             if let Expression::VarRef {
@@ -78,6 +105,15 @@ pub(crate) fn fold_start_values_to_literals(dae: &mut Dae) {
             //   already orders the chain for forward-eval templates.
             if let Expression::VarRef { subscripts, .. } = start
                 && subscripts.is_empty()
+            {
+                return;
+            }
+            // Override-preservation carve-out: keep a *computed* parameter start
+            // (not just a bare alias) symbolic when it references another
+            // parameter, so runtime base-parameter overrides propagate to it.
+            if is_param
+                && preserve_overridable_param_starts
+                && !collect_param_refs(start, &param_names).is_empty()
             {
                 return;
             }
@@ -116,15 +152,15 @@ struct StartRewriter<F> {
 
 impl<F> DaeVariableMutVisitor for StartRewriter<F>
 where
-    F: FnMut(&mut Variable),
+    F: FnMut(&mut Variable, bool),
 {
     fn visit_variable_mut(
         &mut self,
-        _partition: DaeVariablePartition,
+        partition: DaeVariablePartition,
         _name: &VarName,
         variable: &mut Variable,
     ) {
-        (self.rewrite)(variable);
+        (self.rewrite)(variable, partition == DaeVariablePartition::Parameter);
     }
 }
 
@@ -475,6 +511,55 @@ mod tests {
     }
 
     #[test]
+    fn preserve_overridable_keeps_computed_param_start_symbolic() {
+        // `base = 2.0` (literal); `derived.start = base * 3` is a *computed*
+        // start that references another parameter.
+        let make_dae = || {
+            let mut dae = Dae::new();
+            dae.variables
+                .parameters
+                .insert(VarName::new("base"), parameter("base", real(2.0)));
+            dae.variables.parameters.insert(
+                VarName::new("derived"),
+                parameter(
+                    "derived",
+                    Expression::Binary {
+                        op: OpBinary::Mul,
+                        lhs: Box::new(var("base")),
+                        rhs: Box::new(real(3.0)),
+                        span: rumoca_core::Span::DUMMY,
+                    },
+                ),
+            );
+            dae
+        };
+
+        // preserve = true: the computed, parameter-referencing start stays
+        // symbolic so a runtime override of `base` propagates to `derived`.
+        let mut dae = make_dae();
+        fold_start_values_to_literals(&mut dae, true);
+        let derived = &dae.variables.parameters[&VarName::new("derived")];
+        assert!(
+            matches!(derived.start, Some(Expression::Binary { .. })),
+            "expected symbolic start under preservation, got {:?}",
+            derived.start
+        );
+
+        // preserve = false (default): folds to the literal 6.0.
+        let mut dae = make_dae();
+        fold_start_values_to_literals(&mut dae, false);
+        let derived = &dae.variables.parameters[&VarName::new("derived")];
+        assert!(
+            matches!(
+                derived.start,
+                Some(Expression::Literal { value: Literal::Real(v), .. }) if (v - 6.0).abs() <= 1.0e-12
+            ),
+            "expected folded literal 6.0, got {:?}",
+            derived.start
+        );
+    }
+
+    #[test]
     fn reorder_by_index_order_reports_invalid_topological_index() {
         let mut variables = indexmap::IndexMap::new();
         variables.insert(VarName::new("x"), Variable::new(VarName::new("x")));
@@ -538,7 +623,7 @@ mod tests {
             ),
         );
 
-        fold_start_values_to_literals(&mut dae);
+        fold_start_values_to_literals(&mut dae, false);
 
         let c1 = &dae.variables.parameters[&VarName::new("transformerData1.C1")];
         assert!(matches!(

--- a/crates/rumoca-phase-dae/src/lib.rs
+++ b/crates/rumoca-phase-dae/src/lib.rs
@@ -200,12 +200,19 @@ fn run_todae_phase<R>(timing_enabled: bool, label: &str, f: impl FnOnce() -> R) 
 pub struct ToDaeOptions {
     /// Whether to return an error for non-partial unbalanced models.
     pub error_on_unbalanced: bool,
+    /// Keep computed parameter `start` expressions symbolic (instead of
+    /// folding to literals) when they reference other parameters, so a runtime
+    /// override of a base parameter propagates to its dependents without a
+    /// recompile. Used by the interactive/sim compile path; codegen backends
+    /// keep the default (`false`) so they continue to receive literals.
+    pub preserve_overridable_param_starts: bool,
 }
 
 impl Default for ToDaeOptions {
     fn default() -> Self {
         Self {
             error_on_unbalanced: true,
+            preserve_overridable_param_starts: false,
         }
     }
 }
@@ -361,7 +368,10 @@ fn finalize_lowered_dae(
     // possible. Safe as an always-on pass: start values are init-time
     // metadata, not user-observable at runtime.
     run_todae_phase(todae_subphase_timing, "fold_start_values", || {
-        fold_start_values::fold_start_values_to_literals(dae);
+        fold_start_values::fold_start_values_to_literals(
+            dae,
+            options.preserve_overridable_param_starts,
+        );
     });
 
     // Reorder algebraics so any algebraic used in another's defining

--- a/crates/rumoca-phase-dae/src/tests/algorithm_lowering.rs
+++ b/crates/rumoca-phase-dae/src/tests/algorithm_lowering.rs
@@ -631,6 +631,7 @@ fn test_todae_preserves_function_algorithm_bodies_for_codegen_readability() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("to_dae should keep reachable function bodies");
@@ -668,6 +669,7 @@ fn test_todae_lowers_supported_model_algorithms_to_equations() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("to_dae should lower simple model algorithms");
@@ -702,6 +704,7 @@ fn test_todae_routes_discrete_valued_algorithm_assignment_to_f_m() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("discrete-valued model algorithm assignments should lower");
@@ -761,6 +764,7 @@ fn test_todae_lowers_model_algorithm_for_loop_with_static_range() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("for-loop algorithms with static ranges should lower to equations");
@@ -820,6 +824,7 @@ fn test_todae_lowers_model_algorithm_for_loop_with_subscripted_targets() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("for-loop algorithms with static indexed targets should lower to equations");
@@ -888,6 +893,7 @@ fn test_todae_lowers_model_algorithm_dynamic_scalar_index_assignment() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("dynamic scalar index algorithm assignments should lower");
@@ -977,6 +983,7 @@ fn test_todae_lowers_when_algorithm_for_loop_with_subscripted_targets() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("when for-loop algorithms with static indexed targets should lower to event equations");
@@ -1027,6 +1034,7 @@ fn test_todae_lowers_when_algorithm_for_loop_with_sequential_cross_target_update
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("when for-loop algorithms with sequential updates should lower");
@@ -1102,6 +1110,7 @@ fn test_todae_lowers_when_algorithm_preceding_assignment_visible_inside_for_loop
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("when assignments before for-loop should stay visible inside the loop");
@@ -1142,6 +1151,7 @@ fn test_todae_lowers_top_level_algorithm_assignment_before_for_loop_sequentially
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("top-level sequential algorithm state should stay visible inside following for-loop");
@@ -1170,6 +1180,7 @@ fn test_todae_lowers_initial_algorithm_assignment_to_fixed_false_parameter() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("MLS fixed=false parameters may be solved by initial algorithms");
@@ -1209,6 +1220,7 @@ fn test_todae_rejects_initial_algorithm_assignment_to_default_fixed_parameter() 
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("parameter fixed=true by default must not be solved by initial algorithms");
@@ -1241,6 +1253,7 @@ fn test_todae_rejects_initial_algorithm_assignment_to_explicit_fixed_parameter()
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("parameter fixed=true must not be solved by initial algorithms");
@@ -1273,6 +1286,7 @@ fn test_todae_rejects_runtime_algorithm_assignment_to_parameter() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("regular algorithm sections must not assign parameters");
@@ -1315,6 +1329,7 @@ fn test_todae_lowers_initial_when_algorithm_discrete_assignment_to_initial_equat
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("MLS initial algorithms with when-statements initialize discrete targets");
@@ -1368,6 +1383,7 @@ fn test_todae_lowers_vector_when_algorithm_condition_to_scalar_event_guard() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("vector when algorithm should lower");
@@ -1442,6 +1458,7 @@ fn test_todae_rewrites_current_algorithm_value_inside_index_subscript() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("MLS §11.1 sequential algorithm reads inside subscripts use current values");
@@ -1504,6 +1521,7 @@ fn test_todae_rejects_model_algorithm_for_loop_with_non_constant_range() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("for-loop algorithms with non-constant ranges must fail");
@@ -1573,6 +1591,7 @@ fn test_todae_accepts_model_algorithm_for_loop_with_constant_array_binding_range
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("for-loop algorithms with constant array binding ranges should lower");
@@ -1585,6 +1604,7 @@ fn test_todae_lowers_supported_algorithm_slice_row_write_and_read() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("supported row slice algorithm should lower");
@@ -1673,6 +1693,7 @@ fn test_todae_lowers_supported_algorithm_slice_row_read_to_scalar_refs() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("supported row slice read should lower");
@@ -1739,6 +1760,7 @@ fn test_todae_lowers_multi_output_algorithm_function_call_to_output_selections()
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("multi-output model algorithm calls should lower to selection equations");

--- a/crates/rumoca-phase-dae/src/tests/conditions.rs
+++ b/crates/rumoca-phase-dae/src/tests/conditions.rs
@@ -108,6 +108,7 @@ fn to_dae_unbalanced_ok(model: &Model) -> Dae {
         model,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("ToDAE conversion should succeed")

--- a/crates/rumoca-phase-dae/src/tests/initialization.rs
+++ b/crates/rumoca-phase-dae/src/tests/initialization.rs
@@ -73,6 +73,7 @@ fn todae_adds_fixed_start_initial_equation_for_state() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("state with fixed start should lower");
@@ -100,6 +101,7 @@ fn todae_adds_fixed_start_initial_equation_for_algebraic() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("algebraic with fixed start should lower");
@@ -124,6 +126,7 @@ fn todae_does_not_add_fixed_start_initial_equation_by_default() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("default non-parameter fixed=false should lower");
@@ -143,6 +146,7 @@ fn todae_respects_explicit_fixed_false_for_start_attribute() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("fixed=false start attribute should lower");
@@ -161,6 +165,7 @@ fn todae_skips_fixed_start_initial_equation_for_zero_size_array() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("zero-size fixed variable should lower");

--- a/crates/rumoca-phase-dae/src/tests/root/input_promotion_extra.rs
+++ b/crates/rumoca-phase-dae/src/tests/root/input_promotion_extra.rs
@@ -31,6 +31,7 @@ fn test_rhs_intra_component_alias_with_multilayer_connected_lhs_does_not_promote
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("to_dae should succeed for multi-layer connected LHS alias");

--- a/crates/rumoca-phase-dae/src/tests/root/mod.rs
+++ b/crates/rumoca-phase-dae/src/tests/root/mod.rs
@@ -151,6 +151,7 @@ fn test_todae_rewrites_missing_scoped_parameter_start_reference() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("to_dae should succeed for parameter-only model");
@@ -218,6 +219,7 @@ fn test_todae_rewrites_misqualified_record_parameter_alias_field() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("record-parameter alias should resolve to the matching scalar field");
@@ -278,6 +280,7 @@ fn test_todae_rejects_unresolved_function_calls() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("missingFn should fail in ToDae validation");
@@ -315,6 +318,7 @@ fn test_todae_rejects_unresolved_references() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("missingRef should fail in ToDae validation");
@@ -352,6 +356,7 @@ fn test_todae_rejects_unresolved_component_qualified_constant_like_ref() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("unresolved qualified reference should fail in ToDae validation");
@@ -397,6 +402,7 @@ fn test_todae_rejects_non_external_function_without_body() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("empty non-external function should fail in ToDae validation");
@@ -429,6 +435,7 @@ fn test_todae_rejects_reinit_on_non_state_variable() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("reinit(x, ...) must fail when x is not a state");
@@ -469,6 +476,7 @@ fn test_todae_ignores_unreachable_function_without_body() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("unreachable empty function bodies should not fail ToDae validation");
@@ -494,6 +502,7 @@ fn test_todae_rejects_member_style_function_call_without_resolved_name() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("member-style call should fail without prior name resolution");
@@ -518,6 +527,7 @@ fn test_todae_accepts_runtime_intrinsic_cardinality_call() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("cardinality should be treated as runtime intrinsic during validation");
@@ -533,6 +543,7 @@ fn test_todae_accepts_runtime_intrinsic_complex_call() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("Complex should be treated as runtime intrinsic during validation");
@@ -584,6 +595,7 @@ fn test_todae_accepts_record_constructor_calls_for_known_type_names() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("record constructor calls should be accepted for known type names");
@@ -628,6 +640,7 @@ fn test_todae_rejects_constructor_field_selection_without_signature() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("missing constructor signature should fail in ToDae validation");
@@ -685,6 +698,7 @@ fn test_todae_accepts_constructor_field_selection_with_signature() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("constructor selection should pass when signature includes selected field");
@@ -729,6 +743,7 @@ fn test_todae_rejects_complex_constructor_selection_without_signature_metadata()
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("constructor field selections require constructor signature metadata");
@@ -795,6 +810,7 @@ fn test_todae_rejects_parameter_constructor_selection_in_final_dae_validation() 
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect_err("parameter constructor selection should fail in final DAE validation");
@@ -897,6 +913,7 @@ fn test_todae_routes_explicit_discrete_integer_when_assignment_to_f_m() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("explicit discrete integer when assignment should route to f_m");
@@ -978,6 +995,7 @@ fn test_todae_lowers_when_multi_output_function_call_to_selection_updates() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("when multi-output function call should lower to per-output updates");
@@ -1044,6 +1062,7 @@ fn test_todae_preserves_indexed_explicit_discrete_assignment_targets() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("indexed discrete assignments should preserve their element targets in ToDae");
@@ -1126,6 +1145,7 @@ fn test_todae_canonicalizes_constant_expr_subscripts_in_explicit_targets() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("constant-expression indexed targets should canonicalize in ToDae");
@@ -1178,6 +1198,7 @@ fn test_todae_routes_explicit_discrete_real_when_assignment_to_f_z() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("discrete real when assignment should route to f_z");
@@ -1449,6 +1470,7 @@ fn test_top_level_input_with_der_remains_input() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("top-level input der-equation should compile");
@@ -1854,6 +1876,7 @@ fn test_connected_input_binding_kept_for_input_only_connection_alias() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("to_dae should succeed for connected internal input alias");
@@ -1912,6 +1935,7 @@ fn test_connected_input_alias_with_multilayer_subscripts_promotes_internal_input
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("to_dae should succeed for multi-layer indexed input aliases");

--- a/crates/rumoca-phase-dae/src/tests/root/tests_function_param_calls.rs
+++ b/crates/rumoca-phase-dae/src/tests/root/tests_function_param_calls.rs
@@ -45,6 +45,7 @@ fn test_todae_accepts_function_typed_parameter_calls_in_function_body() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("function-typed function parameters should be callable in function bodies");
@@ -94,6 +95,7 @@ fn test_todae_accepts_function_typed_parameter_without_flat_function_entry() {
         &flat,
         ToDaeOptions {
             error_on_unbalanced: false,
+            preserve_overridable_param_starts: false,
         },
     )
     .expect("function-typed formals should not require executable flat function entries");

--- a/crates/rumoca-phase-dae/src/tests/root/tests_regressions.rs
+++ b/crates/rumoca-phase-dae/src/tests/root/tests_regressions.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+/// ToDAE options used by the regression fixtures: allow unbalanced models
+/// (these tests exercise narrow pipeline slices) and keep the historical
+/// literal-folding behaviour.
+fn unbalanced_todae_opts() -> ToDaeOptions {
+    ToDaeOptions {
+        error_on_unbalanced: false,
+        preserve_overridable_param_starts: false,
+    }
+}
+
 #[test]
 fn test_todae_inherits_scalarized_element_start_from_array_base() {
     let mut flat = Model::new();
@@ -30,13 +40,8 @@ fn test_todae_inherits_scalarized_element_start_from_array_base() {
         0,
     );
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("todae should inherit scalarized element starts from array base declaration");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("todae should inherit scalarized element starts from array base declaration");
 
     let inherited = dae
         .variables
@@ -100,13 +105,8 @@ fn test_todae_keeps_non_primitive_leaf_outputs() {
         scalar_count: 1,
     });
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("todae should keep non-primitive leaf output variables");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("todae should keep non-primitive leaf output variables");
 
     assert!(
         dae.variables
@@ -203,13 +203,8 @@ fn test_todae_classifies_clocked_flat_assignment_as_discrete_real_and_routes_to_
         scalar_count: 1,
     });
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("clocked assignment should convert");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("clocked assignment should convert");
 
     assert!(
         dae.variables
@@ -300,13 +295,8 @@ fn test_todae_routes_if_lhs_clocked_assignment_with_supersample_to_f_z() {
         scalar_count: 1,
     });
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("if-lhs clocked superSample assignment should convert");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("if-lhs clocked superSample assignment should convert");
 
     assert!(
         dae.variables
@@ -354,13 +344,8 @@ fn test_todae_routes_clocked_binding_out_of_fx_even_without_discrete_type_flag()
         },
     );
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("clocked binding must not remain in f_x");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("clocked binding must not remain in f_x");
 
     assert!(
         dae.variables
@@ -417,13 +402,8 @@ fn test_todae_routes_discrete_valued_clocked_binding_to_fm() {
         },
     );
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("clocked discrete-valued binding should convert");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("clocked discrete-valued binding should convert");
 
     assert!(
         dae.variables
@@ -488,13 +468,8 @@ fn test_todae_routes_clocked_tuple_assignment_to_f_z() {
         scalar_count: 4,
     });
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("clocked tuple assignment should convert");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("clocked tuple assignment should convert");
 
     assert!(
         dae.variables
@@ -573,13 +548,8 @@ fn test_todae_routes_algorithm_when_sample_assignment_to_f_z() {
     });
     flat.algorithms.push(algorithm);
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("algorithm when sample assignment should lower to discrete partition");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("algorithm when sample assignment should lower to discrete partition");
 
     assert!(
         dae.variables
@@ -651,13 +621,8 @@ fn sequential_when_same_target_model() -> Model {
 #[test]
 fn test_todae_merges_sequential_when_statements_for_same_target_in_source_order() {
     let flat = sequential_when_same_target_model();
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("sequential when-statements should lower to one ordered discrete equation");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("sequential when-statements should lower to one ordered discrete equation");
 
     let eq = dae
         .discrete
@@ -868,13 +833,7 @@ fn test_todae_routes_zero_minus_if_discrete_assignments_to_f_m() {
         add_tick_based_discrete_vars(&mut flat);
         add_tick_based_equation(&mut flat, residual);
 
-        let dae = to_dae_with_options(
-            &flat,
-            ToDaeOptions {
-                error_on_unbalanced: false,
-            },
-        )
-        .unwrap_or_else(|err| {
+        let dae = to_dae_with_options(&flat, unbalanced_todae_opts()).unwrap_or_else(|err| {
             panic!("clocked if-residual assignment should convert ({label}): {err:?}")
         });
 
@@ -926,13 +885,8 @@ fn test_todae_merges_branch_split_discrete_if_assignments_to_f_m() {
         },
     );
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("branch-split if-equation assignments should merge into solved f_m updates");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("branch-split if-equation assignments should merge into solved f_m updates");
 
     let counter_updates = dae
         .discrete
@@ -1027,13 +981,8 @@ fn test_todae_keeps_time_guarded_discrete_output_binding_and_alias_consumer() {
         scalar_count: 1,
     });
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("todae should preserve time-guarded discrete output bindings");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("todae should preserve time-guarded discrete output bindings");
 
     assert!(
         dae.variables
@@ -1133,13 +1082,8 @@ fn test_todae_converts_non_primitive_leaf_discrete_binding_to_f_m() {
         scalar_count: 1,
     });
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("todae should keep non-primitive leaf discrete bindings");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("todae should keep non-primitive leaf discrete bindings");
 
     assert!(
         dae.discrete.valued_updates.iter().any(|eq| eq
@@ -1331,13 +1275,8 @@ fn test_connected_discrete_input_alias_keeps_discrete_partition() {
 
     add_connection_equation(&mut flat, "inner.flagAlias", "inner.flag");
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("to_dae should succeed for connected discrete input aliases");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("to_dae should succeed for connected discrete input aliases");
 
     for name in ["inner.flag", "inner.flagAlias"] {
         let var = rumoca_core::VarName::new(name);
@@ -1404,13 +1343,8 @@ fn test_discrete_input_connected_to_local_output_counts_as_local_unknown() {
     flat.algorithms.push(algorithm);
     add_connection_equation(&mut flat, "sink.u", "source.y");
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("to_dae should succeed for locally driven discrete input");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("to_dae should succeed for locally driven discrete input");
 
     assert!(
         dae.variables
@@ -1469,13 +1403,8 @@ fn test_discrete_input_alias_chain_to_local_output_counts_as_local_unknown() {
     add_connection_equation(&mut flat, "relay.u", "source.y");
     add_connection_equation(&mut flat, "sink.u", "relay.u");
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("to_dae should succeed for locally driven discrete input alias chain");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("to_dae should succeed for locally driven discrete input alias chain");
 
     assert_eq!(
         dae.metadata.discrete_input_names,
@@ -1515,13 +1444,8 @@ fn test_connected_real_input_propagates_discrete_partition_from_peer() {
 
     add_connection_equation(&mut flat, "inner.u", "inner.clocked");
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("to_dae should succeed for connected clocked real inputs");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("to_dae should succeed for connected clocked real inputs");
 
     assert!(
         dae.variables
@@ -1582,13 +1506,8 @@ fn test_when_clause_guard_for_var_condition_uses_edge_activation() {
     ));
     flat.when_clauses.push(when_clause);
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("when clause should lower to guarded discrete update");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("when clause should lower to guarded discrete update");
 
     let guarded = dae
         .discrete
@@ -1650,13 +1569,8 @@ fn test_when_clause_guard_for_clock_condition_uses_clock_tick_directly() {
     ));
     flat.when_clauses.push(when_clause);
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("when Clock clause should lower to guarded discrete update");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("when Clock clause should lower to guarded discrete update");
 
     let guarded = dae
         .discrete
@@ -1728,13 +1642,8 @@ fn test_when_clause_guard_for_vector_var_conditions_uses_edge_activation_per_ele
     ));
     flat.when_clauses.push(when_clause);
 
-    let dae = to_dae_with_options(
-        &flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("vector when clause should lower to guarded discrete update");
+    let dae = to_dae_with_options(&flat, unbalanced_todae_opts())
+        .expect("vector when clause should lower to guarded discrete update");
 
     let guarded = dae
         .discrete
@@ -1909,20 +1818,10 @@ fn test_when_boolean_alias_guard_matches_inline_relational_guard() {
     let direct_flat = build_when_condition_alias_model(false);
     let alias_flat = build_when_condition_alias_model(true);
 
-    let direct_dae = to_dae_with_options(
-        &direct_flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("direct-guard model should lower");
-    let alias_dae = to_dae_with_options(
-        &alias_flat,
-        ToDaeOptions {
-            error_on_unbalanced: false,
-        },
-    )
-    .expect("alias-guard model should lower");
+    let direct_dae = to_dae_with_options(&direct_flat, unbalanced_todae_opts())
+        .expect("direct-guard model should lower");
+    let alias_dae = to_dae_with_options(&alias_flat, unbalanced_todae_opts())
+        .expect("alias-guard model should lower");
 
     let direct_guard = extract_guard_expr_for_lhs(&direct_dae, "z");
     let alias_guard = extract_guard_expr_for_lhs(&alias_dae, "z");


### PR DESCRIPTION
## Summary

- User-facing behavior: Adds an opt-in that keeps a computed parameter start expression symbolic (instead of constant-folding it to a literal) when it references another parameter. This lets an interactive/sim host override a base parameter (e.g. Isp) between runs and have its dependents (e.g. massRatio = exp(dv_hop/(Isp*g0))) recompute via start-expression re-evaluation — without recompiling from source. Default behavior is unchanged: codegen backends still receive folded literals.
- Addresses: runtime-override use case for the interactive/sim compile path; re-applies the earlier preserved_values work onto main's post-rewrite, visitor-based fold_start_values.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0021 (complexity / file-size budget — DRY'd the regression-test ToDaeOptions construction into a helper to keep tests_regressions.rs under the 2000-line cap); SPEC_0029 (crate boundaries — the option lives on ToDaeOptions in rumoca-phase-dae, the folding pass stays in that crate, the session sets it in rumoca-compile); SPEC_0025 (this PR).
- Relevant MLS section(s): none changed. start values are init-time metadata; keeping them symbolic vs. literal is a compile-pipeline choice, not a Modelica semantics change. Folding remains a fixed-point evaluation of start expressions.
- Crate/phase owner: rumoca-phase-dae (ToDAE fold_start_values), with the session wiring in rumoca-compile.

## Risk and Design Notes

- Main correctness risk: enabling preservation on the shared session→DAE path (todae_options_for_target_model) could change codegen-from-session golden output (symbolic starts instead of literals). Verified clear: the full codegen-golden suite (sympy/standalone template regressions, connection-normalization golden, examples_smoke, casadi, msl_sim) passes with the flag on.
- Main maintenance risk: an extra ToDaeOptions field that every full-literal construction site must set. Contained — default is false, and the carve-out is gated behind it; the one place that enables it is the target-model session path.
- Why these crates: the fold pass and its option belong in rumoca-phase-dae; only the session (rumoca-compile) decides to enable it. No new cross-crate surface.
- New abstraction / public API / migration: one new public field ToDaeOptions.preserve_overridable_param_starts: bool (default false). No migration — default preserves current behavior. The carve-out reuses the existing collect_param_refs helper and threads is_param off the StartRewriter visitor's partition, so no new traversal machinery.

## Testing

- Key commands run: cargo fmt --check (clean); cargo clippy --workspace --all-targets -- -D warnings (clean); cargo doc --workspace --no-deps (clean); cargo test -p rumoca-phase-dae (372 pass) and -p rumoca-compile (269 pass); the -p rumoca integration suite incl. the codegen-golden regressions (pass).
- Behavior covered: new unit test preserve_overridable_keeps_computed_param_start_symbolic — a computed parameter start (derived = base*3) stays symbolic when the flag is on and folds to the literal 6.0 when off.
- Commands NOT run and why: the full MSL parity gate (cargo xtask verify full) was not run locally (slow). The default ToDAE path is byte-for-byte unchanged (the carve-out only triggers when the flag is explicitly set), and the golden suite passed, so MSL regression is very unlikely — flagged for CI.
- MSL gate: not run locally; relying on CI.
- Note for reviewers: cargo test --workspace may intermittently fail rumoca-compile’s instrumentation_tests::session_cache_stats_track_query_caches. This is a pre-existing flaky test (reproduced on main with no changes: ~1-in-3 under parallel --workspace; passes 100% in isolation) caused by cross-process on-disk parse-cache contention. It is unrelated to this PR — the failing assertion counts parse-cache misses, which occur before the ToDAE phase this PR touches.

## Code Size Budget (required)

- production_lines_added: 63
- production_lines_deleted: 7
- test_lines_added: 154
- test_lines_deleted: 154
- public_items_added: 1 (ToDaeOptions.preserve_overridable_param_starts)
- public_items_removed: 0
- files_touched: 10
- net_added_lines: 56

Positive net growth:
- Why required: the feature itself (the carve-out + option + session wiring) plus its unit test; the bulk of added test lines is the mandatory new ToDaeOptions field on existing full-literal construction sites.
- Compression done in this pass: extracted unbalanced_todae_opts() in tests_regressions.rs, replacing ~22 inline ToDaeOptions {…} literals — net −101 lines in that file, which also brings it back under the SPEC_0021 2000-line cap.
- Follow-up: none required for this change. (Separately worth filing: the pre-existing flaky cache-stats test above.)