### PR TITLE
Add BaseModelica parser fixture

### DIFF
--- a/crates/rumoca-phase-parse/tests/basemodelica/first_subset.mo
+++ b/crates/rumoca-phase-parse/tests/basemodelica/first_subset.mo
@@ -1,0 +1,19 @@
+package 'First'
+  type 'StateSelect' = enumeration(never, avoid, default, prefer, always);
+
+  model 'First' "Subset of the BaseModelica First example"
+    parameter Real 'amplitude'(unit = "N.m", quantity = "Torque") = 10.0;
+    parameter Real 'f'(unit = "Hz", quantity = "Frequency") = 5.0;
+    parameter Real 'sine.startTime'(unit = "s", quantity = "Time") = 0.0;
+    parameter 'StateSelect' 'inertia1.stateSelect' = 'StateSelect'.default;
+    Real 'inertia1.phi'(stateSelect = 'StateSelect'.default, unit = "rad");
+    Real 'inertia1.w'(stateSelect = 'StateSelect'.default, unit = "rad/s");
+    Real 'inertia1.a'(unit = "rad/s2");
+    Real 'sine.y' "Connector of Real output signal";
+    parameter Boolean 'torque.useSupport' = true annotation(Evaluate = true);
+  equation
+    'inertia1.w' = der('inertia1.phi');
+    'inertia1.a' = der('inertia1.w');
+    'sine.y' = if time < 'sine.startTime' then 0.0 else 'amplitude' * sin(6.283185307179586 * 'f' * (time - 'sine.startTime'));
+  end 'First';
+end 'First';

--- a/crates/rumoca-phase-parse/tests/basemodelica_examples.rs
+++ b/crates/rumoca-phase-parse/tests/basemodelica_examples.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/basemodelica")
+        .join(name)
+}
+
+#[test]
+fn parses_basemodelica_first_subset() {
+    // Based on the BaseModelica flat-output First example from
+    // ModelicaSpecification issue 3505. Keep this fixture compact so it tests
+    // the parser-facing syntax without making routine CI output noisy.
+    let path = fixture_path("first_subset.mo");
+    let source = std::fs::read_to_string(&path).expect("read BaseModelica fixture");
+    let file_name = path.display().to_string();
+    let ast = rumoca_phase_parse::parse_to_ast(&source, &file_name)
+        .expect("BaseModelica First subset should parse");
+
+    let package = ast.classes.get("'First'").expect("top-level package");
+    assert!(package.classes.contains_key("'StateSelect'"));
+    let model = package.classes.get("'First'").expect("nested model");
+    assert!(model.components.contains_key("'inertia1.phi'"));
+    assert!(model.components.contains_key("'torque.useSupport'"));
+    assert_eq!(model.equations.len(), 3);
+}


### PR DESCRIPTION
## Summary

Adds a compact BaseModelica parser fixture based on the ModelicaSpecification `First` example and covers it with a `rumoca-phase-parse` integration test.

The fixture exercises quoted identifiers containing dots, quoted enum references, annotations, `der(...)`, function calls, and conditional expressions without adding the full external example to the repo.

Refs #146

## Validation

- `cargo test -p rumoca-phase-parse --test basemodelica_examples -- --nocapture`
- `cargo test -p rumoca-phase-parse`
- `cargo xtask verify quick`