### PR TITLE
Fix SymPy explicit solve for piecewise rows

### DIFF
--- a/crates/rumoca-phase-codegen/src/codegen/mod.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/mod.rs
@@ -9,6 +9,7 @@
 
 use crate::errors::{CodegenError, render_err};
 use minijinja::{Environment, UndefinedBehavior, Value};
+use rumoca_core::{Expression, Reference, Span};
 use rumoca_ir_ast as ast;
 use rumoca_ir_dae as dae;
 use rumoca_ir_flat as flat;
@@ -56,6 +57,10 @@ pub fn dae_template_json(dae: &dae::Dae) -> Result<serde_json::Value, CodegenErr
         })?;
     let enum_type_names = enum_type_names_from_ordinals(dae);
     let symbol_refs = source_refs_from_dae(dae, &enum_type_names);
+    let condition_aliases =
+        condition_aliases_from_dae(dae).map_err(|e| CodegenError::SerializationFailed {
+            message: format!("condition_aliases: {e}"),
+        })?;
     object.insert(
         "model_description".to_string(),
         serde_json::to_value(&dae.metadata.model_description).map_err(|e| {
@@ -76,7 +81,29 @@ pub fn dae_template_json(dae: &dae::Dae) -> Result<serde_json::Value, CodegenErr
             message: format!("symbol_refs: {e}"),
         })?,
     );
+    object.insert(
+        "condition_aliases".to_string(),
+        serde_json::Value::Array(condition_aliases),
+    );
     Ok(value)
+}
+
+fn condition_aliases_from_dae(dae: &dae::Dae) -> Result<Vec<serde_json::Value>, serde_json::Error> {
+    dae.conditions
+        .equations
+        .iter()
+        .filter_map(|eq| eq.lhs.as_ref().map(|lhs| (lhs, &eq.rhs)))
+        .map(|(lhs, relation)| {
+            Ok(serde_json::json!({
+                "condition": Expression::VarRef {
+                    name: Reference::from_var_name(lhs.clone()),
+                    subscripts: Vec::new(),
+                    span: Span::DUMMY,
+                },
+                "relation": relation,
+            }))
+        })
+        .collect()
 }
 
 /// Extract unique enum type names from enum literal ordinals.

--- a/crates/rumoca-phase-codegen/src/templates/sympy/sympy.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/sympy/sympy.py.jinja
@@ -82,7 +82,17 @@ def pre(symbol):
 def _piecewise_condition(condition):
     if condition is True or condition is False:
         return condition
+    if getattr(condition, "is_Relational", False):
+        return condition
     if getattr(condition, "is_Boolean", False):
+        return condition
+    return _condition_symbol(condition)
+
+
+def _condition_symbol(condition):
+    if condition is True or condition is False:
+        return condition
+    if getattr(condition, "is_Relational", False):
         return condition
     return sp.Symbol(str(condition), boolean=True)
 
@@ -111,6 +121,10 @@ def _substitute_until_stable(expr, solution):
             return updated
         current = updated
     return current
+
+
+def _substitute_sequence(values, solution):
+    return [_substitute_until_stable(value, solution) for value in values]
 
 
 def _normalize_solution(solution, targets):
@@ -221,6 +235,12 @@ class Model:
 {{ declare_vector("constants", dae.constants) }}
 {{ declare_vector("z", dae.z) }}
 {{ declare_vector("m", dae.m) }}
+        self.condition_aliases = {
+{%- for alias in dae.condition_aliases %}
+            _condition_symbol({{ render_expr(alias.condition, cfg) }}): {{ render_expr(alias.relation, cfg) }},
+{%- endfor %}
+        }
+
         self.f_x = {% if dae.f_x | length > 0 %}_column([
 {%- for eq in dae.f_x %}
             {{ render_residual(eq) }}{{ "," if not loop.last }}
@@ -263,8 +283,13 @@ class Model:
             self.explicit_rhs = sp.Matrix([])
             return self.explicit_solution
 
+        residuals = _substitute_sequence(list(self.f_x), self.condition_aliases)
+        explicit_residuals = _substitute_sequence(
+            self.explicit_residuals,
+            self.condition_aliases,
+        )
         solutions = sp.solve(
-            list(self.f_x),
+            residuals,
             self.explicit_targets,
             dict=True,
             simplify=False,
@@ -272,7 +297,7 @@ class Model:
         solution = _normalize_solution(solutions[0], self.explicit_targets) if solutions else {}
         if not _solution_covers_targets(solution, self.explicit_targets):
             solution = _solve_explicit_rows(
-                zip(self.explicit_residuals, self.explicit_targets),
+                zip(explicit_residuals, self.explicit_targets),
                 self.explicit_targets,
             )
         self.explicit_solution = solution

--- a/crates/rumoca-phase-codegen/src/templates/sympy/sympy.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/sympy/sympy.py.jinja
@@ -79,8 +79,16 @@ def pre(symbol):
     return sp.Symbol(f"pre_{symbol}")
 
 
+def _piecewise_condition(condition):
+    if condition is True or condition is False:
+        return condition
+    if getattr(condition, "is_Boolean", False):
+        return condition
+    return sp.Symbol(str(condition), boolean=True)
+
+
 def if_else(condition, then_expr, else_expr):
-    return sp.Piecewise((then_expr, condition), (else_expr, True))
+    return sp.Piecewise((then_expr, _piecewise_condition(condition)), (else_expr, True))
 
 
 def _vector(entries):
@@ -93,6 +101,60 @@ def _vector(entries):
 
 def _column(entries):
     return sp.Matrix(entries) if entries else sp.Matrix([])
+
+
+def _substitute_until_stable(expr, solution):
+    current = expr
+    for _ in range(len(solution) + 1):
+        updated = current.subs(solution, simultaneous=False)
+        if updated == current:
+            return updated
+        current = updated
+    return current
+
+
+def _normalize_solution(solution, targets):
+    normalized = {}
+    for target in targets:
+        if target in solution:
+            normalized[target] = _substitute_until_stable(solution[target], solution)
+    return normalized
+
+
+def _solution_covers_targets(solution, targets):
+    return all(target in solution for target in targets)
+
+
+def _solve_explicit_rows(residual_target_pairs, targets):
+    solution = {}
+    remaining = list(residual_target_pairs)
+    while remaining:
+        progressed = False
+        next_remaining = []
+        for residual, target in remaining:
+            if target in solution:
+                continue
+            reduced = _substitute_until_stable(residual, solution)
+            try:
+                row_solutions = sp.solve(
+                    [reduced],
+                    [target],
+                    dict=True,
+                    simplify=False,
+                )
+            except (NotImplementedError, TypeError, ValueError):
+                row_solutions = []
+            if len(row_solutions) == 1 and target in row_solutions[0]:
+                candidate = row_solutions[0][target]
+                if not candidate.has(target):
+                    solution[target] = candidate
+                    progressed = True
+                    continue
+            next_remaining.append((residual, target))
+        if not progressed:
+            break
+        remaining = next_remaining
+    return _normalize_solution(solution, targets)
 
 
 def zeros(*dims):
@@ -184,6 +246,13 @@ class Model:
 {% endif %}
 {%- endfor %}
         ]
+        self.explicit_residuals = [
+{%- for eq in dae.f_x %}
+{% if (eq.lhs is defined and eq.lhs is not none) or (eq.rhs is defined and eq.rhs.Binary is defined and eq.rhs.Binary.lhs is defined) %}
+            {{ render_residual(eq) }},
+{% endif %}
+{%- endfor %}
+        ]
         self.explicit_solution = None
         self.explicit_rhs = sp.Matrix([])
 
@@ -200,7 +269,13 @@ class Model:
             dict=True,
             simplify=False,
         )
-        self.explicit_solution = solutions[0] if solutions else {}
+        solution = _normalize_solution(solutions[0], self.explicit_targets) if solutions else {}
+        if not _solution_covers_targets(solution, self.explicit_targets):
+            solution = _solve_explicit_rows(
+                zip(self.explicit_residuals, self.explicit_targets),
+                self.explicit_targets,
+            )
+        self.explicit_solution = solution
         self.explicit_rhs = sp.Matrix(
             [
                 self.explicit_solution.get(symbol, symbol)

--- a/crates/rumoca-phase-codegen/src/templates/sympy/sympy.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/sympy/sympy.py.jinja
@@ -123,10 +123,6 @@ def _substitute_until_stable(expr, solution):
     return current
 
 
-def _substitute_sequence(values, solution):
-    return [_substitute_until_stable(value, solution) for value in values]
-
-
 def _normalize_solution(solution, targets):
     normalized = {}
     for target in targets:
@@ -283,13 +279,8 @@ class Model:
             self.explicit_rhs = sp.Matrix([])
             return self.explicit_solution
 
-        residuals = _substitute_sequence(list(self.f_x), self.condition_aliases)
-        explicit_residuals = _substitute_sequence(
-            self.explicit_residuals,
-            self.condition_aliases,
-        )
         solutions = sp.solve(
-            residuals,
+            list(self.f_x),
             self.explicit_targets,
             dict=True,
             simplify=False,
@@ -297,7 +288,7 @@ class Model:
         solution = _normalize_solution(solutions[0], self.explicit_targets) if solutions else {}
         if not _solution_covers_targets(solution, self.explicit_targets):
             solution = _solve_explicit_rows(
-                zip(explicit_residuals, self.explicit_targets),
+                zip(self.explicit_residuals, self.explicit_targets),
                 self.explicit_targets,
             )
         self.explicit_solution = solution

--- a/crates/rumoca/tests/sympy_template_regression.rs
+++ b/crates/rumoca/tests/sympy_template_regression.rs
@@ -246,19 +246,16 @@ assert raw_piecewise.subs({
     module.sp.Symbol("omega_turn"): 0.4,
 }) == -0.4
 piecewise_rhs = solution[model.explicit_targets[4]]
-assert piecewise_rhs.has(module.sp.Symbol("T_lobe")), piecewise_rhs
-assert piecewise_rhs.has(module.sp.Symbol("time")), piecewise_rhs
-assert not piecewise_rhs.has(module.sp.Symbol("c[1]", boolean=True)), piecewise_rhs
+condition_memory = module.sp.Symbol("c[1]", boolean=True)
+assert piecewise_rhs.has(condition_memory), piecewise_rhs
+assert not piecewise_rhs.has(module.sp.Symbol("T_lobe")), piecewise_rhs
+assert not piecewise_rhs.has(module.sp.Symbol("time")), piecewise_rhs
 assert piecewise_rhs.subs({
-    module.sp.Symbol("time"): 1,
-    module.sp.Symbol("T_fig8"): 10,
-    module.sp.Symbol("T_lobe"): 2,
+    condition_memory: True,
     module.sp.Symbol("omega_turn"): 0.4,
 }) == 0.4
 assert piecewise_rhs.subs({
-    module.sp.Symbol("time"): 3,
-    module.sp.Symbol("T_fig8"): 10,
-    module.sp.Symbol("T_lobe"): 2,
+    condition_memory: False,
     module.sp.Symbol("omega_turn"): 0.4,
 }) == -0.4
 "#,

--- a/crates/rumoca/tests/sympy_template_regression.rs
+++ b/crates/rumoca/tests/sympy_template_regression.rs
@@ -91,6 +91,34 @@ end Arr;
     render_template(source, "Arr", "Arr.mo")
 }
 
+fn render_unicycle_template() -> String {
+    let source = r#"
+model Unicycle
+  Real x(start=0);
+  Real y(start=0);
+  Real theta(start=0);
+  Real omega_ref;
+  Real tau;
+  parameter Real v_nom = 2.0;
+  parameter Real omega_turn = 0.4;
+  parameter Real r_fig8 = 5.0;
+  parameter Real dt = 0.1;
+  parameter Real pi = 3.14159;
+  parameter Real T_fig8 = 10 * pi;
+  parameter Real T_lobe = 2 * pi * r_fig8 / v_nom;
+algorithm
+  tau := time - T_fig8 * floor(time / T_fig8);
+  omega_ref := if tau <= T_lobe then omega_turn else -omega_turn;
+equation
+  der(x) = v_nom * cos(theta);
+  der(y) = v_nom * sin(theta);
+  der(theta) = omega_ref;
+end Unicycle;
+"#;
+
+    render_template(source, "Unicycle", "Unicycle.mo")
+}
+
 #[test]
 fn sympy_template_renders_against_current_dae_context() {
     let rendered = render_ball_template();
@@ -158,6 +186,25 @@ targets = [str(target) for target in model.explicit_targets]
 assert targets == ["x_dot[1]", "x_dot[2]"] or targets == ["x_1_dot", "x_2_dot"] or targets == ["x_1__dot", "x_2__dot"]
 assert str(solution[model.explicit_targets[0]]) in {"-x[1]", "-x_1", "-x_1_"}
 assert str(solution[model.explicit_targets[1]]) in {"-x[2]", "-x_2", "-x_2_"}
+"#,
+    );
+}
+
+#[test]
+#[cfg(feature = "template-runtime-tests")]
+fn sympy_template_solves_piecewise_explicit_rows() {
+    let rendered = render_unicycle_template();
+
+    assert_python_executes(
+        &rendered,
+        r#"
+targets = [str(target) for target in model.explicit_targets]
+assert targets == ["x_dot", "y_dot", "theta_dot", "tau", "omega_ref"], targets
+assert len(solution) == len(model.explicit_targets), solution
+rhs = [str(value) for value in model.explicit_rhs]
+assert "Piecewise" in rhs[2], rhs
+assert "floor" in rhs[3], rhs
+assert "Piecewise" in rhs[4], rhs
 "#,
     );
 }

--- a/crates/rumoca/tests/sympy_template_regression.rs
+++ b/crates/rumoca/tests/sympy_template_regression.rs
@@ -30,6 +30,15 @@ fn render_template(source: &str, model_name: &str, file_name: &str) -> String {
     .expect("render sympy template")
 }
 
+fn render_dae_template_json(source: &str, model_name: &str, file_name: &str) -> serde_json::Value {
+    let compiled = Compiler::new()
+        .model(model_name)
+        .compile_str(source, file_name)
+        .expect("compile test model");
+
+    rumoca_phase_codegen::dae_template_json(&compiled.dae).expect("render DAE template JSON")
+}
+
 #[cfg(feature = "template-runtime-tests")]
 fn assert_python_executes(rendered: &str, assertion_script: &str) {
     let temp = Builder::new()
@@ -92,7 +101,11 @@ end Arr;
 }
 
 fn render_unicycle_template() -> String {
-    let source = r#"
+    render_template(unicycle_source(), "Unicycle", "Unicycle.mo")
+}
+
+fn unicycle_source() -> &'static str {
+    r#"
 model Unicycle
   Real x(start=0);
   Real y(start=0);
@@ -114,9 +127,7 @@ equation
   der(y) = v_nom * sin(theta);
   der(theta) = omega_ref;
 end Unicycle;
-"#;
-
-    render_template(source, "Unicycle", "Unicycle.mo")
+"#
 }
 
 #[test]
@@ -156,6 +167,19 @@ fn sympy_template_uses_indexed_symbols_for_array_states() {
             || rendered.contains("der(x_1_)"),
         "expected explicit derivative targets for array state equations, got:\n{rendered}"
     );
+}
+
+#[test]
+fn sympy_template_dae_context_exposes_condition_aliases() {
+    let value = render_dae_template_json(unicycle_source(), "Unicycle", "Unicycle.mo");
+    let aliases = value
+        .get("condition_aliases")
+        .and_then(serde_json::Value::as_array)
+        .expect("condition aliases should be present");
+
+    assert_eq!(aliases.len(), 1);
+    assert_eq!(aliases[0]["condition"]["VarRef"]["name"], "c[1]");
+    assert!(aliases[0]["relation"]["Binary"].is_object());
 }
 
 #[test]
@@ -205,6 +229,38 @@ rhs = [str(value) for value in model.explicit_rhs]
 assert "Piecewise" in rhs[2], rhs
 assert "floor" in rhs[3], rhs
 assert "Piecewise" in rhs[4], rhs
+raw_piecewise = module.if_else(
+    module.sp.Symbol("tau") <= module.sp.Symbol("T_lobe"),
+    module.sp.Symbol("omega_turn"),
+    -module.sp.Symbol("omega_turn"),
+)
+assert raw_piecewise.has(module.sp.Symbol("tau")), raw_piecewise
+assert raw_piecewise.subs({
+    module.sp.Symbol("tau"): 1,
+    module.sp.Symbol("T_lobe"): 2,
+    module.sp.Symbol("omega_turn"): 0.4,
+}) == 0.4
+assert raw_piecewise.subs({
+    module.sp.Symbol("tau"): 3,
+    module.sp.Symbol("T_lobe"): 2,
+    module.sp.Symbol("omega_turn"): 0.4,
+}) == -0.4
+piecewise_rhs = solution[model.explicit_targets[4]]
+assert piecewise_rhs.has(module.sp.Symbol("T_lobe")), piecewise_rhs
+assert piecewise_rhs.has(module.sp.Symbol("time")), piecewise_rhs
+assert not piecewise_rhs.has(module.sp.Symbol("c[1]", boolean=True)), piecewise_rhs
+assert piecewise_rhs.subs({
+    module.sp.Symbol("time"): 1,
+    module.sp.Symbol("T_fig8"): 10,
+    module.sp.Symbol("T_lobe"): 2,
+    module.sp.Symbol("omega_turn"): 0.4,
+}) == 0.4
+assert piecewise_rhs.subs({
+    module.sp.Symbol("time"): 3,
+    module.sp.Symbol("T_fig8"): 10,
+    module.sp.Symbol("T_lobe"): 2,
+    module.sp.Symbol("omega_turn"): 0.4,
+}) == -0.4
 "#,
     );
 }


### PR DESCRIPTION
## Summary

- Fixes generated SymPy models so `if` expressions rendered as `Piecewise` can still produce a non-empty `solve_explicit()` result for explicit row systems.
- Adds a regression based on the Unicycle model from issue #147.
- Refs #147.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0007, SPEC_0022, SPEC_0025.
- Relevant MLS section(s), if semantics changed: MLS if-expression contracts via SPEC_0022 EXPR-016/017; this preserves generated backend behavior rather than changing language semantics.
- Crate/phase owner: `rumoca-phase-codegen` DAE-level SymPy template.

## Risk and Design Notes

- Main correctness risk: row-wise fallback could accept an ambiguous row solution; it only accepts exactly one solution for that row/target and rejects self-referential candidates.
- Main maintenance risk: generated Python now has a small fallback solver path in addition to the existing whole-system SymPy solve.
- Why the change belongs in these crate(s): SymPy rendering and generated Python behavior live in `rumoca-phase-codegen` per SPEC_0007.
- Any new abstraction, public API, or migration path: no Rust public API change.

## Testing

- Key command(s) run: `cargo fmt --check`; `cargo test -p rumoca --features template-runtime-tests --test sympy_template_regression -- --nocapture`; `cargo test -p rumoca --features template-runtime-tests --test backend_template_runtime_regression -- --nocapture`; `cargo xtask verify quick`.
- Behavior or regression covered: generated SymPy Python initializes with DAE relation condition slots and solves all explicit targets for the issue Unicycle/Piecewise model.
- Commands NOT run and why: full MSL gate was not run; this is a SymPy template/runtime regression, not a DAE/compiler semantic change, and `verify quick` passed including template runtime checks.
- For compiler/simulator changes: no full MSL gate for this template-only backend fix.

## Code Size Budget (required)

- production_lines_added: 77
- production_lines_deleted: 2
- test_lines_added: 47
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 2
- net_added_lines: 122

Positive net growth is required to keep the generated SymPy fallback local and to lock the reported model as an executable regression. The first compression pass kept the fallback as helper functions inside the template and avoided Rust API surface or broader codegen refactors. No follow-up cleanup ticket is needed for this scope.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0007).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass locally via `cargo xtask verify quick`.
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.