### PR TITLE
Reduce coverage gate disk pressure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: 1
 
 # Prevent duplicate runs
@@ -128,7 +129,6 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2025]
     env:
-      CARGO_INCREMENTAL: 0
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
     steps:
@@ -401,6 +401,9 @@ jobs:
     # GitHub runners. Keep explicit headroom here to avoid job-level
     # cancellation while tests are still progressing.
     timeout-minutes: 45
+    env:
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
     steps:
       - uses: actions/checkout@v5
         with:
@@ -430,17 +433,56 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
 
-      - name: Generate workspace coverage artifacts
+      - name: Build coverage helper
+        run: cargo build --package xtask --bin xtask
+
+      - name: Reclaim runner disk before coverage
+        shell: bash
         run: |
-          cargo xtask coverage run
+          set -euo pipefail
+          echo "== disk before cleanup =="
+          df -h . / /tmp || true
+          du -sh target target/debug target/debug/deps target/debug/build target/debug/incremental ~/.cargo ~/.rustup /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+
+          rm -rf target/debug/deps target/debug/build target/debug/incremental target/debug/.fingerprint
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+
+          echo "== disk after cleanup =="
+          df -h . / /tmp || true
+          du -sh target target/debug ~/.cargo ~/.rustup 2>/dev/null || true
+
+      - name: Generate workspace coverage artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          monitor() {
+            while true; do
+              echo "== resource snapshot: $(date -Is) =="
+              df -h . / /tmp || true
+              free -h || true
+              du -sh target target/llvm-cov target/llvm-cov-target ~/.cargo ~/.rustup 2>/dev/null || true
+              ps -eo pid,ppid,%cpu,%mem,rss,vsz,comm,args --sort=-rss | head -n 10 || true
+              sleep 60
+            done
+          }
+          monitor &
+          monitor_pid=$!
+          trap 'kill "$monitor_pid" 2>/dev/null || true' EXIT
+          ./target/debug/xtask coverage run
 
       - name: Generate trim candidate inventory
         run: |
-          cargo xtask coverage report
+          ./target/debug/xtask coverage report
 
       - name: Enforce coverage regression gate
         run: |
-          cargo xtask coverage gate --allowed-workspace-line-coverage-drop 3.0
+          ./target/debug/xtask coverage gate --allowed-workspace-line-coverage-drop 3.0
 
   msl-quality-gate:
     name: MSL Quality Gate


### PR DESCRIPTION
## Summary

- Disables Cargo incremental artifacts at the top level of the CI workflow so every CI job inherits `CARGO_INCREMENTAL=0`.
- Further reduces disk pressure in the `Coverage Gate` job by trimming dev/test debug info, building the `xtask` helper once, removing its host-side build artifacts before full workspace coverage, then running coverage/report/gate through `./target/debug/xtask`.
- Reclaims unused GitHub runner SDK/toolcache directories and adds disk snapshots around coverage so future failures show actual free space and artifact growth.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0025 (PR/CI workflow expectations)
- Relevant MLS section(s), if semantics changed: n/a
- Crate/phase owner: n/a, GitHub Actions CI config only

## Risk and Design Notes

- Main correctness risk: coverage output should stay semantically equivalent; this changes runner cleanup and invocation shape, not coverage inputs or thresholds.
- Main maintenance risk: direct `./target/debug/xtask` invocation depends on the helper binary remaining after target cleanup; locally verified after deleting `target/debug/deps`, `build`, `incremental`, and fingerprints.
- Why the change belongs in these crate(s): n/a; scoped to `.github/workflows/ci.yml`.
- Any new abstraction, public API, or migration path: none.

## Testing

- Key command(s) run: `git diff --check`; `cargo fmt --check`; `cargo build --package xtask --bin xtask && rm -rf target/debug/deps target/debug/build target/debug/incremental target/debug/.fingerprint && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 ./target/debug/xtask coverage run --package rumoca-core --no-clean`
- Behavior or regression covered: direct `xtask` invocation works after trimming host build artifacts; package-scoped `cargo-llvm-cov` run passed 59 `rumoca-core` tests and generated coverage artifacts.
- Commands NOT run and why: full workspace coverage was not run locally because this PR specifically changes GitHub runner disk cleanup and a full local run would be disproportionately expensive.
- For compiler/simulator changes: n/a, no compiler/simulator behavior changed.

## Code Size Budget (required)

- production_lines_added: 0
- production_lines_deleted: 0
- test_lines_added: 0
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 1
- net_added_lines: 42

- Why this net growth is required: the workflow needs explicit disk cleanup, helper build separation, and disk snapshots for the coverage step.
- Which code was removed/merged as part of the first compression pass: moved duplicate per-job `CARGO_INCREMENTAL=0` settings into one workflow-level env entry.
- Follow-up cleanup ticket/commit for remaining growth (if any): none planned.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.