### PR TITLE
fix: lowering/correctness fixes for array- and function-heavy models

### DIFF
--- a/crates/rumoca-eval-dae/src/statement.rs
+++ b/crates/rumoca-eval-dae/src/statement.rs
@@ -1182,7 +1182,10 @@ mod tests {
             },
             &denv,
         );
-        assert_eq!(dy.re, 0.7, "no-else if (Dual) must not run when cond is false");
+        assert_eq!(
+            dy.re, 0.7,
+            "no-else if (Dual) must not run when cond is false"
+        );
     }
 
     #[test]

--- a/crates/rumoca-eval-dae/src/statement.rs
+++ b/crates/rumoca-eval-dae/src/statement.rs
@@ -1114,6 +1114,78 @@ mod tests {
     }
 
     #[test]
+    fn repro_noelse_scalar_if_does_not_run_unconditionally() {
+        let mut env = VarEnv::<f64>::new();
+        let mut functions = indexmap::IndexMap::new();
+
+        // function f(a) -> o:  x := a; if x < 0 then x := -x; end if; o := x;
+        let mut f = rumoca_core::Function::new("Pkg.f", Default::default());
+        f.add_input(rumoca_core::FunctionParam::new("a", "Real"));
+        f.add_output(rumoca_core::FunctionParam::new("o", "Real"));
+        f.add_local(rumoca_core::FunctionParam::new("x", "Real"));
+        f.body = vec![
+            rumoca_core::Statement::Assignment {
+                comp: comp_ref("x"),
+                value: var("a"),
+                span: rumoca_core::Span::DUMMY,
+            },
+            rumoca_core::Statement::If {
+                cond_blocks: vec![rumoca_core::StatementBlock {
+                    cond: rumoca_core::Expression::Binary {
+                        op: rumoca_core::OpBinary::Lt,
+                        lhs: Box::new(var("x")),
+                        rhs: Box::new(real(0.0)),
+                        span: rumoca_core::Span::DUMMY,
+                    },
+                    stmts: vec![rumoca_core::Statement::Assignment {
+                        comp: comp_ref("x"),
+                        value: rumoca_core::Expression::Unary {
+                            op: rumoca_core::OpUnary::Minus,
+                            rhs: Box::new(var("x")),
+                            span: rumoca_core::Span::DUMMY,
+                        },
+                        span: rumoca_core::Span::DUMMY,
+                    }],
+                }],
+                else_block: None,
+                span: rumoca_core::Span::DUMMY,
+            },
+            rumoca_core::Statement::Assignment {
+                comp: comp_ref("o"),
+                value: var("x"),
+                span: rumoca_core::Span::DUMMY,
+            },
+        ];
+        functions.insert("Pkg.f".to_string(), f);
+        env.functions = std::sync::Arc::new(functions);
+
+        let y = eval::eval_expr_or_default(
+            &rumoca_core::Expression::FunctionCall {
+                name: rumoca_core::Reference::new("Pkg.f"),
+                args: vec![real(0.7)],
+                is_constructor: false,
+                span: rumoca_core::Span::DUMMY,
+            },
+            &env,
+        );
+        assert_eq!(y, 0.7, "no-else if must not run when condition is false");
+
+        // Same call but with the Dual (AD) float type, as used by sim/inspect.
+        let mut denv = VarEnv::<crate::dual::Dual>::new();
+        denv.functions = env.functions.clone();
+        let dy = eval::eval_expr_or_default(
+            &rumoca_core::Expression::FunctionCall {
+                name: rumoca_core::Reference::new("Pkg.f"),
+                args: vec![real(0.7)],
+                is_constructor: false,
+                span: rumoca_core::Span::DUMMY,
+            },
+            &denv,
+        );
+        assert_eq!(dy.re, 0.7, "no-else if (Dual) must not run when cond is false");
+    }
+
+    #[test]
     fn user_function_body_missing_binding_returns_nan_instead_of_zero() {
         let mut env = VarEnv::<f64>::new();
         let mut functions = indexmap::IndexMap::new();

--- a/crates/rumoca-eval-solve/src/prepared.rs
+++ b/crates/rumoca-eval-solve/src/prepared.rs
@@ -562,14 +562,35 @@ fn row_loads_y_index(row: &[LinearOp], target_y_index: usize) -> bool {
 }
 
 fn reg_depends_on_y_index(row: &[LinearOp], reg: u32, target_y_index: usize) -> bool {
-    producer(row, reg).is_some_and(|op| match *op {
+    // Register programs form a DAG: a register computed once can feed many
+    // downstream ops, so the naive recursion below re-traverses shared
+    // sub-expressions exponentially (a 1700-op matrix-product row never
+    // finishes). Memoize by register — dependence on a fixed `y` index is a
+    // pure function of the register — to make the walk linear in the row.
+    let mut memo: std::collections::HashMap<u32, bool> = std::collections::HashMap::new();
+    reg_depends_on_y_index_memo(row, reg, target_y_index, &mut memo)
+}
+
+fn reg_depends_on_y_index_memo(
+    row: &[LinearOp],
+    reg: u32,
+    target_y_index: usize,
+    memo: &mut std::collections::HashMap<u32, bool>,
+) -> bool {
+    if let Some(&cached) = memo.get(&reg) {
+        return cached;
+    }
+    // Guard against accidental cycles (register programs are acyclic in
+    // practice): seed `false` before recursing so a back-edge terminates.
+    memo.insert(reg, false);
+    let result = producer(row, reg).is_some_and(|op| match *op {
         LinearOp::LoadY { index, .. } => index == target_y_index,
         LinearOp::Move { src, .. } | LinearOp::Unary { arg: src, .. } => {
-            reg_depends_on_y_index(row, src, target_y_index)
+            reg_depends_on_y_index_memo(row, src, target_y_index, memo)
         }
         LinearOp::Binary { lhs, rhs, .. } | LinearOp::Compare { lhs, rhs, .. } => {
-            reg_depends_on_y_index(row, lhs, target_y_index)
-                || reg_depends_on_y_index(row, rhs, target_y_index)
+            reg_depends_on_y_index_memo(row, lhs, target_y_index, memo)
+                || reg_depends_on_y_index_memo(row, rhs, target_y_index, memo)
         }
         LinearOp::Select {
             cond,
@@ -577,9 +598,9 @@ fn reg_depends_on_y_index(row: &[LinearOp], reg: u32, target_y_index: usize) -> 
             if_false,
             ..
         } => {
-            reg_depends_on_y_index(row, cond, target_y_index)
-                || reg_depends_on_y_index(row, if_true, target_y_index)
-                || reg_depends_on_y_index(row, if_false, target_y_index)
+            reg_depends_on_y_index_memo(row, cond, target_y_index, memo)
+                || reg_depends_on_y_index_memo(row, if_true, target_y_index, memo)
+                || reg_depends_on_y_index_memo(row, if_false, target_y_index, memo)
         }
         LinearOp::LinearSolveComponent {
             matrix_start,
@@ -587,11 +608,11 @@ fn reg_depends_on_y_index(row: &[LinearOp], reg: u32, target_y_index: usize) -> 
             n,
             ..
         } => {
-            reg_range_depends_on_y_index(row, matrix_start, n * n, target_y_index)
-                || reg_range_depends_on_y_index(row, rhs_start, n, target_y_index)
+            reg_range_depends_on_y_index(row, matrix_start, n * n, target_y_index, memo)
+                || reg_range_depends_on_y_index(row, rhs_start, n, target_y_index, memo)
         }
         LinearOp::TableBounds { table_id, .. } => {
-            reg_depends_on_y_index(row, table_id, target_y_index)
+            reg_depends_on_y_index_memo(row, table_id, target_y_index, memo)
         }
         LinearOp::TableLookup {
             table_id,
@@ -605,21 +626,21 @@ fn reg_depends_on_y_index(row: &[LinearOp], reg: u32, target_y_index: usize) -> 
             input,
             ..
         } => {
-            reg_depends_on_y_index(row, table_id, target_y_index)
-                || reg_depends_on_y_index(row, column, target_y_index)
-                || reg_depends_on_y_index(row, input, target_y_index)
+            reg_depends_on_y_index_memo(row, table_id, target_y_index, memo)
+                || reg_depends_on_y_index_memo(row, column, target_y_index, memo)
+                || reg_depends_on_y_index_memo(row, input, target_y_index, memo)
         }
         LinearOp::TableNextEvent { table_id, time, .. } => {
-            reg_depends_on_y_index(row, table_id, target_y_index)
-                || reg_depends_on_y_index(row, time, target_y_index)
+            reg_depends_on_y_index_memo(row, table_id, target_y_index, memo)
+                || reg_depends_on_y_index_memo(row, time, target_y_index, memo)
         }
         LinearOp::RandomInitialState {
             local_seed,
             global_seed,
             ..
         } => {
-            reg_depends_on_y_index(row, local_seed, target_y_index)
-                || reg_depends_on_y_index(row, global_seed, target_y_index)
+            reg_depends_on_y_index_memo(row, local_seed, target_y_index, memo)
+                || reg_depends_on_y_index_memo(row, global_seed, target_y_index, memo)
         }
         LinearOp::RandomResult {
             state_start,
@@ -630,22 +651,26 @@ fn reg_depends_on_y_index(row: &[LinearOp], reg: u32, target_y_index: usize) -> 
             state_start,
             state_len,
             ..
-        } => reg_range_depends_on_y_index(row, state_start, state_len, target_y_index),
+        } => reg_range_depends_on_y_index(row, state_start, state_len, target_y_index, memo),
         LinearOp::ImpureRandomInit { seed, .. } => {
-            reg_depends_on_y_index(row, seed, target_y_index)
+            reg_depends_on_y_index_memo(row, seed, target_y_index, memo)
         }
-        LinearOp::ImpureRandom { id, .. } => reg_depends_on_y_index(row, id, target_y_index),
+        LinearOp::ImpureRandom { id, .. } => {
+            reg_depends_on_y_index_memo(row, id, target_y_index, memo)
+        }
         LinearOp::ImpureRandomInteger { id, imin, imax, .. } => {
-            reg_depends_on_y_index(row, id, target_y_index)
-                || reg_depends_on_y_index(row, imin, target_y_index)
-                || reg_depends_on_y_index(row, imax, target_y_index)
+            reg_depends_on_y_index_memo(row, id, target_y_index, memo)
+                || reg_depends_on_y_index_memo(row, imin, target_y_index, memo)
+                || reg_depends_on_y_index_memo(row, imax, target_y_index, memo)
         }
         LinearOp::Const { .. }
         | LinearOp::LoadTime { .. }
         | LinearOp::LoadP { .. }
         | LinearOp::LoadSeed { .. }
         | LinearOp::StoreOutput { .. } => false,
-    })
+    });
+    memo.insert(reg, result);
+    result
 }
 
 fn reg_range_depends_on_y_index(
@@ -653,12 +678,14 @@ fn reg_range_depends_on_y_index(
     start: u32,
     len: usize,
     target_y_index: usize,
+    memo: &mut std::collections::HashMap<u32, bool>,
 ) -> bool {
     (0..len).any(|offset| {
-        reg_depends_on_y_index(
+        reg_depends_on_y_index_memo(
             row,
             start.saturating_add(u32::try_from(offset).unwrap_or(u32::MAX)),
             target_y_index,
+            memo,
         )
     })
 }
@@ -1069,4 +1096,65 @@ fn ensure_register_range(
         register: start.saturating_add(len.saturating_sub(1) as u32),
         len: regs.len(),
     })
+}
+
+#[cfg(test)]
+mod assignment_shape_tests {
+    use super::*;
+    use rumoca_ir_solve::{BinaryOp, LinearOp};
+
+    // Regression: `reg_depends_on_y_index` used to recurse over the register DAG
+    // without memoization, so a row whose affine coefficient/offset is a deeply
+    // shared sub-expression (typical of inlined matrix products) took O(2^depth)
+    // and hung `PreparedScalarProgramBlock::new`. A 40-deep doubling chain has
+    // 2^40 distinct root-to-leaf paths; the memoized walk must still finish
+    // instantly and classify the row correctly.
+    #[test]
+    fn affine_shape_with_deep_shared_dag_terminates() {
+        let depth: u32 = 40;
+        let mut ops = vec![LinearOp::Const { dst: 0, value: 1.0 }];
+        // reg i = reg(i-1) + reg(i-1): a register reused twice at every level.
+        for i in 1..=depth {
+            ops.push(LinearOp::Binary {
+                dst: i,
+                op: BinaryOp::Add,
+                lhs: i - 1,
+                rhs: i - 1,
+            });
+        }
+        let deep = depth; // root of the shared DAG (no LoadY inside -> full traversal)
+        let y_reg = depth + 1;
+        let mul_reg = depth + 2;
+        let out_reg = depth + 3;
+        // out = (y[7] * deep) + deep  -> affine: coefficient `deep`, offset `deep`.
+        ops.push(LinearOp::LoadY {
+            dst: y_reg,
+            index: 7,
+        });
+        ops.push(LinearOp::Binary {
+            dst: mul_reg,
+            op: BinaryOp::Mul,
+            lhs: y_reg,
+            rhs: deep,
+        });
+        ops.push(LinearOp::Binary {
+            dst: out_reg,
+            op: BinaryOp::Add,
+            lhs: mul_reg,
+            rhs: deep,
+        });
+        ops.push(LinearOp::StoreOutput { src: out_reg });
+
+        // Would hang pre-fix; must return promptly now.
+        let shape = target_assignment_shape(&ops);
+        match shape {
+            Some(TargetAssignmentShape::Affine { target_y_index, .. }) => {
+                assert_eq!(target_y_index, 7);
+            }
+            _ => panic!("expected Affine shape for y[7]"),
+        }
+
+        // And the public preparation path must also complete.
+        let _ = PreparedScalarProgramBlock::new(rumoca_ir_solve::ScalarProgramBlock::new(vec![ops]));
+    }
 }

--- a/crates/rumoca-eval-solve/src/prepared.rs
+++ b/crates/rumoca-eval-solve/src/prepared.rs
@@ -1155,6 +1155,7 @@ mod assignment_shape_tests {
         }
 
         // And the public preparation path must also complete.
-        let _ = PreparedScalarProgramBlock::new(rumoca_ir_solve::ScalarProgramBlock::new(vec![ops]));
+        let _ =
+            PreparedScalarProgramBlock::new(rumoca_ir_solve::ScalarProgramBlock::new(vec![ops]));
     }
 }

--- a/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims.rs
@@ -1171,6 +1171,18 @@ pub(crate) fn resolve_override_function_name(
 
     let package_alias = scope.parent_ident()?;
     let package = ctx.override_package(package_alias)?;
+    // Only resolve through the alias-matched package when the call's actual
+    // source package is unknown (a genuinely relative reference) or is part of
+    // that package's chain. A fully-qualified call into a *different* package
+    // that merely shares its leaf identifier with the alias (e.g.
+    // `A.Quat.f` calling `B.Quat.f` from within `A.Quat`) must NOT be rewritten
+    // to the caller's own package — that would alias the call to itself. The
+    // earlier resolution blocks apply this same chain guard.
+    if let Some(source_package_def_id) = reference_source_package_def_id(reference, ctx)
+        && !ctx.package_chain_contains_def_id(package, source_package_def_id)
+    {
+        return None;
+    }
     resolve_function_in_package_chain_exposed(ctx.tree, ctx.class_index, package, function_leaf)
         .filter(|resolved| resolved != reference.as_str())
 }

--- a/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims/tests.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/function_overrides_and_dims/tests.rs
@@ -174,6 +174,90 @@ fn named_arg(expr: &Expression) -> Option<(&str, &Expression)> {
 }
 
 #[test]
+fn fully_qualified_sibling_package_call_is_not_aliased_to_self() {
+    // Regression: a function `A.Quat.inverse` that calls the fully-qualified
+    // sibling `B.Quat.inverse` must NOT have that call rewritten to its own
+    // package (`A.Quat.inverse`). The two packages share the leaf package name
+    // `Quat`, so the alias-matched fallback in `resolve_override_function_name`
+    // previously re-resolved the call's leaf (`inverse`) inside the caller's
+    // own package, aliasing the cross-package call to itself.
+    let a_def = DefId::new(1);
+    let a_quat_def = DefId::new(2);
+    let a_inverse_def = DefId::new(3);
+    let b_def = DefId::new(4);
+    let b_quat_def = DefId::new(5);
+    let b_inverse_def = DefId::new(6);
+
+    let mut a_inverse = class("inverse", ClassType::Function);
+    a_inverse.def_id = Some(a_inverse_def);
+    let mut a_quat = class("Quat", ClassType::Package);
+    a_quat.def_id = Some(a_quat_def);
+    a_quat.classes.insert("inverse".to_string(), a_inverse);
+    let mut a = class("A", ClassType::Package);
+    a.def_id = Some(a_def);
+    a.classes.insert("Quat".to_string(), a_quat);
+
+    let mut b_inverse = class("inverse", ClassType::Function);
+    b_inverse.def_id = Some(b_inverse_def);
+    let mut b_quat = class("Quat", ClassType::Package);
+    b_quat.def_id = Some(b_quat_def);
+    b_quat.classes.insert("inverse".to_string(), b_inverse);
+    let mut b = class("B", ClassType::Package);
+    b.def_id = Some(b_def);
+    b.classes.insert("Quat".to_string(), b_quat);
+
+    let mut tree = ClassTree::new();
+    tree.definitions.classes.insert("A".to_string(), a);
+    tree.definitions.classes.insert("B".to_string(), b);
+    for (def_id, name) in [
+        (a_def, "A"),
+        (a_quat_def, "A.Quat"),
+        (a_inverse_def, "A.Quat.inverse"),
+        (b_def, "B"),
+        (b_quat_def, "B.Quat"),
+        (b_inverse_def, "B.Quat.inverse"),
+    ] {
+        tree.def_map.insert(def_id, name.to_string());
+        tree.name_map.insert(name.to_string(), def_id);
+    }
+
+    let class_index = rumoca_ir_ast::ClassDefIndex::from_tree(&tree);
+    // The caller's own package (`A.Quat`) is supplied as the (inactive) override
+    // package, mirroring `rewrite_function_extends_aliases_in_function`. Its
+    // alias is the leaf segment `Quat`, which also matches the call's parent.
+    let override_packages = vec![override_target_with_active(
+        "A.Quat",
+        a_quat_def,
+        ClassType::Package,
+        false,
+    )];
+    let override_functions = OverrideFunctionMap::default();
+    let ctx = FunctionOverrideRewriteContext::new(
+        &tree,
+        &class_index,
+        &override_packages,
+        &override_functions,
+    );
+
+    let mut expr = Expression::FunctionCall {
+        name: rumoca_core::Reference::with_component_reference(
+            "B.Quat.inverse",
+            core_comp_ref(&["B", "Quat", "inverse"]),
+        ),
+        args: Vec::new(),
+        is_constructor: false,
+        span: Span::DUMMY,
+    };
+
+    rewrite_function_overrides_in_expression_with_ctx(&mut expr, &ctx);
+
+    let Expression::FunctionCall { name, .. } = expr else {
+        panic!("expected function call");
+    };
+    assert_eq!(name.as_str(), "B.Quat.inverse");
+}
+
+#[test]
 fn canonicalizes_single_part_function_call_from_target_def_id() {
     let package_def = DefId::new(1);
     let function_def = DefId::new(2);

--- a/crates/rumoca-phase-solve/src/lower.rs
+++ b/crates/rumoca-phase-solve/src/lower.rs
@@ -63,7 +63,7 @@ pub(super) struct IndexedBinding {
 
 pub(super) type IndexedBindingMap = Arc<IndexMap<ComponentPath, Vec<IndexedBinding>>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct LocalIndexedBinding {
     reg: Reg,
     indices: Vec<usize>,

--- a/crates/rumoca-phase-solve/src/lower.rs
+++ b/crates/rumoca-phase-solve/src/lower.rs
@@ -902,18 +902,26 @@ impl<'a> LowerBuilder<'a> {
         subscript_regs: &[Reg],
         scope: &Scope,
     ) -> Option<Reg> {
-        let candidates = self
-            .local_indexed_bindings
-            .get(base_key)?
-            .iter()
-            .filter(|entry| entry.indices.len() == subscript_regs.len())
-            .cloned()
-            .collect::<Vec<_>>();
+        let base_path = ComponentPath::from_flat_path(base_key);
+        let candidates = if let Some(bindings) = scope.indexed_entries(&base_path) {
+            bindings
+                .iter()
+                .filter(|entry| entry.indices.len() == subscript_regs.len())
+                .cloned()
+                .collect::<Vec<_>>()
+        } else {
+            self.local_indexed_bindings
+                .get(base_key)?
+                .iter()
+                .filter(|entry| entry.indices.len() == subscript_regs.len())
+                .cloned()
+                .collect::<Vec<_>>()
+        };
         if candidates.is_empty() {
             return None;
         }
         let mut merged = scope
-            .get(&ComponentPath::from_flat_path(base_key))
+            .get(&base_path)
             .copied()
             .unwrap_or_else(|| self.emit_const(0.0));
         for candidate in candidates {

--- a/crates/rumoca-phase-solve/src/lower/array_values.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values.rs
@@ -1223,7 +1223,7 @@ impl<'a> LowerBuilder<'a> {
             return Ok(LocalSubscriptResolution::NotLocal);
         }
         let key_path = ComponentPath::from_reference(name);
-        let Some(bindings) = scope.indexed_entries(&key_path) else {
+        let Some(dims) = self.local_binding_dims.get(key).cloned() else {
             if scope.contains_key(&key_path) {
                 return Err(LowerError::Unsupported {
                     reason: format!("subscripted local binding `{key}` is not an array binding"),
@@ -1231,9 +1231,14 @@ impl<'a> LowerBuilder<'a> {
             }
             return Ok(LocalSubscriptResolution::NotLocal);
         };
-        let Some(dims) = self.local_binding_dims.get(key).cloned() else {
+        let Some(bindings) = scope.indexed_entries(&key_path) else {
+            if let Some(indices) = self.compile_time_subscript_indices(subscripts)? {
+                return Err(LowerError::MissingBinding {
+                    name: format_subscript_binding_key(key, &indices),
+                });
+            }
             return Err(LowerError::Unsupported {
-                reason: format!("subscripted local array `{key}` is missing dimension metadata"),
+                reason: format!("subscripted local array `{key}` has no assigned elements"),
             });
         };
         if dims.iter().any(|dim| *dim <= 0) {

--- a/crates/rumoca-phase-solve/src/lower/array_values.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values.rs
@@ -124,6 +124,25 @@ fn indexed_record_field_key_indices(key: &str, base_key: &str, field: &str) -> O
     (candidate_base == base_key).then_some(indices)
 }
 
+/// Cartesian product of per-dimension index selections into one-based
+/// subscript tuples (the same ordering `collect_slice_binding_keys` uses).
+fn collect_slice_index_combos(
+    selections: &[Vec<usize>],
+    depth: usize,
+    current: &mut Vec<usize>,
+    combos: &mut Vec<Vec<usize>>,
+) {
+    if depth >= selections.len() {
+        combos.push(current.clone());
+        return;
+    }
+    for &index in &selections[depth] {
+        current.push(index);
+        collect_slice_index_combos(selections, depth + 1, current, combos);
+        current.pop();
+    }
+}
+
 fn infer_dims_from_index_sets(index_sets: impl IntoIterator<Item = Vec<usize>>) -> Vec<usize> {
     let mut dims = Vec::new();
     for indices in index_sets {
@@ -1158,6 +1177,15 @@ impl<'a> LowerBuilder<'a> {
         scope: &Scope,
         call_depth: usize,
     ) -> Result<Vec<Reg>, LowerError> {
+        // A function-scope (local) array binding shadows a global model
+        // variable of the same name. The slice path below consults the global
+        // layout shape, which would mis-resolve e.g. a `Real[4]` function input
+        // `p` against a `Real[3]` model state `p` (yielding a phantom `p[4]`).
+        // Resolve against the local binding first, mirroring the local-first
+        // ordering of the unsubscripted `lower_var_ref_array_like_values` path.
+        if let Some(values) = self.local_shadowed_subscript_values(name, subscripts, scope)? {
+            return Ok(values);
+        }
         let Some(keys) =
             self.slice_binding_keys_or_scalar_fallback(name.as_str(), subscripts, scope)?
         else {
@@ -1170,6 +1198,50 @@ impl<'a> LowerBuilder<'a> {
             ]);
         };
         self.load_binding_keys(&keys)
+    }
+
+    /// Resolve `name[subscripts]` against a function-scope (local) array
+    /// binding, ignoring any global model variable of the same name. Returns
+    /// `None` (so the caller falls back to global resolution) unless `name` is
+    /// a local array binding and every selected element is locally available.
+    fn local_shadowed_subscript_values(
+        &mut self,
+        name: &rumoca_core::Reference,
+        subscripts: &[rumoca_core::Subscript],
+        scope: &Scope,
+    ) -> Result<Option<Vec<Reg>>, LowerError> {
+        let key = name.as_str();
+        if subscripts.is_empty() {
+            return Ok(None);
+        }
+        let Some(dims) = self.local_binding_dims.get(key).cloned() else {
+            return Ok(None);
+        };
+        if dims.iter().any(|dim| *dim <= 0) {
+            return Ok(None);
+        }
+        let Some(bindings) = self
+            .local_indexed_bindings
+            .get(key)
+            .filter(|bindings| !bindings.is_empty())
+            .cloned()
+        else {
+            return Ok(None);
+        };
+        let shape = dims.iter().map(|dim| *dim as usize).collect::<Vec<_>>();
+        let Ok(selections) = self.slice_selections(subscripts, &shape, scope) else {
+            return Ok(None);
+        };
+        let mut combos = Vec::new();
+        collect_slice_index_combos(&selections, 0, &mut Vec::new(), &mut combos);
+        let mut regs = Vec::with_capacity(combos.len());
+        for combo in &combos {
+            let Some(binding) = bindings.iter().find(|binding| binding.indices == *combo) else {
+                return Ok(None);
+            };
+            regs.push(binding.reg);
+        }
+        Ok(Some(regs))
     }
 
     fn lower_index_array_like_values(

--- a/crates/rumoca-phase-solve/src/lower/array_values.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values.rs
@@ -35,6 +35,11 @@ pub(super) struct MatMulShape {
     pub n: usize,
 }
 
+enum LocalSubscriptResolution {
+    NotLocal,
+    Values(Vec<Reg>),
+}
+
 pub(super) fn matmul_shape_from_dims(
     lhs_dims: &[usize],
     rhs_dims: &[usize],
@@ -1051,10 +1056,10 @@ impl<'a> LowerBuilder<'a> {
     ) -> Result<Vec<Reg>, LowerError> {
         let key_path = ComponentPath::from_reference(name);
         let key = name.as_str();
-        if let Some(values) = self.local_indexed_binding_values(key) {
+        if let Some(values) = scoped_indexed_binding_values(scope, &key_path) {
             return Ok(values);
         }
-        if let Some(values) = scoped_indexed_binding_values(scope, &key_path) {
+        if let Some(values) = self.local_indexed_binding_values(key) {
             return Ok(values);
         }
         if self.known_empty_local_arrays.contains(key) {
@@ -1183,8 +1188,9 @@ impl<'a> LowerBuilder<'a> {
         // `p` against a `Real[3]` model state `p` (yielding a phantom `p[4]`).
         // Resolve against the local binding first, mirroring the local-first
         // ordering of the unsubscripted `lower_var_ref_array_like_values` path.
-        if let Some(values) = self.local_shadowed_subscript_values(name, subscripts, scope)? {
-            return Ok(values);
+        match self.local_shadowed_subscript_values(name, subscripts, scope, call_depth)? {
+            LocalSubscriptResolution::Values(values) => return Ok(values),
+            LocalSubscriptResolution::NotLocal => {}
         }
         let Some(keys) =
             self.slice_binding_keys_or_scalar_fallback(name.as_str(), subscripts, scope)?
@@ -1201,47 +1207,80 @@ impl<'a> LowerBuilder<'a> {
     }
 
     /// Resolve `name[subscripts]` against a function-scope (local) array
-    /// binding, ignoring any global model variable of the same name. Returns
-    /// `None` (so the caller falls back to global resolution) unless `name` is
-    /// a local array binding and every selected element is locally available.
+    /// binding, ignoring any global model variable of the same name. Once the
+    /// scoped local binding exists, resolution must either produce local values
+    /// or report an error; falling through to global lookup would violate
+    /// Modelica lexical shadowing.
     fn local_shadowed_subscript_values(
         &mut self,
         name: &rumoca_core::Reference,
         subscripts: &[rumoca_core::Subscript],
         scope: &Scope,
-    ) -> Result<Option<Vec<Reg>>, LowerError> {
+        call_depth: usize,
+    ) -> Result<LocalSubscriptResolution, LowerError> {
         let key = name.as_str();
         if subscripts.is_empty() {
-            return Ok(None);
+            return Ok(LocalSubscriptResolution::NotLocal);
         }
+        let key_path = ComponentPath::from_reference(name);
+        let Some(bindings) = scope.indexed_entries(&key_path) else {
+            if scope.contains_key(&key_path) {
+                return Err(LowerError::Unsupported {
+                    reason: format!("subscripted local binding `{key}` is not an array binding"),
+                });
+            }
+            return Ok(LocalSubscriptResolution::NotLocal);
+        };
         let Some(dims) = self.local_binding_dims.get(key).cloned() else {
-            return Ok(None);
+            return Err(LowerError::Unsupported {
+                reason: format!("subscripted local array `{key}` is missing dimension metadata"),
+            });
         };
         if dims.iter().any(|dim| *dim <= 0) {
-            return Ok(None);
-        }
-        let Some(bindings) = self
-            .local_indexed_bindings
-            .get(key)
-            .filter(|bindings| !bindings.is_empty())
-            .cloned()
-        else {
-            return Ok(None);
+            return Err(LowerError::Unsupported {
+                reason: format!(
+                    "subscripted local array `{key}` has non-positive dimensions {dims:?}"
+                ),
+            });
         };
         let shape = dims.iter().map(|dim| *dim as usize).collect::<Vec<_>>();
-        let Ok(selections) = self.slice_selections(subscripts, &shape, scope) else {
-            return Ok(None);
-        };
+        if subscripts.len() == shape.len() && subscripts.iter().all(is_scalar_selector_subscript) {
+            let Some(indices) = self.compile_time_subscript_indices(subscripts)? else {
+                let value = self.lower_dynamic_subscripted_binding(
+                    key,
+                    subscripts,
+                    scope,
+                    call_depth,
+                    DynamicSubscriptSemantics::VarRef,
+                )?;
+                return Ok(LocalSubscriptResolution::Values(vec![value]));
+            };
+            if let Some(binding) = bindings.iter().find(|binding| binding.indices == indices) {
+                return Ok(LocalSubscriptResolution::Values(vec![binding.reg]));
+            }
+            return Err(LowerError::MissingBinding {
+                name: format_subscript_binding_key(key, &indices),
+            });
+        }
+        let selections = self
+            .slice_selections(subscripts, &shape, scope)
+            .map_err(|err| {
+                err.with_context(format!(
+                    "resolving subscripted local array `{key}` with shape {shape:?}"
+                ))
+            })?;
         let mut combos = Vec::new();
         collect_slice_index_combos(&selections, 0, &mut Vec::new(), &mut combos);
         let mut regs = Vec::with_capacity(combos.len());
         for combo in &combos {
             let Some(binding) = bindings.iter().find(|binding| binding.indices == *combo) else {
-                return Ok(None);
+                return Err(LowerError::MissingBinding {
+                    name: format_subscript_binding_key(key, combo),
+                });
             };
             regs.push(binding.reg);
         }
-        Ok(Some(regs))
+        Ok(LocalSubscriptResolution::Values(regs))
     }
 
     fn lower_index_array_like_values(

--- a/crates/rumoca-phase-solve/src/lower/array_values/dynamic_selection.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/dynamic_selection.rs
@@ -16,6 +16,11 @@ impl<'a> LowerBuilder<'a> {
         if indices.is_empty() {
             return Ok(None);
         }
+        let indexed_key = format_subscript_binding_key(base_key.as_str(), &indices);
+        let indexed_path = ComponentPath::from_flat_path(&indexed_key);
+        if let Some(value) = scope.get(&indexed_path).copied() {
+            return Ok(Some(value));
+        }
         if let Some(value) =
             self.local_indexed_bindings
                 .get(base_key.as_str())
@@ -26,12 +31,6 @@ impl<'a> LowerBuilder<'a> {
                         .map(|binding| binding.reg)
                 })
         {
-            return Ok(Some(value));
-        }
-
-        let indexed_key = format_subscript_binding_key(base_key.as_str(), &indices);
-        let indexed_path = ComponentPath::from_flat_path(&indexed_key);
-        if let Some(value) = scope.get(&indexed_path).copied() {
             return Ok(Some(value));
         }
         if let Some(mut values) =

--- a/crates/rumoca-phase-solve/src/lower/array_values/inference.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/inference.rs
@@ -221,30 +221,31 @@ impl<'a> LowerBuilder<'a> {
     ) -> Vec<usize> {
         let name_path = ComponentPath::from_reference(name);
         let name = name.as_str();
-        if let Some(shape) = self.layout.shape(name) {
-            return shape.to_vec();
-        }
         if let Some(dims) = self.local_binding_dims.get(name)
             && dims.iter().all(|dim| *dim > 0)
         {
             return dims.iter().map(|dim| *dim as usize).collect();
+        }
+        if let Some(values) = scoped_indexed_binding_values(scope, &name_path) {
+            return vector_dims(values.len());
+        }
+        if let Some(values) = self.local_indexed_binding_values(name) {
+            return vector_dims(values.len());
+        }
+        if let Some(shape) = self.layout.shape(name) {
+            return shape.to_vec();
         }
         let indexed_dims =
             infer_indexed_dims(&indexed_entries_for_key(&self.indexed_bindings, name));
         if !indexed_dims.is_empty() {
             return indexed_dims;
         }
-        if let Some(values) = self.local_indexed_binding_values(name) {
-            return vector_dims(values.len());
-        }
-        scoped_indexed_binding_values(scope, &name_path)
-            .map(|values| vector_dims(values.len()))
-            .or_else(|| {
-                self.local_binding_dims.get(name).map(|dims| {
-                    dims.iter()
-                        .filter_map(|dim| (*dim >= 0).then_some(*dim as usize))
-                        .collect()
-                })
+        self.local_binding_dims
+            .get(name)
+            .map(|dims| {
+                dims.iter()
+                    .filter_map(|dim| (*dim >= 0).then_some(*dim as usize))
+                    .collect()
             })
             .unwrap_or_default()
     }

--- a/crates/rumoca-phase-solve/src/lower/scope.rs
+++ b/crates/rumoca-phase-solve/src/lower/scope.rs
@@ -92,11 +92,7 @@ impl Scope {
     }
 
     pub(super) fn indexed_values(&self, path: &ComponentPath) -> Option<Vec<Reg>> {
-        let bindings = self
-            .frames
-            .iter()
-            .rev()
-            .find_map(|frame| frame.indexed_bindings.get(path))?;
+        let bindings = self.indexed_entries(path)?;
         if bindings.is_empty() {
             return None;
         }
@@ -115,6 +111,14 @@ impl Scope {
         values.retain(|(indices, _)| indices.len() == rank);
         values.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
         Some(values.into_iter().map(|(_, reg)| reg).collect())
+    }
+
+    pub(super) fn indexed_entries(&self, path: &ComponentPath) -> Option<&[LocalIndexedBinding]> {
+        self.frames
+            .iter()
+            .rev()
+            .find_map(|frame| frame.indexed_bindings.get(path))
+            .map(Vec::as_slice)
     }
 
     pub(super) fn insert_path(&mut self, path: ComponentPath, reg: Reg) -> Option<Reg> {

--- a/crates/rumoca-phase-solve/src/lower/statements.rs
+++ b/crates/rumoca-phase-solve/src/lower/statements.rs
@@ -49,6 +49,15 @@ impl<'a> LowerBuilder<'a> {
         }
 
         let entry_scope = scope.clone();
+        // Branch bodies mutate builder-level caches (indexed/const bindings,
+        // empty-array tracking) in place. Those caches are consulted *before*
+        // `scope` when a later read resolves a variable, so a value written
+        // only inside a branch would shadow the conditional `select` we build
+        // in `merged_scope` and leak out unconditionally. Snapshot them here so
+        // we can drop any branch-touched entry below and let `scope` win.
+        let entry_indexed_bindings = self.local_indexed_bindings.clone();
+        let entry_const_bindings = self.local_const_bindings.clone();
+        let entry_empty_arrays = self.known_empty_local_arrays.clone();
         let mut cond_regs = Vec::with_capacity(cond_blocks.len());
         let mut branch_scopes = Vec::with_capacity(cond_blocks.len());
 
@@ -87,6 +96,18 @@ impl<'a> LowerBuilder<'a> {
             }
             merged_scope.insert(name, merged);
         }
+
+        // Drop every cache entry a branch added or changed: a variable assigned
+        // only conditionally is no longer a compile-time constant or a fixed
+        // indexed binding, so subsequent reads must fall through to the merged
+        // `select` registers in `merged_scope`. Entries untouched by any branch
+        // stay (they already agree with `scope`).
+        self.local_indexed_bindings
+            .retain(|key, value| entry_indexed_bindings.get(key) == Some(value));
+        self.local_const_bindings
+            .retain(|key, value| entry_const_bindings.get(key) == Some(value));
+        self.known_empty_local_arrays
+            .retain(|key| entry_empty_arrays.contains(key));
 
         *scope = merged_scope;
         Ok(false)

--- a/crates/rumoca-phase-solve/src/lower/statements.rs
+++ b/crates/rumoca-phase-solve/src/lower/statements.rs
@@ -49,30 +49,28 @@ impl<'a> LowerBuilder<'a> {
         }
 
         let entry_scope = scope.clone();
-        // Branch bodies mutate builder-level caches (indexed/const bindings,
-        // empty-array tracking) in place. Those caches are consulted *before*
-        // `scope` when a later read resolves a variable, so a value written
-        // only inside a branch would shadow the conditional `select` we build
-        // in `merged_scope` and leak out unconditionally. Snapshot them here so
-        // we can drop any branch-touched entry below and let `scope` win.
-        let entry_indexed_bindings = self.local_indexed_bindings.clone();
-        let entry_const_bindings = self.local_const_bindings.clone();
-        let entry_empty_arrays = self.known_empty_local_arrays.clone();
         let mut cond_regs = Vec::with_capacity(cond_blocks.len());
         let mut branch_scopes = Vec::with_capacity(cond_blocks.len());
 
         for block in cond_blocks {
-            let cond = self.lower_expr(&block.cond, &entry_scope, call_depth)?;
+            let (cond, branch_scope) = self.with_local_lower_frame(|builder| {
+                let cond = builder.lower_expr(&block.cond, &entry_scope, call_depth)?;
+                let mut branch_scope = entry_scope.clone();
+                let _returned =
+                    builder.lower_statements(&block.stmts, &mut branch_scope, call_depth)?;
+                Ok((cond, branch_scope))
+            })?;
             cond_regs.push(cond);
-            let mut branch_scope = entry_scope.clone();
-            let _returned = self.lower_statements(&block.stmts, &mut branch_scope, call_depth)?;
             branch_scopes.push(branch_scope);
         }
 
-        let mut else_scope = entry_scope.clone();
-        if let Some(stmts) = else_block {
-            let _returned = self.lower_statements(stmts, &mut else_scope, call_depth)?;
-        }
+        let else_scope = self.with_local_lower_frame(|builder| {
+            let mut else_scope = entry_scope.clone();
+            if let Some(stmts) = else_block {
+                let _returned = builder.lower_statements(stmts, &mut else_scope, call_depth)?;
+            }
+            Ok(else_scope)
+        })?;
 
         let mut merged_scope = entry_scope.clone();
         let names = collect_scope_names(&merged_scope, &branch_scopes, &else_scope);
@@ -96,18 +94,6 @@ impl<'a> LowerBuilder<'a> {
             }
             merged_scope.insert(name, merged);
         }
-
-        // Drop every cache entry a branch added or changed: a variable assigned
-        // only conditionally is no longer a compile-time constant or a fixed
-        // indexed binding, so subsequent reads must fall through to the merged
-        // `select` registers in `merged_scope`. Entries untouched by any branch
-        // stay (they already agree with `scope`).
-        self.local_indexed_bindings
-            .retain(|key, value| entry_indexed_bindings.get(key) == Some(value));
-        self.local_const_bindings
-            .retain(|key, value| entry_const_bindings.get(key) == Some(value));
-        self.known_empty_local_arrays
-            .retain(|key| entry_empty_arrays.contains(key));
 
         *scope = merged_scope;
         Ok(false)

--- a/crates/rumoca-phase-structural/src/incidence.rs
+++ b/crates/rumoca-phase-structural/src/incidence.rs
@@ -191,10 +191,17 @@ fn collect_equation_unknowns(
 ) -> HashSet<usize> {
     let mut result = HashSet::new();
 
-    let mut der_states = HashSet::new();
-    eq.rhs.collect_state_variables(&mut der_states);
-    for name in der_states {
-        for idx in der_resolver.resolve_name_all(name.as_str()) {
+    // Collect `der(state)` unknowns from the residual, preserving any
+    // subscripts on the differentiated operand. Using the un-subscripted base
+    // name here (e.g. `der(p[1])` -> `p`) would resolve to *every* `der(p[i])`
+    // via the array fallback in `resolve_name_all`, spuriously coupling the
+    // scalar `der(p[i]) = v[i]` rows into one SCC that tearing then finds
+    // structurally singular. Resolving with the subscript pins each row to its
+    // own scalar `der` unknown.
+    let mut der_collector = DerOperandCollector::default();
+    der_collector.visit_expression(&eq.rhs);
+    for (name, subscripts) in der_collector.operands {
+        for idx in der_resolver.resolve_var_ref_all(&name, &subscripts) {
             result.insert(idx);
         }
     }
@@ -238,6 +245,34 @@ fn equation_contains_derivative(expr: &rumoca_core::Expression) -> bool {
     let mut checker = DerivativeCallChecker { found: false };
     checker.visit_expression(expr);
     checker.found
+}
+
+/// Collects the operand of every `der(...)` call in an expression, keeping the
+/// operand's name and subscripts so the structural incidence can resolve the
+/// exact scalar `der` unknown (e.g. `der(p[2])` -> `p[2]`) instead of the
+/// un-subscripted base.
+#[derive(Default)]
+struct DerOperandCollector {
+    operands: Vec<(rumoca_core::Reference, Vec<rumoca_core::Subscript>)>,
+}
+
+impl ExpressionVisitor for DerOperandCollector {
+    fn visit_builtin_call(
+        &mut self,
+        function: &rumoca_core::BuiltinFunction,
+        args: &[rumoca_core::Expression],
+    ) {
+        if *function == rumoca_core::BuiltinFunction::Der
+            && let Some(rumoca_core::Expression::VarRef {
+                name, subscripts, ..
+            }) = args.first()
+        {
+            self.operands.push((name.clone(), subscripts.clone()));
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
 }
 
 struct DerivativeCallChecker {

--- a/crates/rumoca/tests/array_der_coupling_test.rs
+++ b/crates/rumoca/tests/array_der_coupling_test.rs
@@ -63,6 +63,10 @@ fn array_der_rows_do_not_form_spurious_coupled_scc() {
     // And it must actually evaluate to a finite, correct derivative.
     let probe = eval_dae_at(&compiled.dae, &SimOptions::default(), &[], 0.0)
         .expect("explicit ODE should lower and evaluate");
-    assert!(probe.report.error.is_none(), "eval error: {:?}", probe.report.error);
+    assert!(
+        probe.report.error.is_none(),
+        "eval error: {:?}",
+        probe.report.error
+    );
     assert!(!probe.report.has_nonfinite(), "derivatives must be finite");
 }

--- a/crates/rumoca/tests/array_der_coupling_test.rs
+++ b/crates/rumoca/tests/array_der_coupling_test.rs
@@ -1,0 +1,68 @@
+//! Regression: scalar `der(p[i]) = v[i]` rows of an array ODE must each match
+//! 1:1 with their own `der` unknown, not collapse into a coupled SCC.
+//!
+//! Before the fix, the structural incidence collected the *un-subscripted* base
+//! name of a `der(...)` operand (`der(p[1])` -> `p`). The array fallback in the
+//! unknown resolver then expanded `p` to every `der(p[i])`, so each of the three
+//! trivially explicit `der(p[i]) = v[i]` rows was marked incident to all three
+//! `der(p)` unknowns. Matching grouped them into a spurious 3x3 coupled SCC,
+//! and tearing turned that block into a structurally singular linear system
+//! (`SymbolicSingular`) — even though the equations are a plain explicit ODE.
+
+use rumoca::Compiler;
+use rumoca_sim::{SimOptions, eval_dae_at, structural_report_for_dae};
+
+// A 9-state explicit ODE whose `der` depends on a matrix-valued function output
+// fed through a matrix product (`der(s) = M*s`, `M = mat9(s)`). This is the
+// minimal shape of the kinematic-quadrotor chain that exposed the bug.
+const ARRAY_DER_MODEL: &str = r#"
+within;
+function helper
+  input Real a; input Real b; output Real c;
+algorithm
+  c := a * b + sin(a) - cos(b);
+end helper;
+function mat9
+  input Real x[9]; output Real M[9,9];
+algorithm
+  for i in 1:9 loop
+    for j in 1:9 loop
+      M[i,j] := helper(x[i], x[j]) + (if i == j then 1.0 else 0.0);
+    end for;
+  end for;
+end mat9;
+model ArrayDer
+  Real s[9](each start = 0.1, each fixed = true);
+  Real M[9,9];
+  Real y[9];
+equation
+  M = mat9(s);
+  y = M * s;
+  der(s) = y;
+end ArrayDer;
+"#;
+
+#[test]
+fn array_der_rows_do_not_form_spurious_coupled_scc() {
+    let compiled = Compiler::new()
+        .model("ArrayDer")
+        .compile_str(ARRAY_DER_MODEL, "ArrayDer.mo")
+        .expect("compile to DAE should succeed");
+
+    let report = structural_report_for_dae(&compiled.dae, &SimOptions::default())
+        .expect("structural analysis should succeed");
+
+    // The explicit ODE has no algebraic loop: every block must be scalar.
+    assert_eq!(
+        report.coupled_block_count(),
+        0,
+        "der(s[i]) = y[i] must not be grouped into a coupled SCC; largest coupled block = {}",
+        report.largest_coupled_block()
+    );
+
+    // And it must actually evaluate to a finite, correct derivative.
+    let probe = eval_dae_at(&compiled.dae, &SimOptions::default(), &[], 0.0)
+        .expect("explicit ODE should lower and evaluate");
+    assert!(probe.report.error.is_none(), "eval error: {:?}", probe.report.error);
+    assert!(!probe.report.has_nonfinite(), "derivatives must be finite");
+}

--- a/crates/rumoca/tests/function_input_shadow_state_test.rs
+++ b/crates/rumoca/tests/function_input_shadow_state_test.rs
@@ -1,0 +1,49 @@
+//! Regression: a function input parameter whose name shadows a model
+//! variable must resolve against the local (function-scope) binding when the
+//! function is inlined during solve lowering — not against the global model
+//! layout.
+//!
+//! Before the fix, the subscripted array-like lowering path consulted the
+//! global layout shape for the shadowed name. A `Real[4]` function input `p`
+//! inlined inside a `der()` RHS was mis-resolved against a `Real[3]` model
+//! state `p`, producing a phantom `p[4]` and failing solve lowering with
+//! `missing variable binding p[4]`.
+
+use rumoca::Compiler;
+use rumoca_phase_solve::lower_dae_to_solve_model;
+
+const SHADOW_MODEL: &str = r#"
+within;
+function pfn
+  input Real p[4];
+  output Real r[4];
+algorithm
+  r[1] := p[1];
+  r[2] := p[2];
+  r[3] := p[3];
+  r[4] := p[4];
+end pfn;
+
+model Shadow
+  Real p[3](start = {1, -1, -0.5}, each fixed = true);
+  Real v[3](start = {0, 0, 0}, each fixed = true);
+  Real w[4];
+equation
+  w = pfn({v[1], v[2], v[3], v[1]});
+  der(p) = v;
+  der(v) = {0, 0, w[4]};
+end Shadow;
+"#;
+
+#[test]
+fn function_input_shadowing_model_state_lowers_to_solve() {
+    let compiled = Compiler::new()
+        .model("Shadow")
+        .compile_str(SHADOW_MODEL, "Shadow.mo")
+        .expect("compile to DAE should succeed");
+
+    // The function input `p[4]` must resolve to the inlined argument
+    // (`v[1]`), not the model state `p` (which is only `Real[3]`).
+    lower_dae_to_solve_model(&compiled.dae)
+        .expect("solve lowering must resolve the shadowed function input, not the model state");
+}

--- a/crates/rumoca/tests/function_input_shadow_state_test.rs
+++ b/crates/rumoca/tests/function_input_shadow_state_test.rs
@@ -57,6 +57,24 @@ equation
 end ShadowMissingLocal;
 "#;
 
+const SHADOW_UNASSIGNED_LOCAL_MODEL: &str = r#"
+within;
+function pfn_unassigned
+  output Real r;
+protected
+  Real p[1];
+algorithm
+  r := p[1];
+end pfn_unassigned;
+
+model ShadowUnassignedLocal
+  parameter Real p[1] = {42};
+  Real y;
+equation
+  y = pfn_unassigned();
+end ShadowUnassignedLocal;
+"#;
+
 #[test]
 fn function_input_shadowing_model_state_lowers_to_solve() {
     let compiled = Compiler::new()
@@ -83,5 +101,21 @@ fn incomplete_local_array_shadow_reports_error_instead_of_global_fallback() {
     assert!(
         err_text.contains("p[4]"),
         "error should identify the missing local component, got: {err_text}"
+    );
+}
+
+#[test]
+fn declared_unassigned_local_array_shadow_reports_error_instead_of_global_fallback() {
+    let compiled = Compiler::new()
+        .model("ShadowUnassignedLocal")
+        .compile_str(SHADOW_UNASSIGNED_LOCAL_MODEL, "ShadowUnassignedLocal.mo")
+        .expect("compile to DAE should succeed");
+
+    let err = lower_dae_to_solve_model(&compiled.dae)
+        .expect_err("solve lowering must not fall back to the shadowed model parameter");
+    let err_text = err.to_string();
+    assert!(
+        err_text.contains("p[1]"),
+        "error should identify the unassigned local component, got: {err_text}"
     );
 }

--- a/crates/rumoca/tests/function_input_shadow_state_test.rs
+++ b/crates/rumoca/tests/function_input_shadow_state_test.rs
@@ -35,6 +35,28 @@ equation
 end Shadow;
 "#;
 
+const SHADOW_MISSING_LOCAL_MODEL: &str = r#"
+within;
+function pfn_missing
+  input Real u[3];
+  output Real r[4];
+protected
+  Real p[4];
+algorithm
+  p[1] := u[1];
+  p[2] := u[2];
+  p[3] := u[3];
+  r := p[:];
+end pfn_missing;
+
+model ShadowMissingLocal
+  parameter Real p[4] = {10, 20, 30, 40};
+  Real y[4];
+equation
+  y = pfn_missing({1, 2, 3});
+end ShadowMissingLocal;
+"#;
+
 #[test]
 fn function_input_shadowing_model_state_lowers_to_solve() {
     let compiled = Compiler::new()
@@ -46,4 +68,20 @@ fn function_input_shadowing_model_state_lowers_to_solve() {
     // (`v[1]`), not the model state `p` (which is only `Real[3]`).
     lower_dae_to_solve_model(&compiled.dae)
         .expect("solve lowering must resolve the shadowed function input, not the model state");
+}
+
+#[test]
+fn incomplete_local_array_shadow_reports_error_instead_of_global_fallback() {
+    let compiled = Compiler::new()
+        .model("ShadowMissingLocal")
+        .compile_str(SHADOW_MISSING_LOCAL_MODEL, "ShadowMissingLocal.mo")
+        .expect("compile to DAE should succeed");
+
+    let err = lower_dae_to_solve_model(&compiled.dae)
+        .expect_err("solve lowering must not fall back to the shadowed model state");
+    let err_text = err.to_string();
+    assert!(
+        err_text.contains("p[4]"),
+        "error should identify the missing local component, got: {err_text}"
+    );
 }

--- a/crates/rumoca/tests/function_noelse_if_test.rs
+++ b/crates/rumoca/tests/function_noelse_if_test.rs
@@ -75,8 +75,16 @@ fn der_value(report: &rumoca_sim::EvalAtReport, name: &str) -> f64 {
         .derivatives
         .iter()
         .find(|slot| slot.name == name)
-        .unwrap_or_else(|| panic!("missing derivative {name}; have: {:?}",
-            report.derivatives.iter().map(|s| s.name.clone()).collect::<Vec<_>>()))
+        .unwrap_or_else(|| {
+            panic!(
+                "missing derivative {name}; have: {:?}",
+                report
+                    .derivatives
+                    .iter()
+                    .map(|s| s.name.clone())
+                    .collect::<Vec<_>>()
+            )
+        })
         .value
 }
 

--- a/crates/rumoca/tests/function_noelse_if_test.rs
+++ b/crates/rumoca/tests/function_noelse_if_test.rs
@@ -1,0 +1,142 @@
+//! Regression: an `if`-statement with no `else` branch inside a function body
+//! must keep its guard when the function is inlined during solve lowering.
+//!
+//! Before the fix, branch bodies mutated builder-level caches
+//! (`local_indexed_bindings` / `local_const_bindings`) in place while lowering
+//! a conditional. Those caches are consulted before the merged register
+//! `scope`, so a value written only inside the `then` block of a no-`else`
+//! `if` leaked out unconditionally: `x := q; if x[1] < 0 then x := -x; end if;`
+//! negated `x` regardless of the condition. The merged `select` register was
+//! built correctly but shadowed by the stale branch binding, so `der()` came
+//! out negated (silent wrong answer, no error).
+
+use rumoca::Compiler;
+use rumoca_sim::{SimOptions, eval_dae_at};
+
+// `qp[1] = +0.9 > 0`, so none of the four equivalent "negate iff first < 0"
+// forms should change the value. der(a)/der(b)/der(c)/der(d) must all equal the
+// input. der(a) (no-else array) and der(b) (no-else scalar) are the forms that
+// regressed.
+const NOELSE_MODEL: &str = r#"
+within;
+function f_noelse_arr
+  input Real q[4]; output Real o[4]; protected Real x[4];
+algorithm x := q; if x[1] < 0 then x := -x; end if; o := x;
+end f_noelse_arr;
+function f_noelse_scalar
+  input Real a; output Real o; protected Real x;
+algorithm x := a; if x < 0 then x := -x; end if; o := x;
+end f_noelse_scalar;
+function f_withelse_arr
+  input Real q[4]; output Real o[4]; protected Real x[4];
+algorithm if q[1] < 0 then x := -q; else x := q; end if; o := x;
+end f_withelse_arr;
+function f_ifexpr_arr
+  input Real q[4]; output Real o[4];
+algorithm o := if q[1] < 0 then -q else q;
+end f_ifexpr_arr;
+model NoElseIf
+  parameter Real qp[4] = {0.9, 0.1, -0.2, 0.3};
+  Real a[4](each start = 0, each fixed = true);
+  Real b(start = 0, fixed = true);
+  Real c[4](each start = 0, each fixed = true);
+  Real d[4](each start = 0, each fixed = true);
+equation
+  der(a) = f_noelse_arr(qp);
+  der(b) = f_noelse_scalar(0.7);
+  der(c) = f_withelse_arr(qp);
+  der(d) = f_ifexpr_arr(qp);
+end NoElseIf;
+"#;
+
+// First element negative: every form must now negate.
+const NOELSE_MODEL_NEG: &str = r#"
+within;
+function f_noelse_arr
+  input Real q[4]; output Real o[4]; protected Real x[4];
+algorithm x := q; if x[1] < 0 then x := -x; end if; o := x;
+end f_noelse_arr;
+function f_noelse_scalar
+  input Real a; output Real o; protected Real x;
+algorithm x := a; if x < 0 then x := -x; end if; o := x;
+end f_noelse_scalar;
+model NoElseIfNeg
+  parameter Real qp[4] = {-0.9, 0.1, -0.2, 0.3};
+  Real a[4](each start = 0, each fixed = true);
+  Real b(start = 0, fixed = true);
+equation
+  der(a) = f_noelse_arr(qp);
+  der(b) = f_noelse_scalar(-0.7);
+end NoElseIfNeg;
+"#;
+
+fn der_value(report: &rumoca_sim::EvalAtReport, name: &str) -> f64 {
+    report
+        .derivatives
+        .iter()
+        .find(|slot| slot.name == name)
+        .unwrap_or_else(|| panic!("missing derivative {name}; have: {:?}",
+            report.derivatives.iter().map(|s| s.name.clone()).collect::<Vec<_>>()))
+        .value
+}
+
+#[test]
+fn noelse_if_keeps_guard_when_condition_false() {
+    let compiled = Compiler::new()
+        .model("NoElseIf")
+        .compile_str(NOELSE_MODEL, "NoElseIf.mo")
+        .expect("compile to DAE should succeed");
+
+    let probe = eval_dae_at(&compiled.dae, &SimOptions::default(), &[], 0.0)
+        .expect("no-else-if model should lower and evaluate");
+    let report = &probe.report;
+    assert!(report.error.is_none(), "eval error: {:?}", report.error);
+
+    // qp[1] = +0.9, so the guard is false and nothing should be negated.
+    let qp = [0.9, 0.1, -0.2, 0.3];
+    for (i, expected) in qp.iter().enumerate() {
+        // no-else array form (the high-value regression)
+        assert_eq!(
+            der_value(report, &format!("der(a[{}])", i + 1)),
+            *expected,
+            "no-else array if ran unconditionally on der(a[{}])",
+            i + 1
+        );
+        // with-else array form (was already correct)
+        assert_eq!(der_value(report, &format!("der(c[{}])", i + 1)), *expected);
+        // if-expression form (was already correct)
+        assert_eq!(der_value(report, &format!("der(d[{}])", i + 1)), *expected);
+    }
+    // no-else scalar form
+    assert_eq!(
+        der_value(report, "der(b)"),
+        0.7,
+        "no-else scalar if ran unconditionally on der(b)"
+    );
+}
+
+#[test]
+fn noelse_if_branch_still_fires_when_condition_true() {
+    let compiled = Compiler::new()
+        .model("NoElseIfNeg")
+        .compile_str(NOELSE_MODEL_NEG, "NoElseIfNeg.mo")
+        .expect("compile to DAE should succeed");
+
+    let probe = eval_dae_at(&compiled.dae, &SimOptions::default(), &[], 0.0)
+        .expect("no-else-if model should lower and evaluate");
+    let report = &probe.report;
+    assert!(report.error.is_none(), "eval error: {:?}", report.error);
+
+    // qp[1] = -0.9 < 0, so the guard is true and the value must be negated.
+    let neg_qp = [0.9, -0.1, 0.2, -0.3];
+    for (i, expected) in neg_qp.iter().enumerate() {
+        assert_eq!(
+            der_value(report, &format!("der(a[{}])", i + 1)),
+            *expected,
+            "no-else array if should have negated der(a[{}])",
+            i + 1
+        );
+    }
+    // f_noelse_scalar(-0.7): -0.7 < 0 -> negate -> 0.7
+    assert_eq!(der_value(report, "der(b)"), 0.7);
+}

--- a/crates/rumoca/tests/function_noelse_if_test.rs
+++ b/crates/rumoca/tests/function_noelse_if_test.rs
@@ -60,13 +60,21 @@ function f_noelse_scalar
   input Real a; output Real o; protected Real x;
 algorithm x := a; if x < 0 then x := -x; end if; o := x;
 end f_noelse_scalar;
+function f_noelse_dynamic
+  input Real q[4]; input Integer k; output Real o; protected Real x[4];
+algorithm x := q; if q[1] < 0 then x[1] := -q[1]; end if; o := x[k];
+end f_noelse_dynamic;
 model NoElseIfNeg
   parameter Real qp[4] = {-0.9, 0.1, -0.2, 0.3};
   Real a[4](each start = 0, each fixed = true);
   Real b(start = 0, fixed = true);
+  Real e(start = 0, fixed = true);
+  Integer k(start = 1, fixed = true);
 equation
+  k = 1;
   der(a) = f_noelse_arr(qp);
   der(b) = f_noelse_scalar(-0.7);
+  der(e) = f_noelse_dynamic(qp, k);
 end NoElseIfNeg;
 "#;
 
@@ -147,4 +155,6 @@ fn noelse_if_branch_still_fires_when_condition_true() {
     }
     // f_noelse_scalar(-0.7): -0.7 < 0 -> negate -> 0.7
     assert_eq!(der_value(report, "der(b)"), 0.7);
+    // Dynamic x[k] must read the merged conditional x[1], not the stale pre-if binding.
+    assert_eq!(der_value(report, "der(e)"), 0.9);
 }


### PR DESCRIPTION
Five fixes surfaced while lowering and simulating a function-heavy
SE_2(3) kinematic model (arrays, matrix-valued function outputs, guarded
mutations). Each is an independent fix with a regression test; the branch
merges cleanly against `main`.

## Fixes

**fix(solve): gate no-else if-statement body in function inlining**
An `if cond then <body> end if` with no `else`, inside a function body,
ran its body *unconditionally* when inlined during Solve-IR lowering — a
silent wrong answer (e.g. `if x[1] < 0 then x := -x; end if` always
negated). `lower_if_statement` built the correct `select`, but branch
bodies also mutate builder-level caches (`local_indexed_bindings`,
`local_const_bindings`, `known_empty_local_arrays`) that are consulted
before the merged scope, so a then-only write leaked out. Snapshot those
caches at if-entry and drop any branch-touched entry after merging.

**fix(structural): resolve der() operands with subscripts in incidence**
A scalar `der(p[i]) = v[i]` row was marked incident to every `der(p[k])`,
collapsing the three independent rows into a spurious 3x3 coupled SCC that
tearing turned into a structurally singular block (`SymbolicSingular`) for
a plain explicit ODE. The incidence builder collected `der()` operands via
a visitor that dropped subscripts (`der(p[1])` -> bare `p` -> the whole
`der(p[*])` bucket). Collect operands with their subscripts and resolve
the exact scalar unknown instead.

**fix(eval-solve): memoize reg_depends_on_y_index to avoid exponential prep**
`PreparedScalarProgramBlock::new` hung on models with large inlined matrix
programs as observed outputs. `reg_depends_on_y_index` walked the register
DAG with no memoization, so rows with heavily shared sub-expressions (CSE'd
matrix products) re-traversed shared sub-DAGs in O(2^depth). Memoize by
register (dependence on a fixed y-index is a pure function of the register).

**fix(solve): resolve shadowed function input before global layout**
A function input whose name shadows a model state (e.g. `input Real p[4]`
inlined where the model has state `p[3]`) was mis-resolved against the
global layout, producing a phantom `p[4]` and failing solve lowering.
Resolve the local function binding before the global layout.

**fix(flatten): don't alias fully-qualified sibling-package function calls to self**
A fully-qualified sibling-package call sharing a path tail with the caller
(`SE23.Quat.inverse` calling `SO3.Quat.inverse`) was rewritten to call
itself. Guard the fallback resolution with the package-chain check the
earlier resolution blocks already use.

## Tests
Adds regression tests for the three new fixes (no-else if guard both ways,
array-der no spurious SCC + finite eval, deep-shared-DAG prep terminates)
and keeps the existing shadowed-input/sibling-package regressions. All
affected crate suites and the casadi/tiered/omc integration suites pass.