### PR TITLE
Onboard rover fix

### DIFF
--- a/crates/rumoca-sim/src/runner/config.rs
+++ b/crates/rumoca-sim/src/runner/config.rs
@@ -231,6 +231,34 @@ pub enum ViewerOnboardCameraConfig {
     },
 }
 
+impl ViewerOnboardCameraConfig {
+    fn signal_names(&self) -> Vec<&str> {
+        match self {
+            ViewerOnboardCameraConfig::PlanarXyHeading { x, y, heading, .. } => {
+                vec![x.as_str(), y.as_str(), heading.as_str()]
+            }
+            ViewerOnboardCameraConfig::QuaternionFlu {
+                px,
+                py,
+                pz,
+                q0,
+                q1,
+                q2,
+                q3,
+                ..
+            } => vec![
+                px.as_str(),
+                py.as_str(),
+                pz.as_str(),
+                q0.as_str(),
+                q1.as_str(),
+                q2.as_str(),
+                q3.as_str(),
+            ],
+        }
+    }
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct ViewerControlsConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -327,7 +355,34 @@ impl SimulationConfig {
                  and vehicle in a Modelica model, then point [model] at that top-level class."
             );
         }
+        self.validate_onboard_camera_signals()?;
         Ok(())
+    }
+
+    fn validate_onboard_camera_signals(&self) -> anyhow::Result<()> {
+        let Some(camera) = self
+            .viewer
+            .as_ref()
+            .and_then(|viewer| viewer.onboard_camera.as_ref())
+        else {
+            return Ok(());
+        };
+        let missing = camera
+            .signal_names()
+            .into_iter()
+            .filter(|name| {
+                self.signals
+                    .as_ref()
+                    .is_none_or(|signals| !signals.viewer.contains_key(*name))
+            })
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "[viewer.onboard_camera] references signal(s) not routed under [signals.viewer]: {}",
+            missing.join(", ")
+        );
     }
 
     /// True when configured for external coupling (all FB sections present).
@@ -464,6 +519,55 @@ port = 8091
         let cfg = toml::from_str::<SimulationConfig>(text).unwrap();
         assert_eq!(cfg.http_port(), 8090);
         assert_eq!(cfg.websocket_port(), 8091);
+    }
+
+    #[test]
+    fn validates_onboard_camera_viewer_signals() {
+        let text = r#"
+[sim]
+dt = 0.01
+
+[viewer.onboard_camera]
+mode = "planar_xy_heading"
+x = "x"
+y = "y"
+heading = "theta"
+
+[signals.viewer]
+x = "stepper:x"
+y = "stepper:y"
+theta = "stepper:theta"
+"#;
+        let cfg = toml::from_str::<SimulationConfig>(text).unwrap();
+        cfg.validate()
+            .expect("camera references are present in signals.viewer");
+    }
+
+    #[test]
+    fn rejects_onboard_camera_missing_viewer_signal() {
+        let text = r#"
+[sim]
+dt = 0.01
+
+[viewer.onboard_camera]
+mode = "planar_xy_heading"
+x = "x"
+y = "y_typo"
+heading = "theta"
+
+[signals.viewer]
+x = "stepper:x"
+y = "stepper:y"
+theta = "stepper:theta"
+"#;
+        let err = toml::from_str::<SimulationConfig>(text)
+            .unwrap()
+            .validate()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("y_typo") && err.to_string().contains("[signals.viewer]"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/rumoca-sim/src/runner/config.rs
+++ b/crates/rumoca-sim/src/runner/config.rs
@@ -196,6 +196,39 @@ pub struct ViewerConfig {
     pub show_armed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub controls: Option<ViewerControlsConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub onboard_camera: Option<ViewerOnboardCameraConfig>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum ViewerOnboardCameraConfig {
+    PlanarXyHeading {
+        x: String,
+        y: String,
+        heading: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mount: Option<[f64; 3]>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        forward: Option<[f64; 3]>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        up: Option<[f64; 3]>,
+    },
+    QuaternionFlu {
+        px: String,
+        py: String,
+        pz: String,
+        q0: String,
+        q1: String,
+        q2: String,
+        q3: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mount: Option<[f64; 3]>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        forward: Option<[f64; 3]>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        up: Option<[f64; 3]>,
+    },
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -354,6 +387,10 @@ mod tests {
         let viewer = cfg.viewer.as_ref().expect("[viewer]");
         assert_eq!(viewer.status_title.as_deref(), Some("Vehicle"));
         assert_eq!(viewer.show_armed, Some(false));
+        assert!(matches!(
+            viewer.onboard_camera,
+            Some(ViewerOnboardCameraConfig::PlanarXyHeading { .. })
+        ));
         let controls = viewer.controls.as_ref().expect("[viewer.controls]");
         assert!(
             controls

--- a/crates/rumoca-sim/src/runner/template.toml
+++ b/crates/rumoca-sim/src/runner/template.toml
@@ -201,3 +201,13 @@ on_signal         = "reset"
 reset_locals      = true
 rebuild_stepper   = true
 restart_external_interface = false
+
+# ── Viewer presentation ───────────────────────────────────────────────────
+# Optional onboard camera configuration for the C key. Referenced signal names
+# must be present in [signals.viewer].
+# [viewer.onboard_camera]
+# mode = "planar_xy_heading"
+# x = "x"
+# y = "y"
+# heading = "theta"
+# mount = [0.95, 0.18, 0.0]

--- a/crates/rumoca-viz-web/web/viewer.html
+++ b/crates/rumoca-viz-web/web/viewer.html
@@ -646,7 +646,7 @@ function vehicleThreeMatrix(state) {
   });
 }
 
-function vehicleThreeMatrixFromSignals(state, names) {
+function vehicleThreeMatrixFromSignals(state, names, target = new THREE.Matrix4()) {
   const px = state[names.px] ?? 0, py = state[names.py] ?? 0, pz = state[names.pz] ?? 0;
   const q0 = state[names.q0] ?? 1, q1 = state[names.q1] ?? 0;
   const q2 = state[names.q2] ?? 0, q3 = state[names.q3] ?? 0;
@@ -654,14 +654,13 @@ function vehicleThreeMatrixFromSignals(state, names) {
   const R11 = 1-2*(q2*q2+q3*q3), R12 = 2*(q1*q2-q0*q3), R13 = 2*(q1*q3+q0*q2);
   const R21 = 2*(q1*q2+q0*q3), R22 = 1-2*(q1*q1+q3*q3), R23 = 2*(q2*q3-q0*q1);
   const R31 = 2*(q1*q3-q0*q2), R32 = 2*(q2*q3+q0*q1), R33 = 1-2*(q1*q1+q2*q2);
-  const m = new THREE.Matrix4();
-  m.set(
+  target.set(
     R22,  -R23, -R21, -py,
    -R32,   R33,  R31,  pz,
    -R12,   R13,  R11,  px,
       0,     0,    0,   1
   );
-  return m;
+  return target;
 }
 
 function visualAttitudeFromMatrix(m) {
@@ -674,15 +673,64 @@ function visualAttitudeFromMatrix(m) {
   };
 }
 
+const ONBOARD_DEFAULT_MOUNT = new THREE.Vector3(0.95, 0.18, 0);
+const ONBOARD_DEFAULT_FORWARD = new THREE.Vector3(1, 0, 0);
+const ONBOARD_DEFAULT_UP = new THREE.Vector3(0, 1, 0);
+const ONBOARD_WORLD_UP_AXIS = new THREE.Vector3(0, 1, 0);
+const ONBOARD_DEFAULT_QUATERNION_SIGNALS = {
+  px: "px",
+  py: "py",
+  pz: "pz",
+  q0: "q0",
+  q1: "q1",
+  q2: "q2",
+  q3: "q3",
+};
+const onboardScratch = {
+  q: new THREE.Quaternion(),
+  matrix: new THREE.Matrix4(),
+  origin: new THREE.Vector3(),
+  mountWorld: new THREE.Vector3(),
+  forwardWorld: new THREE.Vector3(),
+  upWorld: new THREE.Vector3(),
+  lookTarget: new THREE.Vector3(),
+};
+
 function configuredVec3(value, fallback) {
-  if (!Array.isArray(value) || value.length !== 3) return fallback.clone();
+  const configured = fallback.clone();
+  if (!Array.isArray(value) || value.length !== 3) return configured;
   const numbers = value.map(Number);
-  if (!numbers.every(Number.isFinite)) return fallback.clone();
-  return new THREE.Vector3(numbers[0], numbers[1], numbers[2]);
+  if (!numbers.every(Number.isFinite)) return configured;
+  return configured.set(numbers[0], numbers[1], numbers[2]);
 }
 
+function normalizedConfiguredVec3(value, fallback) {
+  return configuredVec3(value, fallback).normalize();
+}
+
+function configuredOnboardCamera(rawConfig) {
+  if (!rawConfig) return undefined;
+  return {
+    ...rawConfig,
+    mount: configuredVec3(rawConfig.mount, ONBOARD_DEFAULT_MOUNT),
+    forward: normalizedConfiguredVec3(rawConfig.forward, ONBOARD_DEFAULT_FORWARD),
+    up: normalizedConfiguredVec3(rawConfig.up, ONBOARD_DEFAULT_UP),
+    signals: {
+      px: rawConfig.px ?? "px",
+      py: rawConfig.py ?? "py",
+      pz: rawConfig.pz ?? "pz",
+      q0: rawConfig.q0 ?? "q0",
+      q1: rawConfig.q1 ?? "q1",
+      q2: rawConfig.q2 ?? "q2",
+      q3: rawConfig.q3 ?? "q3",
+    },
+  };
+}
+
+const ONBOARD_CAMERA_CONFIG = configuredOnboardCamera(VIEWER_CONFIG?.onboard_camera);
+
 function applyOnboardCamera(state) {
-  const config = VIEWER_CONFIG?.onboard_camera;
+  const config = ONBOARD_CAMERA_CONFIG;
   if (config?.mode === "planar_xy_heading") {
     applyPlanarOnboardCamera(state, config);
     return;
@@ -696,39 +744,26 @@ function applyPlanarOnboardCamera(state, config) {
   const heading = Number(state[config.heading]);
   if (![x, y, heading].every(Number.isFinite)) return;
 
-  const mount = configuredVec3(config.mount, new THREE.Vector3(0.95, 0.18, 0));
-  const forward = configuredVec3(config.forward, new THREE.Vector3(1, 0, 0)).normalize();
-  const up = configuredVec3(config.up, new THREE.Vector3(0, 1, 0)).normalize();
-  const q = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), -heading);
-  const origin = new THREE.Vector3(x, 0, y);
-  const mountWorld = origin.clone().add(mount.applyQuaternion(q));
-  const forwardWorld = forward.applyQuaternion(q);
-  const upWorld = up.applyQuaternion(q);
+  const q = onboardScratch.q.setFromAxisAngle(ONBOARD_WORLD_UP_AXIS, -heading);
+  const origin = onboardScratch.origin.set(x, 0, y);
+  const mountWorld = onboardScratch.mountWorld.copy(config.mount).applyQuaternion(q).add(origin);
+  const forwardWorld = onboardScratch.forwardWorld.copy(config.forward).applyQuaternion(q);
+  const upWorld = onboardScratch.upWorld.copy(config.up).applyQuaternion(q);
 
   camera.position.copy(mountWorld);
   camera.up.copy(upWorld);
-  camera.lookAt(mountWorld.clone().add(forwardWorld));
+  camera.lookAt(onboardScratch.lookTarget.copy(mountWorld).add(forwardWorld));
 }
 
 function applyQuaternionOnboardCamera(state, config) {
-  const m = vehicleThreeMatrixFromSignals(state, {
-    px: config?.px ?? "px",
-    py: config?.py ?? "py",
-    pz: config?.pz ?? "pz",
-    q0: config?.q0 ?? "q0",
-    q1: config?.q1 ?? "q1",
-    q2: config?.q2 ?? "q2",
-    q3: config?.q3 ?? "q3",
-  });
-  const mountLocal = configuredVec3(config?.mount, new THREE.Vector3(0.95, 0.18, 0));
-  const forwardLocal = configuredVec3(config?.forward, new THREE.Vector3(1, 0, 0));
-  const upLocal = configuredVec3(config?.up, new THREE.Vector3(0, 1, 0));
-  const mount = mountLocal.applyMatrix4(m);
-  const forward = forwardLocal.transformDirection(m);
-  const up = upLocal.transformDirection(m);
+  const signals = config?.signals ?? ONBOARD_DEFAULT_QUATERNION_SIGNALS;
+  const m = vehicleThreeMatrixFromSignals(state, signals, onboardScratch.matrix);
+  const mount = onboardScratch.mountWorld.copy(config?.mount ?? ONBOARD_DEFAULT_MOUNT).applyMatrix4(m);
+  const forward = onboardScratch.forwardWorld.copy(config?.forward ?? ONBOARD_DEFAULT_FORWARD).transformDirection(m);
+  const up = onboardScratch.upWorld.copy(config?.up ?? ONBOARD_DEFAULT_UP).transformDirection(m);
   camera.position.copy(mount);
   camera.up.copy(up);
-  camera.lookAt(mount.clone().add(forward));
+  camera.lookAt(onboardScratch.lookTarget.copy(mount).add(forward));
 }
 
 function rollingRealtimeSpeed(wallMs, simTime) {

--- a/crates/rumoca-viz-web/web/viewer.html
+++ b/crates/rumoca-viz-web/web/viewer.html
@@ -635,8 +635,21 @@ function drawFlightHud(state, roll, pitch, speed) {
 }
 
 function vehicleThreeMatrix(state) {
-  const px = state.px ?? 0, py = state.py ?? 0, pz = state.pz ?? 0;
-  const q0 = state.q0 ?? 1, q1 = state.q1 ?? 0, q2 = state.q2 ?? 0, q3 = state.q3 ?? 0;
+  return vehicleThreeMatrixFromSignals(state, {
+    px: "px",
+    py: "py",
+    pz: "pz",
+    q0: "q0",
+    q1: "q1",
+    q2: "q2",
+    q3: "q3",
+  });
+}
+
+function vehicleThreeMatrixFromSignals(state, names) {
+  const px = state[names.px] ?? 0, py = state[names.py] ?? 0, pz = state[names.pz] ?? 0;
+  const q0 = state[names.q0] ?? 1, q1 = state[names.q1] ?? 0;
+  const q2 = state[names.q2] ?? 0, q3 = state[names.q3] ?? 0;
 
   const R11 = 1-2*(q2*q2+q3*q3), R12 = 2*(q1*q2-q0*q3), R13 = 2*(q1*q3+q0*q2);
   const R21 = 2*(q1*q2+q0*q3), R22 = 1-2*(q1*q1+q3*q3), R23 = 2*(q2*q3-q0*q1);
@@ -661,11 +674,58 @@ function visualAttitudeFromMatrix(m) {
   };
 }
 
+function configuredVec3(value, fallback) {
+  if (!Array.isArray(value) || value.length !== 3) return fallback.clone();
+  const numbers = value.map(Number);
+  if (!numbers.every(Number.isFinite)) return fallback.clone();
+  return new THREE.Vector3(numbers[0], numbers[1], numbers[2]);
+}
+
 function applyOnboardCamera(state) {
-  const m = vehicleThreeMatrix(state);
-  const mount = new THREE.Vector3(0.95, 0.18, 0).applyMatrix4(m);
-  const forward = new THREE.Vector3(1, 0, 0).transformDirection(m);
-  const up = new THREE.Vector3(0, 1, 0).transformDirection(m);
+  const config = VIEWER_CONFIG?.onboard_camera;
+  if (config?.mode === "planar_xy_heading") {
+    applyPlanarOnboardCamera(state, config);
+    return;
+  }
+  applyQuaternionOnboardCamera(state, config);
+}
+
+function applyPlanarOnboardCamera(state, config) {
+  const x = Number(state[config.x]);
+  const y = Number(state[config.y]);
+  const heading = Number(state[config.heading]);
+  if (![x, y, heading].every(Number.isFinite)) return;
+
+  const mount = configuredVec3(config.mount, new THREE.Vector3(0.95, 0.18, 0));
+  const forward = configuredVec3(config.forward, new THREE.Vector3(1, 0, 0)).normalize();
+  const up = configuredVec3(config.up, new THREE.Vector3(0, 1, 0)).normalize();
+  const q = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), -heading);
+  const origin = new THREE.Vector3(x, 0, y);
+  const mountWorld = origin.clone().add(mount.applyQuaternion(q));
+  const forwardWorld = forward.applyQuaternion(q);
+  const upWorld = up.applyQuaternion(q);
+
+  camera.position.copy(mountWorld);
+  camera.up.copy(upWorld);
+  camera.lookAt(mountWorld.clone().add(forwardWorld));
+}
+
+function applyQuaternionOnboardCamera(state, config) {
+  const m = vehicleThreeMatrixFromSignals(state, {
+    px: config?.px ?? "px",
+    py: config?.py ?? "py",
+    pz: config?.pz ?? "pz",
+    q0: config?.q0 ?? "q0",
+    q1: config?.q1 ?? "q1",
+    q2: config?.q2 ?? "q2",
+    q3: config?.q3 ?? "q3",
+  });
+  const mountLocal = configuredVec3(config?.mount, new THREE.Vector3(0.95, 0.18, 0));
+  const forwardLocal = configuredVec3(config?.forward, new THREE.Vector3(1, 0, 0));
+  const upLocal = configuredVec3(config?.up, new THREE.Vector3(0, 1, 0));
+  const mount = mountLocal.applyMatrix4(m);
+  const forward = forwardLocal.transformDirection(m);
+  const up = upLocal.transformDirection(m);
   camera.position.copy(mount);
   camera.up.copy(up);
   camera.lookAt(mount.clone().add(forward));

--- a/examples/interactive/rover/rum.toml
+++ b/examples/interactive/rover/rum.toml
@@ -103,6 +103,13 @@ mode = "external_web"
 show_armed = false
 status_title = "Vehicle"
 
+[viewer.onboard_camera]
+mode = "planar_xy_heading"
+x = "x"
+y = "y"
+heading = "theta"
+mount = [0.95, 0.24, 0.0]
+
 [[viewer.controls.keyboard]]
 keys = "Up / Down"
 action = "Throttle"

--- a/spec/SPEC_0018_TOOL_CONFIG.md
+++ b/spec/SPEC_0018_TOOL_CONFIG.md
@@ -18,10 +18,9 @@ Tools need configurable behavior:
 
 Configuration and behavior knobs MUST reach the code through a discoverable,
 self-documenting channel. The `RUMOCA_*` environment-variable surface is
-**literal zero** and is enforced by an architecture test that scans **all
-first-party source — Rust and editor/JS alike** (`*.rs`, `*.ts`, `*.mjs`,
-`*.cjs`, `*.js`); any `RUMOCA_*` env-var use (a quoted `"RUMOCA_…"` literal or a
-`…env.RUMOCA_…` access) fails the build.
+**literal zero** across first-party Rust and editor/JS source (`*.rs`, `*.ts`,
+`*.mjs`, `*.cjs`, `*.js`); quoted `"RUMOCA_…"` literals or `…env.RUMOCA_…`
+accesses fail the build.
 
 | Need | Required channel | Why |
 |---|---|---|
@@ -36,22 +35,17 @@ first-party source — Rust and editor/JS alike** (`*.rs`, `*.ts`, `*.mjs`,
   configuration or behavior — in Rust **or** in editor/JS code. Pick a channel
   from the table above.
 - A child process that genuinely cannot accept argv gets a fixed-path file, not
-  an environment variable. Examples: `cargo xtask verify msl-parity` serializes
-  its flags to `target/msl/parity-config.json` for the `rumoca-test-msl` libtest
-  harness; the VS Code smoke runners write their parameters into the launched
-  `.code-workspace` settings (`rumoca.benchmark.*`), which the extension-host
-  test suites read via `getConfiguration` and the extension forwards to
-  `rumoca-lsp` as CLI flags.
+  an environment variable. Examples: `cargo xtask verify msl-parity` writes
+  `target/msl/parity-config.json` for libtest; VS Code smoke runners write
+  `.code-workspace` settings that the extension forwards to `rumoca-lsp` flags.
 - Standard, non-Rumoca environment variables a tool merely passes through
   (`MODELICAPATH`, `GITHUB_ACTIONS`, `ELECTRON_DISABLE_SANDBOX`, …) are not
   configuration knobs and are out of scope for this rule.
 
 **Enforcement:** `crates/rumoca/tests/architecture_hardening/env_var_registry.rs`
-(`test_rumoca_env_vars_are_registered`) scans every source file under the
-workspace (excluding build output, dependencies, and vendored trees). Adding a
-`RUMOCA_*` name to its `REGISTERED_ENV_VARS` allowlist is a deliberate,
-reviewable policy exception with written rationale — not the default escape
-hatch.
+(`test_rumoca_env_vars_are_registered`) scans workspace source files, excluding
+build output, dependencies, and vendored trees. Adding a `RUMOCA_*` name to its
+allowlist is a deliberate, reviewable policy exception with written rationale.
 
 ### Model / Simulation / Visualization Configuration
 
@@ -137,8 +131,7 @@ Editor run controls MUST operate on `rum.toml` scenario files, not on Modelica
 source files. A play/run action executes the scenario's declared task. A
 settings action edits the same scenario. Separate editor toolbar actions for
 simulation versus template generation are intentionally avoided; the task owns
-that
-choice.
+that choice.
 
 Simulation scenarios choose their presentation separately from solver pacing:
 
@@ -159,18 +152,14 @@ Simulation scenarios choose their presentation separately from solver pacing:
   describe control help rows with `keys` and `action` strings. These fields are
   presentation metadata only; actual signal routing stays under `[input]`,
   `[locals]`, `[derived]`, and `[signals]`.
-- `[viewer.onboard_camera]` configures the live viewer's onboard camera pose.
-  Supported modes are `planar_xy_heading` for ground vehicles exposing planar
-  `x`/`y`/heading signals and `quaternion_flu` for 6-DOF vehicles exposing
-  position plus scalar-first quaternion signals. The block names viewer JSON
-  signals, so each referenced signal MUST also be routed under
-  `[signals.viewer]`. Optional `mount`, `forward`, and `up` arrays are
-  vehicle-local 3-vectors. Viewer world space is the Three.js basis: world
-  `Y` is up, the ground plane is world `X/Z`, and planar `x`/`y` map to world
-  `X`/`Z` respectively. For `planar_xy_heading`, zero heading uses vehicle
-  local `+X` as forward and `+Y` as up; positive heading is a rotation about
-  world `+Y`, with the viewer applying `-heading` to align the configured
-  vehicle-local `mount`, `forward`, and `up` vectors into world space.
+- `[viewer.onboard_camera]` configures the live viewer's onboard camera pose:
+  `planar_xy_heading` for planar `x`/`y`/heading signals or `quaternion_flu`
+  for position plus scalar-first quaternion signals. Referenced viewer JSON
+  signals MUST be routed under `[signals.viewer]`; optional `mount`, `forward`,
+  and `up` arrays are vehicle-local 3-vectors. Viewer world space uses Three.js
+  coordinates (`Y` up, ground `X/Z`, planar `x`/`y` to world `X`/`Z`). For
+  `planar_xy_heading`, zero heading uses local `+X` forward and `+Y` up;
+  positive heading rotates about world `+Y`, and the viewer applies `-heading`.
 - If `[viewer].mode` is omitted, editors infer `external_web` only when the
   scenario contains an HTTP transport, explicit input routing, signals, locals,
   derived signals, reset behavior, or external-interface coupling. Otherwise

--- a/spec/SPEC_0018_TOOL_CONFIG.md
+++ b/spec/SPEC_0018_TOOL_CONFIG.md
@@ -165,7 +165,12 @@ Simulation scenarios choose their presentation separately from solver pacing:
   position plus scalar-first quaternion signals. The block names viewer JSON
   signals, so each referenced signal MUST also be routed under
   `[signals.viewer]`. Optional `mount`, `forward`, and `up` arrays are
-  vehicle-local 3-vectors.
+  vehicle-local 3-vectors. Viewer world space is the Three.js basis: world
+  `Y` is up, the ground plane is world `X/Z`, and planar `x`/`y` map to world
+  `X`/`Z` respectively. For `planar_xy_heading`, zero heading uses vehicle
+  local `+X` as forward and `+Y` as up; positive heading is a rotation about
+  world `+Y`, with the viewer applying `-heading` to align the configured
+  vehicle-local `mount`, `forward`, and `up` vectors into world space.
 - If `[viewer].mode` is omitted, editors infer `external_web` only when the
   scenario contains an HTTP transport, explicit input routing, signals, locals,
   derived signals, reset behavior, or external-interface coupling. Otherwise

--- a/spec/SPEC_0018_TOOL_CONFIG.md
+++ b/spec/SPEC_0018_TOOL_CONFIG.md
@@ -159,6 +159,13 @@ Simulation scenarios choose their presentation separately from solver pacing:
   describe control help rows with `keys` and `action` strings. These fields are
   presentation metadata only; actual signal routing stays under `[input]`,
   `[locals]`, `[derived]`, and `[signals]`.
+- `[viewer.onboard_camera]` configures the live viewer's onboard camera pose.
+  Supported modes are `planar_xy_heading` for ground vehicles exposing planar
+  `x`/`y`/heading signals and `quaternion_flu` for 6-DOF vehicles exposing
+  position plus scalar-first quaternion signals. The block names viewer JSON
+  signals, so each referenced signal MUST also be routed under
+  `[signals.viewer]`. Optional `mount`, `forward`, and `up` arrays are
+  vehicle-local 3-vectors.
 - If `[viewer].mode` is omitted, editors infer `external_web` only when the
   scenario contains an HTTP transport, explicit input routing, signals, locals,
   derived signals, reset behavior, or external-interface coupling. Otherwise


### PR DESCRIPTION
# Rumoca PR Review Template

<!--
Mirrors SPEC_0025. Section names here must match SPEC_0025 §"PR Template
Alignment". Update both files together if you change either one.
-->

## Summary

Fixed the onboard camera, now is onboard the rover

## Testing

Ran the simulation and did some turning

## Reviewer Checklist

- [ ] Relevant active specs were checked.
- [ ] MLS-sensitive changes cite the right MLS section.
- [ ] Crate boundaries and phase ownership preserved (SPEC_0029).
- [ ] Tests prove behavior or explain the remaining gap.
- [ ] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [ ] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [ ] Size-budget section completed.
- [ ] Positive net diff has explicit compression justification.
- [ ] New APIs are required and minimal.
- [ ] Old/new parallel paths removed unless explicitly migrating.
- [ ] No `#[allow(clippy::...)]` added outside generated code.
- [ ] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [ ] External material (if any) attributed and Apache-2.0 compatible.
