### PR TITLE
Publish MSL PR stats from workflow artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,46 +659,6 @@ jobs:
             target/msl/modelicatest-results/msl_quality_current.json
           if-no-files-found: warn
 
-      - name: Publish MSL PR summary comment
-        if: github.event_name == 'pull_request' && always() && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            const path = 'target/msl/results/msl_pr_comment.md';
-            if (!fs.existsSync(path)) {
-              core.info(`Skipping MSL PR summary comment; ${path} does not exist.`);
-              return;
-            }
-            const marker = '<!-- rumoca-msl-quality-summary -->';
-            const body = fs.readFileSync(path, 'utf8');
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const previous = comments.find(comment =>
-              comment.user?.type === 'Bot' && comment.body?.includes(marker)
-            );
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: previous.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }
-
   # ============================================================================
   # Documentation
   # ============================================================================

--- a/.github/workflows/msl-pr-comment.yml
+++ b/.github/workflows/msl-pr-comment.yml
@@ -1,0 +1,124 @@
+name: Publish MSL PR Comment
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  publish:
+    name: Publish MSL PR Comment
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download MSL compatibility artifact
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const run_id = context.payload.workflow_run.id;
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner,
+              repo,
+              run_id,
+              per_page: 100,
+            });
+            const artifact = artifacts.find(item =>
+              item.name === 'msl-compatibility-report' && !item.expired
+            );
+            if (!artifact) {
+              core.info(`No msl-compatibility-report artifact found for workflow run ${run_id}.`);
+              return;
+            }
+            const zip = await github.rest.actions.downloadArtifact({
+              owner,
+              repo,
+              artifact_id: artifact.id,
+              archive_format: 'zip',
+            });
+            fs.mkdirSync('target/msl-pr-comment', { recursive: true });
+            fs.writeFileSync(
+              'target/msl-pr-comment/msl-compatibility-report.zip',
+              Buffer.from(zip.data)
+            );
+
+      - name: Extract MSL compatibility artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f target/msl-pr-comment/msl-compatibility-report.zip ]]; then
+            echo "No MSL compatibility artifact downloaded; skipping."
+            exit 0
+          fi
+          unzip -q target/msl-pr-comment/msl-compatibility-report.zip -d target/msl-pr-comment
+          find target/msl-pr-comment -maxdepth 3 -type f | sort
+
+      - name: Publish MSL PR summary comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const candidates = [
+              'target/msl-pr-comment/results/msl_pr_comment.md',
+              'target/msl-pr-comment/msl_pr_comment.md',
+              'target/msl-pr-comment/target/msl/results/msl_pr_comment.md',
+            ];
+            const path = candidates.find(candidate => fs.existsSync(candidate));
+            if (!path) {
+              core.info('Skipping MSL PR summary comment; msl_pr_comment.md was not in the artifact.');
+              return;
+            }
+
+            const marker = '<!-- rumoca-msl-quality-summary -->';
+            const body = fs.readFileSync(path, 'utf8');
+            if (!body.includes(marker)) {
+              core.setFailed(`Refusing to publish ${path}: missing ${marker}`);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            let prs = context.payload.workflow_run.pull_requests ?? [];
+            if (prs.length === 0) {
+              const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: context.payload.workflow_run.head_sha,
+              });
+              prs = associated.data;
+            }
+            if (prs.length === 0) {
+              core.info(`No pull request found for workflow run ${context.payload.workflow_run.id}.`);
+              return;
+            }
+            const issue_number = prs[0].number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previous = comments.find(comment =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

- Moves MSL PR summary publication out of the untrusted `pull_request` CI job and into a trusted `workflow_run` publisher.
- Allows PRs from forks to get the same MSL stats comment as same-repository PRs, using the uploaded `msl-compatibility-report` artifact.
- The publisher does not check out or execute PR code; it only downloads the CI artifact, validates the `<!-- rumoca-msl-quality-summary -->` marker, and creates or updates the PR comment.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0025 (PR/CI workflow expectations)
- Relevant MLS section(s), if semantics changed: n/a
- Crate/phase owner: n/a, GitHub Actions CI config only

## Risk and Design Notes

- Main correctness risk: artifact path layout can vary; the publisher checks the expected extracted paths and skips cleanly if the generated comment is absent.
- Main maintenance risk: workflow publication now happens after the CI workflow completes rather than inside the MSL job.
- Why the change belongs in these crate(s): n/a; scoped to GitHub Actions workflows.
- Any new abstraction, public API, or migration path: none.

## Testing

- Key command(s) run: `git diff --check`; `cargo fmt --check`
- Behavior or regression covered: local syntax/format sanity only; this is GitHub Actions event wiring.
- Commands NOT run and why: `actionlint` is not installed locally; the new `workflow_run` path can only be exercised by GitHub Actions after merge.
- For compiler/simulator changes: n/a, no compiler/simulator behavior changed.

## Code Size Budget (required)

- production_lines_added: 0
- production_lines_deleted: 0
- test_lines_added: 0
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 2
- net_added_lines: 84

- Why this net growth is required: publishing from fork PRs needs a separate trusted workflow because fork `pull_request` jobs receive read-only tokens.
- Which code was removed/merged as part of the first compression pass: removed the same-repo-only inline publisher from `ci.yml`.
- Follow-up cleanup ticket/commit for remaining growth (if any): none planned.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [ ] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.