### PR TITLE
Fix ToDae scalar-path balance for indexed record fields

### DIFF
--- a/crates/rumoca-core/src/ir_primitives.rs
+++ b/crates/rumoca-core/src/ir_primitives.rs
@@ -1513,10 +1513,80 @@ struct VarRefCollector<'a> {
     vars: &'a mut IndexSet<VarName>,
 }
 
+fn render_collected_subscript_suffix(subscripts: &[Subscript]) -> Option<String> {
+    let mut out = String::new();
+    for subscript in subscripts {
+        match subscript {
+            Subscript::Index { value, .. } => out.push_str(&format!("[{value}]")),
+            Subscript::Expr { expr, .. } => {
+                let Expression::Literal {
+                    value: Literal::Integer(value),
+                    ..
+                } = expr.as_ref()
+                else {
+                    return None;
+                };
+                out.push_str(&format!("[{value}]"));
+            }
+            Subscript::Colon { .. } => out.push_str("[:]"),
+        }
+    }
+    Some(out)
+}
+
+fn collect_structured_var_path(expr: &Expression) -> Option<VarName> {
+    match expr {
+        Expression::VarRef {
+            name, subscripts, ..
+        } => {
+            let suffix = render_collected_subscript_suffix(subscripts)?;
+            Some(VarName::new(format!("{}{}", name.as_str(), suffix)))
+        }
+        Expression::Index {
+            base, subscripts, ..
+        } => {
+            let base_name = collect_structured_var_path(base)?;
+            let suffix = render_collected_subscript_suffix(subscripts)?;
+            Some(VarName::new(format!("{}{}", base_name.as_str(), suffix)))
+        }
+        Expression::FieldAccess { base, field, .. } => {
+            let base_name = collect_structured_var_path(base)?;
+            Some(VarName::new(format!("{}.{}", base_name.as_str(), field)))
+        }
+        _ => None,
+    }
+}
+
 impl crate::ExpressionVisitor for VarRefCollector<'_> {
     fn visit_var_ref(&mut self, name: &Reference, subscripts: &[Subscript]) {
-        self.vars.insert(name.var_name().clone());
+        if let Some(suffix) = render_collected_subscript_suffix(subscripts) {
+            self.vars
+                .insert(VarName::new(format!("{}{}", name.as_str(), suffix)));
+        }
         self.walk_var_ref(name, subscripts);
+    }
+
+    fn visit_index(&mut self, base: &Expression, subscripts: &[Subscript]) {
+        if let Some(base_name) = collect_structured_var_path(base)
+            && let Some(suffix) = render_collected_subscript_suffix(subscripts)
+        {
+            self.vars
+                .insert(VarName::new(format!("{}{}", base_name.as_str(), suffix)));
+            for subscript in subscripts {
+                self.visit_subscript(subscript);
+            }
+            return;
+        }
+        for subscript in subscripts {
+            self.visit_subscript(subscript);
+        }
+    }
+
+    fn visit_field_access(&mut self, base: &Expression, field: &str) {
+        if let Some(base_name) = collect_structured_var_path(base) {
+            self.vars
+                .insert(VarName::new(format!("{}.{}", base_name.as_str(), field)));
+        }
     }
 }
 

--- a/crates/rumoca-core/src/ir_primitives/tests.rs
+++ b/crates/rumoca-core/src/ir_primitives/tests.rs
@@ -261,6 +261,75 @@ fn var_name_interner_deduplicates_repeated_workspace_reopens() {
 }
 
 #[test]
+fn collect_var_refs_preserves_indexed_field_access_path() {
+    let expr = Expression::FieldAccess {
+        base: Box::new(Expression::FieldAccess {
+            base: Box::new(Expression::Index {
+                base: Box::new(Expression::VarRef {
+                    name: VarName::new("converter").into(),
+                    subscripts: vec![],
+                    span: Span::DUMMY,
+                }),
+                subscripts: vec![Subscript::generated_index(1, Span::DUMMY)],
+                span: Span::DUMMY,
+            }),
+            field: "port_p".to_string(),
+            span: Span::DUMMY,
+        }),
+        field: "Phi".to_string(),
+        span: Span::DUMMY,
+    };
+
+    let mut refs = Vec::new();
+    expr.collect_var_refs(&mut refs);
+
+    assert_eq!(
+        refs,
+        vec![VarName::new("converter[1].port_p.Phi")],
+        "indexed field access should not collapse to the unsubscripted base array name"
+    );
+}
+
+#[test]
+fn collect_var_refs_rejects_unrenderable_indexed_field_access_base_guess() {
+    let expr = Expression::FieldAccess {
+        base: Box::new(Expression::Index {
+            base: Box::new(Expression::VarRef {
+                name: VarName::new("converter").into(),
+                subscripts: vec![],
+                span: Span::DUMMY,
+            }),
+            subscripts: vec![Subscript::Expr {
+                expr: Box::new(Expression::Binary {
+                    op: OpBinary::Add,
+                    lhs: Box::new(Expression::Literal {
+                        value: Literal::Integer(1),
+                        span: Span::DUMMY,
+                    }),
+                    rhs: Box::new(Expression::Literal {
+                        value: Literal::Integer(1),
+                        span: Span::DUMMY,
+                    }),
+                    span: Span::DUMMY,
+                }),
+                span: Span::DUMMY,
+            }],
+            span: Span::DUMMY,
+        }),
+        field: "Phi".to_string(),
+        span: Span::DUMMY,
+    };
+
+    let mut refs = Vec::new();
+    expr.collect_var_refs(&mut refs);
+
+    assert!(
+        refs.is_empty(),
+        "when the indexed field path cannot be reconstructed safely, collect_var_refs should not fall back to the whole base array"
+    );
+}
+
+#[test]
 fn var_name_interner_retains_unique_names_for_process_lifetime() {
     let sequence = INTERNER_STRESS_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     let prefix = format!("__rumoca_interner_lifecycle_{sequence}_");

--- a/crates/rumoca-phase-dae/src/balance.rs
+++ b/crates/rumoca-phase-dae/src/balance.rs
@@ -905,6 +905,12 @@ fn equation_references_input(
         .any(|name| name_matches_set(&name, input_names))
 }
 fn name_matches_set(name: &rumoca_core::VarName, names: &HashSet<rumoca_core::VarName>) -> bool {
+    fn has_descendant_prefix(candidate: &rumoca_core::VarName, prefix: &str) -> bool {
+        let dot_prefix = format!("{prefix}.");
+        let bracket_prefix = format!("{prefix}[");
+        candidate.as_str().starts_with(&dot_prefix) || candidate.as_str().starts_with(&bracket_prefix)
+    }
+
     if names.contains(name) {
         return true;
     }
@@ -915,18 +921,16 @@ fn name_matches_set(name: &rumoca_core::VarName, names: &HashSet<rumoca_core::Va
         if names.contains(&base) {
             return true;
         }
-        let base_prefix = format!("{base_name}.");
         if names
             .iter()
-            .any(|candidate| candidate.as_str().starts_with(&base_prefix))
+            .any(|candidate| has_descendant_prefix(candidate, &base_name))
         {
             return true;
         }
     }
-    let prefix = format!("{}.", name.as_str());
     names
         .iter()
-        .any(|candidate| candidate.as_str().starts_with(&prefix))
+        .any(|candidate| has_descendant_prefix(candidate, name.as_str()))
 }
 
 pub(crate) fn is_connection_origin(origin: &str) -> bool {
@@ -1404,6 +1408,42 @@ mod tests {
             balance(&dae),
             0,
             "the connection still supplies the second equation for coupled unknowns"
+        );
+    }
+
+    #[test]
+    fn balance_counts_array_prefix_equation_against_scalarized_descendants() {
+        let mut dae = dae::Dae::default();
+        for suffix in ["[1].re", "[1].im", "[2].re", "[2].im", "[3].re", "[3].im"] {
+            let name = format!("voltageSource.v{suffix}");
+            dae.variables.algebraics.insert(
+                rumoca_core::VarName::new(&name),
+                dae::Variable {
+                    name: rumoca_core::VarName::new(&name),
+                    ..Default::default()
+                },
+            );
+        }
+        dae.continuous.equations.push(dae::Equation {
+            lhs: None,
+            rhs: rumoca_core::Expression::Binary {
+                op: rumoca_core::OpBinary::Sub,
+                lhs: Box::new(var_ref("voltageSource.v")),
+                rhs: Box::new(rumoca_core::Expression::Literal {
+                    value: rumoca_core::Literal::Integer(0),
+                    span: rumoca_core::Span::DUMMY,
+                }),
+                span: rumoca_core::Span::DUMMY,
+            },
+            span: Span::DUMMY,
+            origin: "equation from voltageSource".to_string(),
+            scalar_count: 6,
+        });
+
+        assert_eq!(
+            balance(&dae),
+            0,
+            "array prefix equations like voltageSource.v must count against scalarized descendants voltageSource.v[i].re/im"
         );
     }
 }

--- a/crates/rumoca-phase-dae/src/scalar_inference/inference_and_bindings.rs
+++ b/crates/rumoca-phase-dae/src/scalar_inference/inference_and_bindings.rs
@@ -421,7 +421,7 @@ fn indexed_lhs_scalar_size(
     ))
 }
 
-fn render_subscript_suffix(subscripts: &[Subscript]) -> Option<String> {
+pub(crate) fn render_subscript_suffix(subscripts: &[Subscript]) -> Option<String> {
     let mut out = String::new();
     for subscript in subscripts {
         match subscript {
@@ -442,6 +442,29 @@ fn render_subscript_suffix(subscripts: &[Subscript]) -> Option<String> {
     Some(out)
 }
 
+pub(crate) fn extract_var_path(expr: &Expression) -> Option<VarName> {
+    match expr {
+        Expression::VarRef {
+            name, subscripts, ..
+        } => {
+            let suffix = render_subscript_suffix(subscripts)?;
+            Some(VarName::new(format!("{}{}", name.as_str(), suffix)))
+        }
+        Expression::Index {
+            base, subscripts, ..
+        } => {
+            let base_name = extract_var_path(base)?;
+            let suffix = render_subscript_suffix(subscripts)?;
+            Some(VarName::new(format!("{}{}", base_name.as_str(), suffix)))
+        }
+        Expression::FieldAccess { base, field, .. } => {
+            let base_name = extract_var_path(base)?;
+            Some(VarName::new(format!("{}.{}", base_name.as_str(), field)))
+        }
+        _ => None,
+    }
+}
+
 /// Extract a variable name from an LHS expression.
 ///
 /// Handles:
@@ -451,48 +474,19 @@ fn render_subscript_suffix(subscripts: &[Subscript]) -> Option<String> {
 /// - Unary minus: `-y` (common in Modelica equations)
 pub(crate) fn extract_var_from_lhs(lhs: &Expression) -> Option<VarName> {
     match lhs {
-        // Direct variable reference without subscripts
-        Expression::VarRef {
-            name, subscripts, ..
-        } if subscripts.is_empty() => Some(name.var_name().clone()),
         // der(x) - extract the variable from inside the derivative
         Expression::BuiltinCall { function, args, .. }
             if matches!(function, rumoca_core::BuiltinFunction::Der) && args.len() == 1 =>
         {
-            if let Expression::VarRef {
-                name, subscripts, ..
-            } = &args[0]
-                && subscripts.is_empty()
-            {
-                return Some(name.var_name().clone());
-            }
-            None
+            extract_var_path(&args[0])
         }
         // Array containing a single variable reference: [y]
         // This pattern appears in equations like `[y] = [[u1], [u2], ...]`
-        Expression::Array { elements, .. } if elements.len() == 1 => {
-            if let Expression::VarRef {
-                name, subscripts, ..
-            } = &elements[0]
-                && subscripts.is_empty()
-            {
-                return Some(name.var_name().clone());
-            }
-            None
-        }
+        Expression::Array { elements, .. } if elements.len() == 1 => extract_var_path(&elements[0]),
         // Unary minus wrapping a variable reference: -y
         // This pattern appears in equations like `-spacePhasor.i_ = TransformationMatrix * i`
-        Expression::Unary { rhs, .. } => {
-            if let Expression::VarRef {
-                name, subscripts, ..
-            } = rhs.as_ref()
-                && subscripts.is_empty()
-            {
-                return Some(name.var_name().clone());
-            }
-            None
-        }
-        _ => None,
+        Expression::Unary { rhs, .. } => extract_var_path(rhs),
+        _ => extract_var_path(lhs),
     }
 }
 

--- a/crates/rumoca-phase-dae/src/scalar_inference/parts.rs
+++ b/crates/rumoca-phase-dae/src/scalar_inference/parts.rs
@@ -138,6 +138,38 @@ impl rumoca_core::ExpressionVisitor for VarRefCollectionVisitor<'_> {
         self.walk_var_ref(name, subscripts);
     }
 
+    fn visit_index(&mut self, base: &Expression, subscripts: &[Subscript]) {
+        if let Some(base_name) = extract_var_path(base)
+            && let Some(suffix) = render_subscript_suffix(subscripts)
+        {
+            self.vars.push(CollectedVarRef {
+                name: VarName::new(format!("{}{}", base_name.as_str(), suffix)),
+                subscripts: vec![],
+            });
+            for subscript in subscripts {
+                self.visit_subscript(subscript);
+            }
+            return;
+        }
+
+        // If we cannot preserve the indexed path, do not silently collapse
+        // back to the base array path; that inflates one element to the full array.
+        for subscript in subscripts {
+            self.visit_subscript(subscript);
+        }
+    }
+
+    fn visit_field_access(&mut self, base: &Expression, field: &str) {
+        if let Some(base_name) = extract_var_path(base) {
+            self.vars.push(CollectedVarRef {
+                name: VarName::new(format!("{}.{}", base_name.as_str(), field)),
+                subscripts: vec![],
+            });
+        }
+        // If the base path is not recoverable, stay strict and avoid collecting
+        // only the coarse base array name from a nested indexed field access.
+    }
+
     fn visit_builtin_call(&mut self, function: &BuiltinFunction, args: &[Expression]) {
         if is_reduction_builtin(function) {
             // Reduction output is scalar regardless of input size.

--- a/crates/rumoca-phase-dae/src/tests/root/tests_scalar_shape.rs
+++ b/crates/rumoca-phase-dae/src/tests/root/tests_scalar_shape.rs
@@ -72,3 +72,158 @@ fn test_classify_equations_prefers_lhs_scalar_shape_over_flat_scalar_count() {
         "scalar LHS should force a single scalar equation even when flat carried array-sized scalar_count"
     );
 }
+
+fn indexed_field_access(base: &str, index: i64, fields: &[&str]) -> rumoca_core::Expression {
+    let mut expr = rumoca_core::Expression::Index {
+        base: Box::new(make_var_ref(base)),
+        subscripts: vec![rumoca_core::Subscript::generated_index(
+            index,
+            rumoca_core::Span::DUMMY,
+        )],
+        span: rumoca_core::Span::DUMMY,
+    };
+    for field in fields {
+        expr = rumoca_core::Expression::FieldAccess {
+            base: Box::new(expr),
+            field: (*field).to_string(),
+            span: rumoca_core::Span::DUMMY,
+        };
+    }
+    expr
+}
+
+fn arithmetic_indexed_field_access(base: &str, fields: &[&str]) -> rumoca_core::Expression {
+    let mut expr = rumoca_core::Expression::Index {
+        base: Box::new(make_var_ref(base)),
+        subscripts: vec![rumoca_core::Subscript::Expr {
+            expr: Box::new(rumoca_core::Expression::Binary {
+                op: rumoca_core::OpBinary::Sub,
+                lhs: Box::new(rumoca_core::Expression::Binary {
+                    op: rumoca_core::OpBinary::Mul,
+                    lhs: Box::new(rumoca_core::Expression::Literal {
+                        value: rumoca_core::Literal::Integer(2),
+                        span: rumoca_core::Span::DUMMY,
+                    }),
+                    rhs: Box::new(rumoca_core::Expression::Literal {
+                        value: rumoca_core::Literal::Integer(1),
+                        span: rumoca_core::Span::DUMMY,
+                    }),
+                    span: rumoca_core::Span::DUMMY,
+                }),
+                rhs: Box::new(rumoca_core::Expression::Literal {
+                    value: rumoca_core::Literal::Integer(1),
+                    span: rumoca_core::Span::DUMMY,
+                }),
+                span: rumoca_core::Span::DUMMY,
+            }),
+            span: rumoca_core::Span::DUMMY,
+        }],
+        span: rumoca_core::Span::DUMMY,
+    };
+    for field in fields {
+        expr = rumoca_core::Expression::FieldAccess {
+            base: Box::new(expr),
+            field: (*field).to_string(),
+            span: rumoca_core::Span::DUMMY,
+        };
+    }
+    expr
+}
+
+fn add_complex_record_prefix(flat: &mut Model, prefix: &str) {
+    for suffix in [".re", ".im"] {
+        flat.add_variable(
+            VarName::new(format!("{prefix}{suffix}")),
+            flat::Variable {
+                name: VarName::new(format!("{prefix}{suffix}")),
+                is_primitive: true,
+                ..Default::default()
+            },
+        );
+    }
+}
+
+#[test]
+fn test_extract_lhs_var_size_preserves_indexed_record_field_path() {
+    let mut flat = Model::new();
+    for phase in 1..=3 {
+        add_complex_record_prefix(
+            &mut flat,
+            &format!(
+                "converter_m.singlePhaseElectroMagneticConverter[{phase}].port_p.Phi"
+            ),
+        );
+    }
+
+    let lhs = indexed_field_access(
+        "converter_m.singlePhaseElectroMagneticConverter",
+        1,
+        &["port_p", "Phi"],
+    );
+    let residual = rumoca_core::Expression::Binary {
+        op: rumoca_core::OpBinary::Sub,
+        lhs: Box::new(lhs),
+        rhs: Box::new(make_var_ref("rhs")),
+        span: rumoca_core::Span::DUMMY,
+    };
+
+    let prefix_counts = build_prefix_counts(&flat);
+    let scalar_count = extract_lhs_var_size(&residual, &flat, &prefix_counts);
+
+    assert_eq!(
+        scalar_count,
+        Some(2),
+        "indexed Complex field should size to one element's re/im pair, not the full array"
+    );
+}
+
+#[test]
+fn test_infer_scalar_count_from_varrefs_preserves_indexed_record_field_path() {
+    let mut flat = Model::new();
+    for phase in 1..=3 {
+        add_complex_record_prefix(
+            &mut flat,
+            &format!(
+                "converter_m.singlePhaseElectroMagneticConverter[{phase}].port_p.Phi"
+            ),
+        );
+    }
+
+    let expr = indexed_field_access(
+        "converter_m.singlePhaseElectroMagneticConverter",
+        1,
+        &["port_p", "Phi"],
+    );
+    let prefix_counts = build_prefix_counts(&flat);
+
+    assert_eq!(
+        infer_scalar_count_from_varrefs(&expr, &flat, &prefix_counts),
+        Some(2),
+        "var-ref fallback should keep the element index and infer one Complex field"
+    );
+}
+
+#[test]
+fn test_infer_scalar_count_from_varrefs_rejects_unrenderable_indexed_field_guess() {
+    let mut flat = Model::new();
+    for phase in 1..=3 {
+        add_complex_record_prefix(
+            &mut flat,
+            &format!(
+                "converter_m.singlePhaseElectroMagneticConverter[{phase}].port_p.Phi"
+            ),
+        );
+    }
+
+    let expr = arithmetic_indexed_field_access(
+        "converter_m.singlePhaseElectroMagneticConverter",
+        &["port_p", "Phi"],
+    );
+    let prefix_counts = build_prefix_counts(&flat);
+
+    assert_eq!(
+        infer_scalar_count_from_varrefs(&expr, &flat, &prefix_counts),
+        None,
+        "unrenderable indexed field access should not silently fall back to the whole-array prefix size"
+    );
+}

--- a/crates/rumoca/tests/balance_diagnostic.rs
+++ b/crates/rumoca/tests/balance_diagnostic.rs
@@ -3,6 +3,9 @@
 use rumoca_compile::compile::{CompiledSourceRoot, FailedPhase, PhaseResult};
 use rumoca_core::VarName;
 use rumoca_ir_dae::Dae;
+use std::path::PathBuf;
+
+use rumoca::Compiler;
 
 /// Test a simple logical Not model to understand balance
 #[test]
@@ -453,6 +456,72 @@ fn print_dae_summary(dae: &Dae) {
         dae.metadata.interface_flow_count, dae.metadata.overconstrained_interface_count
     );
     println!("Balance: {}", rumoca_phase_dae::balance::balance(dae));
+}
+
+fn cached_msl_source_roots() -> Option<Vec<String>> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/msl/ModelicaStandardLibrary-4.1.0");
+    let candidates = [
+        root.join("Complex.mo"),
+        root.join("Modelica"),
+        root.join("ModelicaReference"),
+        root.join("ModelicaServices"),
+    ];
+    candidates
+        .iter()
+        .all(|path| path.exists())
+        .then(|| {
+            candidates
+                .iter()
+                .map(|path| path.to_string_lossy().into_owned())
+                .collect()
+        })
+}
+
+#[test]
+#[ignore = "requires cached MSL bundle under target/msl"]
+fn test_msl_polyphase_inductance_compiles_to_dae() {
+    let Some(source_roots) = cached_msl_source_roots() else {
+        return;
+    };
+
+    let result = Compiler::new()
+        .model("Modelica.Magnetic.FundamentalWave.Examples.Components.PolyphaseInductance")
+        .source_roots(&source_roots)
+        .compile_str_dae(
+            "import Modelica;\nimport Complex;\nmodel MslEntryPoint\nend MslEntryPoint;\n",
+            "MslEntryPoint.mo",
+        )
+        .expect("PolyphaseInductance should compile through ToDae with cached MSL roots");
+
+    assert_eq!(
+        rumoca_phase_dae::balance::balance(&result.dae),
+        0,
+        "PolyphaseInductance should stay balanced once ToDae scalar inference preserves indexed Complex connector paths"
+    );
+}
+
+#[test]
+#[ignore = "requires cached MSL bundle under target/msl"]
+fn test_msl_balancing_delta_compiles_to_dae() {
+    let Some(source_roots) = cached_msl_source_roots() else {
+        return;
+    };
+
+    let result = Compiler::new()
+        .model("Modelica.Electrical.QuasiStatic.Polyphase.Examples.BalancingDelta")
+        .source_roots(&source_roots)
+        .compile_str_dae(
+            "import Modelica;\nimport Complex;\nmodel MslEntryPoint\nend MslEntryPoint;\n",
+            "MslEntryPoint.mo",
+        )
+        .expect("BalancingDelta should compile through ToDae with cached MSL roots");
+
+    assert_eq!(
+        rumoca_phase_dae::balance::balance(&result.dae),
+        0,
+        "BalancingDelta should stay balanced once balance accounting recognizes scalarized descendants of array-valued equation prefixes"
+    );
 }
 
 /// Test inherited Real connector (like SI units)


### PR DESCRIPTION
  Fix ToDae scalar-path balance for indexed record fields

  - preserve indexed field paths in var-ref collection
  - teach LHS scalar inference to handle indexed record access
  - count array-prefix equations against scalarized descendants
  - add regressions for PolyphaseInductance and BalancingDelta

# Rumoca PR Review Template

<!--
Mirrors SPEC_0025. Section names here must match SPEC_0025 §"PR Template
Alignment". Update both files together if you change either one.
-->

## Summary

- What user-facing behavior changes?
- What issue, spec, or design rule does this address?

## Spec / MLS Alignment

- Relevant active spec(s) checked:
- Relevant MLS section(s), if semantics changed:
- Crate/phase owner:

## Risk and Design Notes

- Main correctness risk:
- Main maintenance risk:
- Why the change belongs in these crate(s):
- Any new abstraction, public API, or migration path:

## Testing

- Key command(s) run (fmt, clippy, workspace test, doc):
- Behavior or regression covered:
- Commands NOT run and why:
- For compiler/simulator changes: did you run the MSL gate
  (`cargo test --release --package rumoca-test-msl --features msl-full-test --test msl_tests
  balance_pipeline::balance_pipeline_core::test_msl_all -- --nocapture`) and
  confirm no regression vs `msl_quality_baseline.json`?

## Code Size Budget (required)

- production_lines_added:
- production_lines_deleted:
- test_lines_added:
- test_lines_deleted:
- public_items_added:
- public_items_removed:
- files_touched:
- net_added_lines:

If `net_added_lines` is positive, add:

- Why this net growth is required.
- Which code was removed/merged as part of the first compression pass.
- Follow-up cleanup ticket/commit for remaining growth (if any).

## Reviewer Checklist

- [ ] Relevant active specs were checked.
- [ ] MLS-sensitive changes cite the right MLS section.
- [ ] Crate boundaries and phase ownership preserved (SPEC_0029).
- [ ] Tests prove behavior or explain the remaining gap.
- [ ] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [ ] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [ ] Size-budget section completed.
- [ ] Positive net diff has explicit compression justification.
- [ ] New APIs are required and minimal.
- [ ] Old/new parallel paths removed unless explicitly migrating.
- [ ] No `#[allow(clippy::...)]` added outside generated code.
- [ ] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [ ] External material (if any) attributed and Apache-2.0 compatible.
