### PR TITLE
fix(ci): resolve fork PRs for MSL comments

### DIFF
--- a/.github/workflows/msl-pr-comment.yml
+++ b/.github/workflows/msl-pr-comment.yml
@@ -94,6 +94,26 @@ jobs:
               prs = associated.data;
             }
             if (prs.length === 0) {
+              const workflowRun = context.payload.workflow_run;
+              const headFullName = workflowRun.head_repository?.full_name ?? '';
+              const headOwner = workflowRun.head_repository?.owner?.login ?? headFullName.split('/')[0];
+              const headBranch = workflowRun.head_branch;
+              if (headOwner && headBranch) {
+                core.info(`Looking up PR by head ${headOwner}:${headBranch}.`);
+                const byHead = await github.paginate(github.rest.pulls.list, {
+                  owner,
+                  repo,
+                  state: 'all',
+                  head: `${headOwner}:${headBranch}`,
+                  per_page: 100,
+                });
+                prs = byHead.filter(pr => pr.head?.sha === workflowRun.head_sha);
+                if (prs.length === 0) {
+                  prs = byHead;
+                }
+              }
+            }
+            if (prs.length === 0) {
               core.info(`No pull request found for workflow run ${context.payload.workflow_run.id}.`);
               return;
             }


### PR DESCRIPTION
## Summary
- Fix the `workflow_run` MSL PR comment publisher so fork PRs can be resolved when GitHub omits `workflow_run.pull_requests` and commit association returns no PR.
- Adds a fallback lookup by `headOwner:headBranch`, preferring the PR whose head SHA matches the completed CI run.

## Spec / MLS Alignment
- Relevant spec checked: `SPEC_0025_PR_REVIEW_PROCESS.md` for PR/CI workflow behavior.
- No Modelica semantics change.
- Owner: CI workflow.

## Risk and Design Notes
- Correctness risk: picking the wrong PR if multiple PRs share the same fork branch. Mitigation: filter by the workflow run head SHA first.
- Maintenance risk: GitHub payload shape can vary; this keeps existing primary lookup paths and adds only a fallback.
- Crate placement: `.github/workflows/msl-pr-comment.yml` is the existing base-repo publisher introduced for fork-safe MSL comments.

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/msl-pr-comment.yml'); puts 'yaml ok'"`
- `git diff --check`

## Code Size Budget
production_lines_added: 0
production_lines_deleted: 0
test_lines_added: 0
test_lines_deleted: 0
public_items_added: 0
public_items_removed: 0
files_touched: 1
net_added_lines: 20

Justification: workflow-only fallback logic to restore MSL PR comment publication for fork PRs.