### PR TITLE
fix(ci): skip MSL comments for canceled runs

### DIFF
--- a/.github/workflows/msl-pr-comment.yml
+++ b/.github/workflows/msl-pr-comment.yml
@@ -14,7 +14,10 @@ permissions:
 jobs:
   publish:
     name: Publish MSL PR Comment
-    if: github.event.workflow_run.event == 'pull_request'
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled' &&
+      github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-24.04
     steps:
       - name: Download MSL compatibility artifact


### PR DESCRIPTION
## Summary
- skip the MSL PR comment publisher when the upstream CI workflow_run is cancelled or skipped
- avoid attempting to publish placeholder MSL comments for canceled CI runs after merge/supersede events

## Spec compliance
- Follows SPEC_0025 PR feedback workflow by keeping MSL comment publishing tied to usable CI artifacts.
- CI workflow-only change; no compiler pipeline or Modelica semantic behavior changed.

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/msl-pr-comment.yml'); puts 'yaml ok'"
- git diff --check