### PR TITLE
Issue 38: Improve MSL trace parity

### DIFF
--- a/crates/rumoca/src/compiler.rs
+++ b/crates/rumoca/src/compiler.rs
@@ -133,9 +133,8 @@ fn render_solve_template_with_name(
 }
 
 impl CompilationResult {
-    fn template_json_with_solve(&self) -> Result<Value, CompilerError> {
-        let dae = scalarized_dae(&self.dae);
-        dae_to_template_json_with_solve(&dae).map_err(CompilerError::TemplateError)
+    fn template_json_dae_only(&self) -> Result<Value, CompilerError> {
+        dae_to_template_json(&self.dae).map_err(CompilerError::TemplateError)
     }
 
     fn is_prunable_child(child: &Value) -> bool {
@@ -319,7 +318,7 @@ impl CompilationResult {
 
     /// Render the DAE using a template string.
     pub fn render_template_str(&self, template: &str) -> Result<String, CompilerError> {
-        let dae_json = self.template_json_with_solve()?;
+        let dae_json = self.template_json_dae_only()?;
         render_dae_template_with_json(&dae_json, template).map_err(CompilerError::TemplateError)
     }
 
@@ -331,7 +330,7 @@ impl CompilationResult {
         template: &str,
         model_name: &str,
     ) -> Result<String, CompilerError> {
-        let dae_json = self.template_json_with_solve()?;
+        let dae_json = self.template_json_dae_only()?;
         render_dae_template_with_json_and_name(&dae_json, template, model_name)
             .map_err(CompilerError::TemplateError)
     }
@@ -1298,6 +1297,32 @@ mod tests {
                 "expected algebraic `{expected}` in template output; got:\n{rendered}"
             );
         }
+    }
+
+    #[test]
+    fn test_dae_template_rendering_does_not_lower_solve_ir() {
+        let source = r#"
+            model DaeOnlyTemplate
+              parameter Real p = 2;
+              Real x[2](start = {1, 2});
+            equation
+              der(x) = {-p * x[1], -p * x[2]};
+            end DaeOnlyTemplate;
+        "#;
+
+        let result = Compiler::new()
+            .model("DaeOnlyTemplate")
+            .compile_str(source, "DaeOnlyTemplate.mo")
+            .expect("compilation should succeed");
+        let rendered = result
+            .render_template_str_with_name_and_ir(
+                "{{ dae.f_x | length }} {{ dae.x.x.dims | join(\",\") }}",
+                "DaeOnlyTemplate",
+                TemplateIr::Dae,
+            )
+            .expect("DAE template should render from native DAE context");
+
+        assert_eq!(rendered.trim(), "1 2");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Issue: #38

This is the ongoing issue-38 branch for improving MSL trace parity. The first committed milestone removes an artificial blocker in DAE debug emission so MSL models can still emit DAE Modelica even when Solve lowering is not yet available for the model.

- Render generic DAE templates from native DAE JSON instead of scalarized solve-coupled JSON.
- Keep explicit Solve IR template rendering on the solve-lowered path.
- Add a regression that verifies DAE template rendering preserves vector equations and array dimensions.

## Root Cause

`--emit dae-mo` went through the generic DAE template path, but that path was building template JSON by scalarizing DAE and lowering Solve IR artifacts first. DAE debug output therefore inherited Solve lowering failures from models that should still be inspectable at the DAE stage. This violated the project IR pipeline contract that DAE renderers consume DAE, while Solve renderers consume Solve.

## Current WIP

The local branch is continuing with issue-38 parity work. The current uncommitted investigation is in Flat `DefId` canonicalization for protected constants such as `Modelica.Clocked.Examples.Elementary.RealSignals.TimeBasedSine.sine.pi`, using MLS 3.7-dev declaration-binding rules and OpenModelica 1.26.8 flattening behavior as references.

## Validation For Committed Milestone

- `cargo fmt --check`
- `cargo test --package rumoca compiler::tests::test_dae_template_rendering_does_not_lower_solve_ir -- --nocapture`
- `cargo test --package rumoca --test cli_emit emit_modelica_stages_render -- --nocapture`
- MSL smoke: `Modelica.Electrical.Machines.Examples.InductionMachines.IMC_DOL --emit dae-mo`
- `cargo xtask verify full`

MSL full gate passed locally on OpenModelica 1.26.8 with Overall pass rates: Ast 100%, Flat 99%, Dae 84%, Solve 69%, IC 37%, Sim 23%. The quality gates passed: Solve 388/566 vs baseline 387, IC 226/566 vs baseline 225, Sim 153/566 unchanged, Trace high bucket unchanged at 76.92% of compared models.