### PR TITLE
Issue 38: Improve MSL Trace Parity

### DIFF
--- a/crates/rumoca/src/compiler.rs
+++ b/crates/rumoca/src/compiler.rs
@@ -133,9 +133,8 @@ fn render_solve_template_with_name(
 }
 
 impl CompilationResult {
-    fn template_json_with_solve(&self) -> Result<Value, CompilerError> {
-        let dae = scalarized_dae(&self.dae);
-        dae_to_template_json_with_solve(&dae).map_err(CompilerError::TemplateError)
+    fn template_json_dae_only(&self) -> Result<Value, CompilerError> {
+        dae_to_template_json(&self.dae).map_err(CompilerError::TemplateError)
     }
 
     fn is_prunable_child(child: &Value) -> bool {
@@ -319,7 +318,7 @@ impl CompilationResult {
 
     /// Render the DAE using a template string.
     pub fn render_template_str(&self, template: &str) -> Result<String, CompilerError> {
-        let dae_json = self.template_json_with_solve()?;
+        let dae_json = self.template_json_dae_only()?;
         render_dae_template_with_json(&dae_json, template).map_err(CompilerError::TemplateError)
     }
 
@@ -331,7 +330,7 @@ impl CompilationResult {
         template: &str,
         model_name: &str,
     ) -> Result<String, CompilerError> {
-        let dae_json = self.template_json_with_solve()?;
+        let dae_json = self.template_json_dae_only()?;
         render_dae_template_with_json_and_name(&dae_json, template, model_name)
             .map_err(CompilerError::TemplateError)
     }
@@ -1298,6 +1297,32 @@ mod tests {
                 "expected algebraic `{expected}` in template output; got:\n{rendered}"
             );
         }
+    }
+
+    #[test]
+    fn test_dae_template_rendering_does_not_lower_solve_ir() {
+        let source = r#"
+            model DaeOnlyTemplate
+              parameter Real p = 2;
+              Real x[2](start = {1, 2});
+            equation
+              der(x) = {-p * x[1], -p * x[2]};
+            end DaeOnlyTemplate;
+        "#;
+
+        let result = Compiler::new()
+            .model("DaeOnlyTemplate")
+            .compile_str(source, "DaeOnlyTemplate.mo")
+            .expect("compilation should succeed");
+        let rendered = result
+            .render_template_str_with_name_and_ir(
+                "{{ dae.f_x | length }} {{ dae.x.x.dims | join(\",\") }}",
+                "DaeOnlyTemplate",
+                TemplateIr::Dae,
+            )
+            .expect("DAE template should render from native DAE context");
+
+        assert_eq!(rendered.trim(), "1 2");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Issue: #38

This draft PR is the ongoing branch for improving Modelica Standard Library trace parity toward the issue-38 target: 169 of 566 models in high agreement with OpenModelica.

The branch is intentionally scoped to root-cause fixes that move the MSL package pass rates forward without regressing later phases. Changes should stay Modelica 3.7-dev compliant, follow the project specs in `./spec`, preserve structured IR data, and avoid textual path recovery or downstream hacks.

## Current Direction

- Use MSL full trace parity as the main progress signal.
- Prefer earliest-phase fixes so downstream IR consumers benefit from the correction.
- Preserve source spans and fail early for real user/compiler errors.
- Use ordered collections such as `IndexMap`/`IndexSet` where deterministic order matters.
- Keep DAE/solve/debug output useful for investigating parity failures.

## Validation Discipline

Before milestone commits on this branch, review the diff against the issue-38 checklist, run focused validation for the bug being fixed, and run the agreed full verification/MSL parity gate before pushing a tested batch.