### PR TITLE
Issue 38: Evaluate scoped extends dimensions in typecheck

### DIFF
--- a/crates/rumoca-eval-ast/src/eval/dimension_inference.rs
+++ b/crates/rumoca-eval-ast/src/eval/dimension_inference.rs
@@ -19,6 +19,8 @@ pub fn infer_dimensions_from_binding_with_scope(
     scope: &str,
 ) -> Option<Vec<usize>> {
     match expr {
+        Expression::Terminal { .. } => Some(Vec::new()),
+
         Expression::Array {
             elements,
             is_matrix,
@@ -52,8 +54,12 @@ pub fn infer_dimensions_from_binding_with_scope(
                 .map(|p| p.ident.text.as_ref())
                 .collect::<Vec<_>>()
                 .join(".");
-            let base_dims =
-                lookup_structural_with_scope(&unindexed_path, scope, &ctx.dimensions)?.clone();
+            let Some(base_dims) =
+                lookup_structural_with_scope(&unindexed_path, scope, &ctx.dimensions)
+            else {
+                return scalar_value_known_with_scope(&unindexed_path, ctx, scope).then(Vec::new);
+            };
+            let base_dims = base_dims.clone();
             Some(apply_component_subscripts_to_dims(
                 base_dims, cr, ctx, scope,
             ))
@@ -94,6 +100,14 @@ pub fn infer_dimensions_from_binding_with_scope(
 
         _ => None,
     }
+}
+
+fn scalar_value_known_with_scope(name: &str, ctx: &TypeCheckEvalContext, scope: &str) -> bool {
+    lookup_with_scope(name, scope, &ctx.integers).is_some()
+        || lookup_with_scope(name, scope, &ctx.reals).is_some()
+        || lookup_with_scope(name, scope, &ctx.booleans).is_some()
+        || lookup_with_scope(name, scope, &ctx.enums).is_some()
+        || lookup_with_scope(name, scope, &ctx.enum_ordinals).is_some()
 }
 
 /// Apply component-reference subscripts to a base dimension vector.

--- a/crates/rumoca-eval-ast/src/eval/late_inference.rs
+++ b/crates/rumoca-eval-ast/src/eval/late_inference.rs
@@ -551,14 +551,7 @@ mod tests {
     fn test_infer_dims_single_row_matrix_literal() {
         let ctx = TypeCheckEvalContext::new();
         let expr = Expression::Array {
-            elements: vec![
-                Expression::Empty {
-                    span: rumoca_core::Span::DUMMY,
-                },
-                Expression::Empty {
-                    span: rumoca_core::Span::DUMMY,
-                },
-            ],
+            elements: vec![make_real_literal(0.0), make_real_literal(1.0)],
             is_matrix: true,
             span: rumoca_core::Span::DUMMY,
         };
@@ -571,27 +564,13 @@ mod tests {
         let expr = Expression::Array {
             elements: vec![
                 Expression::Array {
-                    elements: vec![
-                        Expression::Empty {
-                            span: rumoca_core::Span::DUMMY,
-                        },
-                        Expression::Empty {
-                            span: rumoca_core::Span::DUMMY,
-                        },
-                    ],
+                    elements: vec![make_real_literal(0.0), make_real_literal(1.0)],
                     is_matrix: true,
 
                     span: rumoca_core::Span::DUMMY,
                 },
                 Expression::Array {
-                    elements: vec![
-                        Expression::Empty {
-                            span: rumoca_core::Span::DUMMY,
-                        },
-                        Expression::Empty {
-                            span: rumoca_core::Span::DUMMY,
-                        },
-                    ],
+                    elements: vec![make_real_literal(2.0), make_real_literal(3.0)],
                     is_matrix: true,
 
                     span: rumoca_core::Span::DUMMY,
@@ -601,6 +580,33 @@ mod tests {
             span: rumoca_core::Span::DUMMY,
         };
         assert_eq!(infer_dimensions_from_binding(&expr, &ctx), Some(vec![2, 2]));
+    }
+
+    #[test]
+    fn test_infer_dims_matrix_literal_with_scalar_real_entries() {
+        let ctx = TypeCheckEvalContext::new();
+        let expr = Expression::Array {
+            elements: vec![
+                Expression::Array {
+                    elements: vec![make_real_literal(0.0), make_real_literal(0.595)],
+                    is_matrix: true,
+                    span: rumoca_core::Span::DUMMY,
+                },
+                Expression::Array {
+                    elements: vec![make_real_literal(1.0), make_real_literal(1.0)],
+                    is_matrix: true,
+                    span: rumoca_core::Span::DUMMY,
+                },
+            ],
+            is_matrix: true,
+            span: rumoca_core::Span::DUMMY,
+        };
+
+        assert_eq!(
+            infer_dimensions_from_binding(&expr, &ctx),
+            Some(vec![2, 2]),
+            "MLS matrix constructors made from scalar entries have matrix shape"
+        );
     }
 
     #[test]

--- a/crates/rumoca-phase-typecheck/src/instanced.rs
+++ b/crates/rumoca-phase-typecheck/src/instanced.rs
@@ -15,13 +15,15 @@ impl TypeChecker {
         self.populate_overlay_type_roots(tree, overlay, &type_table);
         self.resolve_overlay_component_types(overlay, &type_table);
         self.collect_overlay_eval_values(overlay);
-        self.collect_instanced_eval_constants(tree, overlay, model_name);
+        if !self.collect_instanced_eval_constants(tree, overlay, model_name) {
+            return;
+        }
         let record_aliases = Self::collect_record_aliases(overlay);
 
         // MLS §10.1: array dimensions must be evaluable at translation time.
         // Evaluate explicit and colon dimensions in one loop because they can
         // depend on each other through bindings and size(..) expressions.
-        self.evaluate_all_dimensions_multi_pass(overlay, &record_aliases);
+        self.evaluate_all_dimensions_multi_pass(tree, overlay, &record_aliases);
         self.validate_dimensions(overlay);
         self.check_instanced_component_modifiers(tree, model_name, &type_table);
         self.check_instanced_equations(tree, overlay, model_name, &type_table);
@@ -124,8 +126,11 @@ impl TypeChecker {
         tree: &ClassTree,
         overlay: &InstanceOverlay,
         model_name: &str,
-    ) {
-        Self::collect_enum_sizes(tree, &mut self.eval_ctx);
+    ) -> bool {
+        if let Err(error) = self.collect_enum_sizes(tree) {
+            self.emit_typecheck_error(*error);
+            return false;
+        }
         Self::collect_import_constants(tree, &mut self.eval_ctx);
         Self::collect_model_extends_redeclare_constants(tree, model_name, &mut self.eval_ctx);
         Self::collect_nested_class_constants(tree, model_name, &mut self.eval_ctx);
@@ -134,6 +139,7 @@ impl TypeChecker {
         Self::collect_enclosing_class_constants(tree, model_name, &mut self.eval_ctx);
         Self::collect_function_defs(tree, &mut self.eval_ctx);
         Self::collect_instance_class_override_constants(tree, overlay, &mut self.eval_ctx);
+        true
     }
 
     fn check_instanced_component_modifiers(

--- a/crates/rumoca-phase-typecheck/src/lib.rs
+++ b/crates/rumoca-phase-typecheck/src/lib.rs
@@ -30,16 +30,16 @@ mod instanced;
 mod modifier_targets;
 mod typechecker;
 
-use rumoca_core::{DefId, ScopeId, Span, TypeId};
+use rumoca_core::{ComponentPath, DefId, ScopeId, Span, TypeId};
 use rumoca_core::{
     Diagnostic as CommonDiagnostic, Diagnostics, PhaseError, PrimaryLabel, SourceMap,
     find_last_top_level_dot, has_top_level_dot, parent_scope, split_first_top_level,
     top_level_last_segment,
 };
 use rumoca_ir_ast::{
-    ClassDef, ClassKind, ClassTree, Component, EnumerationType, Expression, InstanceOverlay,
-    ResolvedTree, ScopeImport, StoredDefinition, Type, TypeAlias, TypeClassType, TypeTable,
-    TypedTree,
+    ClassDef, ClassDefIndex, ClassKind, ClassTree, Component, EnumerationType, Expression,
+    InstanceOverlay, ResolvedTree, ScopeImport, StoredDefinition, Type, TypeAlias, TypeClassType,
+    TypeTable, TypedTree,
 };
 use std::collections::{HashMap, HashSet};
 use thiserror::Error;
@@ -792,6 +792,14 @@ impl TypeChecker {
         }
     }
 
+    fn span_for_location(&self, location: &rumoca_core::Location) -> Span {
+        self.source_map.location_to_span(
+            &location.file_name,
+            location.start as usize,
+            location.end as usize,
+        )
+    }
+
     fn resolve_overlay_type_root(
         &self,
         tree: &ClassTree,
@@ -875,19 +883,43 @@ impl TypeChecker {
     /// the eval context's `enum_sizes` map with type name → literal count mappings.
     /// Also resolves import aliases so that `import L = ...Logic` makes `L` usable
     /// as a dimension.
-    fn collect_enum_sizes(tree: &ClassTree, ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext) {
-        // Scan all classes in the name_map for enumeration types
-        for (name, &def_id) in &tree.name_map {
-            let size = Self::enum_literal_count(tree, def_id);
+    fn collect_enum_sizes(&mut self, tree: &ClassTree) -> TypeCheckResult<()> {
+        let class_index = ClassDefIndex::from_tree(tree);
+        let mut class_entries = Vec::new();
+        for def_id in class_index.def_ids() {
+            let class_def = class_index
+                .get(def_id)
+                .expect("ClassDefIndex::def_ids must only return indexed class definitions");
+            let Some(name) = class_index.qualified_name(def_id) else {
+                return Err(Box::new(TypeCheckError::phase_diagnostic(
+                    "ET001",
+                    format!("missing resolved class name metadata for DefId {def_id:?}"),
+                    "name resolution must preserve class DefId name metadata for enum dimensions",
+                    self.span_for_location(&class_def.name.location),
+                )));
+            };
+            class_entries.push((name.to_string(), def_id));
+        }
+        class_entries.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
+
+        for (name, def_id) in class_entries {
+            let size = class_index
+                .get(def_id)
+                .expect("ClassDefIndex::qualified_name entries must resolve to class definitions")
+                .enum_literals
+                .len();
             if size == 0 {
                 continue;
             }
-            ctx.enum_sizes.insert(name.clone(), size);
+            self.eval_ctx.enum_sizes.insert(name.clone(), size);
             // Also add short name (last segment after dot)
-            let short = top_level_last_segment(name);
-            ctx.enum_sizes.entry(short.to_string()).or_insert(size);
+            let short = top_level_last_segment(&name);
+            self.eval_ctx
+                .enum_sizes
+                .entry(short.to_string())
+                .or_insert(size);
             // Populate enum ordinals (MLS §4.9.5: ordinal is 1-based position)
-            Self::collect_enum_ordinals(tree, def_id, name, ctx);
+            Self::collect_enum_ordinals(&class_index, def_id, &name, &mut self.eval_ctx);
         }
 
         // Scan all scope imports for aliases that resolve to enum types
@@ -897,16 +929,20 @@ impl TypeChecker {
                 continue;
             };
             for import in &scope.imports {
-                Self::collect_enum_from_import(tree, import, ctx);
+                Self::collect_enum_from_import(&class_index, import, &mut self.eval_ctx);
             }
         }
+        Ok(())
     }
 
-    /// Return the number of enum literals for a class, or 0 if not an enum type.
-    fn enum_literal_count(tree: &ClassTree, def_id: rumoca_core::DefId) -> usize {
-        tree.get_class_by_def_id(def_id)
-            .map(|c| c.enum_literals.len())
-            .unwrap_or(0)
+    /// Return the number of enum literals for an indexed class.
+    fn enum_literal_count(
+        class_index: &ClassDefIndex<'_>,
+        def_id: rumoca_core::DefId,
+    ) -> Option<usize> {
+        class_index
+            .get(def_id)
+            .map(|class| class.enum_literals.len())
     }
 
     /// Populate enum ordinals for all literals of an enumeration type.
@@ -918,14 +954,14 @@ impl TypeChecker {
     ///
     /// Also adds short forms without the full prefix.
     fn collect_enum_ordinals(
-        tree: &ClassTree,
+        class_index: &ClassDefIndex<'_>,
         def_id: rumoca_core::DefId,
         type_name: &str,
         ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
     ) {
-        let Some(class) = tree.get_class_by_def_id(def_id) else {
-            return;
-        };
+        let class = class_index
+            .get(def_id)
+            .expect("enum ordinal collection requires an indexed enum class definition");
         for (i, literal) in class.enum_literals.iter().enumerate() {
             let ordinal = (i + 1) as i64; // 1-based per MLS §4.9.5
             let lit_name = &*literal.ident.text;
@@ -942,7 +978,7 @@ impl TypeChecker {
 
     /// Check if an import resolves to an enumeration type and add it to enum_sizes.
     fn collect_enum_from_import(
-        tree: &ClassTree,
+        class_index: &ClassDefIndex<'_>,
         import: &ScopeImport,
         ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
     ) {
@@ -959,11 +995,12 @@ impl TypeChecker {
                 .collect(),
         };
         for (name, def_id) in pairs {
-            let size = Self::enum_literal_count(tree, def_id);
-            if size > 0 {
+            if let Some(size) = Self::enum_literal_count(class_index, def_id)
+                && size > 0
+            {
                 ctx.enum_sizes.entry(name.clone()).or_insert(size);
                 // Also populate ordinals for import aliases
-                Self::collect_enum_ordinals(tree, def_id, &name, ctx);
+                Self::collect_enum_ordinals(class_index, def_id, &name, ctx);
             }
         }
     }
@@ -1292,6 +1329,110 @@ impl TypeChecker {
         }
     }
 
+    /// Re-evaluate component-scoped extends modifiers inside the dimension fixpoint.
+    ///
+    /// MLS §7.2/§7.3 modifications are part of instantiation. When an extends
+    /// modifier depends on a sibling array dimension, such as
+    /// `extends SIMO(final nout=size(columns, 1))`, it cannot be evaluated until
+    /// colon dimensions for `columns[:]` have been inferred.
+    fn reevaluate_component_scoped_extends_modification_constants(
+        tree: &ClassTree,
+        overlay: &InstanceOverlay,
+        ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
+    ) -> bool {
+        let mut progress = false;
+        for instance_data in overlay.components.values() {
+            let comp_scope = instance_data.qualified_name.to_component_path();
+            if comp_scope.is_root() {
+                continue;
+            }
+            let type_name = instance_data.type_name.as_str();
+            if type_name.is_empty() {
+                continue;
+            }
+
+            for ancestor in Self::collect_ancestor_classes(tree, type_name) {
+                progress |= Self::reevaluate_class_extends_modification_constants_for_scope(
+                    &comp_scope,
+                    ancestor,
+                    ctx,
+                );
+            }
+        }
+        progress
+    }
+
+    fn reevaluate_class_extends_modification_constants_for_scope(
+        comp_scope: &ComponentPath,
+        class_def: &ClassDef,
+        ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
+    ) -> bool {
+        let mut progress = false;
+        for ext in &class_def.extends {
+            for ext_mod in &ext.modifications {
+                if ext_mod.redeclare {
+                    continue;
+                }
+                progress |=
+                    Self::reevaluate_extends_modification_expr(comp_scope, &ext_mod.expr, ctx);
+            }
+        }
+        progress
+    }
+
+    fn reevaluate_extends_modification_expr(
+        comp_scope: &ComponentPath,
+        expr: &Expression,
+        ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
+    ) -> bool {
+        let Expression::Modification { target, value, .. } = expr else {
+            return false;
+        };
+        let Some(target_path) = Self::component_reference_path(target) else {
+            return false;
+        };
+        let full_path = comp_scope.join(&target_path).to_flat_string();
+        let scope_name = comp_scope.to_flat_string();
+
+        let mut progress = false;
+        if let Some(val) = rumoca_eval_ast::eval::eval_integer_with_scope(value, ctx, &scope_name)
+            && ctx.integers.get(full_path.as_str()).copied() != Some(val)
+        {
+            ctx.integers.insert(full_path.clone(), val);
+            progress = true;
+        }
+        if let Some(val) = rumoca_eval_ast::eval::eval_boolean_with_scope(value, ctx, &scope_name)
+            && ctx.booleans.get(full_path.as_str()).copied() != Some(val)
+        {
+            ctx.booleans.insert(full_path.clone(), val);
+            progress = true;
+        }
+        if let Some(val) =
+            rumoca_eval_ast::eval::infer_dimensions_from_binding_with_scope(value, ctx, &scope_name)
+            && ctx.dimensions.get(full_path.as_str()) != Some(&val)
+        {
+            ctx.dimensions.insert(full_path, val);
+            progress = true;
+        }
+        progress
+    }
+
+    fn component_reference_path(
+        reference: &rumoca_ir_ast::ComponentReference,
+    ) -> Option<ComponentPath> {
+        if reference.parts.is_empty() {
+            return None;
+        }
+        let mut parts = Vec::with_capacity(reference.parts.len());
+        for part in &reference.parts {
+            if part.subs.as_ref().is_some_and(|subs| !subs.is_empty()) {
+                return None;
+            }
+            parts.push(part.ident.text.to_string());
+        }
+        Some(ComponentPath::from_parts(parts))
+    }
+
     /// Walk an extends-modification expression and record scalar/dimension overrides.
     fn extract_extends_modification_expr(
         alias: &str,
@@ -1522,7 +1663,7 @@ impl TypeChecker {
 
         let ancestors = Self::collect_ancestor_classes(tree, type_name);
         for ancestor in ancestors {
-            Self::extract_class_extends_redeclare_constants_for_scope(
+            Self::extract_class_extends_constants_for_scope(
                 tree,
                 ancestor,
                 &comp_scope,
@@ -1545,7 +1686,7 @@ impl TypeChecker {
     /// `comp_scope = voltage.term`, class has
     /// `extends Interfaces.TerminalDC(redeclare package PhaseSystem = ...);`
     /// -> populate `voltage.term.PhaseSystem.*`.
-    fn extract_class_extends_redeclare_constants_for_scope(
+    fn extract_class_extends_constants_for_scope(
         tree: &ClassTree,
         class_def: &ClassDef,
         comp_scope: &str,
@@ -1553,6 +1694,7 @@ impl TypeChecker {
         ctx: &mut rumoca_eval_ast::eval::TypeCheckEvalContext,
     ) {
         for ext in &class_def.extends {
+            Self::extract_extends_modification_constants(comp_scope, ext, ctx);
             Self::extract_nested_extends_redeclare_constants(
                 tree,
                 comp_scope,
@@ -1779,6 +1921,7 @@ impl TypeChecker {
     /// 4. Re-evaluates boolean and real parameters
     fn evaluate_all_dimensions_multi_pass(
         &mut self,
+        tree: &ClassTree,
         overlay: &mut InstanceOverlay,
         record_aliases: &[(String, String)],
     ) {
@@ -1792,17 +1935,26 @@ impl TypeChecker {
             // Pass 2: Infer colon dimensions from bindings
             let colon_progress = self.infer_colon_dimensions_single_pass(overlay);
 
-            // Pass 3: Re-evaluate integer parameters that may now be computable
+            // Pass 3: Re-evaluate inherited extends modifier parameters that
+            // may depend on dimensions inferred earlier in this pass.
+            let extends_progress = Self::reevaluate_component_scoped_extends_modification_constants(
+                tree,
+                overlay,
+                &mut self.eval_ctx,
+            );
+
+            // Pass 4: Re-evaluate integer parameters that may now be computable
             // This handles cases like `n = size(table, 1)` after table dims are known
             let int_progress = self.reevaluate_integer_parameters(overlay);
 
-            // Pass 4: Re-evaluate boolean, real, and enum parameters that may now be computable
+            // Pass 5: Re-evaluate boolean, real, and enum parameters that may now be computable
             // This enables if-expression evaluation for dimension inference
             let value_progress = self.reevaluate_boolean_real_and_enum_parameters(overlay);
 
             let made_progress = alias_progress
                 || explicit_progress
                 || colon_progress
+                || extends_progress
                 || int_progress
                 || value_progress;
             if !made_progress {

--- a/crates/rumoca-phase-typecheck/src/tests.rs
+++ b/crates/rumoca-phase-typecheck/src/tests.rs
@@ -1131,6 +1131,79 @@ fn test_typecheck_instanced_evaluates_enum_alias_dependent_dimensions() {
 }
 
 #[test]
+fn test_typecheck_instanced_evaluates_component_scoped_extends_modifier_dimensions() {
+    let source = r#"
+        partial block Base
+            parameter Integer nout = 1;
+            Real y[nout];
+        end Base;
+
+        block Table
+            extends Base(final nout = size(columns, 1));
+            parameter Integer columns[:] = 2:2;
+        end Table;
+
+        model Test
+            Table table;
+        end Test;
+    "#;
+
+    let parsed = parse(source);
+    let resolved = resolve(parsed).expect("resolve should succeed");
+    let tree = resolved.into_inner();
+    let base = tree
+        .definitions
+        .classes
+        .get("Base")
+        .expect("Base class should exist");
+    let table = tree
+        .definitions
+        .classes
+        .get("Table")
+        .expect("Table class should exist");
+    let test = tree
+        .definitions
+        .classes
+        .get("Test")
+        .expect("Test class should exist");
+    let mut overlay = InstanceOverlay::new();
+    add_test_instance(
+        &mut overlay,
+        "table",
+        test.components.get("table").expect("table component"),
+        None,
+    );
+
+    let columns = table.components.get("columns").expect("columns component");
+    add_test_instance(
+        &mut overlay,
+        "table.columns",
+        columns,
+        columns.binding.clone(),
+    );
+    add_test_instance(
+        &mut overlay,
+        "table.y",
+        base.components.get("y").expect("inherited y component"),
+        None,
+    );
+
+    typecheck_instanced(&tree, &mut overlay, "Test")
+        .expect("typecheck_instanced should evaluate scoped extends modifier dimensions");
+
+    let y = overlay
+        .components
+        .values()
+        .find(|data| data.qualified_name.to_flat_string() == "table.y")
+        .expect("table.y instance");
+    assert_eq!(
+        y.dims,
+        vec![1],
+        "inherited y[nout] should use nout from the component-scoped extends modifier"
+    );
+}
+
+#[test]
 fn test_typecheck_instanced_resolves_unique_suffix_type_name() {
     let source = r#"
         package A


### PR DESCRIPTION
## Summary

Fixes a Modelica instantiation/typecheck dimension ordering issue found while working on issue #38 MSL trace parity.

The key MSL pattern is an inherited `extends` modifier whose value depends on a sibling array dimension in the component instance scope, for example:

```modelica
extends Modelica.Blocks.Interfaces.SIMO(final nout = size(columns, 1));
parameter Integer columns[:] = 2:size(table, 2);
```

Previously `nout` could be evaluated before colon dimensions like `columns[:]` were inferred, leaving inherited declarations such as `RealOutput y[nout]` unevaluable. This PR re-evaluates non-redeclare `extends` modifier constants inside the instanced dimension fixpoint, after colon dimension inference, using structured component-reference parts and `ComponentPath` rather than textual subscript parsing.

It also fixes scalar matrix literal dimension inference in `rumoca-eval-ast`: literal scalar entries now contribute rank-0 shape, and component references only infer scalar shape when a scalar value is known in the eval context.

## Validation

Ran on rebased branch `issue-38-scoped-extends-dimensions` based on `origin/main` at `45ab1587`:

- `cargo fmt --all --check`
- `cargo test -q -p rumoca-eval-ast infer_dims`
- `cargo test -q -p rumoca-phase-typecheck component_scoped_extends_modifier_dimensions`
- `cargo check -q -p rumoca-eval-ast && cargo check -q -p rumoca-phase-typecheck`
- `cargo xtask repo msl debug-model --model Modelica.Electrical.Batteries.Examples.CCCV_Cell --json --timeout-secs 60`
- `cargo xtask repo msl debug-model --model Modelica.Electrical.PowerConverters.ACAC.Control.VoltageToAngle --json --timeout-secs 60`

Both focused MSL models reached `phase: Success` on the rebased branch.

Full MSL parity was run before rebasing this exact change onto the new main. It completed but failed the quality gate because the committed quality baseline floor is higher than the current branch state. The generated table was:

```text
Overall 566 | Ast 100% | Flat 98% | DAE 76% | Solve 64% | IC 34% | Sim 21%
```

This is improved from the previous scoped work baseline:

```text
Flat 94% -> 98%
DAE 74% -> 76%
Solve 62% -> 64%
IC 32% -> 34%
Sim 20% -> 21%
```

The overall trace high agreement remains below the issue target; this PR is one root-cause step toward issue #38, not the final parity goal.