### PR TITLE
Collapse record-base access trees from array components to structured refs

### DIFF
--- a/crates/rumoca-phase-flatten/src/postprocess.rs
+++ b/crates/rumoca-phase-flatten/src/postprocess.rs
@@ -216,11 +216,7 @@ impl ExpressionRewriter for ConstructorMarker<'_> {
 impl StatementRewriter for ConstructorMarker<'_> {}
 
 pub(super) fn collapse_index_refs_to_known_varrefs(flat: &mut flat::Model) {
-    let known_flat_vars: HashSet<String> = flat
-        .variables
-        .keys()
-        .map(|name| name.as_str().to_string())
-        .collect();
+    let known_flat_vars = KnownFlatVars::build(flat);
 
     for eq in &mut flat.equations {
         collapse_index_expr(&mut eq.residual, &known_flat_vars);
@@ -485,7 +481,7 @@ fn should_replace_dims(current: &[i64], recovered: &[i64]) -> bool {
 
 fn collapse_index_when_equations(
     equations: &mut [rumoca_ir_flat::WhenEquation],
-    known_flat_vars: &HashSet<String>,
+    known_flat_vars: &KnownFlatVars,
 ) {
     for equation in equations {
         match equation {
@@ -522,19 +518,68 @@ fn collapse_index_when_equations(
 
 fn collapse_index_statements(
     statements: &mut [rumoca_core::Statement],
-    known_flat_vars: &HashSet<String>,
+    known_flat_vars: &KnownFlatVars,
 ) {
     for statement in statements {
         *statement = CollapseIndexRewriter { known_flat_vars }.rewrite_statement(statement);
     }
 }
 
-fn collapse_index_expr(expr: &mut rumoca_core::Expression, known_flat_vars: &HashSet<String>) {
+fn collapse_index_expr(expr: &mut rumoca_core::Expression, known_flat_vars: &KnownFlatVars) {
     *expr = CollapseIndexRewriter { known_flat_vars }.rewrite_expression(expr);
 }
 
+/// Flat variable lookup for the collapse pass: exact names plus enough
+/// structure to recover a scalarized record base (`comp[1].port_p.Phi` whose
+/// only flat variables are the `.re`/`.im` leaves).
+struct KnownFlatVars {
+    names: std::collections::BTreeMap<String, Option<rumoca_core::ComponentReference>>,
+}
+
+impl KnownFlatVars {
+    fn build(flat: &flat::Model) -> Self {
+        let names = flat
+            .variables
+            .iter()
+            .map(|(name, var)| (name.as_str().to_string(), var.component_ref.clone()))
+            .collect();
+        Self { names }
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        self.names.contains_key(name)
+    }
+
+    /// Structured reference for a scalarized record base: `path` names no flat
+    /// variable itself, but at least one leaf variable renders as
+    /// `path.<field>...`. The base reference is recovered by truncating that
+    /// leaf's component reference to the parts that render exactly `path`, so
+    /// part identity (spans, subscripts) is owned by the leaf metadata rather
+    /// than re-parsed from text.
+    fn record_base_reference(&self, path: &str) -> Option<rumoca_core::ComponentReference> {
+        let prefix = format!("{path}.");
+        let (leaf_name, leaf_ref) = self.names.range(prefix.clone()..).next()?;
+        if !leaf_name.starts_with(&prefix) {
+            return None;
+        }
+        let leaf_ref = leaf_ref.as_ref()?;
+        for depth in (1..leaf_ref.parts.len()).rev() {
+            let truncated = rumoca_core::ComponentReference {
+                local: leaf_ref.local,
+                span: leaf_ref.span,
+                parts: leaf_ref.parts[..depth].to_vec(),
+                def_id: None,
+            };
+            if truncated.to_var_name().as_str() == path {
+                return Some(truncated);
+            }
+        }
+        None
+    }
+}
+
 struct CollapseIndexRewriter<'a> {
-    known_flat_vars: &'a HashSet<String>,
+    known_flat_vars: &'a KnownFlatVars,
 }
 
 impl ExpressionRewriter for CollapseIndexRewriter<'_> {
@@ -592,7 +637,7 @@ fn collapse_indexed_var_ref_to_known_var(
     base_subscripts: &[rumoca_core::Subscript],
     subscripts: &[rumoca_core::Subscript],
     span: rumoca_core::Span,
-    known_flat_vars: &HashSet<String>,
+    known_flat_vars: &KnownFlatVars,
 ) -> Option<rumoca_core::Expression> {
     let mut merged = base_subscripts.to_vec();
     merged.extend_from_slice(subscripts);
@@ -601,6 +646,16 @@ fn collapse_indexed_var_ref_to_known_var(
         if known_flat_vars.contains(candidate.as_str()) {
             return Some(rumoca_core::Expression::VarRef {
                 name: rumoca_core::Reference::new(candidate),
+                subscripts: vec![],
+                span,
+            });
+        }
+        // Element of a scalarized record array (`r[2]` whose flat variables
+        // are the field leaves `r[2].a`...): same record-base collapse as for
+        // field accesses.
+        if let Some(reference) = known_flat_vars.record_base_reference(&candidate) {
+            return Some(rumoca_core::Expression::VarRef {
+                name: rumoca_core::Reference::with_component_reference(&candidate, reference),
                 subscripts: vec![],
                 span,
             });
@@ -620,16 +675,29 @@ fn collapse_field_access_to_known_var(
     base: &rumoca_core::Expression,
     field: &str,
     span: rumoca_core::Span,
-    known_flat_vars: &HashSet<String>,
+    known_flat_vars: &KnownFlatVars,
 ) -> Option<rumoca_core::Expression> {
-    if let Some(candidate) = field_access_flat_path(base, field)
-        && known_flat_vars.contains(candidate.as_str())
-    {
-        return Some(rumoca_core::Expression::VarRef {
-            name: rumoca_core::Reference::new(candidate),
-            subscripts: vec![],
-            span,
-        });
+    if let Some(candidate) = field_access_flat_path(base, field) {
+        if known_flat_vars.contains(candidate.as_str()) {
+            return Some(rumoca_core::Expression::VarRef {
+                name: rumoca_core::Reference::new(candidate),
+                subscripts: vec![],
+                span,
+            });
+        }
+        // Scalarized record base (`comp[1].port_p.Phi` where only the
+        // `.re`/`.im` leaves exist as flat variables): collapse to a single
+        // structured VarRef so downstream record-equation expansion sees the
+        // record reference instead of an Index/FieldAccess tree it cannot
+        // match (and shape inference does not inflate the equation to the
+        // whole component array).
+        if let Some(reference) = known_flat_vars.record_base_reference(&candidate) {
+            return Some(rumoca_core::Expression::VarRef {
+                name: rumoca_core::Reference::with_component_reference(&candidate, reference),
+                subscripts: vec![],
+                span,
+            });
+        }
     }
 
     match base {
@@ -687,7 +755,7 @@ fn collapse_var_field_access(
     subscripts: &[rumoca_core::Subscript],
     field: &str,
     span: rumoca_core::Span,
-    known_flat_vars: &HashSet<String>,
+    known_flat_vars: &KnownFlatVars,
 ) -> Option<rumoca_core::Expression> {
     let subscript_suffix = subscript_suffix(subscripts)?;
     for candidate in [

--- a/crates/rumoca/tests/balance_diagnostic.rs
+++ b/crates/rumoca/tests/balance_diagnostic.rs
@@ -674,3 +674,59 @@ end Volume;
         }
     }
 }
+
+/// Record-level equations inside an array component instance must collapse
+/// to structured record references and balance exactly (PR #202 regression:
+/// `comp[k].x` stayed an Index/FieldAccess tree, so shape inference counted
+/// the whole component array per equation — MSL PolyphaseInductance reported
+/// balance 2010, BalancingDelta 7371).
+#[test]
+fn test_balance_record_equation_in_component_array() {
+    let source = r#"
+package P
+  record R
+    Real a;
+    Real b;
+  end R;
+
+  model Comp
+    R x;
+    R y;
+  equation
+    x = y;
+    y.a = 1;
+    y.b = 2;
+  end Comp;
+
+  model Top
+    Comp comp[2];
+  end Top;
+end P;
+"#;
+
+    let def = rumoca_phase_parse::parse_to_ast(source, "test.mo").unwrap();
+    let source_root = CompiledSourceRoot::from_stored_definition(def).unwrap();
+
+    match source_root.compile_model_phases("P.Top") {
+        PhaseResult::Success(result) => {
+            let dae = &result.dae;
+            assert_eq!(
+                rumoca_phase_dae::balance::balance(dae).expect("valid DAE balance fixture"),
+                0,
+                "record equations from an array component must not inflate the balance"
+            );
+            assert!(
+                dae.variables
+                    .algebraics
+                    .contains_key(&VarName::new("comp[2].x.b")),
+                "record fields should scalarize per element"
+            );
+        }
+        PhaseResult::NeedsInner { missing_inners, .. } => {
+            panic!("Model needs inner declarations: {:?}", missing_inners);
+        }
+        PhaseResult::Failed { phase, error, .. } => {
+            panic!("Compilation failed at {:?}: {}", phase, error);
+        }
+    }
+}


### PR DESCRIPTION
Supersedes #202 by @yeus — the diagnosis (indexed record-field paths collapsing to the bare base-array name and inflating ToDae balance) and the repro models (PolyphaseInductance, BalancingDelta) are from that investigation, credited via `Co-authored-by`. The implementation is reworked for the post-#223 architecture: structure is recovered once at the flatten boundary from variable metadata, instead of re-deriving paths from strings in DAE shape inference and balance matching.

Closes #202

## Root cause

Record-level equations inside an **array** component instance (`port_p.Phi = Phi`, `port_p.V_m - port_n.V_m = V_m` in MSL `SinglePhaseElectroMagneticConverter` under `converter[3]`) leave flatten as `Index`/`FieldAccess` trees over the bare component-array VarRef. The collapse pass only resolved trees whose composed path names a flat **leaf** variable — but a scalarized record base (`comp[1].port_p.Phi`, whose flat variables are only the `.re`/`.im` leaves) names none. The surviving trees then break two ToDae consumers:

- record-equation expansion keys on VarRef LHS and cannot match a tree, and
- shape inference collects the bare base array as the equation's shape, counting the whole component array per scalar equation (78 scalars for a 2-scalar Complex equation).

## Fix

`collapse_index_refs_to_known_varrefs` now carries each flat variable's `ComponentReference`. When a composed access path is a strict prefix of leaf variables, the tree collapses to a single VarRef whose structure is recovered by **truncating a leaf's component reference** to the parts that render the base path (`to_var_name()` equality) — leaf metadata owns part identity; nothing is re-parsed from text. Applied to both field-access chains and indexed record-array elements.

## Results

| Metric | before | after |
|---|---|---|
| MSL DAE compiled | 485 | **535** |
| balanced | 472 | **522** |
| todae_failed | 68 | **18** |
| `...FundamentalWave...PolyphaseInductance` balance | 2010 | **0** |
| `...Polyphase.Examples.BalancingDelta` balance | 7371 | **0** |
| QuasiStatic `PolyphaseInductance` balance | 42810 | 10 (separate residual issue) |

Sim/trace gates unchanged-or-better; full `cargo xtask verify quick` suite passes. New regression test pins the minimal case (record equation `x = y` inside `Comp comp[2]` must balance exactly).