### PR TITLE
Add SymForce backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,12 @@ jobs:
             /opt/rumoca/cargo/git
           key: template-runtime-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
+      # No-op once the dev image ships it (core-requirements.txt); kept so the
+      # symforce runtime tests exercise the real package even on a stale image
+      # instead of silently skipping.
+      - name: Ensure symforce runtime dependency
+        run: pip install --no-cache-dir 'symforce==0.11.0'
+
       - name: Run template runtime checks
         run: cargo xtask verify template-runtimes
 

--- a/crates/rumoca-phase-codegen/src/templates/symforce/symforce.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/symforce/symforce.py.jinja
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import builtins
+from typing import Any, Dict, Optional
+
+import symforce
+
+if not getattr(symforce, "_have_imported_symbolic", False):
+    symforce.set_symbolic_api("symengine")
+symforce.set_log_level("warning")
+if not getattr(symforce, "_have_used_epsilon", False):
+    symforce.set_epsilon_to_symbol()
+
+import symforce.symbolic as sf
+from symforce import codegen
+from symforce.values import Values
+
+{%- set symforce_symbol_policy = {
+    "separator": "_",
+    "generated_prefixes": ["der_", "pre_"],
+    "reserved": [
+        "Any", "Dict", "False", "None", "Optional", "True", "Values", "and", "as", "assert",
+        "async", "await", "break", "builtins", "class", "codegen", "continue", "def", "del",
+        "der", "elif", "else", "except", "finally", "for", "from", "global", "if", "import",
+        "in", "inputs", "is", "lambda", "metadata", "model", "nonlocal", "not", "or",
+        "outputs", "pass", "pre", "raise", "return", "sf", "symforce", "t", "time", "try",
+        "while", "with", "yield"
+    ]
+} %}
+{%- set symbols = target_symbols(dae.symbol_refs, symforce_symbol_policy) %}
+{%- set cfg = {
+    "prefix": "",
+    "power": "**",
+    "modelica_builtins": true,
+    "mul_elem_fn": "_mul_elem",
+    "and_op": "sf.And",
+    "or_op": "sf.Or",
+    "not_op": "sf.Not",
+    "if_style": "function",
+    "if_else_fn": "if_else",
+    "python_range": true,
+    "subscript_underscore": true,
+    "sum_fn": "_sum",
+    "symbols": symbols
+} %}
+
+
+def _sf_attr(name: str, fallback):
+    return getattr(sf, name, fallback)
+
+
+if not hasattr(sf, "And"):
+    sf.And = lambda lhs, rhs: lhs & rhs
+if not hasattr(sf, "Or"):
+    sf.Or = lambda lhs, rhs: lhs | rhs
+if not hasattr(sf, "Not"):
+    sf.Not = lambda value: ~value
+
+
+def _symbol(name: str):
+    return sf.Symbol(name)
+
+
+def _matrix_from_elements(dims, elements):
+    if not dims:
+        return elements[0]
+    if len(dims) == 1:
+        return sf.Matrix(int(dims[0]), 1, elements)
+    if len(dims) == 2:
+        return sf.Matrix(int(dims[0]), int(dims[1]), elements)
+    return sf.Matrix(len(elements), 1, elements)
+
+
+def _column(entries):
+    return sf.Matrix(len(entries), 1, entries) if entries else sf.Matrix(0, 1, [])
+
+
+def _sum(values):
+    if isinstance(values, sf.Matrix):
+        return builtins.sum(values)
+    if isinstance(values, (list, tuple)):
+        return builtins.sum(values)
+    return values
+
+
+def _mul_elem(lhs, rhs):
+    if hasattr(lhs, "multiply_elementwise"):
+        return lhs.multiply_elementwise(rhs)
+    if hasattr(rhs, "multiply_elementwise"):
+        return rhs.multiply_elementwise(lhs)
+    return lhs * rhs
+
+
+def size(value, dim=None):
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        try:
+            return len(value)
+        except TypeError:
+            return 1
+    if dim is None:
+        return shape
+    return shape[int(dim) - 1]
+
+
+def if_else(condition, then_value, else_value):
+    if condition is True:
+        return then_value
+    if condition is False:
+        return else_value
+    piecewise = getattr(sf, "Piecewise", None)
+    if piecewise is not None:
+        return piecewise((then_value, condition), (else_value, True))
+    return then_value if bool(condition) else else_value
+
+
+def pre(value):
+    return _PRE_BY_SYMBOL.get(str(value), value)
+
+
+def der(value):
+    key = str(value)
+    if key in _DER_BY_SYMBOL:
+        return _DER_BY_SYMBOL[key]
+    raise ValueError(f"der() called on non-state variable: {value}")
+
+
+abs = _sf_attr("Abs", builtins.abs)
+sign = _sf_attr("sign", lambda value: value / abs(value))
+sqrt = _sf_attr("sqrt", None)
+sin = _sf_attr("sin", None)
+cos = _sf_attr("cos", None)
+tan = _sf_attr("tan", None)
+asin = _sf_attr("asin", None)
+acos = _sf_attr("acos", None)
+atan = _sf_attr("atan", None)
+atan2 = _sf_attr("atan2", None)
+sinh = _sf_attr("sinh", None)
+cosh = _sf_attr("cosh", None)
+tanh = _sf_attr("tanh", None)
+exp = _sf_attr("exp", None)
+log = _sf_attr("log", None)
+log10 = lambda value: log(value, 10)
+floor = _sf_attr("floor", None)
+ceil = _sf_attr("ceiling", _sf_attr("ceil", None))
+min = _sf_attr("Min", builtins.min)
+max = _sf_attr("Max", builtins.max)
+sum = _sum
+zeros = lambda *dims: sf.Matrix.zeros(*(int(dim) for dim in dims))
+ones = lambda *dims: sf.Matrix.ones(*(int(dim) for dim in dims))
+identity = lambda dim: sf.Matrix.eye(int(dim))
+transpose = lambda value: sf.Matrix(value).T
+cross = lambda lhs, rhs: sf.Matrix(lhs).cross(sf.Matrix(rhs))
+div = lambda lhs, rhs: floor(lhs / rhs)
+mod = lambda lhs, rhs: lhs % rhs
+rem = mod
+
+_DER_BY_SYMBOL: Dict[str, Any] = {}
+_PRE_BY_SYMBOL: Dict[str, Any] = {}
+{%- macro declare_symbolic_var(name, var, scope_name) %}
+{%- if var.dims %}
+        {{ symbol(symbols, name) }}_elements = [
+{%- for i in range(var.dims | product) %}
+            _symbol("{{ source_ref(name, var.dims, i + 1) }}"),
+{%- endfor %}
+        ]
+{%- for i in range(var.dims | product) %}
+        {{ symbol(symbols, source_ref(name, var.dims, i + 1)) }} = {{ symbol(symbols, name) }}_elements[{{ i }}]
+{%- endfor %}
+        {{ symbol(symbols, name) }} = _matrix_from_elements([{{ var.dims | join(", ") }}], {{ symbol(symbols, name) }}_elements)
+{%- else %}
+        {{ symbol(symbols, name) }} = _symbol("{{ name }}")
+{%- endif %}
+        {{ scope_name }}["{{ name | sanitize }}"] = {{ symbol(symbols, name) }}
+{%- endmacro %}
+{%- macro declare_derivative_var(name, var, scope_name) %}
+{%- if var.dims %}
+        der_{{ symbol(symbols, name) }}_elements = [
+{%- for i in range(var.dims | product) %}
+            _symbol("der({{ source_ref(name, var.dims, i + 1) }})"),
+{%- endfor %}
+        ]
+{%- for i in range(var.dims | product) %}
+        der_{{ symbol(symbols, source_ref(name, var.dims, i + 1)) }} = der_{{ symbol(symbols, name) }}_elements[{{ i }}]
+        _DER_BY_SYMBOL[str({{ symbol(symbols, source_ref(name, var.dims, i + 1)) }})] = der_{{ symbol(symbols, source_ref(name, var.dims, i + 1)) }}
+{%- endfor %}
+        der_{{ symbol(symbols, name) }} = _matrix_from_elements([{{ var.dims | join(", ") }}], der_{{ symbol(symbols, name) }}_elements)
+        _DER_BY_SYMBOL[str({{ symbol(symbols, name) }})] = der_{{ symbol(symbols, name) }}
+{%- else %}
+        der_{{ symbol(symbols, name) }} = _symbol("der({{ name }})")
+        _DER_BY_SYMBOL[str({{ symbol(symbols, name) }})] = der_{{ symbol(symbols, name) }}
+{%- endif %}
+        {{ scope_name }}["{{ name | sanitize }}"] = der_{{ symbol(symbols, name) }}
+{%- endmacro %}
+{%- macro declare_pre_var(name, var, scope_name) %}
+{%- if var.dims %}
+        pre_{{ symbol(symbols, name) }}_elements = [
+{%- for i in range(var.dims | product) %}
+            _symbol("pre({{ source_ref(name, var.dims, i + 1) }})"),
+{%- endfor %}
+        ]
+{%- for i in range(var.dims | product) %}
+        pre_{{ symbol(symbols, source_ref(name, var.dims, i + 1)) }} = pre_{{ symbol(symbols, name) }}_elements[{{ i }}]
+        _PRE_BY_SYMBOL[str({{ symbol(symbols, source_ref(name, var.dims, i + 1)) }})] = pre_{{ symbol(symbols, source_ref(name, var.dims, i + 1)) }}
+{%- endfor %}
+        pre_{{ symbol(symbols, name) }} = _matrix_from_elements([{{ var.dims | join(", ") }}], pre_{{ symbol(symbols, name) }}_elements)
+        _PRE_BY_SYMBOL[str({{ symbol(symbols, name) }})] = pre_{{ symbol(symbols, name) }}
+{%- else %}
+        pre_{{ symbol(symbols, name) }} = _symbol("pre({{ name }})")
+        _PRE_BY_SYMBOL[str({{ symbol(symbols, name) }})] = pre_{{ symbol(symbols, name) }}
+{%- endif %}
+        {{ scope_name }}["{{ name | sanitize }}"] = pre_{{ symbol(symbols, name) }}
+{%- endmacro %}
+{%- macro scalar_names(vars) -%}
+[{% for name, var in vars | items %}{% if var.dims %}{% for i in range(var.dims | product) %}"{{ source_ref(name, var.dims, i + 1) }}",{% endfor %}{% else %}"{{ name }}",{% endif %}{% endfor %}]
+{%- endmacro -%}
+{%- for func_name, func in dae.functions | items %}
+
+
+def {{ func_name | sanitize }}({% for p in func.inputs %}{{ p.name | sanitize }}{% if p.default %}={{ render_expr(p.default, cfg) }}{% endif %}{{ ", " if not loop.last else "" }}{% endfor %}):
+{%- for p in func.locals %}
+    {{ p.name | sanitize }} = {% if p.default %}{{ render_expr(p.default, cfg) }}{% else %}0{% endif %}
+{%- endfor %}
+{%- if func.outputs | length > 0 %}
+    {{ func.outputs[0].name | sanitize }} = 0
+{%- endif %}
+{%- if func.body | length > 0 %}
+{{ render_statements(func.body, cfg, "    ") }}
+{%- endif %}
+{%- if func.outputs | length > 0 %}
+    return {{ func.outputs[0].name | sanitize }}
+{%- else %}
+    return None
+{%- endif %}
+{%- endfor %}
+
+
+def create_model() -> Dict[str, Any]:
+    _DER_BY_SYMBOL.clear()
+    _PRE_BY_SYMBOL.clear()
+
+    inputs = Values()
+    outputs = Values()
+    metadata = {
+        "model_name": "{{ model_name }}",
+        "description": None,
+        "states": {{ scalar_names(dae.x) }},
+        "algebraics": {{ scalar_names(dae.y) }},
+        "inputs": {{ scalar_names(dae.u) }},
+        "outputs": {{ scalar_names(dae.w) }},
+        "parameters": {{ scalar_names(dae.p) }},
+        "discrete_reals": {{ scalar_names(dae.z) }},
+        "discrete_valued": {{ scalar_names(dae.m) }},
+    }
+
+    time = _symbol("time")
+    t = time
+    inputs["time"] = time
+
+    with inputs.scope("states"):
+{%- if dae.x | length > 0 %}
+{%- for name, var in dae.x | items %}{{ declare_symbolic_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("derivatives"):
+{%- if dae.x | length > 0 %}
+{%- for name, var in dae.x | items %}{{ declare_derivative_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("algebraics"):
+{%- if dae.y | length > 0 %}
+{%- for name, var in dae.y | items %}{{ declare_symbolic_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("model_outputs"):
+{%- if dae.w | length > 0 %}
+{%- for name, var in dae.w | items %}{{ declare_symbolic_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("external_inputs"):
+{%- if dae.u | length > 0 %}
+{%- for name, var in dae.u | items %}{{ declare_symbolic_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("parameters"):
+{%- if dae.p | length > 0 %}
+{%- for name, var in dae.p | items %}{{ declare_symbolic_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("constants"):
+{%- if dae.constants | length > 0 %}
+{%- for name, var in dae.constants | items %}{{ declare_symbolic_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("discrete_reals"):
+{%- if dae.z | length > 0 %}
+{%- for name, var in dae.z | items %}{{ declare_symbolic_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("discrete_valued"):
+{%- if dae.m | length > 0 %}
+{%- for name, var in dae.m | items %}{{ declare_symbolic_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("pre"):
+{%- if dae.z | length > 0 or dae.m | length > 0 %}
+{%- for name, var in dae.z | items %}{{ declare_pre_var(name, var, "inputs") }}{% endfor %}
+{%- for name, var in dae.m | items %}{{ declare_pre_var(name, var, "inputs") }}{% endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    with inputs.scope("conditions"):
+{%- if dae.condition_aliases | length > 0 %}
+{%- for alias in dae.condition_aliases %}
+        {{ alias.condition.VarRef.name | sanitize }} = _symbol("{{ alias.condition.VarRef.name }}")
+        inputs["{{ alias.condition.VarRef.name | sanitize }}"] = {{ alias.condition.VarRef.name | sanitize }}
+{%- endfor %}
+{%- else %}
+        pass
+{%- endif %}
+
+    f_x = _column([
+{%- for eq in dae.f_x %}
+        {{ render_expr(eq.rhs, cfg) }},
+{%- endfor %}
+    ])
+    outputs["f_x"] = f_x
+
+    initial_residuals = _column([
+{%- for eq in dae.initial_equations %}
+        {{ render_expr(eq.rhs, cfg) }},
+{%- endfor %}
+    ])
+    outputs["initial_residuals"] = initial_residuals
+
+    f_z = _column([
+{%- for eq in dae.f_z %}
+        {{ render_expr(eq.rhs, cfg) }},
+{%- endfor %}
+    ])
+    outputs["f_z"] = f_z
+
+    f_m = _column([
+{%- for eq in dae.f_m %}
+        {{ render_expr(eq.rhs, cfg) }},
+{%- endfor %}
+    ])
+    outputs["f_m"] = f_m
+
+    relation_residuals = _column([
+{%- for alias in dae.condition_aliases %}
+        {{ render_expr(alias.relation, cfg) }},
+{%- endfor %}
+    ])
+    outputs["relation_residuals"] = relation_residuals
+
+    return {
+        "inputs": inputs,
+        "outputs": outputs,
+        "metadata": metadata,
+        "f_x": f_x,
+        "initial_residuals": initial_residuals,
+        "f_z": f_z,
+        "f_m": f_m,
+        "relation_residuals": relation_residuals,
+    }
+
+
+def make_residual_codegen(
+    config: Optional[Any] = None,
+    name: str = "{{ model_name | sanitize }}_dae_residual",
+) -> codegen.Codegen:
+    model = create_model()
+    if config is None:
+        config = codegen.CppConfig()
+    return codegen.Codegen(
+        inputs=model["inputs"],
+        outputs=Values(f_x=model["f_x"]),
+        config=config,
+        name=name,
+        return_key="f_x",
+    )
+
+
+def make_residual_jacobian_codegen(
+    which_args=None,
+    config: Optional[Any] = None,
+    name: str = "{{ model_name | sanitize }}_dae_residual_jacobians",
+) -> codegen.Codegen:
+    return make_residual_codegen(config=config).with_jacobians(
+        which_args=which_args,
+        include_results=True,
+        name=name,
+    )
+
+
+def generate_residual_code(
+    output_dir=None,
+    config: Optional[Any] = None,
+    namespace: str = "sym",
+    name: str = "{{ model_name | sanitize }}_dae_residual",
+):
+    residual_codegen = make_residual_codegen(config=config, name=name)
+    return residual_codegen.generate_function(
+        output_dir=output_dir,
+        namespace=namespace,
+        generated_file_name=name,
+    )
+
+
+if __name__ == "__main__":
+    model = create_model()
+    print("SymForce DAE model: {{ model_name }}")
+    print("states:", model["metadata"]["states"])
+    print("parameters:", model["metadata"]["parameters"])
+    print("residual rows:", model["f_x"].shape[0])

--- a/crates/rumoca-phase-codegen/src/templates/symforce/symforce.py.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/symforce/symforce.py.jinja
@@ -27,7 +27,7 @@ from symforce.values import Values
         "while", "with", "yield"
     ]
 } %}
-{%- set symbols = target_symbols(dae.symbol_refs, symforce_symbol_policy) %}
+{%- set symbols = target_symbols(dae.symbol_refs, symforce_symbol_policy, dae.symbol_aliases) %}
 {%- set cfg = {
     "prefix": "",
     "power": "**",

--- a/crates/rumoca-phase-codegen/src/templates/symforce/target.toml
+++ b/crates/rumoca-phase-codegen/src/templates/symforce/target.toml
@@ -1,0 +1,20 @@
+version = 1
+ir = "dae"
+name = "symforce"
+description = "SymForce Python symbolic DAE export"
+execution_mode = "symbolic"
+deployment_class = "symbolic"
+readiness_level = 1
+
+[capabilities]
+residual_equations = true
+scalar_fallback = true
+initialization = true
+events = true
+forward_ad = true
+dynamic_control_flow = true
+
+
+[[files]]
+path = "{{ model_name }}_symforce.py"
+template = "symforce.py.jinja"

--- a/crates/rumoca/Cargo.toml
+++ b/crates/rumoca/Cargo.toml
@@ -91,6 +91,11 @@ path = "tests/backend_template_runtime_regression.rs"
 required-features = ["template-runtime-tests"]
 
 [[test]]
+name = "symforce_template_regression"
+path = "tests/symforce_template_regression.rs"
+required-features = ["template-runtime-tests"]
+
+[[test]]
 name = "msl_sim_regression"
 path = "tests/msl_sim_regression.rs"
 required-features = ["msl-sim-tests"]

--- a/crates/rumoca/tests/symforce_template_regression.rs
+++ b/crates/rumoca/tests/symforce_template_regression.rs
@@ -157,3 +157,165 @@ fn symforce_template_can_express_reprojection_residuals_for_ba_style_models() {
         "expected external input Values scope for observations/points, got:\n{rendered}"
     );
 }
+
+// ============================================================================
+// Runtime checks: execute the generated module under an installed symforce.
+// Run via `cargo xtask verify template-runtimes` (CI dev image ships
+// symforce); skipped with a notice when the package is missing locally.
+// ============================================================================
+
+#[cfg(feature = "template-runtime-tests")]
+fn python_command() -> &'static str {
+    for candidate in ["python3", "python"] {
+        if std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .is_ok()
+        {
+            return candidate;
+        }
+    }
+    panic!("expected python3 or python to be available");
+}
+
+#[cfg(feature = "template-runtime-tests")]
+fn python_has_symforce() -> bool {
+    std::process::Command::new(python_command())
+        .args(["-c", "import symforce"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(feature = "template-runtime-tests")]
+fn run_python(rendered: &str, driver: &str) -> String {
+    let dir = tempfile::Builder::new()
+        .prefix("rumoca_symforce_runtime_")
+        .tempdir()
+        .expect("create temp dir");
+    let model_path = dir.path().join("model.py");
+    let driver_path = dir.path().join("driver.py");
+    std::fs::write(&model_path, rendered).expect("write model.py");
+    std::fs::write(&driver_path, driver).expect("write driver.py");
+
+    let output = std::process::Command::new(python_command())
+        .arg(driver_path.to_str().unwrap())
+        .output()
+        .expect("run Python driver");
+
+    assert!(
+        output.status.success(),
+        "Python execution failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout).expect("stdout is utf8")
+}
+
+/// The generated module must build a symbolic DAE under real symforce and the
+/// residual must vanish numerically at a consistent point of
+/// `der(x) = -k*x` (x=1, k=2, der(x)=-2).
+#[cfg(feature = "template-runtime-tests")]
+const SYMFORCE_EVAL_DRIVER: &str = r#"
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import model
+
+m = model.create_model()
+inputs = m["inputs"]
+f_x = m["f_x"]
+assert f_x.shape == (1, 1), f"expected one residual row, got {f_x.shape}"
+
+# derivatives Values are keyed by state name; the symbol itself renders
+# as der(<state>).
+der_x = inputs["derivatives"]["x"]
+subs = {
+    inputs["states"]["x"]: 1.0,
+    inputs["parameters"]["k"]: 2.0,
+    der_x: -2.0,
+}
+residual = float(f_x.subs(subs)[0, 0])
+print(f"RESIDUAL={residual}")
+
+off = float(f_x.subs({**subs, der_x: 0.0})[0, 0])
+print(f"OFF_RESIDUAL={off}")
+"#;
+
+/// The symforce Codegen path (the EKF/controller deployment use case) must
+/// produce a compilable C++ residual-with-jacobians function.
+#[cfg(feature = "template-runtime-tests")]
+const SYMFORCE_CODEGEN_DRIVER: &str = r#"
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import model
+
+out = tempfile.mkdtemp(prefix="rumoca_symforce_codegen_")
+model.make_residual_jacobian_codegen().generate_function(
+    output_dir=out, namespace="sym"
+)
+headers = []
+for root, _, files in os.walk(out):
+    for name in files:
+        if name.endswith(".h"):
+            headers.append(name)
+print(f"HEADERS={sorted(headers)}")
+"#;
+
+#[cfg(feature = "template-runtime-tests")]
+#[test]
+fn symforce_runtime_evaluates_generated_residual() {
+    if !python_has_symforce() {
+        eprintln!("SKIP: symforce not available");
+        return;
+    }
+    let rendered = render_ball_template();
+    let stdout = run_python(&rendered, SYMFORCE_EVAL_DRIVER);
+
+    let residual: f64 = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("RESIDUAL="))
+        .expect("driver prints RESIDUAL=")
+        .parse()
+        .expect("residual parses as f64");
+    assert!(
+        residual.abs() < 1.0e-12,
+        "residual at the consistent point should vanish, got {residual}"
+    );
+
+    let off: f64 = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("OFF_RESIDUAL="))
+        .expect("driver prints OFF_RESIDUAL=")
+        .parse()
+        .expect("off residual parses as f64");
+    assert!(
+        (off - 2.0).abs() < 1.0e-12,
+        "residual with der(x)=0 should equal k*x = 2, got {off}"
+    );
+}
+
+#[cfg(feature = "template-runtime-tests")]
+#[test]
+fn symforce_runtime_generates_cpp_residual_jacobians() {
+    if !python_has_symforce() {
+        eprintln!("SKIP: symforce not available");
+        return;
+    }
+    let rendered = render_ball_template();
+    let stdout = run_python(&rendered, SYMFORCE_CODEGEN_DRIVER);
+
+    let headers = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("HEADERS="))
+        .expect("driver prints HEADERS=");
+    assert!(
+        headers.contains("Ball_dae_residual_jacobians.h"),
+        "symforce Codegen should emit the residual-with-jacobians header, got {headers}"
+    );
+}

--- a/crates/rumoca/tests/symforce_template_regression.rs
+++ b/crates/rumoca/tests/symforce_template_regression.rs
@@ -1,0 +1,159 @@
+use rumoca::Compiler;
+use rumoca_phase_codegen::templates;
+
+fn render_template(source: &str, model_name: &str, file_name: &str) -> String {
+    let compiled = Compiler::new()
+        .model(model_name)
+        .compile_str(source, file_name)
+        .expect("compile test model");
+
+    rumoca_phase_codegen::render_template_with_name(
+        &compiled.dae,
+        templates::builtin_template_source("symforce", "symforce.py.jinja").unwrap(),
+        model_name,
+    )
+    .expect("render symforce template")
+}
+
+fn render_ball_template() -> String {
+    let source = r#"
+model Ball
+  Real x(start = 1);
+  parameter Real k = 2;
+equation
+  der(x) = -k * x;
+end Ball;
+"#;
+
+    render_template(source, "Ball", "Ball.mo")
+}
+
+fn render_array_template() -> String {
+    let source = r#"
+model Arr
+  Real x[2](start = {1, 2});
+equation
+  der(x[1]) = -x[1];
+  der(x[2]) = -x[2];
+end Arr;
+"#;
+
+    render_template(source, "Arr", "Arr.mo")
+}
+
+fn render_reprojection_template() -> String {
+    let source = r#"
+model ReprojectionResidual
+  input Real pointCam[3];
+  input Real observed[2];
+  parameter Real focal = 1;
+  Real residual[2];
+equation
+  residual[1] = focal * pointCam[1] / pointCam[3] - observed[1];
+  residual[2] = focal * pointCam[2] / pointCam[3] - observed[2];
+end ReprojectionResidual;
+"#;
+
+    render_template(source, "ReprojectionResidual", "ReprojectionResidual.mo")
+}
+
+#[test]
+fn symforce_template_renders_symbolic_dae_codegen_surface() {
+    let rendered = render_ball_template();
+
+    assert!(
+        rendered.contains("import symforce.symbolic as sf"),
+        "expected SymForce symbolic import, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("from symforce.values import Values"),
+        "expected SymForce Values import, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("if not getattr(symforce, \"_have_used_epsilon\", False):"),
+        "expected idempotent SymForce epsilon setup, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("def create_model()"),
+        "expected create_model entry point, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("def make_residual_codegen("),
+        "expected residual Codegen helper, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("return codegen.Codegen("),
+        "expected Codegen construction, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("outputs=Values(f_x=model[\"f_x\"]),"),
+        "expected residual Codegen to exclude empty auxiliary outputs, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("x = _symbol(\"x\")"),
+        "expected state symbol declaration, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("der_x = _symbol(\"der(x)\")"),
+        "expected derivative symbol declaration, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("f_x = _column(["),
+        "expected DAE residual vector, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("der(x)") && rendered.contains("k * x"),
+        "expected rendered DAE residual to reference der(x), k, and x, got:\n{rendered}"
+    );
+}
+
+#[test]
+fn symforce_template_scalarizes_fixed_size_arrays_readably() {
+    let rendered = render_array_template();
+
+    assert!(
+        rendered.contains("_symbol(\"x[1]\")") && rendered.contains("_symbol(\"x[2]\")"),
+        "expected scalar array element symbols, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("x = _matrix_from_elements([2], x_elements)"),
+        "expected array base matrix construction, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("der_x_1 = der_x_elements[0]")
+            && rendered.contains("der_x_2 = der_x_elements[1]"),
+        "expected derivative aliases for array state elements, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("der(x_1)") && rendered.contains("der(x_2)"),
+        "expected residuals to reference derivative aliases, got:\n{rendered}"
+    );
+}
+
+#[test]
+fn symforce_template_can_express_reprojection_residuals_for_ba_style_models() {
+    let rendered = render_reprojection_template();
+
+    assert!(
+        rendered.contains("pointCam_1")
+            && rendered.contains("pointCam_2")
+            && rendered.contains("pointCam_3"),
+        "expected point array aliases for reprojection residual, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("observed_1") && rendered.contains("observed_2"),
+        "expected observation array aliases for reprojection residual, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("residual_1") && rendered.contains("residual_2"),
+        "expected residual array aliases, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("focal") && rendered.contains("pointCam_3"),
+        "expected rendered residual expression to include focal projection denominator, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("with inputs.scope(\"external_inputs\")"),
+        "expected external input Values scope for observations/points, got:\n{rendered}"
+    );
+}

--- a/crates/xtask/src/verify_cmd.rs
+++ b/crates/xtask/src/verify_cmd.rs
@@ -517,6 +517,8 @@ fn run_template_runtime_checks(root: &Path) -> Result<()> {
         .arg("--test")
         .arg("sympy_template_regression")
         .arg("--test")
+        .arg("symforce_template_regression")
+        .arg("--test")
         .arg("backend_template_runtime_regression")
         .arg("--")
         .arg("--nocapture")
@@ -538,6 +540,7 @@ fn trim_template_runtime_artifacts(root: &Path) -> Result<()> {
         "template_target_ci",
         "standalone_template_regression",
         "sympy_template_regression",
+        "symforce_template_regression",
         "backend_template_runtime_regression",
     ];
     for entry in fs::read_dir(&deps_dir)

--- a/packaging/docker/python/core-requirements.txt
+++ b/packaging/docker/python/core-requirements.txt
@@ -7,5 +7,6 @@ numpy==2.4.3
 onnx==1.20.1
 onnxruntime==1.24.3
 scipy==1.17.1
+symforce==0.11.0
 sympy==1.14.0
 torch==2.10.0+cpu


### PR DESCRIPTION
Supersedes #219 by @micahkc: the backend commit is cherry-picked verbatim (micahkc remains the commit author); the four `examples/workflows` demos are dropped per review direction, and the testing is hardened from render-only assertions to executing the generated module against the real `symforce` package in CI.

Closes #219

## What lands

- **`--target symforce`** (from #219, author @micahkc): renders a DAE model to a SymForce/SymPy Python module exposing `create_model()` (symbolic states/derivatives/parameters as `Values`, residual partitions `f_x`/`f_z`/`f_m`, initial residuals) plus `make_residual_codegen()` / `make_residual_jacobian_codegen()` / `generate_residual_code()` for symforce's C++ codegen path.
- **Adaptation to current main**: `target_symbols` gained a `symbol_aliases` argument since the template was written.
- **Real runtime CI** (new): two tests under `template-runtime-tests` execute the generated module with an installed symforce —
  - numeric residual check of `der(x) = -k*x` at a consistent point (residual ≡ 0) and an inconsistent one (residual = k·x),
  - `make_residual_jacobian_codegen().generate_function(...)` must produce the C++ residual-with-jacobians header via symforce `Codegen` (the EKF/controller deployment path).
- `symforce==0.11.0` added to the dev image requirements, and the template-runtime CI job pip-installs it explicitly so the tests run for real even while the published image predates the requirement (skip-with-notice remains for local runs without the package, matching the jax/onnx pattern).

## Validation

- `cargo xtask verify template-runtimes` passes end-to-end against symforce 0.11.0 (57 tests; symforce render + runtime tests green) and in skip mode without the package.
- `cargo xtask verify lint` clean.

The workflow examples (JAX param-id, SymPy linearize, CasADi NMPC, SymForce EKF notebooks) are intentionally not included; they can return later as documentation if wanted.