### PR TITLE
Make viewer frames, cameras, and HUD generic and config-driven

### DIFF
--- a/crates/rumoca-sim/src/runner/config.rs
+++ b/crates/rumoca-sim/src/runner/config.rs
@@ -200,6 +200,163 @@ pub struct ViewerConfig {
     pub show_armed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub controls: Option<ViewerControlsConfig>,
+    /// Named kinematic frames driven by viewer signals ([[viewer.frame]]).
+    #[serde(default, rename = "frame", skip_serializing_if = "Vec::is_empty")]
+    pub frames: Vec<ViewerFrameConfig>,
+    /// Cameras mounted on frames ([[viewer.camera]]); the C key cycles
+    /// between the scene-controlled camera and these.
+    #[serde(default, rename = "camera", skip_serializing_if = "Vec::is_empty")]
+    pub cameras: Vec<ViewerCameraConfig>,
+    /// Opt-in heads-up overlay ([viewer.hud]); absent means no HUD.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hud: Option<ViewerHudConfig>,
+}
+
+/// A kinematic frame driven by viewer signals, expressed in model FLU
+/// coordinates (x forward, y left, z up). The viewer owns the single
+/// FLU-to-renderer conversion; scenes receive the resolved matrices.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ViewerFrameConfig {
+    pub name: String,
+    /// Position coordinates: signal names or numeric constants. Two entries
+    /// mean planar `[x, y]` with `z = 0`.
+    pub position: Vec<SignalOrConst>,
+    /// Scalar-first body-to-world quaternion signal names `[q0, q1, q2, q3]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quaternion: Option<[String; 4]>,
+    /// Planar yaw signal (radians about model +z). Mutually exclusive with
+    /// `quaternion`; omitting both leaves the frame unrotated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub heading: Option<String>,
+}
+
+/// A signal name or a numeric constant.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SignalOrConst {
+    Const(f64),
+    Signal(String),
+}
+
+/// A camera rigidly mounted on a frame ([[viewer.camera]]). All vectors are
+/// in the frame's model (FLU) coordinates.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ViewerCameraConfig {
+    pub name: String,
+    /// Frame the camera is mounted on; must name a [[viewer.frame]].
+    pub frame: String,
+    /// Mount offset (default the frame origin).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mount: Option<[f64; 3]>,
+    /// View direction (default `[1, 0, 0]`, along frame forward).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub look: Option<[f64; 3]>,
+    /// Camera up (default `[0, 0, 1]`, frame up).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub up: Option<[f64; 3]>,
+}
+
+/// Opt-in HUD overlay. The only built-in mode is "flight" (attitude ladder,
+/// altitude/speed readouts, stick echo). Models that are not aircraft simply
+/// omit this table.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ViewerHudConfig {
+    pub mode: String,
+    /// Frame supplying roll/pitch; must name a [[viewer.frame]].
+    pub frame: String,
+    /// Altitude readout signal (row hidden when absent).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub altitude: Option<String>,
+    /// Velocity component signals for the speed readout (hidden when absent).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speed: Option<Vec<String>>,
+    /// Stick echo signals (row hidden when absent).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sticks: Option<ViewerHudSticks>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ViewerHudSticks {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub roll: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pitch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub yaw: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub throttle: Option<String>,
+}
+
+impl ViewerFrameConfig {
+    /// Shape-check one frame and collect its unrouted signal references.
+    fn validate(
+        &self,
+        signal_routed: &dyn Fn(&str) -> bool,
+        missing: &mut Vec<String>,
+    ) -> anyhow::Result<()> {
+        if self.position.is_empty() || self.position.len() > 3 {
+            anyhow::bail!(
+                "[[viewer.frame]] '{}' position needs 1-3 entries, got {}",
+                self.name,
+                self.position.len()
+            );
+        }
+        if self.quaternion.is_some() && self.heading.is_some() {
+            anyhow::bail!(
+                "[[viewer.frame]] '{}' sets both quaternion and heading; pick one",
+                self.name
+            );
+        }
+        let position_signals = self.position.iter().filter_map(|coord| match coord {
+            SignalOrConst::Signal(name) => Some(name),
+            SignalOrConst::Const(_) => None,
+        });
+        missing.extend(
+            position_signals
+                .chain(self.quaternion.iter().flatten())
+                .chain(self.heading.iter())
+                .filter(|name| !signal_routed(name))
+                .cloned(),
+        );
+        Ok(())
+    }
+}
+
+impl ViewerHudConfig {
+    /// Check the HUD mode/frame and collect unrouted signal references.
+    fn validate(
+        &self,
+        frame_names: &[&str],
+        signal_routed: &dyn Fn(&str) -> bool,
+        missing: &mut Vec<String>,
+    ) -> anyhow::Result<()> {
+        if self.mode != "flight" {
+            anyhow::bail!(
+                "[viewer.hud] mode '{}' is not supported; the built-in mode is 'flight'",
+                self.mode
+            );
+        }
+        if !frame_names.contains(&self.frame.as_str()) {
+            anyhow::bail!(
+                "[viewer.hud] references unknown frame '{}'; declare it as [[viewer.frame]]",
+                self.frame
+            );
+        }
+        let stick_signals = self.sticks.iter().flat_map(|sticks| {
+            [&sticks.roll, &sticks.pitch, &sticks.yaw, &sticks.throttle]
+                .into_iter()
+                .flatten()
+        });
+        missing.extend(
+            self.altitude
+                .iter()
+                .chain(self.speed.iter().flatten())
+                .chain(stick_signals)
+                .filter(|name| !signal_routed(name))
+                .cloned(),
+        );
+        Ok(())
+    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -298,7 +455,58 @@ impl SimulationConfig {
                  and vehicle in a Modelica model, then point [model] at that top-level class."
             );
         }
+        self.validate_viewer_presentation()?;
         Ok(())
+    }
+
+    /// Cross-check [[viewer.frame]], [[viewer.camera]], and [viewer.hud]:
+    /// frame names are unique, orientation is at most one parametrization,
+    /// camera/HUD frame references resolve, and every referenced signal is
+    /// routed under [signals.viewer].
+    fn validate_viewer_presentation(&self) -> anyhow::Result<()> {
+        let Some(viewer) = self.viewer.as_ref() else {
+            return Ok(());
+        };
+        let signal_routed = |name: &str| {
+            self.signals
+                .as_ref()
+                .is_some_and(|signals| signals.viewer.contains_key(name))
+        };
+        let mut missing: Vec<String> = Vec::new();
+        let mut frame_names: Vec<&str> = Vec::new();
+        for frame in &viewer.frames {
+            if frame_names.contains(&frame.name.as_str()) {
+                anyhow::bail!("[[viewer.frame]] name '{}' is declared twice", frame.name);
+            }
+            frame_names.push(frame.name.as_str());
+            frame.validate(&signal_routed, &mut missing)?;
+        }
+        let mut camera_names: Vec<&str> = Vec::new();
+        for camera in &viewer.cameras {
+            if camera_names.contains(&camera.name.as_str()) {
+                anyhow::bail!("[[viewer.camera]] name '{}' is declared twice", camera.name);
+            }
+            camera_names.push(camera.name.as_str());
+            if !frame_names.contains(&camera.frame.as_str()) {
+                anyhow::bail!(
+                    "[[viewer.camera]] '{}' references unknown frame '{}'; declare it as [[viewer.frame]]",
+                    camera.name,
+                    camera.frame
+                );
+            }
+        }
+        if let Some(hud) = &viewer.hud {
+            hud.validate(&frame_names, &signal_routed, &mut missing)?;
+        }
+        if missing.is_empty() {
+            return Ok(());
+        }
+        missing.sort();
+        missing.dedup();
+        anyhow::bail!(
+            "[viewer] frame/hud references signal(s) not routed under [signals.viewer]: {}",
+            missing.join(", ")
+        );
     }
 
     /// True when configured for external coupling (all FB sections present).
@@ -356,8 +564,22 @@ mod tests {
         let sig = cfg.signals.as_ref().expect("[signals]");
         assert_eq!(sig.stepper_inputs.len(), 2, "steering + throttle");
         let viewer = cfg.viewer.as_ref().expect("[viewer]");
-        assert_eq!(viewer.status_title.as_deref(), Some("Vehicle"));
+        assert_eq!(viewer.status_title.as_deref(), Some("Rover"));
         assert_eq!(viewer.show_armed, Some(false));
+        let chassis = viewer
+            .frames
+            .iter()
+            .find(|frame| frame.name == "chassis")
+            .expect("rover declares the chassis frame");
+        assert!(chassis.heading.is_some(), "planar rover uses heading");
+        assert!(
+            viewer
+                .cameras
+                .iter()
+                .any(|camera| camera.frame == "chassis"),
+            "onboard camera mounts on the chassis frame"
+        );
+        cfg.validate().expect("rover viewer config validates");
         let controls = viewer.controls.as_ref().expect("[viewer.controls]");
         assert!(
             controls
@@ -431,6 +653,125 @@ port = 8091
         let cfg = toml::from_str::<SimulationConfig>(text).unwrap();
         assert_eq!(cfg.http_port(), 8090);
         assert_eq!(cfg.websocket_port(), 8091);
+    }
+
+    #[test]
+    fn validates_viewer_frame_and_camera_references() {
+        let text = r#"
+[sim]
+dt = 0.01
+
+[[viewer.frame]]
+name = "chassis"
+position = ["x", "y"]
+heading = "theta"
+
+[[viewer.camera]]
+name = "onboard"
+frame = "chassis"
+mount = [0.95, 0.0, 0.24]
+
+[signals.viewer]
+x = "stepper:x"
+y = "stepper:y"
+theta = "stepper:theta"
+"#;
+        let cfg = toml::from_str::<SimulationConfig>(text).unwrap();
+        cfg.validate()
+            .expect("frame signals routed and camera frame resolves");
+    }
+
+    #[test]
+    fn rejects_viewer_frame_with_unrouted_signal() {
+        let text = r#"
+[sim]
+dt = 0.01
+
+[[viewer.frame]]
+name = "chassis"
+position = ["x", "y_typo"]
+heading = "theta"
+
+[signals.viewer]
+x = "stepper:x"
+y = "stepper:y"
+theta = "stepper:theta"
+"#;
+        let err = toml::from_str::<SimulationConfig>(text)
+            .unwrap()
+            .validate()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("y_typo") && err.to_string().contains("[signals.viewer]"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_camera_on_unknown_frame() {
+        let text = r#"
+[sim]
+dt = 0.01
+
+[[viewer.camera]]
+name = "onboard"
+frame = "missing"
+"#;
+        let err = toml::from_str::<SimulationConfig>(text)
+            .unwrap()
+            .validate()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("missing") && err.to_string().contains("[[viewer.frame]]"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_frame_with_both_orientations() {
+        let text = r#"
+[sim]
+dt = 0.01
+
+[[viewer.frame]]
+name = "body"
+position = [0.0, 0.0, 0.0]
+heading = "theta"
+quaternion = ["q0", "q1", "q2", "q3"]
+
+[signals.viewer]
+theta = "stepper:theta"
+q0 = "stepper:q0"
+q1 = "stepper:q1"
+q2 = "stepper:q2"
+q3 = "stepper:q3"
+"#;
+        let err = toml::from_str::<SimulationConfig>(text)
+            .unwrap()
+            .validate()
+            .unwrap_err();
+        assert!(err.to_string().contains("pick one"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_hud_with_unknown_mode_or_frame() {
+        let text = r#"
+[sim]
+dt = 0.01
+
+[[viewer.frame]]
+name = "body"
+position = [0.0, 0.0, 0.0]
+
+[viewer.hud]
+mode = "flight"
+frame = "wing"
+"#;
+        let err = toml::from_str::<SimulationConfig>(text)
+            .unwrap()
+            .validate()
+            .unwrap_err();
+        assert!(err.to_string().contains("wing"), "got: {err}");
     }
 
     #[test]

--- a/crates/rumoca-sim/src/runner/template.toml
+++ b/crates/rumoca-sim/src/runner/template.toml
@@ -201,3 +201,29 @@ on_signal         = "reset"
 reset_locals      = true
 rebuild_stepper   = true
 restart_external_interface = false
+
+# ── Viewer presentation ───────────────────────────────────────────────────
+# Optional named kinematic frames in model FLU coordinates (x forward,
+# y left, z up), driven by [signals.viewer] entries. Cameras mount on
+# frames; the C key cycles scene camera → configured cameras. The opt-in
+# flight HUD reads attitude from a frame. Position entries may be signal
+# names or numeric constants; orientation is quaternion = [q0,q1,q2,q3]
+# (scalar first) OR heading = "yaw_signal" (planar), or omitted (fixed).
+# [[viewer.frame]]
+# name = "body"
+# position = ["x", "y"]
+# heading = "theta"
+#
+# [[viewer.camera]]
+# name = "onboard"
+# frame = "body"
+# mount = [0.95, 0.0, 0.24]   # frame-local FLU offset
+# look = [1.0, 0.0, 0.0]      # view direction (default: frame forward)
+# up = [0.0, 0.0, 1.0]        # camera up (default: frame up)
+#
+# [viewer.hud]
+# mode = "flight"
+# frame = "body"
+# altitude = "pz"
+# speed = ["vx", "vy", "vz"]
+# sticks = { roll = "stick_roll", pitch = "stick_pitch", yaw = "stick_yaw", throttle = "stick_throttle" }

--- a/crates/rumoca-viz-web/web/viewer.html
+++ b/crates/rumoca-viz-web/web/viewer.html
@@ -67,7 +67,7 @@
     <span class="label">rate:</span> <span class="val" id="v-simrate">—</span>x<br>
     <span class="label">realtime:</span> <span class="val" id="v-realtime">ON</span><br>
     <span class="label">cam:</span> <span class="val" id="v-camera-mode">CHASE</span><br>
-    <span class="label">hud:</span> <span class="val" id="v-hud-visible">ON</span><br>
+    <span class="label">hud:</span> <span class="val" id="v-hud-visible">OFF</span><br>
     <span class="label">ws:</span> <span class="val" id="v-ws-state">pending</span>
     <span class="label">hz:</span> <span class="val" id="v-wsHz">—</span><br>
     <span class="label">msgs:</span> <span class="val" id="v-msgs">0</span>
@@ -257,8 +257,73 @@ window.addEventListener("resize", () => {
 
 // Camera orbit state (mutable — scene script and mouse events update these)
 const cam = { angle: -Math.PI / 2, elev: 0.35, dist: 4, target: new THREE.Vector3(0, 1, 0) };
-let cameraMode = "chase";
-let flightHudVisible = true;
+
+// ── Model frames and cameras (generic, config-driven) ─────────────
+// [[viewer.frame]] entries are kinematic frames in model FLU coordinates
+// (x forward, y left, z up) driven by viewer signals. The single
+// FLU-to-renderer conversion lives in updateFrameMatrices: renderer
+// X = -y, Y = z, Z = x. At identity orientation a frame's axes coincide
+// with renderer axes, so frame-mounted meshes are authored nose +Z, up +Y.
+const VIEWER_FRAMES = VIEWER_CONFIG?.frame ?? [];
+const VIEWER_CAMERAS = VIEWER_CONFIG?.camera ?? [];
+const frameMatrices = new Map(VIEWER_FRAMES.map(f => [f.name, new THREE.Matrix4()]));
+
+function fluVector(value, fallback) {
+  const a = Array.isArray(value) && value.length === 3 && value.every(Number.isFinite)
+    ? value : fallback;
+  return new THREE.Vector3(-a[1], a[2], a[0]);
+}
+
+const configuredCameras = VIEWER_CAMERAS.map(c => ({
+  name: c.name,
+  frame: c.frame,
+  mount: fluVector(c.mount, [0, 0, 0]),
+  look: fluVector(c.look, [1, 0, 0]).normalize(),
+  up: fluVector(c.up, [0, 0, 1]).normalize(),
+}));
+
+function signalCoord(state, ref) {
+  if (typeof ref === "number") return ref;
+  const v = Number(state[ref]);
+  return Number.isFinite(v) ? v : 0;
+}
+
+function updateFrameMatrices(state) {
+  for (const f of VIEWER_FRAMES) {
+    const m = frameMatrices.get(f.name);
+    const p = f.position ?? [];
+    const px = signalCoord(state, p[0] ?? 0);
+    const py = signalCoord(state, p[1] ?? 0);
+    const pz = signalCoord(state, p[2] ?? 0);
+    let q0 = 1, q1 = 0, q2 = 0, q3 = 0;
+    if (f.quaternion) {
+      q0 = signalCoord(state, f.quaternion[0]);
+      q1 = signalCoord(state, f.quaternion[1]);
+      q2 = signalCoord(state, f.quaternion[2]);
+      q3 = signalCoord(state, f.quaternion[3]);
+      if (q0 === 0 && q1 === 0 && q2 === 0 && q3 === 0) q0 = 1;
+    } else if (f.heading !== undefined && f.heading !== null) {
+      const psi = signalCoord(state, f.heading);
+      q0 = Math.cos(psi / 2);
+      q3 = Math.sin(psi / 2);
+    }
+    const R11 = 1-2*(q2*q2+q3*q3), R12 = 2*(q1*q2-q0*q3), R13 = 2*(q1*q3+q0*q2);
+    const R21 = 2*(q1*q2+q0*q3), R22 = 1-2*(q1*q1+q3*q3), R23 = 2*(q2*q3-q0*q1);
+    const R31 = 2*(q1*q3-q0*q2), R32 = 2*(q2*q3+q0*q1), R33 = 1-2*(q1*q1+q2*q2);
+    m.set(
+      R22,  -R23, -R21, -py,
+     -R32,   R33,  R31,  pz,
+     -R12,   R13,  R11,  px,
+        0,     0,    0,   1
+    );
+  }
+}
+
+// "scene" hands the camera to the scene script; other entries are the
+// configured [[viewer.camera]] names.
+const cameraModes = ["scene", ...configuredCameras.map(c => c.name)];
+let cameraMode = cameraModes[0];
+let flightHudVisible = Boolean(VIEWER_CONFIG?.hud);
 const MIN_CAMERA_ELEV = 0.08;
 const MAX_CAMERA_ELEV = 1.5;
 container.addEventListener("wheel", (e) => {
@@ -284,7 +349,7 @@ try {
   const ctx = {};
   new Function("ctx", scriptText)(ctx);
   if (ctx.onInit) {
-    await ctx.onInit({ THREE, GLTFLoader, scene, renderer, state: sceneState, camera, cam });
+    await ctx.onInit({ THREE, GLTFLoader, scene, renderer, state: sceneState, camera, cam, frames: frameMatrices });
   }
   sceneOnFrame = ctx.onFrame || null;
   pipeline.scene = true;
@@ -372,8 +437,9 @@ document.addEventListener("keydown", (event) => {
   }
   event.preventDefault();
   if (event.code === "KeyC") {
-    if (!event.repeat) {
-      cameraMode = cameraMode === "onboard" ? "chase" : "onboard";
+    if (!event.repeat && cameraModes.length > 1) {
+      const next = (cameraModes.indexOf(cameraMode) + 1) % cameraModes.length;
+      cameraMode = cameraModes[next];
       echoKey(`camera ${cameraMode}`);
     }
     return;
@@ -386,7 +452,7 @@ document.addEventListener("keydown", (event) => {
     return;
   }
   if (event.code === "KeyH") {
-    if (!event.repeat) {
+    if (!event.repeat && VIEWER_CONFIG?.hud) {
       flightHudVisible = !flightHudVisible;
       flightHud.style.display = flightHudVisible ? "" : "none";
       document.getElementById("v-hud-visible").textContent = flightHudVisible ? "ON" : "OFF";
@@ -478,7 +544,7 @@ function connectWs() {
 
       if (msgCount % 60 === 1) {
         const s = latestState;
-        dbg(`ws: ${wsHz.toFixed(0)}Hz latency=${latency}ms dropped=${droppedFrames} t=${s.t?.toFixed(1)} alt=${(s.pz ?? 0).toFixed(2)}`);
+        dbg(`ws: ${wsHz.toFixed(0)}Hz latency=${latency}ms dropped=${droppedFrames} t=${s.t?.toFixed(1)}`);
       }
     } catch (_) {}
   };
@@ -504,7 +570,7 @@ connectWs();
 document.addEventListener("keydown", (e) => {
   if (DEBUG && e.code === "KeyP" && window._renderLog) {
     const lines = window._renderLog.map(r =>
-      `t=${r.renderTime.toFixed(1)} age=${r.stateAge.toFixed(1)}ms frame=${r.frame} raw_pz=${r.raw_pz?.toFixed(4)} render_pz=${r.render_pz?.toFixed(4)} vz=${r.vz?.toFixed(4)} q0=${r.q0?.toFixed(6)}`
+      `t=${r.renderTime.toFixed(1)} age=${r.stateAge.toFixed(1)}ms frame=${r.frame} sim_t=${r.t?.toFixed(4)}`
     );
     const blob = new Blob([lines.join("\n")], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
@@ -524,7 +590,7 @@ let firstStateWallMs = null;
 const speedWindowSamples = [];
 const SPEED_WINDOW_MS = 5000;
 
-function drawFlightHud(state, roll, pitch, speed) {
+function drawFlightHud(state, hud, roll, pitch, speed) {
   const ctx = flightHudCtx;
   const w = innerWidth;
   const h = innerHeight;
@@ -617,38 +683,23 @@ function drawFlightHud(state, roll, pitch, speed) {
     ctx.fillText(text, x, y);
   }
 
-  const alt = Number(state.pz ?? 0);
-  const throttle = Number(state.stick_throttle ?? state.rc_throttle ?? 0);
-  const aileron = Number(state.stick_roll ?? 0);
-  const elevator = Number(state.stick_pitch ?? 0);
-  const rudder = Number(state.stick_yaw ?? 0);
-  hudText(`ALT ${alt.toFixed(1)} m`, w - 34, cy - 40, "right");
-  hudText(`SPD ${speed.toFixed(1)} m/s`, 34, cy - 40);
+  if (hud.altitude) {
+    hudText(`ALT ${Number(state[hud.altitude] ?? 0).toFixed(1)} m`, w - 34, cy - 40, "right");
+  }
+  if (Array.isArray(hud.speed) && hud.speed.length > 0) {
+    hudText(`SPD ${speed.toFixed(1)} m/s`, 34, cy - 40);
+  }
   hudText(`ROLL ${(roll * 180 / Math.PI).toFixed(1)}°`, 34, cy + 44);
   hudText(`PITCH ${(pitch * 180 / Math.PI).toFixed(1)}°`, w - 34, cy + 44, "right");
-  hudText(
-    `AIL ${aileron.toFixed(2)}  ELE ${elevator.toFixed(2)}  RUD ${rudder.toFixed(2)}  THR ${throttle.toFixed(2)}`,
-    cx,
-    h - 44,
-    "center"
-  );
-}
-
-function vehicleThreeMatrix(state) {
-  const px = state.px ?? 0, py = state.py ?? 0, pz = state.pz ?? 0;
-  const q0 = state.q0 ?? 1, q1 = state.q1 ?? 0, q2 = state.q2 ?? 0, q3 = state.q3 ?? 0;
-
-  const R11 = 1-2*(q2*q2+q3*q3), R12 = 2*(q1*q2-q0*q3), R13 = 2*(q1*q3+q0*q2);
-  const R21 = 2*(q1*q2+q0*q3), R22 = 1-2*(q1*q1+q3*q3), R23 = 2*(q2*q3-q0*q1);
-  const R31 = 2*(q1*q3-q0*q2), R32 = 2*(q2*q3+q0*q1), R33 = 1-2*(q1*q1+q2*q2);
-  const m = new THREE.Matrix4();
-  m.set(
-    R22,  -R23, -R21, -py,
-   -R32,   R33,  R31,  pz,
-   -R12,   R13,  R11,  px,
-      0,     0,    0,   1
-  );
-  return m;
+  if (hud.sticks) {
+    const stick = (name) => Number(state[name] ?? 0).toFixed(2);
+    const rows = [];
+    if (hud.sticks.roll) rows.push(`AIL ${stick(hud.sticks.roll)}`);
+    if (hud.sticks.pitch) rows.push(`ELE ${stick(hud.sticks.pitch)}`);
+    if (hud.sticks.yaw) rows.push(`RUD ${stick(hud.sticks.yaw)}`);
+    if (hud.sticks.throttle) rows.push(`THR ${stick(hud.sticks.throttle)}`);
+    if (rows.length > 0) hudText(rows.join("  "), cx, h - 44, "center");
+  }
 }
 
 function visualAttitudeFromMatrix(m) {
@@ -661,14 +712,22 @@ function visualAttitudeFromMatrix(m) {
   };
 }
 
-function applyOnboardCamera(state) {
-  const m = vehicleThreeMatrix(state);
-  const mount = new THREE.Vector3(0.95, 0.18, 0).applyMatrix4(m);
-  const forward = new THREE.Vector3(1, 0, 0).transformDirection(m);
-  const up = new THREE.Vector3(0, 1, 0).transformDirection(m);
+const cameraScratch = {
+  mount: new THREE.Vector3(),
+  look: new THREE.Vector3(),
+  up: new THREE.Vector3(),
+  target: new THREE.Vector3(),
+};
+
+function applyConfiguredCamera(config) {
+  const m = frameMatrices.get(config.frame);
+  if (!m) return;
+  const mount = cameraScratch.mount.copy(config.mount).applyMatrix4(m);
+  const look = cameraScratch.look.copy(config.look).transformDirection(m);
+  const up = cameraScratch.up.copy(config.up).transformDirection(m);
   camera.position.copy(mount);
   camera.up.copy(up);
-  camera.lookAt(mount.clone().add(forward));
+  camera.lookAt(cameraScratch.target.copy(mount).add(look));
 }
 
 function rollingRealtimeSpeed(wallMs, simTime) {
@@ -716,18 +775,16 @@ function animate() {
   // Record render positions for debugging (debug mode only)
   if (DEBUG) {
     if (!window._renderLog) window._renderLog = [];
-    const _rpz = getAuthoritative("pz");
     window._renderLog.push({
       renderTime: now,
       stateAge: dtExtrap * 1000,
       frame: s.frame,
-      raw_pz: s.pz,
-      render_pz: _rpz,
-      vz: s.vz,
-      q0: s.q0,
+      t: s.t,
     });
     if (window._renderLog.length > 600) window._renderLog.shift();
   }
+
+  updateFrameMatrices(s);
 
   // Call scene script with authoritative state
   if (sceneOnFrame) {
@@ -738,6 +795,7 @@ function animate() {
         motors: s,
         camera, cam,
         cameraMode,
+        frames: frameMatrices,
       });
     } catch (e) {
       dbg(`Scene error: ${e}`);
@@ -746,14 +804,7 @@ function animate() {
     }
   }
 
-  // HUD
-  const pz = s.pz ?? 0;
-  const vx = s.vx ?? 0, vy = s.vy ?? 0, vz = s.vz ?? 0;
-
   document.getElementById("v-t").textContent = (s.t ?? 0).toFixed(2);
-  const attitude = visualAttitudeFromMatrix(vehicleThreeMatrix(s));
-  const hudRoll = attitude.roll;
-  const hudPitch = attitude.pitch;
   document.getElementById("v-armed").textContent = controlSignalOn(s.armed) ? "YES" : "no";
   if (Number.isFinite(s.wall_ms) && Number.isFinite(s.t)) {
     if (firstStateWallMs === null) {
@@ -773,13 +824,22 @@ function animate() {
     echoKey(s.input_message);
   }
 
-  if (cameraMode === "onboard") {
-    applyOnboardCamera(s);
+  const activeCamera = configuredCameras.find(c => c.name === cameraMode);
+  if (activeCamera) {
+    applyConfiguredCamera(activeCamera);
   } else {
     camera.up.set(0, 1, 0);
   }
-  if (flightHudVisible) {
-    drawFlightHud(s, hudRoll, hudPitch, Math.sqrt(vx*vx + vy*vy + vz*vz));
+  const hud = VIEWER_CONFIG?.hud;
+  if (hud && flightHudVisible) {
+    const frame = frameMatrices.get(hud.frame);
+    const attitude = frame ? visualAttitudeFromMatrix(frame) : { roll: 0, pitch: 0 };
+    const speedSignals = Array.isArray(hud.speed) ? hud.speed : [];
+    const speed = Math.sqrt(speedSignals.reduce((sum, name) => {
+      const v = Number(s[name] ?? 0);
+      return sum + v * v;
+    }, 0));
+    drawFlightHud(s, hud, attitude.roll, attitude.pitch, speed);
   }
 
   renderer.render(scene, camera);

--- a/examples/interactive/fixedwing/rum.toml
+++ b/examples/interactive/fixedwing/rum.toml
@@ -224,6 +224,20 @@ mode = "external_web"
 show_armed = true
 status_title = "Aircraft"
 
+# Body frame in model FLU coordinates, driven by viewer signals. The HUD
+# attitude reads from this frame; the scene keeps its own mesh placement.
+[[viewer.frame]]
+name = "body"
+position = ["px", "py", "pz"]
+quaternion = ["q0", "q1", "q2", "q3"]
+
+[viewer.hud]
+mode = "flight"
+frame = "body"
+altitude = "pz"
+speed = ["airspeed"]
+sticks = { roll = "stick_roll", pitch = "stick_pitch", yaw = "stick_yaw", throttle = "stick_throttle" }
+
 [[viewer.controls.keyboard]]
 keys = "Up / Down"
 action = "Pitch (elevator)"

--- a/examples/interactive/quadrotor/quadrotor_scene.js
+++ b/examples/interactive/quadrotor/quadrotor_scene.js
@@ -525,7 +525,7 @@ ctx.onFrame = function(api) {
   s.shadow.scale.set(sc, sc, 1);
   s.shadow.material.opacity = Math.max(0.03, 0.25 - alt * 0.015);
 
-  if (api.cameraMode !== "onboard") {
+  if (api.cameraMode === "scene") {
     // Camera follow. Keep the camera anchors translated with the vehicle and
     // rotated by heading only, so roll/pitch maneuvers do not shake the camera.
     const c = api.cam;

--- a/examples/interactive/quadrotor/rum.acro.toml
+++ b/examples/interactive/quadrotor/rum.acro.toml
@@ -217,7 +217,26 @@ port = 8081
 [viewer]
 mode = "external_web"
 show_armed = true
-status_title = "Vehicle"
+status_title = "Quadrotor"
+
+# Body frame in model FLU coordinates, driven by viewer signals.
+[[viewer.frame]]
+name = "body"
+position = ["px", "py", "pz"]
+quaternion = ["q0", "q1", "q2", "q3"]
+
+# Forward-looking body camera: C cycles scene chase → onboard.
+[[viewer.camera]]
+name = "onboard"
+frame = "body"
+mount = [0.3, 0.0, 0.1]
+
+[viewer.hud]
+mode = "flight"
+frame = "body"
+altitude = "pz"
+speed = ["vx", "vy", "vz"]
+sticks = { roll = "stick_roll", pitch = "stick_pitch", yaw = "stick_yaw", throttle = "stick_throttle" }
 
 [[viewer.controls.keyboard]]
 keys = "Up / Down"

--- a/examples/interactive/rover/rover_scene.js
+++ b/examples/interactive/rover/rover_scene.js
@@ -18,16 +18,17 @@
 const JEEP_URL = "https://static.poly.pizza/8036e526-b08a-4d8c-a4b3-0214097cbc18.glb";
 const JEEP_SCALE = 0.30;  // tune to match Rover.mo physical dimensions
 // Wheel node indices, identified from the GLB by bbox analysis. The jeep
-// models' nose points at GLB -X, so we rotate 180° about Y below to align
-// with the rover's +X=forward convention. After that rotation, a node at
-// GLB cz=+c ends up at rover-z=-c, so left/right labels flip.
+// model's nose points at GLB -X, and the viewer frame convention puts
+// model-forward on renderer +Z at identity, so we rotate 90° about Y below
+// (Ry(π/2): GLB (x,z) → renderer (z,-x)). GLB cz=-c lands at renderer
+// X=-c, the left side (model FLU +y/left is renderer -X).
 //   Front wheels (thin, narrower track): nodes 82, 83 at cx≈-1.27
 //   Rear wheels  (fat off-road tires):   nodes 76, 77 at cx≈+0.78
 const WHEEL_NODES = {
-  frontLeft:  83,  // GLB cz=-0.58 → rover +Z (left)
-  frontRight: 82,  // GLB cz=+0.59 → rover -Z (right)
-  rearLeft:   77,  // GLB cz=-0.78 → rover +Z (left)
-  rearRight:  76,  // GLB cz=+0.75 → rover -Z (right)
+  frontLeft:  83,  // GLB cz=-0.58 → renderer -X (left)
+  frontRight: 82,  // GLB cz=+0.59 → renderer +X (right)
+  rearLeft:   77,  // GLB cz=-0.78 → renderer -X (left)
+  rearRight:  76,  // GLB cz=+0.75 → renderer +X (right)
 };
 
 ctx.onInit = async function(api) {
@@ -164,10 +165,11 @@ ctx.onInit = async function(api) {
     wheelPivots[slot] = { pivot, wheel: node };
   }
 
-  // Fit the jeep onto the rover group: rotate 180° about Y so the GLB's
-  // -X (nose) aligns with the rover's +X (forward), scale, then lift so
-  // the lowest vertex sits on y=0.
-  model.rotation.y = Math.PI;
+  // Fit the jeep onto the rover group: the viewer's frame convention puts
+  // model-forward on renderer +Z at identity, and the GLB nose is authored
+  // on -X, so rotate 90° about Y; scale, then lift so the lowest vertex
+  // sits on y=0.
+  model.rotation.y = Math.PI / 2;
   model.scale.setScalar(JEEP_SCALE);
   rover.add(model);
   const box = new THREE.Box3().setFromObject(model);
@@ -206,21 +208,21 @@ ctx.onFrame = function(api) {
   // so early-return until the model is ready.
   if (!s.rover || !s.wheels) return;
 
-  const xr    = get("x") ?? 0;
-  const yr    = get("y") ?? 0;
-  const theta = get("theta") ?? 0;
   const rpm   = get("wheel_rpm") ?? 0;
   const steer = get("front_wheel_yaw") ?? 0;
 
-  // Map rover world (x, y) to three.js (x, z). Keep axes aligned so the
-  // body points the same direction it translates:
-  //   rover +X (forward at theta=0) → three +X
-  //   rover +Y                     → three +Z
-  //   rover theta (CCW around +Z)  → three -Y yaw (+Y is up in three)
-  s.rover.position.x = xr;
-  s.rover.position.z = yr;
-  s.rover.rotation.y = -theta;
-  s.shadow.position.set(xr, 0.001, yr);
+  // The chassis pose comes from the viewer's [[viewer.frame]] "chassis"
+  // (planar x/y + heading in model FLU coordinates); the viewer owns the
+  // FLU-to-renderer conversion, so the configured onboard camera and this
+  // placement can never drift apart.
+  const chassis = api.frames && api.frames.get("chassis");
+  if (!chassis) return;
+  s.rover.matrixAutoUpdate = false;
+  s.rover.matrix.copy(chassis);
+  s.rover.matrixWorldNeedsUpdate = true;
+  if (!s.chassisPos) s.chassisPos = new THREE.Vector3();
+  const pos = s.chassisPos.setFromMatrixPosition(chassis);
+  s.shadow.position.set(pos.x, 0.001, pos.z);
 
   // Integrate rolling phase from wheel_rpm (wall-time so it's smooth
   // regardless of sim realtime ratio).
@@ -235,25 +237,24 @@ ctx.onFrame = function(api) {
   s.wheels.frontLeft.wheel.rotation.z  = s.rollPhase;
   s.wheels.frontRight.wheel.rotation.z = s.rollPhase;
 
-  // Front pivots yaw with steering angle. Sign is flipped to match the
-  // body yaw convention (s.rover.rotation.y = -theta), since the scene
-  // mirrors rover +Y onto three +Z.
+  // Front pivots yaw with steering angle. Model CCW yaw (about FLU +z) maps
+  // to renderer rotation.y = -angle under the viewer frame convention.
   s.wheels.frontLeft.pivot.rotation.y  = -steer;
   s.wheels.frontRight.pivot.rotation.y = -steer;
 
   // Trail
   const idx = s.trailCount % s.maxTrail;
-  s.trailPos[idx*3    ] = xr;
+  s.trailPos[idx*3    ] = pos.x;
   s.trailPos[idx*3 + 1] = 0.02;
-  s.trailPos[idx*3 + 2] = yr;
+  s.trailPos[idx*3 + 2] = pos.z;
   s.trailCount++;
   s.trailGeo.attributes.position.needsUpdate = true;
   s.trailGeo.setDrawRange(0, Math.min(s.trailCount, s.maxTrail));
 
-  // Chase camera
-  if (api.cam && api.camera) {
+  // Chase camera (scene-controlled mode)
+  if (api.cameraMode === "scene" && api.cam && api.camera) {
     const c = api.cam;
-    c.target.lerp(new THREE.Vector3(xr, 0.15, yr), 0.08);
+    c.target.lerp(new THREE.Vector3(pos.x, 0.15, pos.z), 0.08);
     api.camera.position.set(
       c.target.x + c.dist * Math.sin(c.angle) * Math.cos(c.elev),
       c.target.y + c.dist * Math.sin(c.elev),

--- a/examples/interactive/rover/rum.toml
+++ b/examples/interactive/rover/rum.toml
@@ -101,7 +101,20 @@ port = 8081
 [viewer]
 mode = "external_web"
 show_armed = false
-status_title = "Vehicle"
+status_title = "Rover"
+
+# Chassis frame in model FLU coordinates: planar position + heading. The
+# scene places the body from this frame and the onboard camera mounts on it.
+[[viewer.frame]]
+name = "chassis"
+position = ["x", "y"]
+heading = "theta"
+
+# Hood camera: C cycles scene chase → onboard.
+[[viewer.camera]]
+name = "onboard"
+frame = "chassis"
+mount = [0.95, 0.0, 0.24]
 
 [[viewer.controls.keyboard]]
 keys = "Up / Down"

--- a/spec/SPEC_0018_TOOL_CONFIG.md
+++ b/spec/SPEC_0018_TOOL_CONFIG.md
@@ -18,10 +18,9 @@ Tools need configurable behavior:
 
 Configuration and behavior knobs MUST reach the code through a discoverable,
 self-documenting channel. The `RUMOCA_*` environment-variable surface is
-**literal zero** and is enforced by an architecture test that scans **all
-first-party source — Rust and editor/JS alike** (`*.rs`, `*.ts`, `*.mjs`,
-`*.cjs`, `*.js`); any `RUMOCA_*` env-var use (a quoted `"RUMOCA_…"` literal or a
-`…env.RUMOCA_…` access) fails the build.
+**literal zero** across first-party Rust and editor/JS source (`*.rs`, `*.ts`,
+`*.mjs`, `*.cjs`, `*.js`); quoted `"RUMOCA_…"` literals or `…env.RUMOCA_…`
+accesses fail the build.
 
 | Need | Required channel | Why |
 |---|---|---|
@@ -36,22 +35,17 @@ first-party source — Rust and editor/JS alike** (`*.rs`, `*.ts`, `*.mjs`,
   configuration or behavior — in Rust **or** in editor/JS code. Pick a channel
   from the table above.
 - A child process that genuinely cannot accept argv gets a fixed-path file, not
-  an environment variable. Examples: `cargo xtask verify msl-parity` serializes
-  its flags to `target/msl/parity-config.json` for the `rumoca-test-msl` libtest
-  harness; the VS Code smoke runners write their parameters into the launched
-  `.code-workspace` settings (`rumoca.benchmark.*`), which the extension-host
-  test suites read via `getConfiguration` and the extension forwards to
-  `rumoca-lsp` as CLI flags.
+  an environment variable. Examples: `cargo xtask verify msl-parity` writes
+  `target/msl/parity-config.json` for libtest; VS Code smoke runners write
+  `.code-workspace` settings that the extension forwards to `rumoca-lsp` flags.
 - Standard, non-Rumoca environment variables a tool merely passes through
   (`MODELICAPATH`, `GITHUB_ACTIONS`, `ELECTRON_DISABLE_SANDBOX`, …) are not
   configuration knobs and are out of scope for this rule.
 
 **Enforcement:** `crates/rumoca/tests/architecture_hardening/env_var_registry.rs`
-(`test_rumoca_env_vars_are_registered`) scans every source file under the
-workspace (excluding build output, dependencies, and vendored trees). Adding a
-`RUMOCA_*` name to its `REGISTERED_ENV_VARS` allowlist is a deliberate,
-reviewable policy exception with written rationale — not the default escape
-hatch.
+(`test_rumoca_env_vars_are_registered`) scans workspace source files, excluding
+build output, dependencies, and vendored trees. Adding a `RUMOCA_*` name to its
+allowlist is a deliberate, reviewable policy exception with written rationale.
 
 ### Model / Simulation / Visualization Configuration
 
@@ -137,8 +131,7 @@ Editor run controls MUST operate on `rum.toml` scenario files, not on Modelica
 source files. A play/run action executes the scenario's declared task. A
 settings action edits the same scenario. Separate editor toolbar actions for
 simulation versus template generation are intentionally avoided; the task owns
-that
-choice.
+that choice.
 
 Simulation scenarios choose their presentation separately from solver pacing:
 
@@ -148,21 +141,29 @@ Simulation scenarios choose their presentation separately from solver pacing:
   batch simulation and renders configured `[[plot.views]]` in the editor
   results panel. `external_web` starts the interactive runner and opens the
   HTTP/WebSocket viewer for scenarios with keyboard/gamepad/input routing.
-- `[viewer].prefer_external` is an editor presentation hint. When false or
-  omitted, editors should prefer embedded VS Code panels for both results and
-  interactive HTTP viewers. When true, editors should open the relevant
-  viewer/report in the system browser. Command-line tools ignore this hint.
-- Interactive viewer presentation settings live in the scenario `rum.toml` file.
-  `[viewer].status_title` sets the status panel title, `[viewer].show_armed`
-  controls whether the standard armed row is visible, and
-  `[[viewer.controls.keyboard]]` / `[[viewer.controls.gamepad]]` entries
-  describe control help rows with `keys` and `action` strings. These fields are
-  presentation metadata only; actual signal routing stays under `[input]`,
-  `[locals]`, `[derived]`, and `[signals]`.
+- `[viewer].prefer_external` is an editor presentation hint: false/omitted
+  prefers embedded VS Code panels; true opens the system browser.
+  Command-line tools ignore it.
+- Interactive viewer presentation settings live in the scenario `rum.toml`:
+  `[viewer].status_title` (status panel title), `[viewer].show_armed` (armed
+  row visibility), and `[[viewer.controls.keyboard]]`/`[[...gamepad]]` help
+  rows (`keys` + `action`). Presentation metadata only; signal routing stays
+  under `[input]`, `[locals]`, `[derived]`, and `[signals]`.
+- The viewer is model-agnostic — nothing vehicle-specific is built in:
+
+  | Table | Rule | Why |
+  |---|---|---|
+  | `[[viewer.frame]]` | Named frame in model FLU coordinates (x forward, y left, z up); `position` entries are `[signals.viewer]` names or numeric constants (2 entries = planar); orientation is `quaternion = [q0..q3]` (scalar-first) XOR `heading = "yaw_signal"`, else fixed | One signal-driven pose source per moving part; the viewer owns the single FLU→renderer conversion (renderer `X = -y`, `Y = z`, `Z = x`), so cameras, HUD, and scene placement cannot drift apart |
+  | `[[viewer.camera]]` | `name` + `frame` + optional frame-local FLU `mount`/`look`/`up`; the C key cycles scene camera → configured cameras | Cameras hook onto any model part (rover hood, arm end-effector, wing tip) without viewer code changes |
+  | `[viewer.hud]` | Opt-in; `mode = "flight"` with `frame` for attitude and optional `altitude`/`speed`/`sticks` signal names | Reusable feature, off by default — a robot arm scenario simply omits it |
+
+  Signal references MUST be routed under `[signals.viewer]` and frame
+  references MUST resolve (`sim check` rejects violations). Scenes receive
+  the resolved matrices (`api.frames`) and SHOULD place meshes from them
+  (meshes authored nose `+Z`, up `+Y`, matching frame identity).
 - If `[viewer].mode` is omitted, editors infer `external_web` only when the
-  scenario contains an HTTP transport, explicit input routing, signals, locals,
-  derived signals, reset behavior, or external-interface coupling. Otherwise
-  the default is `results_panel`.
+  scenario has an HTTP transport, input routing, signals, locals, derived
+  signals, reset behavior, or external coupling; else `results_panel`.
 
 Codegen/template runs MUST materialize the target renderer's returned files
 under `[codegen].output_dir` when present, or under a deterministic colocated


### PR DESCRIPTION
Supersedes #199 by @pradyunnkale — credited as co-author. His fix (mounting the onboard camera on the moving body, with a planar-heading mode for the rover) was right, but the review direction was that the viewer must stay generic: no rover/drone specifics hardcoded, reusable opt-in features, and user-specified camera attachment to any model part. This PR rebuilds the change on that design.

Closes #199

## Design

The viewer shell is now model-agnostic. Scenario config declares the moving parts and attaches reusable features to them:

- **`[[viewer.frame]]`** — named kinematic frames in model FLU coordinates (x forward, y left, z up), positioned by `[signals.viewer]` names or numeric constants (2 entries = planar), oriented by scalar-first quaternion signals XOR a planar `heading` signal. The viewer owns the single FLU→renderer conversion (`X=-y, Y=z, Z=x`); scenes receive the resolved matrices as `api.frames` and place meshes from them — so cameras, HUD, and scene placement cannot drift apart (the drift was the actual root cause of #199's bug: three scenes used three different axis mappings and the built-in camera matched only the quadrotor).
- **`[[viewer.camera]]`** — cameras mounted on any frame (`mount`/`look`/`up` in frame-local FLU): rover hood, robot-arm end-effector, wing tip — no viewer code changes. The C key cycles scene camera → configured cameras.
- **`[viewer.hud]`** — the flight HUD is opt-in with explicit `frame`, `altitude`, `speed`, and `sticks` signals. A robot-arm scenario simply omits it (H key inert, no HUD canvas drawn).

`sim check` cross-validates everything: unique names, resolvable frame references, one orientation parametrization, all referenced signals routed under `[signals.viewer]`.

## What got removed from the viewer

`vehicleThreeMatrix` (hardcoded `px..q3`), the rover-hood mount `(0.95, 0.18, 0)`, the always-on flight HUD reading `pz`/`stick_*`/`vx,vy,vz`, and the binary onboard/chase camera toggle.

## Examples migrated

| Example | Config | Scene |
|---|---|---|
| rover | planar `chassis` frame (`x`,`y`,`theta`) + hood camera | places body from `api.frames` (this is the #199 fix, now convention-safe) |
| quadrotor | `body` frame (`px..q3`) + onboard camera + flight HUD | `cameraMode === "scene"` contract |
| fixedwing | `body` frame + flight HUD (airspeed/sticks) | unchanged (own mesh-mirror placement; declares no camera) |

SPEC_0018 documents the tables (and absorbs #199's env-var prose trims to stay within the spec size budget); the `sim init` template shows the commented schema.

## Validation

- 6 new config validation tests (frame/camera/HUD acceptance + rejection paths); rover `rum.toml` parse pin extended to the new tables; `sim check` passes on all three example scenarios.
- Workspace tests, `cargo xtask verify lint`, and the JS module syntax check pass.
