### PR TITLE
Defer unresolvable type-alias errors to use sites; fix editor MSL root

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "rumoca.sourceRootPaths": [
-    "target/msl/ModelicaStandardLibrary-4.1.0/Modelica 4.1.0",
+    "target/msl/ModelicaStandardLibrary-4.1.0",
     "target/cmm/CMM-v0.0.2"
   ]
 }

--- a/crates/rumoca-phase-typecheck/src/lib.rs
+++ b/crates/rumoca-phase-typecheck/src/lib.rs
@@ -266,6 +266,13 @@ pub struct TypeChecker {
     /// Keys are class DefIds; values map component member names to their TypeIds
     /// (including inherited members, with extends `break` names removed).
     component_modifier_member_types: HashMap<DefId, HashMap<String, TypeId>>,
+    /// Type aliases whose targets could not be resolved during type-table
+    /// construction (e.g. an MSL alias into a library that is not loaded).
+    ///
+    /// The error is deferred and surfaced only when the alias is actually
+    /// used by the model being checked, so unrelated broken library classes
+    /// cannot fail every compile in the session (strict-reachable semantics).
+    deferred_alias_errors: HashMap<TypeId, (String, Span)>,
 }
 
 impl TypeChecker {
@@ -283,6 +290,7 @@ impl TypeChecker {
             current_component_shapes: HashMap::new(),
             component_modifier_targets: HashMap::new(),
             component_modifier_member_types: HashMap::new(),
+            deferred_alias_errors: HashMap::new(),
         }
     }
 
@@ -607,7 +615,7 @@ impl TypeChecker {
 
     /// Build a type context that includes user-defined classes, enums, and aliases.
     fn build_type_context(
-        &self,
+        &mut self,
         tree: &ClassTree,
     ) -> TypeCheckResult<(TypeTable, HashMap<DefId, TypeId>)> {
         let mut type_table = tree.type_table.clone();
@@ -675,7 +683,21 @@ impl TypeChecker {
                 continue;
             };
             let aliased =
-                self.resolve_alias_target_type_id(class, &type_table, &type_ids_by_def_id)?;
+                match self.resolve_alias_target_type_id(class, &type_table, &type_ids_by_def_id) {
+                    Ok(aliased) => aliased,
+                    // An unresolvable alias target anywhere in the tree (an
+                    // MSL alias into a library that is not loaded) must not
+                    // fail every model in the session. Defer the error; it is
+                    // surfaced when the alias is actually used.
+                    Err(error) => {
+                        if let TypeCheckError::UndefinedType { name, span } = error.as_ref() {
+                            self.deferred_alias_errors
+                                .insert(alias_id, (name.clone(), *span));
+                            continue;
+                        }
+                        return Err(error);
+                    }
+                };
             if let Some(Type::Alias(alias)) = type_table.get_mut(alias_id) {
                 alias.aliased = aliased;
             }
@@ -867,6 +889,10 @@ impl TypeChecker {
     ) {
         for (_instance_id, data) in overlay.components.iter_mut() {
             let resolved = self.resolve_type_name(&data.type_name, data.type_def_id, type_table);
+            if let Some((missing, span)) = self.deferred_alias_errors.get(&resolved) {
+                let error = TypeCheckError::undefined_type(missing.clone(), *span);
+                self.emit_typecheck_error(error);
+            }
             if resolved.is_unknown() {
                 let instance_name = data.qualified_name.to_flat_string();
                 let span = self.source_map.location_to_span(

--- a/crates/rumoca-phase-typecheck/src/lib.rs
+++ b/crates/rumoca-phase-typecheck/src/lib.rs
@@ -682,28 +682,48 @@ impl TypeChecker {
             let Some(&alias_id) = type_ids_by_def_id.get(&def_id) else {
                 continue;
             };
-            let aliased =
-                match self.resolve_alias_target_type_id(class, &type_table, &type_ids_by_def_id) {
-                    Ok(aliased) => aliased,
-                    // An unresolvable alias target anywhere in the tree (an
-                    // MSL alias into a library that is not loaded) must not
-                    // fail every model in the session. Defer the error; it is
-                    // surfaced when the alias is actually used.
-                    Err(error) => {
-                        if let TypeCheckError::UndefinedType { name, span } = error.as_ref() {
-                            self.deferred_alias_errors
-                                .insert(alias_id, (name.clone(), *span));
-                            continue;
-                        }
-                        return Err(error);
-                    }
-                };
+            let Some(aliased) = self.resolve_alias_target_or_defer(
+                alias_id,
+                class,
+                &type_table,
+                &type_ids_by_def_id,
+            )?
+            else {
+                continue;
+            };
             if let Some(Type::Alias(alias)) = type_table.get_mut(alias_id) {
                 alias.aliased = aliased;
             }
         }
 
         Ok((type_table, type_ids_by_def_id))
+    }
+
+    /// Resolve an alias target, deferring `UndefinedType` failures.
+    ///
+    /// An unresolvable alias target anywhere in the tree (an MSL alias into a
+    /// library that is not loaded) must not fail every model in the session.
+    /// The error is recorded per alias `TypeId` and surfaced when a model's
+    /// overlay actually resolves a component to the alias; `Ok(None)` means
+    /// the alias keeps its `UNKNOWN` target. Other errors still propagate.
+    fn resolve_alias_target_or_defer(
+        &mut self,
+        alias_id: TypeId,
+        class: &ClassDef,
+        type_table: &TypeTable,
+        type_ids_by_def_id: &HashMap<DefId, TypeId>,
+    ) -> TypeCheckResult<Option<TypeId>> {
+        match self.resolve_alias_target_type_id(class, type_table, type_ids_by_def_id) {
+            Ok(aliased) => Ok(Some(aliased)),
+            Err(error) => match error.as_ref() {
+                TypeCheckError::UndefinedType { name, span } => {
+                    self.deferred_alias_errors
+                        .insert(alias_id, (name.clone(), *span));
+                    Ok(None)
+                }
+                _ => Err(error),
+            },
+        }
     }
 
     fn build_type_suffix_index(type_table: &TypeTable) -> HashMap<String, Option<TypeId>> {

--- a/crates/rumoca-tool-lsp/src/server/tests/simulation_surface_tests.rs
+++ b/crates/rumoca-tool-lsp/src/server/tests/simulation_surface_tests.rs
@@ -117,6 +117,231 @@ fn compile_model_for_simulation_ignores_unrelated_local_parse_errors() {
 }
 
 #[test]
+fn compile_model_for_simulation_ignores_unreferenced_library_typecheck_errors() {
+    run_async_test(async {
+        // Editor setup from .vscode/settings.json: a configured library source
+        // root that does not fully typecheck on its own (the MSL `Modelica`
+        // package without its `ModelicaServices` sibling references
+        // `ModelicaServices.Types.SolverMethod`). A focus model that never
+        // references the library must still compile, exactly like the CLI's
+        // tolerant load + strict-reachable recovery path.
+        let temp = new_temp_dir("compile-unreferenced-library-typecheck");
+        let focus = temp.join("Ball.mo");
+        std::fs::write(
+            &focus,
+            "model Ball\n  Real x(start=1);\nequation\n  der(x) = -x;\nend Ball;\n",
+        )
+        .expect("write focus");
+        let lib_dir = temp.join("lib").join("Lib");
+        std::fs::create_dir_all(&lib_dir).expect("mkdir lib");
+        std::fs::write(
+            lib_dir.join("package.mo"),
+            "package Lib\n  model Broken\n    MissingServices.Types.SolverMethod method;\n  end Broken;\nend Lib;\n",
+        )
+        .expect("write lib package");
+
+        let service = new_test_service();
+        let server = service.inner();
+        let lib_root = lib_dir.to_string_lossy().to_string();
+        let source_set_key = source_root_source_set_key(&lib_root);
+        let source_root_key = canonical_path_key(&lib_root);
+        {
+            let mut session = server.session.write().await;
+            session.update_document(
+                &focus.to_string_lossy(),
+                &std::fs::read_to_string(&focus).expect("read focus"),
+            );
+        }
+        let source_root_epoch = server.session.read().await.source_root_state_epoch();
+        server
+            .load_source_root_if_current(
+                &lib_root,
+                &source_root_key,
+                &source_set_key,
+                None,
+                source_root_epoch,
+                SourceRootIndexingReason::CompletionImports,
+            )
+            .await
+            .expect("source-root load should succeed")
+            .expect("source root should load");
+
+        let compiled = server
+            .compile_model_for_simulation("Ball", &focus.to_string_lossy())
+            .await
+            .expect("focus model must compile despite unreferenced library typecheck errors");
+        assert_eq!(compiled.dae.variables.states.len(), 1);
+    });
+}
+
+#[test]
+fn compile_model_for_simulation_ignores_sibling_pulled_library_typecheck_errors() {
+    run_async_test(async {
+        // The user-reported editor failure: Ball.mo sits in examples/models/
+        // next to siblings (PIDMSL.mo) that DO reference the configured
+        // library, and the library does not fully typecheck on its own (MSL
+        // `Modelica` without `ModelicaServices`). Compiling Ball must not
+        // fail on the library's unresolved references.
+        let temp = new_temp_dir("compile-sibling-pulled-library");
+        let focus = temp.join("Ball.mo");
+        std::fs::write(
+            &focus,
+            "model Ball\n  Real x(start=1);\nequation\n  der(x) = -x;\nend Ball;\n",
+        )
+        .expect("write focus");
+        std::fs::write(
+            temp.join("UsesLib.mo"),
+            "model UsesLib\n  Lib.Good g;\nend UsesLib;\n",
+        )
+        .expect("write sibling");
+        let lib_dir = temp.join("lib").join("Lib");
+        std::fs::create_dir_all(&lib_dir).expect("mkdir lib");
+        std::fs::write(
+            lib_dir.join("package.mo"),
+            "package Lib\n  model Good\n    Real x(start=0);\n  equation\n    der(x) = 1;\n  end Good;\n  model Broken\n    MissingServices.Types.SolverMethod method;\n  end Broken;\nend Lib;\n",
+        )
+        .expect("write lib package");
+
+        let service = new_test_service();
+        let server = service.inner();
+        let lib_root = lib_dir.to_string_lossy().to_string();
+        let source_set_key = source_root_source_set_key(&lib_root);
+        let source_root_key = canonical_path_key(&lib_root);
+        {
+            let mut session = server.session.write().await;
+            session.update_document(
+                &focus.to_string_lossy(),
+                &std::fs::read_to_string(&focus).expect("read focus"),
+            );
+        }
+        let source_root_epoch = server.session.read().await.source_root_state_epoch();
+        server
+            .load_source_root_if_current(
+                &lib_root,
+                &source_root_key,
+                &source_set_key,
+                None,
+                source_root_epoch,
+                SourceRootIndexingReason::CompletionImports,
+            )
+            .await
+            .expect("source-root load should succeed")
+            .expect("source root should load");
+
+        let compiled = server
+            .compile_model_for_simulation("Ball", &focus.to_string_lossy())
+            .await
+            .expect("focus model must compile despite sibling-pulled library typecheck errors");
+        assert_eq!(compiled.dae.variables.states.len(), 1);
+    });
+}
+
+#[test]
+fn compile_model_for_simulation_handles_real_examples_ball_with_msl_root() {
+    run_async_test(async {
+        // Exact user-reported editor setup: focus examples/models/Ball.mo
+        // (siblings PIDMSL.mo etc. reference Modelica) with the repo
+        // .vscode/settings.json source root `.../Modelica 4.1.0` (no
+        // ModelicaServices sibling). Reported failure: "Ball failed in
+        // Typecheck: undefined type: `ModelicaServices.Types.SolverMethod`".
+        let Some(msl_root) = cached_msl_source_root() else {
+            eprintln!("SKIP: MSL cache not present");
+            return;
+        };
+        let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let focus = workspace.join("examples/models/Ball.mo");
+        assert!(focus.is_file(), "repo Ball.mo expected");
+
+        let service = new_test_service();
+        let server = service.inner();
+        let lib_root = msl_root.to_string_lossy().to_string();
+        let source_set_key = source_root_source_set_key(&lib_root);
+        let source_root_key = canonical_path_key(&lib_root);
+        {
+            let mut session = server.session.write().await;
+            session.update_document(
+                &focus.to_string_lossy(),
+                &std::fs::read_to_string(&focus).expect("read focus"),
+            );
+        }
+        let source_root_epoch = server.session.read().await.source_root_state_epoch();
+        server
+            .load_source_root_if_current(
+                &lib_root,
+                &source_root_key,
+                &source_set_key,
+                None,
+                source_root_epoch,
+                SourceRootIndexingReason::CompletionImports,
+            )
+            .await
+            .expect("source-root load should succeed")
+            .expect("source root should load");
+
+        let compiled = server
+            .compile_model_for_simulation("Ball", &focus.to_string_lossy())
+            .await
+            .expect("Ball must compile with the editor-configured MSL source root");
+        assert_eq!(compiled.dae.variables.states.len(), 2, "Ball has x and v");
+    });
+}
+
+#[test]
+fn compile_model_for_simulation_still_fails_models_that_use_broken_library_alias() {
+    run_async_test(async {
+        // Counterpart to the Ball test above: deferring unresolvable alias
+        // targets must not weaken checking for models that actually USE the
+        // alias — they keep failing in Typecheck with the missing target.
+        let Some(msl_root) = cached_msl_source_root() else {
+            eprintln!("SKIP: MSL cache not present");
+            return;
+        };
+        let temp = new_temp_dir("compile-uses-broken-alias");
+        let focus = temp.join("UsesClocked.mo");
+        std::fs::write(
+            &focus,
+            "model UsesClocked\n  parameter Modelica.Clocked.Types.SolverMethod m = \"x\";\n  Real x(start = 1);\nequation\n  der(x) = -x;\nend UsesClocked;\n",
+        )
+        .expect("write focus");
+
+        let service = new_test_service();
+        let server = service.inner();
+        let lib_root = msl_root.to_string_lossy().to_string();
+        let source_set_key = source_root_source_set_key(&lib_root);
+        let source_root_key = canonical_path_key(&lib_root);
+        {
+            let mut session = server.session.write().await;
+            session.update_document(
+                &focus.to_string_lossy(),
+                &std::fs::read_to_string(&focus).expect("read focus"),
+            );
+        }
+        let source_root_epoch = server.session.read().await.source_root_state_epoch();
+        server
+            .load_source_root_if_current(
+                &lib_root,
+                &source_root_key,
+                &source_set_key,
+                None,
+                source_root_epoch,
+                SourceRootIndexingReason::CompletionImports,
+            )
+            .await
+            .expect("source-root load should succeed")
+            .expect("source root should load");
+
+        let error = server
+            .compile_model_for_simulation("UsesClocked", &focus.to_string_lossy())
+            .await
+            .expect_err("a model using the broken alias must keep failing");
+        assert!(
+            error.contains("ModelicaServices.Types.SolverMethod") || error.contains("SolverMethod"),
+            "failure should name the unresolved alias target, got: {error}"
+        );
+    });
+}
+
+#[test]
 fn compile_model_for_simulation_repeated_runs_ignore_new_unrelated_local_parse_errors() {
     run_async_test(async {
         let temp = new_temp_dir("compile-repeated-sibling-parse-error");


### PR DESCRIPTION
Fixes the editor failure `Ball failed in Typecheck: undefined type: ModelicaServices.Types.SolverMethod not found` when running `examples/simulation/rum.ball.toml` from `xtask vscode edit`. This is a main bug (the LSP/typecheck code is untouched by any open branch); the CLI path never hit it, which is why CLI testing of every example toml stayed green.

## Two stacked causes

1. **Editor config**: `.vscode/settings.json` pointed `rumoca.sourceRootPaths` at `.../Modelica 4.1.0` alone, so the session loaded `Modelica` without its `ModelicaServices` companion — `Modelica.Clocked.Types.SolverMethod` is a type alias into it. Now points at the MSL distribution root (Modelica + ModelicaServices + Complex).
2. **Compiler**: typecheck's `build_type_context` resolved every type alias in the whole tree with a hard error, so one unresolvable alias **anywhere** failed **every** model in the session — including Ball, which references nothing from the library. The editor reaches this because the focus directory's siblings (`PIDMSL.mo`) reference `Modelica`, keeping the MSL in the session; the CLI's strict-reachable recovery only gates a model on its own files.

## Fix

Unresolvable alias targets are deferred per `TypeId` (alias keeps an `UNKNOWN` target) and surfaced when a model's overlay actually resolves a component to that alias — strict-reachable semantics, no weakened checks:

- a model **using** the broken alias still fails in Typecheck naming the missing target (pinned with a real-MSL LSP test),
- a broken alias in the user's **own** compile unit still fails at Resolve as before,
- unrelated models stop being poisoned (pinned with the exact reported scenario: Ball + editor-configured MSL root through `compile_model_for_simulation`).

## Validation

- 4 new LSP tests (real-MSL Ball repro, real-MSL use-site strictness, synthetic sibling-pulled and unreferenced-library cases); typecheck, LSP (190), and balance suites green.
- MSL gate: CI will validate; the deferral only relaxes alias errors for models that never touch the alias, and gate models compile against the full MSL distribution where ModelicaServices resolves.