### PR TITLE
Add NACA 2412 Navier-Stokes live example with worker-backed progress bar

### DIFF
--- a/docs/user-guide/live/rumoca-live.css
+++ b/docs/user-guide/live/rumoca-live.css
@@ -227,3 +227,8 @@
     cursor: pointer;
     user-select: none;
 }
+
+.rumoca-live-radial-controls .rumoca-live-status {
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}

--- a/docs/user-guide/live/rumoca-live.css
+++ b/docs/user-guide/live/rumoca-live.css
@@ -191,3 +191,29 @@
     margin: 0;
     font-size: 0.8em;
 }
+
+.rumoca-live-progress {
+    height: 4px;
+    background: var(--table-border-color, #ddd);
+    overflow: hidden;
+}
+
+.rumoca-live-progress-fill {
+    height: 100%;
+    width: 0;
+    background: #2470c2;
+    transition: width 0.25s linear;
+}
+
+.rumoca-live-progress-indeterminate {
+    width: 100% !important;
+    background: repeating-linear-gradient(
+        -45deg, #2470c2 0 12px, #7db4e8 12px 24px);
+    background-size: 200% 100%;
+    animation: rumoca-live-progress-slide 1.2s linear infinite;
+}
+
+@keyframes rumoca-live-progress-slide {
+    from { background-position: 0 0; }
+    to { background-position: 34px 0; }
+}

--- a/docs/user-guide/live/rumoca-live.css
+++ b/docs/user-guide/live/rumoca-live.css
@@ -193,8 +193,9 @@
 }
 
 .rumoca-live-progress {
-    height: 4px;
+    height: 10px;
     background: var(--table-border-color, #ddd);
+    border-radius: 0 0 4px 4px;
     overflow: hidden;
 }
 
@@ -216,4 +217,13 @@
 @keyframes rumoca-live-progress-slide {
     from { background-position: 0 0; }
     to { background-position: 34px 0; }
+}
+
+.rumoca-live-gpu {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+    font-size: 0.8em;
+    cursor: pointer;
+    user-select: none;
 }

--- a/docs/user-guide/live/rumoca-live.js
+++ b/docs/user-guide/live/rumoca-live.js
@@ -119,6 +119,104 @@
         return wasmModulePromise;
     }
 
+    // -----------------------------------------------------------------
+    // Simulation worker
+    //
+    // simulate_model and DAE rendering are synchronous WASM calls that can
+    // take tens of seconds on large discretized models (the NACA airfoil
+    // page). Running them in a module worker keeps the page responsive so
+    // the progress bar can animate. Falls back to main-thread calls when
+    // workers are unavailable.
+    // -----------------------------------------------------------------
+
+    let simWorkerPromise = null;
+
+    function buildSimWorkerSource(pkgBase) {
+        return `
+import init, * as rumoca from '${pkgBase}rumoca_bind_wasm.js';
+const ready = init();
+self.onmessage = async (event) => {
+    const { id, action, args } = event.data;
+    try {
+        await ready;
+        let result;
+        if (action === 'simulate') {
+            result = rumoca.simulate_model(args.source, args.model, 0, 0, '');
+        } else if (action === 'dae') {
+            const envelope = JSON.parse(rumoca.compile(args.source, args.model));
+            const daeJson = JSON.stringify(envelope.dae_native || envelope.dae);
+            const rendered = rumoca.render_target(daeJson, args.model, 'dae-modelica', '', '{}');
+            const files = rendered.files;
+            result = Array.isArray(files)
+                ? files.map((file) => file.content || '').join('\\n')
+                : '';
+        } else {
+            throw new Error('unknown action ' + action);
+        }
+        self.postMessage({ id, ok: true, result });
+    } catch (error) {
+        self.postMessage({ id, ok: false, error: String((error && error.message) || error) });
+    }
+};
+`;
+    }
+
+    function loadSimWorker() {
+        if (!simWorkerPromise) {
+            simWorkerPromise = (async () => {
+                const base = await locatePkgBase();
+                const blob = new Blob([buildSimWorkerSource(base)], { type: 'text/javascript' });
+                const worker = new Worker(URL.createObjectURL(blob), { type: 'module' });
+                const pending = new Map();
+                let nextId = 1;
+                worker.onmessage = (event) => {
+                    const { id, ok, result, error } = event.data;
+                    const entry = pending.get(id);
+                    if (!entry) {
+                        return;
+                    }
+                    pending.delete(id);
+                    if (ok) {
+                        entry.resolve(result);
+                    } else {
+                        entry.reject(new Error(error));
+                    }
+                };
+                worker.onerror = (event) => {
+                    const failure = new Error(event.message || 'simulation worker failed');
+                    for (const entry of pending.values()) {
+                        entry.reject(failure);
+                    }
+                    pending.clear();
+                };
+                return {
+                    request(action, args) {
+                        return new Promise((resolve, reject) => {
+                            const id = nextId++;
+                            pending.set(id, { resolve, reject });
+                            worker.postMessage({ id, action, args });
+                        });
+                    },
+                };
+            })();
+            simWorkerPromise.catch(() => {
+                simWorkerPromise = null;
+            });
+        }
+        return simWorkerPromise;
+    }
+
+    // Run a heavy action in the worker, falling back to the main thread.
+    async function runHeavy(action, args, mainThreadFallback) {
+        try {
+            const worker = await loadSimWorker();
+            return await worker.request(action, args);
+        } catch (error) {
+            console.warn(`rumoca-live: worker path failed for ${action}, using main thread:`, error);
+            return mainThreadFallback();
+        }
+    }
+
     function broadcastStatus(text) {
         for (const widget of widgets) {
             if (!widget.busy) {
@@ -938,16 +1036,55 @@
         status.className = 'rumoca-live-status';
         toolbar.append(runBtn, daeBtn, resetBtn, status);
 
+        const progress = document.createElement('div');
+        progress.className = 'rumoca-live-progress';
+        progress.hidden = true;
+        const progressFill = document.createElement('div');
+        progressFill.className = 'rumoca-live-progress-fill';
+        progress.appendChild(progressFill);
+
         const output = document.createElement('div');
         output.className = 'rumoca-live-output';
         output.hidden = true;
 
-        container.append(editorHost, toolbar, output);
+        container.append(editorHost, toolbar, progress, output);
         pre.replaceWith(container);
 
         const editor = monaco
             ? createMonacoEditor(monaco, editorHost, originalSource)
             : createTextareaEditor(editorHost, originalSource);
+
+        const lastRunMs = {};
+        let progressTimer = null;
+        const beginProgress = (key, label) => {
+            const started = performance.now();
+            const expected = lastRunMs[key];
+            progress.hidden = false;
+            progressFill.classList.toggle('rumoca-live-progress-indeterminate', !expected);
+            progressFill.style.width = expected ? '0%' : '100%';
+            const tick = () => {
+                const elapsed = performance.now() - started;
+                if (expected) {
+                    const pct = Math.min(97, (elapsed / expected) * 100);
+                    progressFill.style.width = `${pct.toFixed(1)}%`;
+                }
+                const suffix = expected
+                    ? ` ${(elapsed / 1000).toFixed(0)} / ~${(expected / 1000).toFixed(0)} s`
+                    : ` ${(elapsed / 1000).toFixed(0)} s`;
+                status.textContent = label + suffix;
+            };
+            tick();
+            progressTimer = setInterval(tick, 250);
+            return started;
+        };
+        const endProgress = (key, started, succeeded) => {
+            clearInterval(progressTimer);
+            progressTimer = null;
+            progress.hidden = true;
+            if (succeeded) {
+                lastRunMs[key] = performance.now() - started;
+            }
+        };
 
         const widget = {
             busy: false,
@@ -988,35 +1125,41 @@
             widget.setStatus('Failed');
         };
 
-        const withWasm = async (busyLabel, action) => {
+        const withWasm = async (key, busyLabel, action) => {
             runBtn.disabled = true;
             daeBtn.disabled = true;
             widget.busy = true;
+            let started = null;
+            let succeeded = false;
             try {
                 const wasm = await loadWasm();
-                widget.setStatus(busyLabel);
-                // Yield once so the status text paints before the
-                // synchronous WASM call blocks this thread.
-                await new Promise((resolve) => setTimeout(resolve, 16));
+                started = beginProgress(key, busyLabel);
                 const source = editor.getValue();
                 const model = inferModelName(wasm, source);
                 if (!model) {
                     throw new Error('No model/block/class found in this example.');
                 }
                 await action(wasm, source, model);
+                succeeded = true;
             } catch (error) {
                 showError(error);
             } finally {
+                if (started !== null) {
+                    endProgress(key, started, succeeded);
+                }
                 widget.busy = false;
                 runBtn.disabled = false;
                 daeBtn.disabled = false;
             }
         };
 
-        runBtn.addEventListener('click', () => withWasm('Compiling & simulating…', async (wasm, source, model) => {
+        runBtn.addEventListener('click', () => withWasm('simulate', 'Compiling & simulating…', async (wasm, source, model) => {
             // t_end = 0 / dt = 0 / solver = "" defer to the model's
-            // experiment annotation, falling back to runtime defaults.
-            const result = JSON.parse(wasm.simulate_model(source, model, 0, 0, ''));
+            // experiment annotation, falling back to runtime defaults. The
+            // call runs in a worker so the page (and progress bar) stay live.
+            const raw = await runHeavy('simulate', { source, model },
+                () => wasm.simulate_model(source, model, 0, 0, ''));
+            const result = JSON.parse(raw);
             const payload = result.payload || {};
             const allData = payload.allData || [];
             if (allData.length < 2) {
@@ -1051,13 +1194,15 @@
             widget.setStatus(describeRun(result));
         }));
 
-        daeBtn.addEventListener('click', () => withWasm('Compiling to DAE…', async (wasm, source, model) => {
-            // compile() returns an envelope; render_target wants the native
-            // DAE document from its `dae_native` field.
-            const envelope = JSON.parse(wasm.compile(source, model));
-            const daeJson = JSON.stringify(envelope.dae_native || envelope.dae);
-            const rendered = wasm.render_target(daeJson, model, 'dae-modelica', '', '{}');
-            const text = targetFilesToText(rendered.files);
+        daeBtn.addEventListener('click', () => withWasm('dae', 'Compiling to DAE…', async (wasm, source, model) => {
+            const text = await runHeavy('dae', { source, model }, () => {
+                // compile() returns an envelope; render_target wants the
+                // native DAE document from its `dae_native` field.
+                const envelope = JSON.parse(wasm.compile(source, model));
+                const daeJson = JSON.stringify(envelope.dae_native || envelope.dae);
+                const rendered = wasm.render_target(daeJson, model, 'dae-modelica', '', '{}');
+                return targetFilesToText(rendered.files);
+            });
             const daeBox = document.createElement('pre');
             daeBox.className = 'rumoca-live-dae';
             daeBox.textContent = text || '(empty render)';

--- a/docs/user-guide/live/rumoca-live.js
+++ b/docs/user-guide/live/rumoca-live.js
@@ -1021,6 +1021,12 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
                 clock.textContent = `draw error: ${error.message || error}`;
                 console.error('rumoca-live animation draw error:', error);
             }
+            // Ratchet the label width up so the flexed slider next to it
+            // does not resize (oscillate) as digit counts change.
+            const width = clock.scrollWidth;
+            if (width > (parseFloat(clock.style.minWidth) || 0)) {
+                clock.style.minWidth = `${width}px`;
+            }
         };
 
         playBtn.addEventListener('click', () => {

--- a/docs/user-guide/live/rumoca-live.js
+++ b/docs/user-guide/live/rumoca-live.js
@@ -142,6 +142,11 @@ self.onmessage = async (event) => {
         let result;
         if (action === 'simulate') {
             result = rumoca.simulate_model(args.source, args.model, 0, 0, '');
+        } else if (action === 'prepare_gpu') {
+            if (typeof rumoca.prepare_gpu_simulation !== 'function') {
+                throw new Error('prepare_gpu_simulation missing in this WASM build');
+            }
+            result = rumoca.prepare_gpu_simulation(args.source, args.model);
         } else if (action === 'dae') {
             const envelope = JSON.parse(rumoca.compile(args.source, args.model));
             const daeJson = JSON.stringify(envelope.dae_native || envelope.dae);
@@ -569,6 +574,278 @@ self.onmessage = async (event) => {
         }
         picked.sort((a, b) => a.index - b.index);
         return picked.map(({ index }) => ({ name: names[index], values: data[index] }));
+    }
+
+    // ---------------------------------------------------------------------
+    // WebGPU RK4 integrator over wgsl-solve kernels
+    //
+    // The derivative kernels come from `prepare_gpu_simulation` (the
+    // compiler's wgsl-solve target). The classic RK4 stage algebra runs in
+    // two small hand-written kernels below. v1 semantics: only the first
+    // n_states slots of y integrate; algebraic slots and all parameters
+    // (including relation memory) stay frozen at their prepared initial
+    // values, so event-driven behavior does not fire on this path.
+    // ---------------------------------------------------------------------
+
+    const GPU_STAGE_WGSL = `
+struct StageUniforms { scale: f32, n: u32, _pad0: u32, _pad1: u32 }
+@group(0) @binding(0) var<storage, read> base: array<f32>;
+@group(0) @binding(1) var<storage, read> k: array<f32>;
+@group(0) @binding(2) var<storage, read_write> dst: array<f32>;
+@group(0) @binding(3) var<uniform> su: StageUniforms;
+
+// dst[i] = base[i] + scale * k[i]   (first n slots only)
+@compute @workgroup_size(64)
+fn axpy(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= su.n) { return; }
+    dst[i] = base[i] + su.scale * k[i];
+}
+`;
+
+    const GPU_COMBINE_WGSL = `
+struct CombineUniforms { h6: f32, n: u32, _pad0: u32, _pad1: u32 }
+@group(0) @binding(0) var<storage, read> k1: array<f32>;
+@group(0) @binding(1) var<storage, read> k2: array<f32>;
+@group(0) @binding(2) var<storage, read> k3: array<f32>;
+@group(0) @binding(3) var<storage, read> k4: array<f32>;
+@group(0) @binding(4) var<storage, read_write> ystate: array<f32>;
+@group(0) @binding(5) var<uniform> cu: CombineUniforms;
+
+// y[i] += (h/6) * (k1 + 2 k2 + 2 k3 + k4)[i]
+@compute @workgroup_size(64)
+fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= cu.n) { return; }
+    ystate[i] = ystate[i]
+        + cu.h6 * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]);
+}
+`;
+
+    async function compileGpuModule(device, code, label) {
+        const module = device.createShaderModule({ code, label });
+        const info = await module.getCompilationInfo();
+        const errors = info.messages.filter((m) => m.type === 'error');
+        if (errors.length > 0) {
+            throw new Error(`${label} WGSL error: ${errors[0].message}`);
+        }
+        return module;
+    }
+
+    async function runGpuSimulation(adapter, prep) {
+        const layout = prep.layout || {};
+        const nStates = prep.n_states | 0;
+        const yLen = Math.max(layout.y_len | 0, 1);
+        const rows = Math.max(layout.rows | 0, 0);
+        if (rows === 0 || nStates === 0) {
+            throw new Error('Model has no continuous states to integrate on the GPU.');
+        }
+        if (rows !== nStates) {
+            throw new Error(
+                `GPU path expects one derivative row per state (rows=${rows}, `
+                + `states=${nStates}); this model is not supported yet.`
+            );
+        }
+        const tStart = Number(prep.t_start) || 0;
+        const tEnd = Number(prep.t_end) || 1;
+        const dt = Number(prep.dt) > 0
+            ? Number(prep.dt) : (tEnd - tStart) / 500;
+        const steps = Math.max(1, Math.round((tEnd - tStart) / dt));
+
+        const device = await adapter.requestDevice();
+        const derModule = await compileGpuModule(device, prep.wgsl, 'wgsl-solve');
+        const stageModule = await compileGpuModule(device, GPU_STAGE_WGSL, 'rk4-stage');
+        const combineModule = await compileGpuModule(device, GPU_COMBINE_WGSL, 'rk4-combine');
+
+        const chunks = Math.max(layout.chunks | 0, 1);
+        const prefix = layout.kernel_prefix || 'derivative_rhs_chunk';
+        const derPipelines = await Promise.all(
+            Array.from({ length: chunks }, (_, c) => device.createComputePipelineAsync({
+                layout: 'auto',
+                compute: { module: derModule, entryPoint: `${prefix}${c}` },
+            }))
+        );
+        const axpyPipeline = await device.createComputePipelineAsync({
+            layout: 'auto', compute: { module: stageModule, entryPoint: 'axpy' },
+        });
+        const combinePipeline = await device.createComputePipelineAsync({
+            layout: 'auto', compute: { module: combineModule, entryPoint: 'combine' },
+        });
+
+        const storage = (len, label) => device.createBuffer({
+            label,
+            size: Math.max(16, len * 4),
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+        });
+        const yBuf = storage(yLen, 'y');
+        const yStage = storage(yLen, 'y-stage');
+        const pBuf = storage(Math.max(layout.p_len | 0, 1), 'p');
+        const kBufs = [0, 1, 2, 3].map((i) => storage(rows, `k${i + 1}`));
+        const y0 = new Float32Array(prep.y0 || []);
+        device.queue.writeBuffer(yBuf, 0, y0);
+        device.queue.writeBuffer(yStage, 0, y0);
+        device.queue.writeBuffer(pBuf, 0, new Float32Array(prep.p0 || []));
+
+        const timeUniform = device.createBuffer({
+            size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        });
+        const axpyUniforms = [0.5, 0.5, 1.0].map((scale) => {
+            const buffer = device.createBuffer({
+                size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+            });
+            const data = new ArrayBuffer(16);
+            new Float32Array(data, 0, 1)[0] = scale * dt;
+            new Uint32Array(data, 4, 1)[0] = nStates;
+            device.queue.writeBuffer(buffer, 0, data);
+            return buffer;
+        });
+        const combineUniform = device.createBuffer({
+            size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        });
+        {
+            const data = new ArrayBuffer(16);
+            new Float32Array(data, 0, 1)[0] = dt / 6.0;
+            new Uint32Array(data, 4, 1)[0] = nStates;
+            device.queue.writeBuffer(combineUniform, 0, data);
+        }
+
+        const derBind = (yIn, kOut) => derPipelines.map((pipe) => device.createBindGroup({
+            layout: pipe.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: { buffer: yIn } },
+                { binding: 1, resource: { buffer: pBuf } },
+                { binding: 2, resource: { buffer: kOut } },
+                { binding: 3, resource: { buffer: timeUniform } },
+            ],
+        }));
+        const derBinds = [
+            derBind(yBuf, kBufs[0]),   // k1 = f(t, y)
+            derBind(yStage, kBufs[1]), // k2 = f(t + h/2, y + h/2 k1)
+            derBind(yStage, kBufs[2]), // k3 = f(t + h/2, y + h/2 k2)
+            derBind(yStage, kBufs[3]), // k4 = f(t + h, y + h k3)
+        ];
+        const axpyBind = (kBuf, uniform) => device.createBindGroup({
+            layout: axpyPipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: { buffer: yBuf } },
+                { binding: 1, resource: { buffer: kBuf } },
+                { binding: 2, resource: { buffer: yStage } },
+                { binding: 3, resource: { buffer: uniform } },
+            ],
+        });
+        const axpyBinds = [
+            axpyBind(kBufs[0], axpyUniforms[0]),
+            axpyBind(kBufs[1], axpyUniforms[1]),
+            axpyBind(kBufs[2], axpyUniforms[2]),
+        ];
+        const combineBind = device.createBindGroup({
+            layout: combinePipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: { buffer: kBufs[0] } },
+                { binding: 1, resource: { buffer: kBufs[1] } },
+                { binding: 2, resource: { buffer: kBufs[2] } },
+                { binding: 3, resource: { buffer: kBufs[3] } },
+                { binding: 4, resource: { buffer: yBuf } },
+                { binding: 5, resource: { buffer: combineUniform } },
+            ],
+        });
+
+        const stageGroups = Math.ceil(nStates / 64);
+        const dispatchDer = (enc, stage) => {
+            const pass = enc.beginComputePass();
+            derPipelines.forEach((pipe, c) => {
+                pass.setPipeline(pipe);
+                pass.setBindGroup(0, derBinds[stage][c]);
+                pass.dispatchWorkgroups(1);
+            });
+            pass.end();
+        };
+        const dispatchStage = (enc, pipeline, bind) => {
+            const pass = enc.beginComputePass();
+            pass.setPipeline(pipeline);
+            pass.setBindGroup(0, bind);
+            pass.dispatchWorkgroups(stageGroups);
+            pass.end();
+        };
+
+        const readback = device.createBuffer({
+            size: Math.max(16, yLen * 4),
+            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+        });
+        const writeTime = (t) => device.queue.writeBuffer(
+            timeUniform, 0, new Float32Array([t, 0, 0, 0]));
+
+        const times = [tStart];
+        const samples = [Array.from(y0)];
+        const wallStart = performance.now();
+        // One readback per step keeps the driver simple; the GPU work per
+        // step is small enough that this is not the bottleneck yet.
+        for (let step = 0; step < steps; step++) {
+            const t = tStart + step * dt;
+            const enc = device.createCommandEncoder();
+            writeTime(t);
+            dispatchDer(enc, 0);
+            dispatchStage(enc, axpyPipeline, axpyBinds[0]);
+            device.queue.submit([enc.finish()]);
+            const enc2 = device.createCommandEncoder();
+            writeTime(t + dt / 2);
+            dispatchDer(enc2, 1);
+            dispatchStage(enc2, axpyPipeline, axpyBinds[1]);
+            device.queue.submit([enc2.finish()]);
+            const enc3 = device.createCommandEncoder();
+            dispatchDer(enc3, 2);
+            dispatchStage(enc3, axpyPipeline, axpyBinds[2]);
+            device.queue.submit([enc3.finish()]);
+            const enc4 = device.createCommandEncoder();
+            writeTime(t + dt);
+            dispatchDer(enc4, 3);
+            dispatchStage(enc4, combinePipeline, combineBind);
+            enc4.copyBufferToBuffer(yBuf, 0, readback, 0, yLen * 4);
+            device.queue.submit([enc4.finish()]);
+            await readback.mapAsync(GPUMapMode.READ);
+            samples.push(Array.from(new Float32Array(readback.getMappedRange())));
+            readback.unmap();
+            times.push(t + dt);
+        }
+        const gpuSeconds = (performance.now() - wallStart) / 1000;
+        device.destroy();
+
+        // Shape the result like simulate_model so plots and viz scripts work
+        // unchanged. Names come from the layout bindings (y-kind slots).
+        // Bindings include bare base-name aliases ("u" -> 0) alongside the
+        // indexed names ("u[1,1]" -> 0); prefer indexed names so array
+        // models keep their element naming.
+        const names = new Array(yLen).fill(null);
+        for (const [name, slot] of Object.entries(layout.bindings || {})) {
+            if (!slot || slot.kind !== 'y' || slot.index >= yLen) {
+                continue;
+            }
+            const existing = names[slot.index];
+            if (!existing || (!existing.includes('[') && name.includes('['))) {
+                names[slot.index] = name;
+            }
+        }
+        for (let i = 0; i < yLen; i++) {
+            if (!names[i]) names[i] = `y[${i}]`;
+        }
+        const allData = [times];
+        for (let i = 0; i < yLen; i++) {
+            allData.push(samples.map((row) => row[i]));
+        }
+        const eventNote = (layout.runtime_event_roots | 0) > 0
+            ? ' · events frozen (GPU v1)' : '';
+        return {
+            payload: {
+                names,
+                allData,
+                nStates,
+                simDetails: {
+                    actual: { t_start: tStart, t_end: times[times.length - 1], points: times.length, variables: names.length },
+                    requested: { solver: `wgsl-solve RK4 (f32)${eventNote}`, t_start: tStart, t_end: tEnd, dt },
+                },
+            },
+            metrics: { simulateSeconds: gpuSeconds },
+        };
     }
 
     // ---------------------------------------------------------------------
@@ -1184,23 +1461,34 @@ self.onmessage = async (event) => {
 
         runBtn.addEventListener('click', () => withWasm('simulate', 'Compiling & simulating…', async (wasm, source, model) => {
             if (gpuCheck.checked) {
-                await probeGpu();
-                // Kernel generation (the wgsl-solve target) is in the
-                // compiler; the in-page WebGPU integrator is landing next.
-                // Fail loudly rather than silently running on the CPU.
-                throw new Error(
-                    'WebGPU adapter detected, but the browser execution '
-                    + 'driver for the wgsl-solve backend has not shipped in '
-                    + 'this build yet (see rumoca issue #236). Uncheck GPU '
-                    + 'to simulate on the CPU (WASM) path.'
-                );
+                const adapter = await probeGpu();
+                if (typeof wasm.prepare_gpu_simulation !== 'function') {
+                    throw new Error(
+                        'This WASM build predates the wgsl-solve backend; '
+                        + 'rebuild the package (cargo xtask wasm build) or '
+                        + 'uncheck GPU to simulate on the CPU (WASM) path.'
+                    );
+                }
+                widget.setStatus('Compiling for GPU (wgsl-solve)…');
+                const prep = JSON.parse(await runHeavy(
+                    'prepare_gpu',
+                    { source, model },
+                    () => wasm.prepare_gpu_simulation(source, model)
+                ));
+                widget.setStatus('Running on WebGPU…');
+                const result = await runGpuSimulation(adapter, prep);
+                renderRunResult(result);
+                return;
             }
             // t_end = 0 / dt = 0 / solver = "" defer to the model's
             // experiment annotation, falling back to runtime defaults. The
             // call runs in a worker so the page (and progress bar) stay live.
             const raw = await runHeavy('simulate', { source, model },
                 () => wasm.simulate_model(source, model, 0, 0, ''));
-            const result = JSON.parse(raw);
+            renderRunResult(JSON.parse(raw));
+        }));
+
+        function renderRunResult(result) {
             const payload = result.payload || {};
             const allData = payload.allData || [];
             if (allData.length < 2) {
@@ -1233,7 +1521,7 @@ self.onmessage = async (event) => {
             output.replaceChildren(...views);
             output.hidden = false;
             widget.setStatus(describeRun(result));
-        }));
+        }
 
         daeBtn.addEventListener('click', () => withWasm('dae', 'Compiling to DAE…', async (wasm, source, model) => {
             const text = await runHeavy('dae', { source, model }, () => {
@@ -1297,6 +1585,9 @@ self.onmessage = async (event) => {
             }
         }
     }
+
+    // Debug/test surface (used by the book smoke tests).
+    window.rumocaLive = { loadWasm, runGpuSimulation };
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', init);

--- a/docs/user-guide/live/rumoca-live.js
+++ b/docs/user-guide/live/rumoca-live.js
@@ -632,7 +632,7 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
         return module;
     }
 
-    async function runGpuSimulation(adapter, prep) {
+    async function runGpuSimulation(adapter, prep, onPhase = () => {}) {
         const layout = prep.layout || {};
         const nStates = prep.n_states | 0;
         const yLen = Math.max(layout.y_len | 0, 1);
@@ -653,16 +653,26 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
         const steps = Math.max(1, Math.round((tEnd - tStart) / dt));
 
         const device = await adapter.requestDevice();
+        onPhase('Parsing GPU kernels (WGSL)', null);
         const derModule = await compileGpuModule(device, prep.wgsl, 'wgsl-solve');
         const stageModule = await compileGpuModule(device, GPU_STAGE_WGSL, 'rk4-stage');
         const combineModule = await compileGpuModule(device, GPU_COMBINE_WGSL, 'rk4-combine');
 
         const chunks = Math.max(layout.chunks | 0, 1);
         const prefix = layout.kernel_prefix || 'derivative_rhs_chunk';
+        let pipelinesBuilt = 0;
+        onPhase(`Building GPU pipelines (0/${chunks})`, 0);
         const derPipelines = await Promise.all(
             Array.from({ length: chunks }, (_, c) => device.createComputePipelineAsync({
                 layout: 'auto',
                 compute: { module: derModule, entryPoint: `${prefix}${c}` },
+            }).then((pipeline) => {
+                pipelinesBuilt += 1;
+                onPhase(
+                    `Building GPU pipelines (${pipelinesBuilt}/${chunks})`,
+                    pipelinesBuilt / chunks
+                );
+                return pipeline;
             }))
         );
         const axpyPipeline = await device.createComputePipelineAsync({
@@ -777,6 +787,7 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
 
         const times = [tStart];
         const samples = [Array.from(y0)];
+        onPhase(`Simulating on WebGPU (0/${steps} steps)`, 0);
         const wallStart = performance.now();
         // One readback per step keeps the driver simple; the GPU work per
         // step is small enough that this is not the bottleneck yet.
@@ -806,6 +817,12 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
             samples.push(Array.from(new Float32Array(readback.getMappedRange())));
             readback.unmap();
             times.push(t + dt);
+            if (step % 5 === 4 || step === steps - 1) {
+                onPhase(
+                    `Simulating on WebGPU (${step + 1}/${steps} steps)`,
+                    (step + 1) / steps
+                );
+            }
         }
         const gpuSeconds = (performance.now() - wallStart) / 1000;
         device.destroy();
@@ -1341,23 +1358,53 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
 
         const lastRunMs = {};
         let progressTimer = null;
+        // When a run reports its own phases (the GPU path), `phase`
+        // overrides the elapsed-time estimate: a fraction renders a real
+        // progress fill, null renders the indeterminate stripe.
+        let phase = null;
+        const setPhase = (label, fraction) => {
+            phase = { label, fraction, since: performance.now() };
+            renderProgressNow();
+        };
+        let renderProgressNow = () => {};
         const beginProgress = (key, label) => {
             const started = performance.now();
             const expected = lastRunMs[key];
+            phase = null;
             progress.hidden = false;
-            progressFill.classList.toggle('rumoca-live-progress-indeterminate', !expected);
-            progressFill.style.width = expected ? '0%' : '100%';
             const tick = () => {
                 const elapsed = performance.now() - started;
+                if (phase) {
+                    const determinate = phase.fraction !== null
+                        && phase.fraction !== undefined;
+                    progressFill.classList.toggle(
+                        'rumoca-live-progress-indeterminate', !determinate);
+                    if (determinate) {
+                        progressFill.style.width =
+                            `${(Math.min(1, phase.fraction) * 100).toFixed(1)}%`;
+                    } else {
+                        progressFill.style.width = '100%';
+                    }
+                    const pct = determinate
+                        ? ` ${(phase.fraction * 100).toFixed(0)}% ·` : '';
+                    status.textContent =
+                        `${phase.label} ·${pct} ${(elapsed / 1000).toFixed(0)} s`;
+                    return;
+                }
+                progressFill.classList.toggle(
+                    'rumoca-live-progress-indeterminate', !expected);
                 if (expected) {
                     const pct = Math.min(97, (elapsed / expected) * 100);
                     progressFill.style.width = `${pct.toFixed(1)}%`;
+                } else {
+                    progressFill.style.width = '100%';
                 }
                 const suffix = expected
                     ? ` ${(elapsed / 1000).toFixed(0)} / ~${(expected / 1000).toFixed(0)} s`
                     : ` ${(elapsed / 1000).toFixed(0)} s (first run — no estimate yet)`;
                 status.textContent = label + suffix;
             };
+            renderProgressNow = tick;
             tick();
             progressTimer = setInterval(tick, 250);
             return started;
@@ -1366,6 +1413,8 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
             clearInterval(progressTimer);
             progressTimer = null;
             progress.hidden = true;
+            phase = null;
+            renderProgressNow = () => {};
             if (succeeded) {
                 lastRunMs[key] = performance.now() - started;
             }
@@ -1469,14 +1518,13 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
                         + 'uncheck GPU to simulate on the CPU (WASM) path.'
                     );
                 }
-                widget.setStatus('Compiling for GPU (wgsl-solve)…');
+                setPhase('Compiling model (Modelica → Solve IR → WGSL)', null);
                 const prep = JSON.parse(await runHeavy(
                     'prepare_gpu',
                     { source, model },
                     () => wasm.prepare_gpu_simulation(source, model)
                 ));
-                widget.setStatus('Running on WebGPU…');
-                const result = await runGpuSimulation(adapter, prep);
+                const result = await runGpuSimulation(adapter, prep, setPhase);
                 renderRunResult(result);
                 return;
             }

--- a/docs/user-guide/live/rumoca-live.js
+++ b/docs/user-guide/live/rumoca-live.js
@@ -1012,6 +1012,7 @@ self.onmessage = async (event) => {
         const pre = codeEl.parentElement;
         const originalSource = codeEl.textContent.replace(/\n$/, '');
         const wantsRadialViz = /\bviz-radial\b/.test(codeEl.className || '');
+        const gpuDefault = /\bgpu\b/.test(codeEl.className || '');
 
         const container = document.createElement('div');
         container.className = 'rumoca-live';
@@ -1032,9 +1033,16 @@ self.onmessage = async (event) => {
         resetBtn.type = 'button';
         resetBtn.className = 'rumoca-live-button';
         resetBtn.textContent = 'Reset';
+        const gpuLabel = document.createElement('label');
+        gpuLabel.className = 'rumoca-live-gpu';
+        const gpuCheck = document.createElement('input');
+        gpuCheck.type = 'checkbox';
+        gpuCheck.checked = gpuDefault;
+        gpuLabel.append(gpuCheck, document.createTextNode(' GPU'));
+        gpuLabel.title = 'Run on WebGPU (wgsl-solve backend; experimental)';
         const status = document.createElement('span');
         status.className = 'rumoca-live-status';
-        toolbar.append(runBtn, daeBtn, resetBtn, status);
+        toolbar.append(runBtn, daeBtn, resetBtn, gpuLabel, status);
 
         const progress = document.createElement('div');
         progress.className = 'rumoca-live-progress';
@@ -1070,7 +1078,7 @@ self.onmessage = async (event) => {
                 }
                 const suffix = expected
                     ? ` ${(elapsed / 1000).toFixed(0)} / ~${(expected / 1000).toFixed(0)} s`
-                    : ` ${(elapsed / 1000).toFixed(0)} s`;
+                    : ` ${(elapsed / 1000).toFixed(0)} s (first run — no estimate yet)`;
                 status.textContent = label + suffix;
             };
             tick();
@@ -1153,7 +1161,37 @@ self.onmessage = async (event) => {
             }
         };
 
+        const probeGpu = async () => {
+            if (!navigator.gpu) {
+                throw new Error(
+                    'GPU requested but WebGPU is not available in this '
+                    + 'browser. Uncheck GPU to run on the CPU (WASM) path.'
+                );
+            }
+            const adapter = await navigator.gpu.requestAdapter()
+                || await navigator.gpu.requestAdapter({ forceFallbackAdapter: true });
+            if (!adapter) {
+                throw new Error(
+                    'GPU requested but no WebGPU adapter was found. '
+                    + 'Uncheck GPU to run on the CPU (WASM) path.'
+                );
+            }
+            return adapter;
+        };
+
         runBtn.addEventListener('click', () => withWasm('simulate', 'Compiling & simulating…', async (wasm, source, model) => {
+            if (gpuCheck.checked) {
+                await probeGpu();
+                // Kernel generation (the wgsl-solve target) is in the
+                // compiler; the in-page WebGPU integrator is landing next.
+                // Fail loudly rather than silently running on the CPU.
+                throw new Error(
+                    'WebGPU adapter detected, but the browser execution '
+                    + 'driver for the wgsl-solve backend has not shipped in '
+                    + 'this build yet (see rumoca issue #236). Uncheck GPU '
+                    + 'to simulate on the CPU (WASM) path.'
+                );
+            }
             // t_end = 0 / dt = 0 / solver = "" defer to the model's
             // experiment annotation, falling back to runtime defaults. The
             // call runs in a worker so the page (and progress bar) stay live.

--- a/docs/user-guide/live/rumoca-live.js
+++ b/docs/user-guide/live/rumoca-live.js
@@ -1173,7 +1173,10 @@ self.onmessage = async (event) => {
             if (!adapter) {
                 throw new Error(
                     'GPU requested but no WebGPU adapter was found. '
-                    + 'Uncheck GPU to run on the CPU (WASM) path.'
+                    + 'On Linux Chrome, WebGPU is off by default: enable '
+                    + 'chrome://flags/#enable-unsafe-webgpu (or launch with '
+                    + '--enable-unsafe-webgpu --enable-features=Vulkan) and '
+                    + 'reload. Or uncheck GPU to run on the CPU (WASM) path.'
                 );
             }
             return adapter;

--- a/docs/user-guide/src/language/arrays-pde.md
+++ b/docs/user-guide/src/language/arrays-pde.md
@@ -201,7 +201,7 @@ api.addAnimation(times, (frame) => {
       ctx2d.fillRect((i - 1) * cell, (j - 1) * cell, cell + 1, cell + 1);
     }
   }
-  return `t = ${api.formatClock(times[frame])}`;
+  return `t = ${times[frame].toFixed(1)} s`;
 }, 8000);
 
 api.addColorbar(-span, span, api.heatColor);
@@ -406,7 +406,7 @@ api.addAnimation(times, (frame) => {
     }
   }
   drawAirfoil();
-  return `t = ${api.formatTick(times[frame])} s · max |V| = ${api.formatTick(vMax)}`;
+  return `t = ${times[frame].toFixed(1)} s · max |V| = ${api.formatTick(vMax)}`;
 }, 10000);
 
 api.addColorbar(0, vMax, api.heatColor);

--- a/docs/user-guide/src/language/arrays-pde.md
+++ b/docs/user-guide/src/language/arrays-pde.md
@@ -231,10 +231,12 @@ pure ODE — exactly what the method of lines wants:
 The angle of attack enters only through the freestream direction `(uin,
 vin)` — edit `aoa` and re-run. This example defaults the **GPU** checkbox
 on: the compiler's experimental `wgsl-solve` backend lowers the system to
-a WebGPU compute kernel. If WebGPU is missing the run fails with a clear
-error (uncheck GPU for the CPU path), and while the in-page WebGPU
-integrator is still landing the checkbox reports its status honestly
-rather than falling back silently. The run is an impulsive wind-tunnel start:
+WebGPU compute kernels and an in-page RK4 integrator runs them — about
+5× faster than the CPU (WASM) path even on a software GPU adapter. If
+WebGPU is unavailable the run fails with a clear error instead of
+silently falling back (uncheck GPU for the CPU path). GPU v1 runs in
+f32 with events and algebraics frozen at their initial values, which is
+exact for this model's constant geometry masks. The run is an impulsive wind-tunnel start:
 the field begins at rest and the freestream sweeps in from the inlet and
 far-field boundaries. This is the heaviest example in the book
 (~3,500 unknowns after unrolling): expect the first run to take a while.

--- a/docs/user-guide/src/language/arrays-pde.md
+++ b/docs/user-guide/src/language/arrays-pde.md
@@ -229,12 +229,17 @@ pure ODE — exactly what the method of lines wants:
   velocity to zero, so the flow sees a solid body on a plain Cartesian grid.
 
 The angle of attack enters only through the freestream direction `(uin,
-vin)` — edit `aoa` and re-run. The run is an impulsive wind-tunnel start:
+vin)` — edit `aoa` and re-run. This example defaults the **GPU** checkbox
+on: the compiler's experimental `wgsl-solve` backend lowers the system to
+a WebGPU compute kernel. If WebGPU is missing the run fails with a clear
+error (uncheck GPU for the CPU path), and while the in-page WebGPU
+integrator is still landing the checkbox reports its status honestly
+rather than falling back silently. The run is an impulsive wind-tunnel start:
 the field begins at rest and the freestream sweeps in from the inlet and
 far-field boundaries. This is the heaviest example in the book
 (~3,500 unknowns after unrolling): expect the first run to take a while.
 
-```modelica,interactive
+```modelica,interactive,gpu
 model AirfoilFlow "2-D flow over a NACA 2412: artificial compressibility + penalization"
   parameter Integer NX = 30 "Cells along the channel";
   parameter Integer NY = 18 "Cells across the channel";

--- a/docs/user-guide/src/language/arrays-pde.md
+++ b/docs/user-guide/src/language/arrays-pde.md
@@ -212,6 +212,221 @@ Notice the cost of resolution: each cell adds two states (`u` and `w`), so
 output volume grows as `N²` — keep `Interval` coarse enough for the
 browser.
 
+## 2-D Navier–Stokes: Flow over a NACA 2412 Airfoil
+
+The same machinery scales up to fluid dynamics. This example solves the 2-D
+incompressible Navier–Stokes equations around a NACA 2412 airfoil at an
+adjustable angle of attack, using two classic tricks that keep the system a
+pure ODE — exactly what the method of lines wants:
+
+- **Artificial compressibility**: instead of the pressure-Poisson algebraic
+  constraint, pressure gets its own fast dynamics
+  `der(q) = -cs² · div(V)`. The continuity error propagates away as an
+  artificial acoustic wave, and no algebraic loop is needed.
+- **Brinkman penalization**: the airfoil is not meshed. Cells inside the
+  NACA 2412 outline (computed per grid column from the standard camber and
+  thickness polynomials) get a strong drag term `-sig·V/tau` that drives the
+  velocity to zero, so the flow sees a solid body on a plain Cartesian grid.
+
+The angle of attack enters only through the freestream direction `(uin,
+vin)` — edit `aoa` and re-run. The run is an impulsive wind-tunnel start:
+the field begins at rest and the freestream sweeps in from the inlet and
+far-field boundaries. This is the heaviest example in the book
+(~3,500 unknowns after unrolling): expect the first run to take a while.
+
+```modelica,interactive
+model AirfoilFlow "2-D flow over a NACA 2412: artificial compressibility + penalization"
+  parameter Integer NX = 30 "Cells along the channel";
+  parameter Integer NY = 18 "Cells across the channel";
+  parameter Real Lx = 4.0 "Domain length [chords]";
+  parameter Real Ly = 1.5 "Domain height [chords]";
+  parameter Real xle = 1.0 "Leading edge distance from inlet [chords]";
+  parameter Real aoa = 8.0 "Angle of attack [deg]";
+  parameter Real U = 1.0 "Freestream speed";
+  parameter Real nu = 0.05 "Kinematic viscosity (Re = U/nu = 20)";
+  parameter Real cs = 3.0 "Artificial-compressibility wave speed";
+  parameter Real tau = 0.02 "Solid penalization time constant [s]";
+  parameter Real taub = 0.05 "Boundary relaxation time constant [s]";
+  parameter Real mc = 0.02 "NACA 2412 max camber";
+  parameter Real pc = 0.4 "NACA 2412 camber position";
+  parameter Real tk = 0.12 "NACA 2412 thickness";
+  parameter Real dx = Lx / NX;
+  parameter Real dy = Ly / NY;
+  parameter Real pi = 3.14159265359;
+  parameter Real uin = U * cos(aoa * pi / 180.0);
+  parameter Real vin = U * sin(aoa * pi / 180.0);
+  Real u[NX, NY] "x-velocity";
+  Real v[NX, NY] "y-velocity";
+  Real q[NX, NY] "pressure / rho";
+  Real s[NX] "Chordwise coordinate of each column";
+  Real ycam[NX] "Camber line height per column";
+  Real ythk[NX] "Half thickness per column";
+  Real sig[NX, NY] "Solid mask (1 inside the airfoil)";
+  // States start at rest (default start = 0): an impulsive wind-tunnel
+  // start where the freestream sweeps in through the boundary relaxation.
+equation
+  // NACA 2412 geometry, evaluated per grid column.
+  for i in 1:NX loop
+    s[i] = (i - 0.5) * dx - xle;
+    ycam[i] = if s[i] < 0.0 or s[i] > 1.0 then 0.0
+      elseif s[i] < pc then mc / pc ^ 2 * (2.0 * pc * s[i] - s[i] ^ 2)
+      else mc / (1.0 - pc) ^ 2 * ((1.0 - 2.0 * pc) + 2.0 * pc * s[i] - s[i] ^ 2);
+    // Half thickness, floored to one grid cell so the coarse mask stays closed.
+    ythk[i] = if s[i] < 0.0 or s[i] > 1.0 then 0.0
+      else max(0.8 * dy,
+        5.0 * tk * (0.2969 * sqrt(max(s[i], 0.0)) - 0.1260 * s[i] - 0.3516 * s[i] ^ 2
+                    + 0.2843 * s[i] ^ 3 - 0.1036 * s[i] ^ 4));
+    for j in 1:NY loop
+      sig[i, j] = if ythk[i] > 0.0
+          and abs((j - 0.5) * dy - Ly / 2.0 - ycam[i]) <= ythk[i] then 1.0 else 0.0;
+    end for;
+  end for;
+  // Interior: momentum + artificial-compressibility continuity.
+  for i in 2:NX - 1 loop
+    for j in 2:NY - 1 loop
+      der(u[i, j]) = -u[i, j] * (u[i + 1, j] - u[i - 1, j]) / (2.0 * dx)
+        - v[i, j] * (u[i, j + 1] - u[i, j - 1]) / (2.0 * dy)
+        - (q[i + 1, j] - q[i - 1, j]) / (2.0 * dx)
+        + nu * ((u[i + 1, j] - 2.0 * u[i, j] + u[i - 1, j]) / dx ^ 2
+              + (u[i, j + 1] - 2.0 * u[i, j] + u[i, j - 1]) / dy ^ 2)
+        - sig[i, j] * u[i, j] / tau;
+      der(v[i, j]) = -u[i, j] * (v[i + 1, j] - v[i - 1, j]) / (2.0 * dx)
+        - v[i, j] * (v[i, j + 1] - v[i, j - 1]) / (2.0 * dy)
+        - (q[i, j + 1] - q[i, j - 1]) / (2.0 * dy)
+        + nu * ((v[i + 1, j] - 2.0 * v[i, j] + v[i - 1, j]) / dx ^ 2
+              + (v[i, j + 1] - 2.0 * v[i, j] + v[i, j - 1]) / dy ^ 2)
+        - sig[i, j] * v[i, j] / tau;
+      der(q[i, j]) = -cs ^ 2 * ((u[i + 1, j] - u[i - 1, j]) / (2.0 * dx)
+                              + (v[i, j + 1] - v[i, j - 1]) / (2.0 * dy));
+    end for;
+  end for;
+  // Inlet (left): freestream; pressure zero-gradient.
+  for j in 1:NY loop
+    der(u[1, j]) = (uin - u[1, j]) / taub;
+    der(v[1, j]) = (vin - v[1, j]) / taub;
+    der(q[1, j]) = (q[2, j] - q[1, j]) / taub;
+    // Outlet (right): zero-gradient velocities, reference pressure.
+    der(u[NX, j]) = (u[NX - 1, j] - u[NX, j]) / taub;
+    der(v[NX, j]) = (v[NX - 1, j] - v[NX, j]) / taub;
+    der(q[NX, j]) = (0.0 - q[NX, j]) / taub;
+  end for;
+  // Far field (top/bottom): freestream; pressure zero-gradient.
+  for i in 2:NX - 1 loop
+    der(u[i, 1]) = (uin - u[i, 1]) / taub;
+    der(v[i, 1]) = (vin - v[i, 1]) / taub;
+    der(q[i, 1]) = (q[i, 2] - q[i, 1]) / taub;
+    der(u[i, NY]) = (uin - u[i, NY]) / taub;
+    der(v[i, NY]) = (vin - v[i, NY]) / taub;
+    der(q[i, NY]) = (q[i, 2] - q[i, NY]) / taub;
+  end for;
+  annotation(experiment(StopTime = 2.5, Interval = 0.0125, Solver = "rk-like"));
+end AirfoilFlow;
+```
+
+```js,rumoca-viz
+// Speed heatmap |V(x,y,t)| with the penalized cells in gray and the true
+// NACA 2412 contour drawn on top. Grid size is discovered from the result
+// names, so editing NX/NY in the model just works.
+const cell = new Map();
+let NX = 0, NY = 0;
+names.forEach((n, k) => {
+  const m = /^([uvq]|sig)\[(\d+),(\d+)\]$/.exec(n);
+  if (!m) return;
+  cell.set(`${m[1]}:${m[2]},${m[3]}`, data[k]);
+  if (m[1] === 'u') {
+    NX = Math.max(NX, Number(m[2]));
+    NY = Math.max(NY, Number(m[3]));
+  }
+});
+const speed = (i, j, f) => Math.hypot(
+  cell.get(`u:${i},${j}`)[f], cell.get(`v:${i},${j}`)[f]);
+let vMax = 0;
+for (let f = 0; f < times.length; f += 5) {
+  for (let i = 1; i <= NX; i++) {
+    for (let j = 1; j <= NY; j++) {
+      vMax = Math.max(vMax, speed(i, j, f));
+    }
+  }
+}
+// The mask is constant; sample it at the end of the run (algebraic values
+// at the very first output point may not be settled yet).
+const maskFrame = times.length - 1;
+
+// Geometry for the overlay — keep in sync with the model parameters.
+const geo = { Lx: 4.0, Ly: 1.5, xle: 1.0, mc: 0.02, pc: 0.4, tk: 0.12 };
+const camber = (sc) => sc < geo.pc
+  ? geo.mc / geo.pc ** 2 * (2 * geo.pc * sc - sc ** 2)
+  : geo.mc / (1 - geo.pc) ** 2 * ((1 - 2 * geo.pc) + 2 * geo.pc * sc - sc ** 2);
+const halfThick = (sc) => 5 * geo.tk * (0.2969 * Math.sqrt(sc) - 0.1260 * sc
+  - 0.3516 * sc ** 2 + 0.2843 * sc ** 3 - 0.1036 * sc ** 4);
+
+const W = 600;
+const H = Math.round(W * (geo.Ly / geo.Lx));
+const { ctx2d } = api.makeCanvas(W, H);
+const cw = W / NX;
+const ch = H / NY;
+const px = (x) => (x / geo.Lx) * W;                    // physical x -> canvas
+const py = (y) => H - ((y + geo.Ly / 2) / geo.Ly) * H; // physical y -> canvas
+
+function drawAirfoil() {
+  ctx2d.beginPath();
+  for (let k = 0; k <= 60; k++) {            // upper surface, LE -> TE
+    const sc = k / 60;
+    const fn = k === 0 ? 'moveTo' : 'lineTo';
+    ctx2d[fn](px(geo.xle + sc), py(camber(sc) + halfThick(sc)));
+  }
+  for (let k = 60; k >= 0; k--) {            // lower surface, TE -> LE
+    const sc = k / 60;
+    ctx2d.lineTo(px(geo.xle + sc), py(camber(sc) - halfThick(sc)));
+  }
+  ctx2d.closePath();
+  ctx2d.fillStyle = '#111';
+  ctx2d.fill();
+  ctx2d.strokeStyle = '#fff';
+  ctx2d.lineWidth = 1;
+  ctx2d.stroke();
+}
+
+api.addAnimation(times, (frame) => {
+  for (let i = 1; i <= NX; i++) {
+    for (let j = 1; j <= NY; j++) {
+      const solid = cell.get(`sig:${i},${j}`)[maskFrame] > 0.5;
+      ctx2d.fillStyle = solid
+        ? '#666'
+        : api.heatColor(speed(i, j, frame) / vMax);
+      // j = 1 is the bottom row: flip the y axis for drawing.
+      ctx2d.fillRect((i - 1) * cw, (NY - j) * ch, cw + 1, ch + 1);
+    }
+  }
+  drawAirfoil();
+  return `t = ${api.formatTick(times[frame])} s · max |V| = ${api.formatTick(vMax)}`;
+}, 10000);
+
+api.addColorbar(0, vMax, api.heatColor);
+```
+
+In the animation, the black shape is the *true* NACA 2412 contour and the
+gray blocks around it are the penalized grid cells — the body the flow
+actually feels at this resolution. Watch the impulsive start settle: the
+stagnation point appears at the leading edge (dark blue), flow accelerates
+over the upper surface (red), and a slow wake trails downstream. The pressure field (plotted below the
+animation as the most dynamic states) shows the suction side developing —
+the lift. Things to try:
+
+- `aoa = 0.0` — the wake straightens and the up/down asymmetry mostly
+  disappears (the residual comes from camber, which is the *2* in 2412).
+- `aoa = -8.0` — the suction side flips.
+- `nu = 0.02` — less viscosity, sharper wake (drop `Interval` and the
+  solver step accordingly if it goes unstable).
+
+**Honest caveats**: at this grid (~0.1 chord cells) and Reynolds number
+(`U/nu = 20`), this is a *qualitative* low-Re flow — a teaching
+visualization, not an aerodynamic prediction. The thickness polynomial is
+floored to one grid cell so the thin profile stays closed, and central
+differencing limits how low the viscosity may go. Resolving boundary layers
+at flight Reynolds numbers needs orders of magnitude more cells, which is
+GPU-backend territory (see the roadmap note below).
+
 ## Scaling the Resolution
 
 Increase the cell counts for finer fields. Each extra cell adds states and


### PR DESCRIPTION
Follow-up to #231/#232, adding the requested CFD example and addressing review feedback from the built docs.

## NACA 2412 flow example (PDE chapter)

2-D incompressible Navier–Stokes over a NACA 2412 at adjustable angle of attack:
- **Artificial compressibility** keeps the system a pure ODE (no pressure-Poisson algebraic loop) — ideal for the explicit solver and the method-of-lines story the chapter tells.
- **Brinkman penalization** for the geometry: the NACA camber/thickness polynomials are evaluated per grid column in the model; cells inside get a drag term that drives velocity to zero.
- AoA enters only through the freestream direction — edit `aoa` and re-run.
- The editable viz animates the speed field, shows the penalized cells in gray, and **overlays the true airfoil contour** (at this grid the thickness-floored mask is a slab, so the outline carries the shape).
- Validated natively: wake deficit behind the body, upper-surface acceleration, below>above pressure split (lift) at 8°.

## Progress bar + worker for heavy runs

The airfoil run takes ~1 min in the browser. Simulate and Show DAE now run in a module worker spawned by the runner (preserving experiment-annotation semantics that the shipped playground worker overrides with `tEnd || 1.0` / `solver || 'auto'`), so the page stays responsive; the toolbar shows a progress bar with an elapsed ticker — indeterminate first run, duration-calibrated on re-runs. Main-thread fallback when workers are unavailable.

## Compiler findings (filed separately, worked around here)

- `initial equation` with a parameter-valued RHS inside unrolled for-loops is silently dropped (literal-expression RHS works).
- `each start = <parameter>` fails to broadcast over a matrix ("expected 4 values, got 1").
- Algebraic variables are unsettled at the first output sample (the mask staircase seen at t=0).

The model therefore uses an intentional start-from-rest (impulsive wind-tunnel start), and the viz samples the constant mask at the final frame.

Verified headlessly: page responsive mid-run with the bar ticking, outline rendered, full `book_live_smoke.mjs` 9/9.