### PR TITLE
Issue #235: settle relation guard discretes before first rk-like sample

### DIFF
--- a/crates/rumoca-solver-rk45/src/lib.rs
+++ b/crates/rumoca-solver-rk45/src/lib.rs
@@ -993,6 +993,29 @@ impl SimulationBackend for Rk45Backend<'_> {
             self.atol,
             UPDATE_MAX_ITERS,
         )?;
+        // Settle discrete relation/condition variables (the `c[]` guards behind
+        // `if` expressions, which "follow current" relation values) against the
+        // initialized state before the first output sample. Without this the
+        // conditions keep their default value at t_start and only get corrected by
+        // the first integration step, so the very first output frame reports the
+        // wrong values for any algebraic gated by such a relation. This uses the
+        // FollowCurrent-only update so edge-triggered `when` clauses do not fire at
+        // init. Mirrors the diffsol init path.
+        if !self.model.model.problem.discrete.update_targets.is_empty() {
+            let runtime = self.model;
+            let state_count = runtime.state_count;
+            let tol = self.atol;
+            let t = self.time;
+            let outcome = runtime.apply_projected_post_initial_event_update(
+                &mut solver_y,
+                &mut self.params,
+                t,
+                tol,
+                UPDATE_MAX_ITERS,
+                move |y, p| project_rk_algebraics(runtime, y, p, t, state_count, tol),
+            )?;
+            self.apply_event_action_outcome(outcome, t)?;
+        }
         self.copy_state_from_solver_y(&solver_y);
         self.model.update_relation_memory_from_state(
             self.time,
@@ -1398,6 +1421,7 @@ mod tests {
         model.problem.solve_layout.discrete_valued_scalar_names = vec!["m".to_string()];
         model.problem.events.scheduled_time_events = vec![0.05];
         model.problem.discrete.update_targets = vec![solve::scalar_slot_p(0)];
+        model.problem.discrete.pre_modes = vec![solve::DiscreteEventPreMode::EventEntry];
         model.problem.discrete.rhs = const_scalar_program_block(2.0);
         model.parameters = vec![0.0];
         model.visible_names = vec!["x".to_string(), "m".to_string()];
@@ -1465,6 +1489,7 @@ mod tests {
             LinearOp::StoreOutput { src: 2 },
         ]]);
         model.problem.discrete.update_targets = vec![solve::scalar_slot_p(0)];
+        model.problem.discrete.pre_modes = vec![solve::DiscreteEventPreMode::EventEntry];
         model.problem.discrete.rhs = const_scalar_program_block(2.0);
         model.parameters = vec![0.0];
         model.visible_names = vec!["x".to_string(), "m".to_string()];
@@ -1560,6 +1585,7 @@ mod tests {
             phase_seconds: 0.05,
         }];
         model.problem.discrete.update_targets = vec![solve::scalar_slot_p(0)];
+        model.problem.discrete.pre_modes = vec![solve::DiscreteEventPreMode::EventEntry];
         model.problem.discrete.rhs = const_scalar_program_block(3.0);
         model.parameters = vec![0.0];
         model.visible_names = vec!["x".to_string(), "m".to_string()];
@@ -1589,6 +1615,7 @@ mod tests {
         model.problem.solve_layout.discrete_valued_scalar_names = vec!["m".to_string()];
         model.problem.events.dynamic_time_event_names = vec!["next".to_string()];
         model.problem.discrete.update_targets = vec![solve::scalar_slot_p(1)];
+        model.problem.discrete.pre_modes = vec![solve::DiscreteEventPreMode::EventEntry];
         model.problem.discrete.rhs = const_scalar_program_block(4.0);
         model.parameters = vec![0.05, 0.0];
         model.visible_names = vec!["x".to_string(), "next".to_string(), "m".to_string()];


### PR DESCRIPTION
This fixes #235.

# Rumoca PR Review Template

<!--
Mirrors SPEC_0025. Section names here must match SPEC_0025 §"PR Template
Alignment". Update both files together if you change either one.
-->

## Summary

- Time-invariant algebraic variables gated by `if` conditions (e.g. the `sig` solid
  mask in the NACA `AirfoilFlow` example) had wrong values in the first output row
  only under `--solver rk-like`: 53 solid cells at frame 0, then a correct constant
  16 from frame 1 onward. Frame 0 is now correct (16), matching every later frame.
- Addresses #235. The `rk-like` backend's `init()` never settled the FollowCurrent
  discrete relation guards (`c[]` behind `if` expressions) before recording the
  `t_start` sample, while the `diffsol` backend already does.

## Spec / MLS Alignment

- Relevant active spec(s) checked: solver/runtime initialization behavior, no spec text changed.
- Relevant MLS section(s), if semantics changed: MLS 8.6 (initialization) / 8.5 (events):
  relation values must be settled at the initial point before output. This brings
  `rk-like` into line with that and with `diffsol`.
- Crate/phase owner: `rumoca-solver-rk45` (rk-like backend `init()`).

## Risk and Design Notes

- Main correctness risk: applying a discrete settle at init could shift frame 0 of
  other models. Mitigated by the `FollowCurrentOnly` filter (relation guards only, no
  `when` actions), a guard that runs only when the model has discrete update targets,
  and the fact that it converges to the same values the first step already produces.
  Verified parity with `diffsol` (`bdf` reports 16 at frame 0 too).
- Main maintenance risk: low. Reuses the existing
  `apply_projected_post_initial_event_update` already used by `diffsol`.
- Why the change belongs in these crate(s): it is a `rk-like`-specific gap in
  `Rk45Backend::init()`.
- Any new abstraction, public API, or migration path: none.

## Testing

- Key command(s) run (fmt, clippy, workspace test, doc): `cargo fmt --all -- --check`;
  `cargo clippy -p rumoca-solver-rk45 --all-targets -- -D warnings`;
  `RUSTDOCFLAGS="-D warnings" cargo doc -p rumoca-solver-rk45 --no-deps`;
  `cargo test -p rumoca-solver-rk45 -p rumoca-eval-solve -p rumoca-solver-diffsol -p rumoca-sim -p rumoca`;
  `cargo check --workspace --tests`.
- Behavior or regression covered: `rumoca sim AirfoilFlow.mo --solver rk-like
  --t-end 2.5 --dt 0.0125` now reports `sig > 0.5` = 16 at frame 0, constant across
  all 201 frames (was 53 then 16). rk45 15/15, eval-solve 36/36, diffsol 36/36, sim 47/47.
- Commands NOT run and why: clippy/doc were scoped to the one changed crate to avoid an
  OOM the full-workspace run hit in my environment; fmt and `cargo check --workspace`
  did cover everything.
- For compiler/simulator changes: did you run the MSL gate ...? Not run locally (needs
  a release build and network MSL download in this environment). Requesting CI to run
  the gate and confirm no regression vs `msl_quality_baseline.json`.

## Code Size Budget (required)

- production_lines_added: 23
- production_lines_deleted: 0
- test_lines_added: 4
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 1
- net_added_lines: 27

If `net_added_lines` is positive, add:

- Why this net growth is required: the fix adds one settle call plus an explanatory
  comment in `init()`, and four one-line `pre_modes` declarations to event-update test
  fixtures. 
- Which code was removed/merged as part of the first compression pass: none applicable,
  there was no parallel path to remove.
- Follow-up cleanup ticket/commit for remaining growth (if any): none.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [ ] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.
