### PR TITLE
ci: trigger release on v* tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: ['main']
+    tags: ['v*']
   pull_request:
     branches: ['main']
 
@@ -27,7 +28,7 @@ permissions:
 jobs:
   detect-release-tag:
     name: Detect release tag on commit
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-24.04
     outputs:
       is_release: ${{ steps.detect.outputs.is_release }}
@@ -845,7 +846,7 @@ jobs:
 
   deploy-pages:
     name: Deploy Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     needs: [build-wasm]
     runs-on: ubuntu-24.04
     environment:
@@ -1113,7 +1114,7 @@ jobs:
   # ============================================================================
   deploy:
     name: Deploy
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect-release-tag.outputs.is_release == 'true'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && needs.detect-release-tag.outputs.is_release == 'true'
     needs: [detect-release-tag, lint, test, coverage-gate, msl-quality-gate, docs, vscode, deploy-pages, build-rust-binaries, build-python-wheels, build-python-sdist]
     runs-on: ubuntu-24.04
     steps:
@@ -1125,11 +1126,17 @@ jobs:
 
       - name: Verify tag is on main
         run: |
-          if ! git tag --points-at "${{ github.sha }}" | grep -Fx "${{ needs.detect-release-tag.outputs.tag }}" >/dev/null; then
-            echo "::error::Detected release tag '${{ needs.detect-release-tag.outputs.tag }}' is not on commit ${{ github.sha }}"
+          tag='${{ needs.detect-release-tag.outputs.tag }}'
+          if ! git tag --points-at "${{ github.sha }}" | grep -Fx "$tag" >/dev/null; then
+            echo "::error::Release tag '$tag' does not point at built commit ${{ github.sha }}"
             exit 1
           fi
-          echo "Release tag '${{ needs.detect-release-tag.outputs.tag }}' points to current main commit"
+          git fetch --no-tags --depth=2147483647 origin main
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "::error::Release tag '$tag' commit ${{ github.sha }} is not on origin/main; refusing to release"
+            exit 1
+          fi
+          echo "Release tag '$tag' points to commit ${{ github.sha }} on origin/main"
 
       - name: Get tag name
         id: tag


### PR DESCRIPTION
## Problem

The release `deploy` job is gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'` and only *detects* whether a `v*` tag points at the pushed commit. There is no `push: tags:` trigger, so **pushing a tag fires no workflow at all**. Cutting a release today requires tagging the merged commit and then re-running that commit's main CI run so `detect-release-tag` re-evaluates with the tag present — non-obvious and easy to get wrong.

## Change

- Add a `push: tags: ['v*']` trigger.
- Broaden the `detect-release-tag`, `deploy-pages`, and `deploy` gates to also fire on `v*` tag refs. (`deploy` depends on `deploy-pages`, so that gate must widen too or the dependency would be skipped on a tag push.)
- Strengthen the "Verify tag is on main" guard: with a direct tag trigger the commit is no longer guaranteed to be on main, so it now also checks the tagged commit is an ancestor of `origin/main` before releasing.

The existing `detect-release-tag` script already works on a tag push — `GITHUB_SHA` is the tagged commit, so `git tag --points-at` finds the tag. The legacy push-to-main + re-run path still works unchanged.

## Result

Cutting a release becomes one step:

```bash
git tag v0.9.0 && git push origin v0.9.0
```

## Note for reviewers

`deploy-pages` now also runs on a release tag (it had to, to satisfy `deploy`'s `needs`), so a release re-publishes GitHub Pages from the tagged commit. If the `github-pages` environment has a deployment-branch policy restricting it to `main`, that policy needs to allow `v*` tags.