### PR TITLE
ci: build releases once (drop redundant v* tag trigger)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 name: CI
 
 on:
+  # Releases push main + the v* tag together in one operation, so the
+  # main-branch run already sees the tag (detect-release-tag resolves it via
+  # `git tag --points-at`) and runs the deploy. Triggering on the tag ref as
+  # well spawned a second, identical full-matrix run at the same SHA, so we do
+  # not list tags here.
   push:
     branches: ['main']
-    tags: ['v*']
   pull_request:
     branches: ['main']
 


### PR DESCRIPTION
## Summary

Releases were building the **same commit twice**. `cargo xtask repo release` pushes `main` and the `vX.Y.Z` tag together in one operation, and CI triggered on **both** `push: branches:[main]` and `push: tags:[v*]` — so two full matrix runs (build-rust ×5, build-python ×4, tests, WASM, gates) ran on the identical SHA.

Example from v0.9.1 (both at `4766ad8`):
- `27448099141` — push, `main`
- `27448099158` — push, `v0.9.1`

Only the final Pages deploy deduped (via the `github-pages` environment serializing); everything before it was duplicated compute.

## Fix

Drop `tags: ['v*']` from the `push` trigger. The main-branch run already handles releases:
- `detect-release-tag` resolves the tag with `git tag --points-at "$GITHUB_SHA" 'v*'` — independent of which ref triggered the run.
- The `deploy` / `deploy-pages` `if:` conditions already accept `refs/heads/main`.

So the single main-push run detects the co-pushed tag and deploys. The leftover `startsWith(github.ref, 'refs/tags/v')` `if:` clauses are harmless (OR'd with `refs/heads/main`, which still holds).

## Tradeoff

Tagging an **existing** main commit without moving `main` (i.e. a tag-only push) will no longer trigger a release run. This is not the sanctioned release path — `xtask repo release --push` always co-pushes a fresh main commit + tag. If we ever want to preserve tag-only releases, the alternative is SHA-keyed concurrency instead.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid.
- Audited remaining tag-ref usages: all are `if:` guards OR'd with `refs/heads/main`; none read the tag from the ref.