### PR TITLE
ci: deploy docs/Pages only on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,8 +846,12 @@ jobs:
 
   deploy-pages:
     name: Deploy Pages
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-    needs: [build-wasm]
+    # Publish the docs/WASM site only on a release (a v* tag on the commit),
+    # not on every main merge. detect-release-tag resolves the tag via
+    # `git tag --points-at`, so this fires for both the co-pushed main+tag
+    # release and a tag pushed onto an already-merged commit.
+    if: github.event_name == 'push' && needs.detect-release-tag.outputs.is_release == 'true'
+    needs: [detect-release-tag, build-wasm]
     runs-on: ubuntu-24.04
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

The `deploy-pages` job published the docs + WASM site on **every push to main**. This switches it to publish **only on a release** — a `v*` tag on the commit, the same `is_release` signal the `deploy` job already uses.

## Change

`deploy-pages` `if:` now gates on `needs.detect-release-tag.outputs.is_release == 'true'` (and adds `detect-release-tag` to `needs`), instead of `refs/heads/main || refs/tags/v*`.

- `detect-release-tag` resolves the tag via `git tag --points-at "$GITHUB_SHA"`, so this fires for both the co-pushed `main`+tag release and a `v*` tag pushed onto an already-merged commit.
- WASM/docs are still **built** on PRs and main (the `build-wasm` job is unchanged), so doc builds are still validated — they're just not **deployed** until a release.

Kept as a separate job (not folded into `deploy`) because `actions/deploy-pages` requires the `github-pages` environment and a job can hold only one environment; folding it in would brand the PyPI/marketplace release job as a github-pages deployment and block future OIDC PyPI publishing.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid.