### PR TITLE
ci: quiet the MSL PR Comment workflow (no skipped runs on main merges)

### DIFF
--- a/.github/workflows/msl-pr-comment.yml
+++ b/.github/workflows/msl-pr-comment.yml
@@ -4,6 +4,12 @@ on:
   workflow_run:
     workflows: ['CI']
     types: [completed]
+    # This workflow only does work for CI runs triggered by a pull_request (see
+    # the job `if`). workflow_run can't filter on the triggering event type, but
+    # PR runs carry the PR's source branch as head_branch while push-to-main /
+    # tag runs carry 'main' / the tag. Ignoring those stops GitHub from creating
+    # (and listing) a skipped run for every main merge, which was the noise.
+    branches-ignore: ['main']
 
 # Commenting on a pull request through the issues API requires
 # `pull-requests: write` (GitHub returns 403 "Resource not accessible by


### PR DESCRIPTION
## Summary

The **Publish MSL PR Comment** workflow (`msl-pr-comment.yml`) clutters the Actions list: it triggers via `workflow_run` on *every* CI completion, but only does work for CI runs that came from a `pull_request` (job-level `if`). For main-push / tag CI completions GitHub still **creates and lists a run** that then skips in ~1s — one piece of noise per main merge.

## Change

Add `branches-ignore: ['main']` to the `workflow_run` trigger. `workflow_run` can't filter on the triggering event type, but:
- a **PR** CI run carries the PR's source branch as `head_branch` (e.g. `wgsl-backend`) → still triggers, comment still posted/updated;
- a **push-to-main** CI run carries `head_branch == 'main'` → now filtered out, so no skipped run is created.

Net: the comment behavior on PRs is unchanged; the per-main-merge 1s skipped runs disappear.

## Caveat

A PR opened **from a fork branch literally named `main`** would also be skipped. This is rare (contributors use feature branches); if it matters we can switch to a path that inspects the event type instead.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/msl-pr-comment.yml'))"` — valid.