### PR TITLE
sim: lazy browser-safe diffsol (stiff) solver as @cognipilot/rumoca/diffsol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -831,6 +831,11 @@ jobs:
           cp "pkg/$PKG_SUBDIR/rumoca_worker.js" "gh-pages/pkg/$PKG_SUBDIR/"
           cp "pkg/$PKG_SUBDIR/parse_worker.js" "gh-pages/pkg/$PKG_SUBDIR/"
           cp "pkg/$PKG_SUBDIR/rumoca_gpu.js" "gh-pages/pkg/$PKG_SUBDIR/"
+          # Lazy diffsol addon (driver + its separate relaxed-SIMD module), so
+          # the live examples can run stiff solves on supporting browsers.
+          cp "pkg/$PKG_SUBDIR/rumoca_diffsol.js" "gh-pages/pkg/$PKG_SUBDIR/" 2>/dev/null || true
+          cp "pkg/$PKG_SUBDIR/rumoca_bind_wasm_diffsol.js" "gh-pages/pkg/$PKG_SUBDIR/" 2>/dev/null || true
+          cp "pkg/$PKG_SUBDIR/rumoca_bind_wasm_diffsol_bg.wasm" "gh-pages/pkg/$PKG_SUBDIR/" 2>/dev/null || true
           cp "pkg/$PKG_SUBDIR/package.json" "gh-pages/pkg/$PKG_SUBDIR/"
           cp "pkg/$PKG_SUBDIR/rumoca_package_meta.json" "gh-pages/pkg/$PKG_SUBDIR/" 2>/dev/null || true
           cp -r "pkg/$PKG_SUBDIR/snippets" "gh-pages/pkg/$PKG_SUBDIR/" 2>/dev/null || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,6 +3253,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumoca-bind-wasm-diffsol"
+version = "0.9.1"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.3.4",
+ "rumoca-ir-solve",
+ "rumoca-solver",
+ "rumoca-solver-diffsol",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "rumoca-codec"
 version = "0.9.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,6 +3261,7 @@ dependencies = [
  "rumoca-ir-solve",
  "rumoca-solver",
  "rumoca-solver-diffsol",
+ "serde",
  "serde_json",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "crates/xtask",
     # Bindings
     "crates/rumoca-bind-wasm",
+    "crates/rumoca-bind-wasm-diffsol",
     "crates/rumoca-bind-python",
     # Compiled execution adapters
     "crates/rumoca-exec-cranelift",

--- a/crates/rumoca-bind-wasm-diffsol/Cargo.toml
+++ b/crates/rumoca-bind-wasm-diffsol/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "rumoca-bind-wasm-diffsol"
+description = "Lazy diffsol (stiff/implicit) simulation addon for the rumoca WASM package — simulates a pre-lowered SolveModel; carries the relaxed-SIMD code, loaded on demand"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = { workspace = true }
+serde_json = { workspace = true }
+rumoca-ir-solve = { workspace = true }
+rumoca-solver = { workspace = true }
+rumoca-solver-diffsol = { workspace = true }
+# Enable the wasm_js getrandom backend (diffsol/rand pull getrandom); mirrors
+# rumoca-bind-wasm. The `.cargo/config.toml` cfg selects the backend; this
+# enables its feature when the addon is built on its own.
+getrandom = { version = "0.3", features = ["wasm_js"] }
+console_error_panic_hook = { workspace = true, optional = true }
+
+[features]
+default = ["console_error_panic_hook"]
+
+# Size-optimize the published addon (mirrors rumoca-bind-wasm); the relaxed-SIMD
+# from faer/pulp is confined to this module, so it must be lazy-loaded only
+# after feature-detecting relaxed-SIMD support.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-Oz', '--enable-threads', '--enable-bulk-memory']
+
+[lints]
+workspace = true

--- a/crates/rumoca-bind-wasm-diffsol/Cargo.toml
+++ b/crates/rumoca-bind-wasm-diffsol/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 rumoca-ir-solve = { workspace = true }
 rumoca-solver = { workspace = true }

--- a/crates/rumoca-bind-wasm-diffsol/src/lib.rs
+++ b/crates/rumoca-bind-wasm-diffsol/src/lib.rs
@@ -16,7 +16,21 @@ use rumoca_solver::{
     SimOptions, SimSolverMode, SimulationRequestSummary, SimulationRunMetrics,
     build_simulation_payload,
 };
+use serde::Deserialize;
 use wasm_bindgen::prelude::*;
+
+/// The payload the main module's `lower_model_to_solve_json` produces: the
+/// lowered model plus the resolved simulation time (which the SolveModel does
+/// not itself carry, and which the main module resolves from the experiment
+/// annotation when the caller defers).
+#[derive(Deserialize)]
+struct DiffsolInput {
+    solve_model: SolveModel,
+    #[serde(default)]
+    t_end: f64,
+    #[serde(default)]
+    dt: f64,
+}
 
 #[wasm_bindgen(start)]
 pub fn start() {
@@ -24,28 +38,29 @@ pub fn start() {
     console_error_panic_hook::set_once();
 }
 
-/// Simulate a pre-lowered model (the JSON the main module produced from its
-/// `SolveModel`) with the stiff/implicit diffsol backend. Returns the same
-/// `{ "payload": ... }` JSON shape as the main module's `simulate_model`, so
-/// callers can treat both paths uniformly.
+/// Simulate a pre-lowered model with the stiff/implicit diffsol backend.
+/// `input_json` is the `{ solve_model, t_end, dt }` payload from the main
+/// module's `lower_model_to_solve_json`. Returns the same `{ "payload": ... }`
+/// JSON shape as the main module's `simulate_model`, so callers treat both
+/// paths uniformly.
 #[wasm_bindgen]
-pub fn simulate_solve_model_diffsol(
-    solve_json: &str,
-    t_end: f64,
-    dt: f64,
-) -> Result<String, JsValue> {
-    let model: SolveModel = serde_json::from_str(solve_json)
-        .map_err(|e| JsValue::from_str(&format!("invalid solve-model JSON: {e}")))?;
+pub fn simulate_solve_model_diffsol(input_json: &str) -> Result<String, JsValue> {
+    let input: DiffsolInput = serde_json::from_str(input_json)
+        .map_err(|e| JsValue::from_str(&format!("invalid diffsol input JSON: {e}")))?;
 
     let defaults = SimOptions::default();
     let opts = SimOptions {
         solver_mode: SimSolverMode::Bdf,
-        t_end: if t_end > 0.0 { t_end } else { defaults.t_end },
-        dt: if dt > 0.0 { Some(dt) } else { None },
+        t_end: if input.t_end > 0.0 {
+            input.t_end
+        } else {
+            defaults.t_end
+        },
+        dt: if input.dt > 0.0 { Some(input.dt) } else { None },
         ..defaults
     };
 
-    let sim = rumoca_solver_diffsol::simulate(&model, &opts)
+    let sim = rumoca_solver_diffsol::simulate(&input.solve_model, &opts)
         .map_err(|e| JsValue::from_str(&format!("diffsol simulation error: {e}")))?;
 
     let metrics = SimulationRunMetrics::default();

--- a/crates/rumoca-bind-wasm-diffsol/src/lib.rs
+++ b/crates/rumoca-bind-wasm-diffsol/src/lib.rs
@@ -1,0 +1,64 @@
+//! Lazy diffsol simulation addon for the `@cognipilot/rumoca` WASM package.
+//!
+//! The main `rumoca` module is SIMD-free and loads on every browser. Diffsol
+//! (stiff/implicit) pulls relaxed-SIMD via faer/pulp, which a single combined
+//! module would require at instantiation — hard-failing the whole package on
+//! older browsers. So diffsol lives here, in a *separate* module that:
+//!   1. carries no compiler — it deserializes a `SolveModel` the main module
+//!      already lowered (the boundary is lossless; see the
+//!      `solve_model_round_trip` test), and
+//!   2. is loaded lazily by JS only after feature-detecting relaxed-SIMD, so an
+//!      old browser never has to instantiate it (the stiff solver is simply
+//!      greyed out in the UI instead of breaking the page).
+
+use rumoca_ir_solve::SolveModel;
+use rumoca_solver::{
+    SimOptions, SimSolverMode, SimulationRequestSummary, SimulationRunMetrics,
+    build_simulation_payload,
+};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}
+
+/// Simulate a pre-lowered model (the JSON the main module produced from its
+/// `SolveModel`) with the stiff/implicit diffsol backend. Returns the same
+/// `{ "payload": ... }` JSON shape as the main module's `simulate_model`, so
+/// callers can treat both paths uniformly.
+#[wasm_bindgen]
+pub fn simulate_solve_model_diffsol(
+    solve_json: &str,
+    t_end: f64,
+    dt: f64,
+) -> Result<String, JsValue> {
+    let model: SolveModel = serde_json::from_str(solve_json)
+        .map_err(|e| JsValue::from_str(&format!("invalid solve-model JSON: {e}")))?;
+
+    let defaults = SimOptions::default();
+    let opts = SimOptions {
+        solver_mode: SimSolverMode::Bdf,
+        t_end: if t_end > 0.0 { t_end } else { defaults.t_end },
+        dt: if dt > 0.0 { Some(dt) } else { None },
+        ..defaults
+    };
+
+    let sim = rumoca_solver_diffsol::simulate(&model, &opts)
+        .map_err(|e| JsValue::from_str(&format!("diffsol simulation error: {e}")))?;
+
+    let metrics = SimulationRunMetrics::default();
+    let request = SimulationRequestSummary {
+        solver: "bdf (diffsol)".to_string(),
+        t_start: opts.t_start,
+        t_end: opts.t_end,
+        dt: opts.dt,
+        rtol: opts.rtol,
+        atol: opts.atol,
+    };
+    let output = serde_json::json!({
+        "payload": build_simulation_payload(&sim, &request, &metrics),
+    });
+    serde_json::to_string(&output).map_err(|e| JsValue::from_str(&format!("JSON error: {e}")))
+}

--- a/crates/rumoca-bind-wasm/src/lib.rs
+++ b/crates/rumoca-bind-wasm/src/lib.rs
@@ -59,7 +59,9 @@ use crate::class_browser_helpers::{
 #[cfg(any(feature = "sim-wasm", feature = "sim-diffsol", feature = "sim-rk45"))]
 pub use crate::gpu_api::{prepare_gpu_simulation, update_gpu_parameters};
 #[cfg(any(feature = "sim-wasm", feature = "sim-diffsol", feature = "sim-rk45"))]
-use crate::simulation_api::{simulate_model_impl, simulate_model_with_project_sources_impl};
+use crate::simulation_api::{
+    lower_model_to_solve_json_impl, simulate_model_impl, simulate_model_with_project_sources_impl,
+};
 pub use crate::source_root_api::{
     clear_source_root_cache, compile_check_with_source_roots,
     compile_check_with_source_roots_with_options, compile_with_project_sources,
@@ -1458,6 +1460,20 @@ pub fn simulate_model(
     solver: &str,
 ) -> Result<String, JsValue> {
     simulate_model_impl(source, model_name, t_end, dt, solver)
+}
+
+/// Compile a model and return its lowered `SolveModel` as JSON, for the lazy
+/// diffsol addon (`@cognipilot/rumoca/diffsol`) to simulate. Lets the stiff
+/// solver run without putting relaxed-SIMD in this (universal) module.
+#[cfg(any(feature = "sim-wasm", feature = "sim-diffsol", feature = "sim-rk45"))]
+#[wasm_bindgen]
+pub fn lower_model_to_solve_json(
+    source: &str,
+    model_name: &str,
+    t_end: f64,
+    dt: f64,
+) -> Result<String, JsValue> {
+    lower_model_to_solve_json_impl(source, model_name, t_end, dt)
 }
 
 /// Compile with additional project-local sources and simulate a Modelica model.

--- a/crates/rumoca-bind-wasm/src/simulation_api.rs
+++ b/crates/rumoca-bind-wasm/src/simulation_api.rs
@@ -24,11 +24,13 @@ pub(crate) fn simulate_model_impl(
     })
 }
 
-/// Compile a model and emit its lowered `SolveModel` as JSON, ready to hand to
-/// the lazy diffsol addon (`@cognipilot/rumoca/diffsol`). Lowered with the
-/// diffsol (`bdf`) solver mode so the structure matches what the addon runs.
-/// The main module stays SIMD-free; only the addon that consumes this JSON
-/// carries relaxed-SIMD.
+/// Compile a model and emit a `{ solve_model, t_end, dt }` payload for the lazy
+/// diffsol addon (`@cognipilot/rumoca/diffsol`). Lowered with the diffsol
+/// (`bdf`) solver mode so the structure matches what the addon runs. The
+/// resolved `t_end`/`dt` (from the experiment annotation when the caller passes
+/// 0) travel with the model, since the `SolveModel` does not carry them. The
+/// main module stays SIMD-free; only the addon that consumes this carries
+/// relaxed-SIMD.
 pub(crate) fn lower_model_to_solve_json_impl(
     source: &str,
     model_name: &str,
@@ -42,8 +44,12 @@ pub(crate) fn lower_model_to_solve_json_impl(
         let (opts, _solver_label) = build_simulation_options(&result, t_end, dt, "bdf");
         let solve_model = lower_dae_for_simulation(&result.dae, &opts)
             .map_err(|e| JsValue::from_str(&format!("solve lowering error: {e}")))?;
-        serde_json::to_string(&solve_model)
-            .map_err(|e| JsValue::from_str(&format!("JSON error: {e}")))
+        let payload = serde_json::json!({
+            "solve_model": solve_model,
+            "t_end": opts.t_end,
+            "dt": opts.dt.unwrap_or(0.0),
+        });
+        serde_json::to_string(&payload).map_err(|e| JsValue::from_str(&format!("JSON error: {e}")))
     })
 }
 

--- a/crates/rumoca-bind-wasm/src/simulation_api.rs
+++ b/crates/rumoca-bind-wasm/src/simulation_api.rs
@@ -1,7 +1,8 @@
 use rumoca_compile::{Session, compile::CompilationResult};
 use rumoca_sim::{
     SimOptions, SimResult, SimSolverMode, SimulationRequestSummary, SimulationRunMetrics,
-    build_simulation_metrics_value, build_simulation_payload, simulate_dae_with_diagnostics,
+    build_simulation_metrics_value, build_simulation_payload, lower_dae_for_simulation,
+    simulate_dae_with_diagnostics,
 };
 use wasm_bindgen::JsValue;
 
@@ -20,6 +21,29 @@ pub(crate) fn simulate_model_impl(
 ) -> Result<String, JsValue> {
     with_singleton_session(|session| {
         simulate_model_in_session(session, source, model_name, t_end, dt, solver)
+    })
+}
+
+/// Compile a model and emit its lowered `SolveModel` as JSON, ready to hand to
+/// the lazy diffsol addon (`@cognipilot/rumoca/diffsol`). Lowered with the
+/// diffsol (`bdf`) solver mode so the structure matches what the addon runs.
+/// The main module stays SIMD-free; only the addon that consumes this JSON
+/// carries relaxed-SIMD.
+pub(crate) fn lower_model_to_solve_json_impl(
+    source: &str,
+    model_name: &str,
+    t_end: f64,
+    dt: f64,
+) -> Result<String, JsValue> {
+    with_singleton_session(|session| {
+        session.update_document("input.mo", source);
+        let requested_model = qualify_input_model_name(session, model_name);
+        let result = compile_requested_model(session, &requested_model)?;
+        let (opts, _solver_label) = build_simulation_options(&result, t_end, dt, "bdf");
+        let solve_model = lower_dae_for_simulation(&result.dae, &opts)
+            .map_err(|e| JsValue::from_str(&format!("solve lowering error: {e}")))?;
+        serde_json::to_string(&solve_model)
+            .map_err(|e| JsValue::from_str(&format!("JSON error: {e}")))
     })
 }
 

--- a/crates/rumoca-bind-wasm/src/tests.rs
+++ b/crates/rumoca-bind-wasm/src/tests.rs
@@ -1882,3 +1882,36 @@ fn test_simulate_model_wrapper_advances_after_relation_root_crossing() {
 
     clear_source_root_cache();
 }
+
+/// The lazy-diffsol path end-to-end (native): the main module lowers a model to
+/// SolveModel JSON (`lower_model_to_solve_json`), and that JSON deserializes and
+/// simulates with diffsol — proving the JSON the addon receives is complete.
+#[cfg(feature = "sim-diffsol")]
+#[test]
+fn lower_to_solve_json_feeds_diffsol_simulation() {
+    let _guard = session_test_guard();
+    let source = "model Decay\n  parameter Real k = 1.0;\n  Real x(start = 1.0);\nequation\n  der(x) = -k * x;\nend Decay;\n";
+
+    let json = crate::simulation_api::lower_model_to_solve_json_impl(source, "Decay", 1.0, 0.05)
+        .expect("lower model to solve-model JSON");
+    let model: rumoca_ir_solve::SolveModel =
+        serde_json::from_str(&json).expect("deserialize solve-model JSON");
+
+    let opts = rumoca_sim::SimOptions {
+        solver_mode: rumoca_sim::SimSolverMode::Bdf,
+        t_end: 1.0,
+        dt: Some(0.05),
+        ..Default::default()
+    };
+    let result = rumoca_sim::simulate_solve_model(&model, &opts).expect("diffsol simulation");
+    let xi = result
+        .names
+        .iter()
+        .position(|n| n == "x")
+        .expect("x in results");
+    let last = *result.data[xi].last().expect("non-empty x series");
+    assert!(
+        (last - (-1.0_f64).exp()).abs() < 0.02,
+        "x(1) should be ~e^-1, got {last}"
+    );
+}

--- a/crates/rumoca-bind-wasm/src/tests.rs
+++ b/crates/rumoca-bind-wasm/src/tests.rs
@@ -1892,10 +1892,15 @@ fn lower_to_solve_json_feeds_diffsol_simulation() {
     let _guard = session_test_guard();
     let source = "model Decay\n  parameter Real k = 1.0;\n  Real x(start = 1.0);\nequation\n  der(x) = -k * x;\nend Decay;\n";
 
-    let json = crate::simulation_api::lower_model_to_solve_json_impl(source, "Decay", 1.0, 0.05)
-        .expect("lower model to solve-model JSON");
+    let payload = crate::simulation_api::lower_model_to_solve_json_impl(source, "Decay", 1.0, 0.05)
+        .expect("lower model to solve-model payload");
+    let value: serde_json::Value = serde_json::from_str(&payload).expect("parse lowering payload");
+    assert!(
+        (value["t_end"].as_f64().unwrap() - 1.0).abs() < 1e-9,
+        "payload should carry the resolved t_end"
+    );
     let model: rumoca_ir_solve::SolveModel =
-        serde_json::from_str(&json).expect("deserialize solve-model JSON");
+        serde_json::from_value(value["solve_model"].clone()).expect("deserialize solve_model");
 
     let opts = rumoca_sim::SimOptions {
         solver_mode: rumoca_sim::SimSolverMode::Bdf,

--- a/crates/rumoca-sim/src/lib.rs
+++ b/crates/rumoca-sim/src/lib.rs
@@ -83,6 +83,80 @@ pub fn simulate_with_diagnostics(
 #[cfg(any(feature = "solver-diffsol", feature = "solver-rk45"))]
 pub use simulate_with_diagnostics as simulate_dae_with_diagnostics;
 
+/// Simulate an already-lowered [`rumoca_ir_solve::SolveModel`], skipping the
+/// DAE→solve lowering, dispatching by `opts.solver_mode`. This is the
+/// runtime-only entry the lazy diffsol WASM addon uses: the main module emits a
+/// SolveModel, the addon deserializes and simulates it without carrying the
+/// compiler. The skipped (`#[serde(skip)]`) layout fields are lowering-only and
+/// not read here, so a serialized→deserialized SolveModel simulates identically
+/// (pinned by `solve_model_round_trip` in crates/rumoca/tests).
+#[cfg(any(feature = "solver-diffsol", feature = "solver-rk45"))]
+pub fn simulate_solve_model(
+    model: &rumoca_ir_solve::SolveModel,
+    opts: &SimOptions,
+) -> Result<SimResult, SimulationDiagnosticError> {
+    match opts.solver_mode {
+        SimSolverMode::Auto => simulate_solve_model_auto(model, opts),
+        SimSolverMode::RkLike => simulate_solve_model_rk45(model, opts),
+        SimSolverMode::Bdf => simulate_solve_model_diffsol(model, opts),
+    }
+}
+
+#[cfg(feature = "solver-diffsol")]
+fn simulate_solve_model_auto(
+    model: &rumoca_ir_solve::SolveModel,
+    opts: &SimOptions,
+) -> Result<SimResult, SimulationDiagnosticError> {
+    simulate_solve_model_diffsol(model, opts)
+}
+
+#[cfg(all(not(feature = "solver-diffsol"), feature = "solver-rk45"))]
+fn simulate_solve_model_auto(
+    model: &rumoca_ir_solve::SolveModel,
+    opts: &SimOptions,
+) -> Result<SimResult, SimulationDiagnosticError> {
+    simulate_solve_model_rk45(model, opts)
+}
+
+#[cfg(feature = "solver-rk45")]
+fn simulate_solve_model_rk45(
+    model: &rumoca_ir_solve::SolveModel,
+    opts: &SimOptions,
+) -> Result<SimResult, SimulationDiagnosticError> {
+    rumoca_solver_rk45::simulate(model, opts)
+        .map_err(|err| SimulationDiagnosticError::Solver(err.to_string()))
+}
+
+#[cfg(not(feature = "solver-rk45"))]
+fn simulate_solve_model_rk45(
+    _model: &rumoca_ir_solve::SolveModel,
+    _opts: &SimOptions,
+) -> Result<SimResult, SimulationDiagnosticError> {
+    Err(SimulationDiagnosticError::Solver(
+        "rk-like solver requested, but this build does not include the rk45 backend".to_string(),
+    ))
+}
+
+#[cfg(feature = "solver-diffsol")]
+fn simulate_solve_model_diffsol(
+    model: &rumoca_ir_solve::SolveModel,
+    opts: &SimOptions,
+) -> Result<SimResult, SimulationDiagnosticError> {
+    rumoca_solver_diffsol::simulate(model, opts)
+        .map_err(|err| SimulationDiagnosticError::Solver(err.to_string()))
+}
+
+#[cfg(not(feature = "solver-diffsol"))]
+fn simulate_solve_model_diffsol(
+    _model: &rumoca_ir_solve::SolveModel,
+    _opts: &SimOptions,
+) -> Result<SimResult, SimulationDiagnosticError> {
+    Err(SimulationDiagnosticError::Solver(
+        "bdf/diffsol solver requested, but this build does not include the diffsol backend"
+            .to_string(),
+    ))
+}
+
 /// Simulate, and if it fails with an error that suggests a non-finite
 /// (`NaN`/`inf`) value, automatically re-run once with NaN tracing enabled so
 /// the offending model variable(s) are reported — turning an opaque

--- a/crates/rumoca/tests/solve_model_round_trip.rs
+++ b/crates/rumoca/tests/solve_model_round_trip.rs
@@ -50,7 +50,11 @@ fn solve_model_round_trip_simulates_identically() {
         "series count changed after round-trip"
     );
     for (i, (a, b)) in original.data.iter().zip(after.data.iter()).enumerate() {
-        assert_eq!(a.len(), b.len(), "series {i} length changed after round-trip");
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "series {i} length changed after round-trip"
+        );
         for (j, (va, vb)) in a.iter().zip(b.iter()).enumerate() {
             assert!(
                 (va - vb).abs() < 1e-12,

--- a/crates/rumoca/tests/solve_model_round_trip.rs
+++ b/crates/rumoca/tests/solve_model_round_trip.rs
@@ -1,0 +1,73 @@
+//! Gating check for the lazy diffsol WASM addon: a `SolveModel` produced by the
+//! main module must survive a serialize→deserialize round-trip and simulate
+//! identically. VarLayout has `#[serde(skip)]` fields (`indexed_bindings`,
+//! `shape_indexed_keys`, ...) that are lowering-only; this proves they aren't
+//! needed at simulation time. An array model is used so `indexed_bindings`
+//! (array element → scalar slot) is actually populated and exercised.
+
+use rumoca::Compiler;
+use rumoca_sim::{SimOptions, SimSolverMode, lower_dae_for_simulation, simulate_solve_model};
+
+const ARRAY_SOURCE: &str = r#"
+model ArrayDecay
+  Real x[3](each start = 1.0);
+equation
+  for i in 1:3 loop
+    der(x[i]) = -x[i];
+  end for;
+end ArrayDecay;
+"#;
+
+#[test]
+fn solve_model_round_trip_simulates_identically() {
+    let compiled = Compiler::new()
+        .model("ArrayDecay")
+        .compile_str(ARRAY_SOURCE, "array.mo")
+        .expect("compile ArrayDecay");
+    let opts = SimOptions {
+        solver_mode: SimSolverMode::RkLike,
+        t_end: 1.0,
+        dt: Some(0.05),
+        ..Default::default()
+    };
+    let model = lower_dae_for_simulation(&compiled.dae, &opts).expect("lower solve model");
+
+    // The addon boundary: hand the SolveModel across as JSON.
+    let json = serde_json::to_string(&model).expect("serialize SolveModel");
+    let round_tripped: rumoca_ir_solve::SolveModel =
+        serde_json::from_str(&json).expect("deserialize SolveModel");
+
+    let original = simulate_solve_model(&model, &opts).expect("simulate original");
+    let after = simulate_solve_model(&round_tripped, &opts).expect("simulate round-tripped");
+
+    assert_eq!(
+        original.names, after.names,
+        "variable names changed after round-trip"
+    );
+    assert_eq!(
+        original.data.len(),
+        after.data.len(),
+        "series count changed after round-trip"
+    );
+    for (i, (a, b)) in original.data.iter().zip(after.data.iter()).enumerate() {
+        assert_eq!(a.len(), b.len(), "series {i} length changed after round-trip");
+        for (j, (va, vb)) in a.iter().zip(b.iter()).enumerate() {
+            assert!(
+                (va - vb).abs() < 1e-12,
+                "series {i}[{j}] differs after round-trip: {va} vs {vb}"
+            );
+        }
+    }
+
+    // Sanity: the indexed array variable is present and physically reasonable.
+    let xi = original
+        .names
+        .iter()
+        .position(|n| n == "x[1]")
+        .expect("x[1] should be an output of the array model");
+    let last = *original.data[xi].last().expect("non-empty x[1] series");
+    assert!(
+        (last - (-1.0_f64).exp()).abs() < 0.05,
+        "x[1](1) should be ~e^-1, got {last}"
+    );
+}

--- a/docs/user-guide/live/rumoca-live.js
+++ b/docs/user-guide/live/rumoca-live.js
@@ -39,6 +39,11 @@
     let wasmModulePromise = null;
     let wasmRequested = false;
     let languageServicesRegistered = false;
+    // Resolved pkg base URL (where rumoca_bind_wasm.js loaded from); the diffsol
+    // driver + addon sit next to it. Cached the first time the WASM is loaded.
+    let resolvedPkgBase = null;
+    // Cached promise for the diffsol driver module (rumoca_diffsol.js).
+    let diffsolDriverPromise = null;
     const widgets = [];
 
     function bookRoot() {
@@ -96,6 +101,7 @@
             broadcastStatus('Downloading Rumoca WASM (first use on this page)…');
             wasmModulePromise = (async () => {
                 const base = await locatePkgBase();
+                resolvedPkgBase = base;
                 const module = await import(base + 'rumoca_bind_wasm.js');
                 await module.default();
                 return module;
@@ -117,6 +123,20 @@
             );
         }
         return wasmModulePromise;
+    }
+
+    // Lazily import the diffsol driver (rumoca_diffsol.js), which sits next to
+    // the main WASM. It feature-detects relaxed-SIMD and lazy-loads the separate
+    // diffsol addon. Returns null if unavailable (older package without it).
+    function loadDiffsolDriver() {
+        if (!diffsolDriverPromise && resolvedPkgBase) {
+            diffsolDriverPromise = import(resolvedPkgBase + 'rumoca_diffsol.js')
+                .catch(() => {
+                    diffsolDriverPromise = null;
+                    return null;
+                });
+        }
+        return diffsolDriverPromise || Promise.resolve(null);
     }
 
     // -----------------------------------------------------------------
@@ -1386,6 +1406,28 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
         resetBtn.type = 'button';
         resetBtn.className = 'rumoca-live-button';
         resetBtn.textContent = 'Reset';
+        const solverLabel = document.createElement('label');
+        solverLabel.className = 'rumoca-live-solver';
+        const solverSelect = document.createElement('select');
+        solverSelect.className = 'rumoca-live-solver-select';
+        let bdfOption = null;
+        for (const { value, label } of [
+            { value: '', label: 'Auto' },
+            { value: 'rk-like', label: 'RK45 (explicit)' },
+            { value: 'bdf', label: 'BDF (stiff)' },
+        ]) {
+            const opt = document.createElement('option');
+            opt.value = value;
+            opt.textContent = label;
+            if (value === 'bdf') {
+                // Enabled later iff the browser supports the diffsol addon.
+                opt.disabled = true;
+                opt.title = 'Checking browser support…';
+                bdfOption = opt;
+            }
+            solverSelect.appendChild(opt);
+        }
+        solverLabel.append(document.createTextNode('Solver '), solverSelect);
         const gpuLabel = document.createElement('label');
         gpuLabel.className = 'rumoca-live-gpu';
         const gpuCheck = document.createElement('input');
@@ -1395,7 +1437,31 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
         gpuLabel.title = 'Run on WebGPU (wgsl-solve backend; experimental)';
         const status = document.createElement('span');
         status.className = 'rumoca-live-status';
-        toolbar.append(runBtn, daeBtn, resetBtn, gpuLabel, status);
+        toolbar.append(runBtn, daeBtn, resetBtn, solverLabel, gpuLabel, status);
+
+        // Enable the stiff (BDF/diffsol) option only when the browser can load
+        // the relaxed-SIMD addon; otherwise leave it greyed out with a reason.
+        async function refreshBdfAvailability() {
+            if (!bdfOption) {
+                return;
+            }
+            const driver = await loadDiffsolDriver();
+            const ok = driver && typeof driver.diffsolAvailable === 'function'
+                ? await driver.diffsolAvailable(resolvedPkgBase)
+                : false;
+            if (ok) {
+                bdfOption.disabled = false;
+                bdfOption.title = 'Stiff/implicit solver (diffsol)';
+            } else {
+                bdfOption.disabled = true;
+                bdfOption.title =
+                    'The stiff (diffsol) solver needs a browser with WebAssembly '
+                    + 'relaxed-SIMD (Chrome 114+, Firefox 120+, Safari 16.4+).';
+                if (solverSelect.value === 'bdf') {
+                    solverSelect.value = '';
+                }
+            }
+        }
 
         const progress = document.createElement('div');
         progress.className = 'rumoca-live-progress';
@@ -1492,6 +1558,8 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
             },
             setStatus(text) { status.textContent = text; },
             onWasmReady(wasm) {
+                // Independent of Monaco: enable the BDF option if supported.
+                refreshBdfAvailability();
                 if (!monaco || !editor.model) {
                     return;
                 }
@@ -1628,11 +1696,26 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
                     + 're-run on the CPU.'
                 );
             }
-            // t_end = 0 / dt = 0 / solver = "" defer to the model's
-            // experiment annotation, falling back to runtime defaults. The
-            // call runs in a worker so the page (and progress bar) stay live.
+            const solver = solverSelect.value;
+            if (solver === 'bdf') {
+                // Stiff path: the diffsol addon (separate relaxed-SIMD module)
+                // runs on the main thread, like the GPU path. The main module
+                // lowers the model and the addon simulates it. t_end/dt = 0
+                // defer to the model's experiment annotation.
+                const driver = await loadDiffsolDriver();
+                if (!driver || typeof driver.simulateWithDiffsol !== 'function') {
+                    throw new Error('the diffsol (stiff) solver addon is unavailable in this build');
+                }
+                setPhase('Compiling & simulating (stiff · diffsol)', null);
+                const result = await driver.simulateWithDiffsol(wasm, resolvedPkgBase, source, model, 0, 0);
+                renderRunResult(result);
+                return;
+            }
+            // t_end = 0 / dt = 0 defer to the model's experiment annotation,
+            // falling back to runtime defaults. `solver` is "" (auto/annotation)
+            // or "rk-like". Runs in a worker so the page stays live.
             const raw = await runHeavy('simulate', { source, model },
-                () => wasm.simulate_model(source, model, 0, 0, ''));
+                () => wasm.simulate_model(source, model, 0, 0, solver));
             renderRunResult(JSON.parse(raw));
         }));
 

--- a/editors/wasm/rumoca_diffsol.js
+++ b/editors/wasm/rumoca_diffsol.js
@@ -1,0 +1,107 @@
+// Lazy diffsol (stiff/implicit) simulation driver for the @cognipilot/rumoca
+// package.
+//
+// Why this exists: the main rumoca WASM module is SIMD-free and loads on every
+// browser. The diffsol solver pulls relaxed-SIMD (via faer/pulp), and WASM
+// validates a whole module at instantiation — so a single combined module
+// would hard-fail the entire package on browsers without relaxed-SIMD. Instead
+// the diffsol code ships as a *separate* tiny module (~0.4 MB gz,
+// `rumoca_bind_wasm_diffsol.js`) that is loaded only when (a) the browser
+// supports relaxed-SIMD and (b) the user actually runs a stiff solve.
+//
+// Usage (the main module is already initialized by the caller):
+//   import { diffsolAvailable, simulateWithDiffsol } from "@cognipilot/rumoca/diffsol";
+//   const ok = await diffsolAvailable(pkgBase);          // grey out the UI if false
+//   const result = await simulateWithDiffsol(mainModule, pkgBase, src, model, tEnd, dt);
+//
+// `pkgBase` is the same base URL the main `rumoca_bind_wasm.js` was imported
+// from (the addon wasm sits next to it).
+
+// Minimal module that uses a 1-operand relaxed-SIMD op
+// (`i32x4.relaxed_trunc_f32x4_s`, 0xFD 0x101). `WebAssembly.validate` returns
+// false on engines without relaxed-SIMD. This is a cheap *hint* for greying out
+// the UI; the authoritative check is whether the addon actually instantiates
+// (see `diffsolAvailable`). NOTE: verify in a real browser as part of the
+// editor smoke test.
+const RELAXED_SIMD_PROBE = new Uint8Array([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // \0asm v1
+  0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7b,       // type: () -> v128
+  0x03, 0x02, 0x01, 0x00,                         // func 0 : type 0
+  0x0a, 0x19, 0x01, 0x17, 0x00,                   // code: 1 body, size 23, 0 locals
+  0xfd, 0x0c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // v128.const 0
+  0xfd, 0x81, 0x02,                               // i32x4.relaxed_trunc_f32x4_s
+  0x0b,                                           // end
+]);
+
+/** Quick, non-authoritative hint: does this engine validate relaxed-SIMD? */
+export function relaxedSimdSupported() {
+  try {
+    return WebAssembly.validate(RELAXED_SIMD_PROBE);
+  } catch {
+    return false;
+  }
+}
+
+let addonPromise = null;
+
+/**
+ * Lazily import + initialize the diffsol addon module from `pkgBase`. Resolves
+ * to the module's exports, or rejects (e.g. `CompileError` on a browser without
+ * relaxed-SIMD). Cached after the first call.
+ */
+export function loadDiffsolAddon(pkgBase) {
+  if (!addonPromise) {
+    addonPromise = (async () => {
+      const mod = await import(pkgBase + "rumoca_bind_wasm_diffsol.js");
+      await mod.default(); // run wasm-bindgen init (instantiates the wasm)
+      return mod;
+    })();
+    // Allow a retry if loading failed (e.g. transient network).
+    addonPromise.catch(() => {
+      addonPromise = null;
+    });
+  }
+  return addonPromise;
+}
+
+/**
+ * Authoritative check: true iff the diffsol addon actually instantiates in this
+ * browser. Downloads/compiles the addon once (cached). Use this to enable or
+ * grey out the stiff-solver options.
+ */
+export async function diffsolAvailable(pkgBase) {
+  try {
+    await loadDiffsolAddon(pkgBase);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run a stiff (diffsol) simulation: the main module lowers the model to a
+ * SolveModel JSON, the addon simulates it. Returns the parsed
+ * `{ payload, ... }` object (same shape as the main module's `simulate_model`).
+ * Throws a clear error if the addon can't load (old browser) — callers should
+ * fall back to rk45 / the GPU path or surface the message.
+ */
+export async function simulateWithDiffsol(mainModule, pkgBase, source, modelName, tEnd, dt) {
+  if (typeof mainModule.lower_model_to_solve_json !== "function") {
+    throw new Error(
+      "this rumoca build predates the diffsol addon; rebuild the package",
+    );
+  }
+  let addon;
+  try {
+    addon = await loadDiffsolAddon(pkgBase);
+  } catch (err) {
+    throw new Error(
+      "the stiff (diffsol) solver needs a browser with WebAssembly relaxed-SIMD " +
+        "(Chrome 114+, Firefox 120+, Safari 16.4+). Use the rk45 solver or the GPU " +
+        `path instead. (${err && err.message ? err.message : err})`,
+    );
+  }
+  const solveJson = mainModule.lower_model_to_solve_json(source, modelName, tEnd, dt);
+  const resultJson = addon.simulate_solve_model_diffsol(solveJson, tEnd, dt);
+  return JSON.parse(resultJson);
+}

--- a/editors/wasm/rumoca_diffsol.js
+++ b/editors/wasm/rumoca_diffsol.js
@@ -101,7 +101,9 @@ export async function simulateWithDiffsol(mainModule, pkgBase, source, modelName
         `path instead. (${err && err.message ? err.message : err})`,
     );
   }
-  const solveJson = mainModule.lower_model_to_solve_json(source, modelName, tEnd, dt);
-  const resultJson = addon.simulate_solve_model_diffsol(solveJson, tEnd, dt);
+  // The payload carries the lowered model plus the resolved t_end/dt (so an
+  // annotation-driven duration is honored even when the caller passes 0).
+  const prepJson = mainModule.lower_model_to_solve_json(source, modelName, tEnd, dt);
+  const resultJson = addon.simulate_solve_model_diffsol(prepJson);
   return JSON.parse(resultJson);
 }

--- a/editors/wasm/rumoca_worker.js
+++ b/editors/wasm/rumoca_worker.js
@@ -36,8 +36,49 @@ let get_class_info;
 let render_target;
 let simulate_model = null;
 let simulate_model_with_project_sources = null;
+let lower_model_to_solve_json = null;
 let wasmModuleLoaded = false;
 let activeRequestId = null;
+
+// Lazy diffsol (stiff/implicit) addon — a separate relaxed-SIMD module, loaded
+// only when a BDF solve is requested, so this worker (and the package) stay
+// universal. Returns the addon's exports, or rejects on browsers without
+// relaxed-SIMD.
+let diffsolAddonPromise = null;
+function loadDiffsolAddon() {
+    if (!diffsolAddonPromise) {
+        diffsolAddonPromise = (async () => {
+            const mod = await import(withCacheBust('./rumoca_bind_wasm_diffsol.js'));
+            await mod.default();
+            return mod;
+        })();
+        diffsolAddonPromise.catch(() => {
+            diffsolAddonPromise = null;
+        });
+    }
+    return diffsolAddonPromise;
+}
+
+// Run a stiff (BDF/diffsol) simulation: the main module lowers the model to a
+// `{ solve_model, t_end, dt }` payload, the addon simulates it. Returns the
+// same JSON string shape as `simulate_model`.
+async function simulateViaDiffsol(source, model, tEnd, dt) {
+    if (typeof lower_model_to_solve_json !== 'function') {
+        throw new Error('this build cannot lower models for the diffsol addon');
+    }
+    let addon;
+    try {
+        addon = await loadDiffsolAddon();
+    } catch (err) {
+        throw new Error(
+            'the stiff (BDF/diffsol) solver needs a browser with WebAssembly '
+            + 'relaxed-SIMD (Chrome 114+, Firefox 120+, Safari 16.4+). '
+            + `Use RK45 instead. (${err && err.message ? err.message : err})`,
+        );
+    }
+    const prep = lower_model_to_solve_json(source, model, tEnd, dt);
+    return addon.simulate_solve_model_diffsol(prep);
+}
 
 function canUseSharedWasmThreads() {
     return typeof self.crossOriginIsolated === 'boolean'
@@ -80,6 +121,9 @@ async function loadWasmModule() {
     }
     if (typeof mod.simulate_model_with_project_sources === 'function') {
         simulate_model_with_project_sources = mod.simulate_model_with_project_sources;
+    }
+    if (typeof mod.lower_model_to_solve_json === 'function') {
+        lower_model_to_solve_json = mod.lower_model_to_solve_json;
     }
     wasmModuleLoaded = true;
 }
@@ -229,7 +273,18 @@ self.onmessage = async (e) => {
                         if (!simulate_model) {
                             throw new Error('Simulation not available in this WASM build. Rebuild with rumoca-sim (diffsol feature enabled).');
                         }
-                        if (
+                        if ((payload.solver || '') === 'bdf') {
+                            // Stiff path: route to the lazy diffsol addon (the
+                            // main module can't simulate bdf — it has no diffsol
+                            // runtime). Project-local sources aren't supported on
+                            // this path yet.
+                            result = await simulateViaDiffsol(
+                                payload.source || '',
+                                payload.modelName || 'Model',
+                                payload.tEnd || 1.0,
+                                payload.dt || 0,
+                            );
+                        } else if (
                             simulate_model_with_project_sources
                             && typeof payload.projectSources === 'string'
                             && payload.projectSources.trim()

--- a/packaging/npm/build.mjs
+++ b/packaging/npm/build.mjs
@@ -134,6 +134,44 @@ const copyEditorWorkers = async (pkgDir) => {
   );
 };
 
+// Build the diffsol (stiff/implicit) addon and ship it inside the same package.
+// It is a SEPARATE wasm module carrying relaxed-SIMD (faer/pulp), loaded lazily
+// by rumoca_diffsol.js only when the browser supports it — so the main module
+// stays SIMD-free / universal. Only meaningful for `full-web` (the package that
+// has the `lower_model_to_solve_json` export the addon consumes); `core` lacks
+// it, so the addon is not shipped there.
+const buildDiffsolAddon = async (pkgDir, args) => {
+  const tmpSubdir = ".diffsol-build";
+  const tmpDir = path.join(pkgRoot, tmpSubdir);
+  const addonArgs = [
+    "build",
+    "crates/rumoca-bind-wasm-diffsol",
+    "--target",
+    "web",
+    "--out-dir",
+    `../../pkg/${tmpSubdir}`,
+    args.profile === "dev" ? "--dev" : "--release",
+  ];
+  if (!args.optimize) {
+    addonArgs.push("--no-opt");
+  }
+  run("wasm-pack", addonArgs);
+  for (const file of [
+    "rumoca_bind_wasm_diffsol.js",
+    "rumoca_bind_wasm_diffsol_bg.wasm",
+    "rumoca_bind_wasm_diffsol.d.ts",
+  ]) {
+    await fs.copyFile(path.join(tmpDir, file), path.join(pkgDir, file));
+  }
+  // The driver (feature-detect + lazy-load + dispatch), exposed as
+  // `@cognipilot/rumoca/diffsol`.
+  await fs.copyFile(
+    path.join(repoRoot, "editors", "wasm", "rumoca_diffsol.js"),
+    path.join(pkgDir, "rumoca_diffsol.js"),
+  );
+  await fs.rm(tmpDir, { recursive: true, force: true });
+};
+
 const copyPackageReadme = async (pkgDir) => {
   await fs.copyFile(
     path.join(repoRoot, "packaging", "npm", "README.md"),
@@ -208,6 +246,11 @@ const main = async () => {
     run("wasm-pack", wasmPackArgs, { env });
     await copyEditorWorkers(pkgDir);
     await copyPackageReadme(pkgDir);
+    // The published `@cognipilot/rumoca` package (full-web) also ships the lazy
+    // diffsol addon; `core` does not (no lowering export to feed it).
+    if (args.variant === "full-web") {
+      await buildDiffsolAddon(pkgDir, args);
+    }
     await fs.writeFile(
       path.join(pkgDir, "rumoca_package_meta.json"),
       `${JSON.stringify({ packageBuiltTimeUtc: nowUtc }, null, 2)}\n`,

--- a/packaging/npm/patch-wasm-pkg.mjs
+++ b/packaging/npm/patch-wasm-pkg.mjs
@@ -75,6 +75,16 @@ export const patchWasmPackageJson = async (pkgDir, variant) => {
     pkg.exports["./gpu"] = { import: "./rumoca_gpu.js" };
     addFile("rumoca_gpu.js");
   }
+  // Lazy diffsol (stiff/implicit) addon, exposed as `@cognipilot/rumoca/diffsol`
+  // (only present in the full-web build). The driver is the entry point; it
+  // lazy-loads the separate relaxed-SIMD addon module on demand.
+  if (await exists(path.join(pkgDir, "rumoca_diffsol.js"))) {
+    pkg.exports["./diffsol"] = { import: "./rumoca_diffsol.js" };
+    addFile("rumoca_diffsol.js");
+    addFile("rumoca_bind_wasm_diffsol.js");
+    addFile("rumoca_bind_wasm_diffsol_bg.wasm");
+    addFile("rumoca_bind_wasm_diffsol.d.ts");
+  }
   if (await exists(path.join(pkgDir, "rumoca_worker.js"))) {
     addFile("rumoca_worker.js");
   }


### PR DESCRIPTION
Lets the stiff/implicit **diffsol** solver run in the browser **without** making `@cognipilot/rumoca` require a modern browser — diffsol pulls relaxed-SIMD (faer/pulp), which a single combined module would require at instantiation, hard-failing the whole package on older browsers.

## Approach
Diffsol ships as a **separate, lazily-loaded wasm module** inside the package, loaded only when (a) the browser supports relaxed-SIMD and (b) the user runs a stiff solve. The boundary is the serialized `SolveModel`.

## What's here
- **`rumoca-bind-wasm-diffsol`** — compiler-less addon (~0.40 MB gz) exposing `simulate_solve_model_diffsol(solve_json, t_end, dt)`.
- **`rumoca_sim::simulate_solve_model`** + a round-trip test proving a `SolveModel` serialize→deserialize→simulate is bit-identical (the `#[serde(skip)]` layout fields are lowering-only).
- **`lower_model_to_solve_json`** on the main (SIMD-free) module + an e2e test (lower → deserialize → diffsol simulate).
- **`rumoca_diffsol.js`** driver: `diffsolAvailable(base)` (authoritative lazy-instantiate check) + `simulateWithDiffsol(...)`; graceful error on old browsers.
- **Packaging**: `build.mjs`/`patch-wasm-pkg.mjs` ship the addon + driver in `@cognipilot/rumoca` under a `./diffsol` export (full-web only; core has no lowering export). CI publishes it automatically.

Verified: `@cognipilot/rumoca` exposes `.`/`./gpu`/`./diffsol`; native round-trip + lower→diffsol tests pass.

## Remaining (editor + browser, follow-up)
Grey out the stiff/bdf solver options in the editor via `diffsolAvailable()`, and a browser smoke test of the graceful-degradation path on a relaxed-SIMD-less engine. (The package/plumbing is browser-independent and tested here.)