### PR TITLE
ci: two-phase tag-driven release; drop release-create skip band-aid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1283,20 +1283,14 @@ jobs:
           echo "=== Release assets ==="
           ls -la release-assets/
 
-      # Create GitHub Release (idempotent: a re-run after a later step failed,
-      # e.g. a transient npm/PyPI publish error, must not abort on an
-      # already-existing release).
+      # Create GitHub Release. Deploy is gated to the tag-push event (see the
+      # job `if:` above), so this runs exactly once per release and a fresh tag
+      # never collides with an existing release.
       - name: Create GitHub Release
         run: |
-          set -euo pipefail
-          tag='${{ steps.tag.outputs.name }}'
-          if gh release view "$tag" >/dev/null 2>&1; then
-            echo "Release $tag already exists; skipping creation."
-          else
-            gh release create "$tag" \
-              --title "Release $tag" \
-              --generate-notes
-          fi
+          gh release create ${{ steps.tag.outputs.name }} \
+            --title "Release ${{ steps.tag.outputs.name }}" \
+            --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -278,9 +278,14 @@ struct ReleaseArgs {
     /// Create git tag vX.Y.Z
     #[arg(long)]
     tag: bool,
-    /// Push main and tag in one git push (implies --commit --tag)
+    /// Phase 1: commit the version bump and push it to main (implies --commit).
+    /// Does not tag; deploy is driven by the tag push in phase 2.
     #[arg(long)]
     push: bool,
+    /// Phase 2: tag the (already-pushed) release commit and push only the tag
+    /// (implies --tag). The tag push is what triggers the release/deploy CI.
+    #[arg(long)]
+    push_tag: bool,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/crates/xtask/src/release_cmd.rs
+++ b/crates/xtask/src/release_cmd.rs
@@ -23,29 +23,63 @@ struct ReleaseEdits {
 
 pub(crate) fn cmd_release(mut args: ReleaseArgs) -> Result<()> {
     validate_semver(&args.version)?;
+    ensure!(
+        !(args.push && args.push_tag),
+        "--push (phase 1: commit + push main) and --push-tag (phase 2: push the tag) \
+         are separate steps; run them one at a time"
+    );
     normalize_release_flags(&mut args);
     let root = crate::repo_root();
     ensure_release_worktree_state(&root, &args)?;
     let paths = release_paths(&root);
-    let edits = build_release_edits(&paths, &args.version)?;
 
     println!("Release version: {}", args.version);
     if args.dry_run {
-        println!("Dry run: no files written.");
-    } else {
-        write_release_edits(&paths, &edits)?;
-        run_quiet_cargo_check(&root)?;
-        run_release_git_steps(&root, &args)?;
+        println!("Dry run: no actions taken.");
+        return Ok(());
     }
 
+    // Phase 2 (--push-tag / --tag without --commit) tags an already-committed
+    // bump, so it must not rewrite the version files; just confirm HEAD is the
+    // release commit. Every other mode (re)writes the bump.
+    if args.push_tag {
+        ensure_version_committed(&root, &args.version)?;
+    } else {
+        let edits = build_release_edits(&paths, &args.version)?;
+        write_release_edits(&paths, &edits)?;
+        run_quiet_cargo_check(&root)?;
+    }
+
+    run_release_git_steps(&root, &args)?;
     Ok(())
 }
 
 fn normalize_release_flags(args: &mut ReleaseArgs) {
     if args.push {
         args.commit = true;
+    }
+    if args.push_tag {
         args.tag = true;
     }
+}
+
+/// Confirm the commit at HEAD already carries version `version` before tagging
+/// it in phase 2, so `--push-tag` can't accidentally tag an unbumped commit.
+fn ensure_version_committed(root: &Path, version: &str) -> Result<()> {
+    let mut show = Command::new("git");
+    show.arg("show").arg("HEAD:Cargo.toml").current_dir(root);
+    let cargo = crate::run_capture(show).context("failed to read Cargo.toml at HEAD")?;
+    let found = cargo.lines().find_map(|line| {
+        line.trim_start()
+            .strip_prefix("version = \"")
+            .and_then(|rest| rest.split('"').next())
+    });
+    ensure!(
+        found == Some(version),
+        "HEAD Cargo.toml version is {found:?}, expected \"{version}\"; \
+         run `cargo xtask repo release {version} --push` first to commit and push the bump"
+    );
+    Ok(())
 }
 
 fn ensure_release_worktree_state(root: &Path, args: &ReleaseArgs) -> Result<()> {
@@ -65,7 +99,7 @@ fn ensure_release_worktree_state(root: &Path, args: &ReleaseArgs) -> Result<()> 
 }
 
 fn ensure_release_push_branch(root: &Path, args: &ReleaseArgs) -> Result<()> {
-    if !args.push {
+    if !args.push && !args.push_tag {
         return Ok(());
     }
     let mut branch = Command::new("git");
@@ -77,7 +111,7 @@ fn ensure_release_push_branch(root: &Path, args: &ReleaseArgs) -> Result<()> {
     let current_branch = crate::run_capture(branch)?;
     ensure!(
         current_branch.trim() == "main",
-        "release --push must run from branch 'main' (current: '{}')",
+        "release --push/--push-tag must run from branch 'main' (current: '{}')",
         current_branch.trim()
     );
     Ok(())
@@ -144,7 +178,10 @@ fn run_release_git_steps(root: &Path, args: &ReleaseArgs) -> Result<()> {
         run_release_git_tag(root, &args.version)?;
     }
     if args.push {
-        run_release_git_push(root, &args.version)?;
+        run_release_git_push_main(root)?;
+    }
+    if args.push_tag {
+        run_release_git_push_tag(root, &args.version)?;
     }
     Ok(())
 }
@@ -170,21 +207,54 @@ fn run_release_git_commit(root: &Path, version: &str) -> Result<()> {
 }
 
 fn run_release_git_tag(root: &Path, version: &str) -> Result<()> {
-    let mut tag = Command::new("git");
-    tag.arg("tag").arg(format!("v{version}")).current_dir(root);
-    crate::run_status(tag)
+    let tag = format!("v{version}");
+    // Tolerate a re-run (e.g. phase 2 retried) as long as the existing tag still
+    // points at the commit we are about to release.
+    let mut list = Command::new("git");
+    list.arg("tag").arg("--list").arg(&tag).current_dir(root);
+    if !crate::run_capture(list)?.trim().is_empty() {
+        let mut points = Command::new("git");
+        points
+            .arg("tag")
+            .arg("--points-at")
+            .arg("HEAD")
+            .current_dir(root);
+        let at_head = crate::run_capture(points)?;
+        ensure!(
+            at_head.lines().any(|line| line.trim() == tag),
+            "tag {tag} already exists but does not point at HEAD; \
+             delete it or choose a new version"
+        );
+        println!("Tag {tag} already exists at HEAD; reusing it.");
+        return Ok(());
+    }
+    let mut create = Command::new("git");
+    create.arg("tag").arg(&tag).current_dir(root);
+    crate::run_status(create)
 }
 
-fn run_release_git_push(root: &Path, version: &str) -> Result<()> {
-    // Push branch and release tag together so main-push CI can detect the v* tag on this SHA.
-    let mut push_main_and_tag = Command::new("git");
-    push_main_and_tag
+fn run_release_git_push_main(root: &Path) -> Result<()> {
+    // Phase 1: push only the bump commit. Deploy is gated to the tag push, so
+    // this main push runs CI without releasing.
+    let mut push_main = Command::new("git");
+    push_main
         .arg("push")
         .arg("origin")
         .arg("main")
+        .current_dir(root);
+    crate::run_status(push_main)
+}
+
+fn run_release_git_push_tag(root: &Path, version: &str) -> Result<()> {
+    // Phase 2: push only the tag. The bump commit is already on main, so this is
+    // the single ref update that triggers the release/deploy CI run.
+    let mut push_tag = Command::new("git");
+    push_tag
+        .arg("push")
+        .arg("origin")
         .arg(format!("refs/tags/v{version}"))
         .current_dir(root);
-    crate::run_status(push_main_and_tag)
+    crate::run_status(push_tag)
 }
 
 fn read_file_string(path: &Path) -> Result<String> {
@@ -238,7 +308,41 @@ fn validate_semver(version: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::replace_json_version_line;
+    use super::{normalize_release_flags, replace_json_version_line};
+    use crate::ReleaseArgs;
+
+    fn args() -> ReleaseArgs {
+        ReleaseArgs {
+            version: "1.2.3".to_string(),
+            dry_run: false,
+            allow_dirty: false,
+            commit: false,
+            tag: false,
+            push: false,
+            push_tag: false,
+        }
+    }
+
+    #[test]
+    fn push_implies_commit_only_not_tag() {
+        let mut a = args();
+        a.push = true;
+        normalize_release_flags(&mut a);
+        assert!(a.commit, "phase 1 --push must commit the bump");
+        assert!(!a.tag, "phase 1 --push must not tag; the tag is phase 2");
+    }
+
+    #[test]
+    fn push_tag_implies_tag_only_not_commit() {
+        let mut a = args();
+        a.push_tag = true;
+        normalize_release_flags(&mut a);
+        assert!(a.tag, "phase 2 --push-tag must create the tag");
+        assert!(
+            !a.commit,
+            "phase 2 --push-tag must not re-commit; the bump is already on main"
+        );
+    }
 
     #[test]
     fn replace_json_version_line_preserves_order_and_updates_version() {


### PR DESCRIPTION
Follow-up to #249, addressing review feedback that the "skip if release exists" guard masks the symptom rather than fixing the root cause.

## Root cause (recap)

`cargo xtask repo release --push` ran `git push origin main refs/tags/vX.Y.Z` — one push updating **two refs**, so GitHub fires two CI runs (one for `refs/heads/main`, one for `refs/tags/vX`). #249's tag-only deploy gating is the real fix: deploy/deploy-pages now run on the tag ref only, so the GitHub release is created exactly once.

## Changes

- **Drop the `Create GitHub Release` skip-if-exists guard.** With tag-only deploy gating it can never trigger on a normal release, and it would silently swallow a genuinely conflicting or mispointed tag. Back to a plain `gh release create`.
- **Make the release tool tag-driven and two-phase:**
  - `--push` (phase 1): commit the bump, push **only `main`** → CI runs, no deploy.
  - `--push-tag` (phase 2): tag the already-pushed release commit, push **only the tag** → the single ref update that triggers deploy/publish.
- Guards: `--push-tag` verifies HEAD already carries the target version (can't tag an unbumped commit) and tolerates a re-run when the tag already points at HEAD; both phases must run from `main`; `--push` and `--push-tag` are mutually exclusive.

## Release flow now

```
cargo xtask repo release X.Y.Z --push       # phase 1: bump -> main, CI runs
# wait for main CI to go green
cargo xtask repo release X.Y.Z --push-tag    # phase 2: push tag -> deploy + publish
```

Unit tests cover the phase-1/phase-2 flag normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)