### PR TITLE
ci: build release artifacts once by gating heavy builds to PR/tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,6 +755,10 @@ jobs:
   # ============================================================================
   build-wasm:
     name: Build WASM
+    # Release artifacts are built on PRs (pre-merge validation) and on the
+    # release tag (the run that deploys). A direct main push doesn't rebuild,
+    # so a release commit's heavy build runs exactly once — on the tag.
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -889,6 +893,8 @@ jobs:
   # ============================================================================
   build-rust-binaries:
     name: Build Rust (${{ matrix.target }})
+    # Built on PRs and on the release tag only (see Build WASM note).
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -1020,6 +1026,8 @@ jobs:
 
   build-python-wheels:
     name: Build Python (${{ matrix.name }})
+    # Built on PRs and on the release tag only (see Build WASM note).
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -1091,6 +1099,8 @@ jobs:
 
   build-python-sdist:
     name: Build Python sdist
+    # Built on PRs and on the release tag only (see Build WASM note).
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -278,14 +278,10 @@ struct ReleaseArgs {
     /// Create git tag vX.Y.Z
     #[arg(long)]
     tag: bool,
-    /// Phase 1: commit the version bump and push it to main (implies --commit).
-    /// Does not tag; deploy is driven by the tag push in phase 2.
+    /// Push main and tag in one git push (implies --commit --tag). Heavy build
+    /// jobs and deploy are gated to the tag ref, so the release builds once.
     #[arg(long)]
     push: bool,
-    /// Phase 2: tag the (already-pushed) release commit and push only the tag
-    /// (implies --tag). The tag push is what triggers the release/deploy CI.
-    #[arg(long)]
-    push_tag: bool,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/crates/xtask/src/release_cmd.rs
+++ b/crates/xtask/src/release_cmd.rs
@@ -23,63 +23,29 @@ struct ReleaseEdits {
 
 pub(crate) fn cmd_release(mut args: ReleaseArgs) -> Result<()> {
     validate_semver(&args.version)?;
-    ensure!(
-        !(args.push && args.push_tag),
-        "--push (phase 1: commit + push main) and --push-tag (phase 2: push the tag) \
-         are separate steps; run them one at a time"
-    );
     normalize_release_flags(&mut args);
     let root = crate::repo_root();
     ensure_release_worktree_state(&root, &args)?;
     let paths = release_paths(&root);
+    let edits = build_release_edits(&paths, &args.version)?;
 
     println!("Release version: {}", args.version);
     if args.dry_run {
-        println!("Dry run: no actions taken.");
-        return Ok(());
-    }
-
-    // Phase 2 (--push-tag / --tag without --commit) tags an already-committed
-    // bump, so it must not rewrite the version files; just confirm HEAD is the
-    // release commit. Every other mode (re)writes the bump.
-    if args.push_tag {
-        ensure_version_committed(&root, &args.version)?;
+        println!("Dry run: no files written.");
     } else {
-        let edits = build_release_edits(&paths, &args.version)?;
         write_release_edits(&paths, &edits)?;
         run_quiet_cargo_check(&root)?;
+        run_release_git_steps(&root, &args)?;
     }
 
-    run_release_git_steps(&root, &args)?;
     Ok(())
 }
 
 fn normalize_release_flags(args: &mut ReleaseArgs) {
     if args.push {
         args.commit = true;
-    }
-    if args.push_tag {
         args.tag = true;
     }
-}
-
-/// Confirm the commit at HEAD already carries version `version` before tagging
-/// it in phase 2, so `--push-tag` can't accidentally tag an unbumped commit.
-fn ensure_version_committed(root: &Path, version: &str) -> Result<()> {
-    let mut show = Command::new("git");
-    show.arg("show").arg("HEAD:Cargo.toml").current_dir(root);
-    let cargo = crate::run_capture(show).context("failed to read Cargo.toml at HEAD")?;
-    let found = cargo.lines().find_map(|line| {
-        line.trim_start()
-            .strip_prefix("version = \"")
-            .and_then(|rest| rest.split('"').next())
-    });
-    ensure!(
-        found == Some(version),
-        "HEAD Cargo.toml version is {found:?}, expected \"{version}\"; \
-         run `cargo xtask repo release {version} --push` first to commit and push the bump"
-    );
-    Ok(())
 }
 
 fn ensure_release_worktree_state(root: &Path, args: &ReleaseArgs) -> Result<()> {
@@ -99,7 +65,7 @@ fn ensure_release_worktree_state(root: &Path, args: &ReleaseArgs) -> Result<()> 
 }
 
 fn ensure_release_push_branch(root: &Path, args: &ReleaseArgs) -> Result<()> {
-    if !args.push && !args.push_tag {
+    if !args.push {
         return Ok(());
     }
     let mut branch = Command::new("git");
@@ -111,7 +77,7 @@ fn ensure_release_push_branch(root: &Path, args: &ReleaseArgs) -> Result<()> {
     let current_branch = crate::run_capture(branch)?;
     ensure!(
         current_branch.trim() == "main",
-        "release --push/--push-tag must run from branch 'main' (current: '{}')",
+        "release --push must run from branch 'main' (current: '{}')",
         current_branch.trim()
     );
     Ok(())
@@ -178,10 +144,7 @@ fn run_release_git_steps(root: &Path, args: &ReleaseArgs) -> Result<()> {
         run_release_git_tag(root, &args.version)?;
     }
     if args.push {
-        run_release_git_push_main(root)?;
-    }
-    if args.push_tag {
-        run_release_git_push_tag(root, &args.version)?;
+        run_release_git_push(root, &args.version)?;
     }
     Ok(())
 }
@@ -233,28 +196,18 @@ fn run_release_git_tag(root: &Path, version: &str) -> Result<()> {
     crate::run_status(create)
 }
 
-fn run_release_git_push_main(root: &Path) -> Result<()> {
-    // Phase 1: push only the bump commit. Deploy is gated to the tag push, so
-    // this main push runs CI without releasing.
-    let mut push_main = Command::new("git");
-    push_main
+fn run_release_git_push(root: &Path, version: &str) -> Result<()> {
+    // Push the bump commit and the release tag together. Heavy build jobs and
+    // deploy are gated to the tag ref (and PRs), so the main-ref run only lints
+    // and tests while the tag-ref run builds and deploys exactly once.
+    let mut push_main_and_tag = Command::new("git");
+    push_main_and_tag
         .arg("push")
         .arg("origin")
         .arg("main")
-        .current_dir(root);
-    crate::run_status(push_main)
-}
-
-fn run_release_git_push_tag(root: &Path, version: &str) -> Result<()> {
-    // Phase 2: push only the tag. The bump commit is already on main, so this is
-    // the single ref update that triggers the release/deploy CI run.
-    let mut push_tag = Command::new("git");
-    push_tag
-        .arg("push")
-        .arg("origin")
         .arg(format!("refs/tags/v{version}"))
         .current_dir(root);
-    crate::run_status(push_tag)
+    crate::run_status(push_main_and_tag)
 }
 
 fn read_file_string(path: &Path) -> Result<String> {
@@ -319,29 +272,16 @@ mod tests {
             commit: false,
             tag: false,
             push: false,
-            push_tag: false,
         }
     }
 
     #[test]
-    fn push_implies_commit_only_not_tag() {
+    fn push_implies_commit_and_tag() {
         let mut a = args();
         a.push = true;
         normalize_release_flags(&mut a);
-        assert!(a.commit, "phase 1 --push must commit the bump");
-        assert!(!a.tag, "phase 1 --push must not tag; the tag is phase 2");
-    }
-
-    #[test]
-    fn push_tag_implies_tag_only_not_commit() {
-        let mut a = args();
-        a.push_tag = true;
-        normalize_release_flags(&mut a);
-        assert!(a.tag, "phase 2 --push-tag must create the tag");
-        assert!(
-            !a.commit,
-            "phase 2 --push-tag must not re-commit; the bump is already on main"
-        );
+        assert!(a.commit, "--push must commit the bump");
+        assert!(a.tag, "--push must create the tag (pushed alongside main)");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #249/#250. Those fixed the duplicate *deploy*, but a release commit's heavy build matrix still ran twice — once on its main push, once on its tag push.

## Root cause

`build-wasm`, `build-rust-binaries`, `build-python-wheels`, and `build-python-sdist` had **no `if:`**, so they ran on every PR, every main push, and every tag push.

## Change

Gate those four jobs to **PRs or the tag-push event**:

```yaml
if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
```

- PR → builds (pre-merge validation).
- main push → **does not build**; just lint + test (fast).
- tag push → builds + deploys, **exactly once**.

Only `deploy` and `deploy-pages` consume these artifacts and both are already tag-gated, so nothing on a main push is left stranded.

## Release tool simplified back to one-shot

With heavy builds off the main ref, the two-phase split from #250 is no longer needed to avoid duplicate builds, so `--push` again pushes main + tag together:

```
cargo xtask repo release X.Y.Z --push
#  main-ref run: lint + test (no build)
#  tag-ref run:  build + deploy + publish  (once)
```

(`--push-tag` removed; idempotent tag creation retained.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)