### PR TITLE
docs: add npm badge and tidy README license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/cognipilot/rumoca/actions/workflows/ci.yml/badge.svg)](https://github.com/cognipilot/rumoca/actions/workflows/ci.yml)
 [![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-live-2ea44f?logo=github)](https://cognipilot.github.io/rumoca/)
 [![PyPI](https://img.shields.io/pypi/v/rumoca)](https://pypi.org/project/rumoca/)
+[![npm](https://img.shields.io/npm/v/@cognipilot/rumoca)](https://www.npmjs.com/package/@cognipilot/rumoca)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 **[Try Rumoca in your browser](https://cognipilot.github.io/rumoca/)** (no installation required).
@@ -422,4 +423,4 @@ Compiler-affecting changes should still follow:
 
 ## License
 
-Apache-2.0 (`LICENSE`)
+Rumoca is licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary
- Add an npm version badge for [`@cognipilot/rumoca`](https://www.npmjs.com/package/@cognipilot/rumoca) next to the existing PyPI badge (now that 0.9.4 is published to npm).
- Replace the awkward `Apache-2.0 (`LICENSE`)` line at the bottom with a proper linked sentence: "Rumoca is licensed under the [Apache License 2.0](LICENSE)."

## Notes
Docs-only change. The npm badge resolves to `v0.9.4` via shields.io.