### PR TITLE
project-config: rum.toml scenario config + dual-view editor GUI

### DIFF
--- a/crates/rumoca-bind-wasm/src/lib.rs
+++ b/crates/rumoca-bind-wasm/src/lib.rs
@@ -596,6 +596,34 @@ pub fn project_get_scenario_config(
     project_config_api::get_scenario_config_impl(project_sources_json, path)
 }
 
+/// Full `rum.toml` scenario as a JSON tree for the config GUI:
+/// `{ ok, config: <toml-as-json>, descriptor }`. The `config` tree round-trips
+/// every section (including nested interactive-IO) losslessly.
+#[wasm_bindgen]
+pub fn project_get_scenario_config_full(
+    project_sources_json: &str,
+    path: &str,
+) -> Result<String, JsValue> {
+    project_config_api::get_scenario_config_full_impl(project_sources_json, path)
+}
+
+/// Render a `rum.toml` from the config GUI's JSON tree. Returns
+/// `{ writes: [{path, content}], result }` for the editor to apply.
+#[wasm_bindgen]
+pub fn project_set_scenario_config(path: &str, config_json: &str) -> Result<String, JsValue> {
+    project_config_api::set_scenario_config_impl(path, config_json)
+}
+
+/// Default colocated `rum.<model>.toml` (`{ ok, path, content }`) for the
+/// lightning-bolt "create config" action on a Modelica model.
+#[wasm_bindgen]
+pub fn project_default_scenario_config(
+    project_sources_json: &str,
+    model: &str,
+) -> Result<String, JsValue> {
+    project_config_api::default_scenario_config_impl(project_sources_json, model)
+}
+
 #[derive(Default)]
 struct DocumentationFields {
     info_html: Option<String>,

--- a/crates/rumoca-bind-wasm/src/lib.rs
+++ b/crates/rumoca-bind-wasm/src/lib.rs
@@ -10,6 +10,7 @@ include!(concat!(env!("OUT_DIR"), "/build_metadata.rs"));
 mod class_browser_helpers;
 #[cfg(any(feature = "sim-wasm", feature = "sim-diffsol", feature = "sim-rk45"))]
 mod gpu_api;
+mod project_config_api;
 #[cfg(any(feature = "sim-wasm", feature = "sim-diffsol", feature = "sim-rk45"))]
 mod simulation_api;
 pub mod source_root_api;
@@ -528,6 +529,71 @@ pub fn get_simulation_models(source: &str, default_model: &str) -> Result<String
         error: None,
     })
     .map_err(|e| JsValue::from_str(&format!("JSON error: {}", e)))
+}
+
+// --- Project (`rum.toml`) configuration commands ---------------------------
+// These operate on the editor's in-memory `projectSources` map (`path ->
+// content` JSON) and mirror the LSP server's `rumoca.project.*` config
+// commands, sharing the implementation in `rumoca_compile::project`.
+
+/// Effective + preset + default simulation settings for a model, given the
+/// project's `rum.toml` files and an optional editor `fallback` settings JSON.
+#[wasm_bindgen]
+pub fn project_get_simulation_config(
+    project_sources_json: &str,
+    model: &str,
+    fallback_json: &str,
+) -> Result<String, JsValue> {
+    project_config_api::get_simulation_config_impl(project_sources_json, model, fallback_json)
+}
+
+/// Write a model's simulation preset into its colocated `rum.<model>.toml`.
+/// Returns `{ writes, result }` for the editor to apply to its project store.
+#[wasm_bindgen]
+pub fn project_set_simulation_preset(
+    project_sources_json: &str,
+    model: &str,
+    preset_json: &str,
+) -> Result<String, JsValue> {
+    project_config_api::set_simulation_preset_impl(project_sources_json, model, preset_json)
+}
+
+/// Clear a model's simulation preset. Returns `{ writes, result }`.
+#[wasm_bindgen]
+pub fn project_reset_simulation_preset(
+    project_sources_json: &str,
+    model: &str,
+) -> Result<String, JsValue> {
+    project_config_api::reset_simulation_preset_impl(project_sources_json, model)
+}
+
+/// Configured plot/visualization views for a model (`{ views: [...] }`).
+#[wasm_bindgen]
+pub fn project_get_visualization_config(
+    project_sources_json: &str,
+    model: &str,
+) -> Result<String, JsValue> {
+    project_config_api::get_visualization_config_impl(project_sources_json, model)
+}
+
+/// Write a model's plot/visualization views. Returns `{ writes, result }`.
+#[wasm_bindgen]
+pub fn project_set_visualization_config(
+    project_sources_json: &str,
+    model: &str,
+    views_json: &str,
+) -> Result<String, JsValue> {
+    project_config_api::set_visualization_config_impl(project_sources_json, model, views_json)
+}
+
+/// Parse a single `rum.toml` scenario file (by project path) into the editor's
+/// scenario descriptor (`task`, `model`, `viewerMode`, interactive ports, ...).
+#[wasm_bindgen]
+pub fn project_get_scenario_config(
+    project_sources_json: &str,
+    path: &str,
+) -> Result<String, JsValue> {
+    project_config_api::get_scenario_config_impl(project_sources_json, path)
 }
 
 #[derive(Default)]

--- a/crates/rumoca-bind-wasm/src/project_config_api.rs
+++ b/crates/rumoca-bind-wasm/src/project_config_api.rs
@@ -1,0 +1,152 @@
+//! Project (`rum.toml`) configuration commands for the browser editor.
+//!
+//! These mirror the LSP server's `rumoca.project.*` config commands but operate
+//! on the editor's in-memory project files (the `projectSources` JSON map of
+//! `path -> content`) instead of a real filesystem. The actual logic and JSON
+//! shaping live in `rumoca_compile::project`, shared with the LSP server, so the
+//! browser editor and VS Code stay in lockstep.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use rumoca_compile::project::{
+    ProjectConfig, parse_fallback_simulation, parse_views_payload, scenario_config_response,
+    simulation_override_from_json, simulation_preset_to_json, simulation_settings_to_json,
+    visualization_views_to_json,
+};
+use serde_json::{Value, json};
+use wasm_bindgen::JsValue;
+
+// Editor project paths are workspace-relative, so an empty workspace root keeps
+// any newly created `rum.<model>.toml` write path relative too.
+fn project_config_from_sources(project_sources_json: &str) -> Result<ProjectConfig, JsValue> {
+    Ok(ProjectConfig::from_files(
+        Path::new(""),
+        parse_project_files(project_sources_json)?,
+    ))
+}
+
+fn parse_project_files(project_sources_json: &str) -> Result<Vec<(PathBuf, String)>, JsValue> {
+    let trimmed = project_sources_json.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let map: BTreeMap<String, String> = serde_json::from_str(trimmed)
+        .map_err(|e| JsValue::from_str(&format!("Invalid project sources JSON: {e}")))?;
+    Ok(map
+        .into_iter()
+        .map(|(path, content)| (PathBuf::from(path), content))
+        .collect())
+}
+
+fn parse_optional_json(raw: &str) -> Option<Value> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "null" {
+        return None;
+    }
+    serde_json::from_str(trimmed).ok()
+}
+
+fn to_json_string(value: &Value) -> Result<String, JsValue> {
+    serde_json::to_string(value).map_err(|e| JsValue::from_str(&format!("JSON error: {e}")))
+}
+
+/// Build a `{ writes: [{path, content}], result: { ok: true } }` response for a
+/// single model's config file, applied by the editor to its project store.
+fn writes_response(config: &ProjectConfig, model: &str) -> Result<String, JsValue> {
+    let mut writes = Vec::new();
+    if let Some(result) = config.compute_write_for_model(model) {
+        let (path, content) =
+            result.map_err(|e| JsValue::from_str(&format!("render config error: {e}")))?;
+        writes.push(json!({ "path": path.to_string_lossy(), "content": content }));
+    }
+    to_json_string(&json!({ "writes": writes, "result": { "ok": true } }))
+}
+
+pub(crate) fn get_simulation_config_impl(
+    project_sources_json: &str,
+    model: &str,
+    fallback_json: &str,
+) -> Result<String, JsValue> {
+    let config = project_config_from_sources(project_sources_json)?;
+    let fallback = parse_optional_json(fallback_json)
+        .as_ref()
+        .and_then(|value| parse_fallback_simulation(Some(value)))
+        .unwrap_or_default();
+    let snapshot = config.simulation_snapshot_for_model(model, &fallback);
+    to_json_string(&json!({
+        "preset": snapshot.preset.as_ref().map(simulation_preset_to_json),
+        "defaults": simulation_settings_to_json(&snapshot.defaults),
+        "effective": simulation_settings_to_json(&snapshot.effective),
+        "diagnostics": snapshot.diagnostics,
+    }))
+}
+
+pub(crate) fn set_simulation_preset_impl(
+    project_sources_json: &str,
+    model: &str,
+    preset_json: &str,
+) -> Result<String, JsValue> {
+    let mut config = project_config_from_sources(project_sources_json)?;
+    let model_override = parse_optional_json(preset_json)
+        .as_ref()
+        .and_then(simulation_override_from_json)
+        .ok_or_else(|| JsValue::from_str("invalid simulation preset payload"))?;
+    config.set_model_simulation_preset(model, model_override);
+    writes_response(&config, model)
+}
+
+pub(crate) fn reset_simulation_preset_impl(
+    project_sources_json: &str,
+    model: &str,
+) -> Result<String, JsValue> {
+    let mut config = project_config_from_sources(project_sources_json)?;
+    config.remove_model_override(model);
+    writes_response(&config, model)
+}
+
+pub(crate) fn get_visualization_config_impl(
+    project_sources_json: &str,
+    model: &str,
+) -> Result<String, JsValue> {
+    let config = project_config_from_sources(project_sources_json)?;
+    to_json_string(&visualization_views_to_json(
+        config.plot_views_for_model(model),
+    ))
+}
+
+pub(crate) fn set_visualization_config_impl(
+    project_sources_json: &str,
+    model: &str,
+    views_json: &str,
+) -> Result<String, JsValue> {
+    let mut config = project_config_from_sources(project_sources_json)?;
+    let views = parse_optional_json(views_json)
+        .as_ref()
+        .and_then(parse_views_payload)
+        .ok_or_else(|| JsValue::from_str("invalid visualization views payload"))?;
+    config.set_plot_views(model, views);
+    writes_response(&config, model)
+}
+
+pub(crate) fn get_scenario_config_impl(
+    project_sources_json: &str,
+    path: &str,
+) -> Result<String, JsValue> {
+    let files = parse_project_files(project_sources_json)?;
+    let needle = path.trim();
+    let content = files
+        .iter()
+        .find(|(file_path, _)| {
+            let candidate = file_path.to_string_lossy();
+            candidate == needle || (!needle.is_empty() && candidate.ends_with(needle))
+        })
+        .map(|(_, content)| content.clone());
+    match content {
+        Some(content) => to_json_string(&scenario_config_response(&content)),
+        None => to_json_string(&json!({
+            "ok": false,
+            "error": "rum.toml scenario was not found in the project",
+        })),
+    }
+}

--- a/crates/rumoca-bind-wasm/src/project_config_api.rs
+++ b/crates/rumoca-bind-wasm/src/project_config_api.rs
@@ -10,9 +10,9 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use rumoca_compile::project::{
-    ProjectConfig, parse_fallback_simulation, parse_views_payload, scenario_config_response,
-    simulation_override_from_json, simulation_preset_to_json, simulation_settings_to_json,
-    visualization_views_to_json,
+    ProjectConfig, parse_fallback_simulation, parse_views_payload, scenario_config_full_to_json,
+    scenario_config_response, scenario_config_text_from_json, simulation_override_from_json,
+    simulation_preset_to_json, simulation_settings_to_json, visualization_views_to_json,
 };
 use serde_json::{Value, json};
 use wasm_bindgen::JsValue;
@@ -134,19 +134,60 @@ pub(crate) fn get_scenario_config_impl(
     path: &str,
 ) -> Result<String, JsValue> {
     let files = parse_project_files(project_sources_json)?;
-    let needle = path.trim();
-    let content = files
-        .iter()
-        .find(|(file_path, _)| {
-            let candidate = file_path.to_string_lossy();
-            candidate == needle || (!needle.is_empty() && candidate.ends_with(needle))
-        })
-        .map(|(_, content)| content.clone());
-    match content {
-        Some(content) => to_json_string(&scenario_config_response(&content)),
+    match find_project_file(&files, path.trim()) {
+        Some(content) => to_json_string(&scenario_config_response(content)),
         None => to_json_string(&json!({
             "ok": false,
             "error": "rum.toml scenario was not found in the project",
         })),
     }
+}
+
+fn find_project_file<'a>(files: &'a [(PathBuf, String)], needle: &str) -> Option<&'a str> {
+    files
+        .iter()
+        .find(|(file_path, _)| {
+            let candidate = file_path.to_string_lossy();
+            candidate == needle || (!needle.is_empty() && candidate.ends_with(needle))
+        })
+        .map(|(_, content)| content.as_str())
+}
+
+pub(crate) fn get_scenario_config_full_impl(
+    project_sources_json: &str,
+    path: &str,
+) -> Result<String, JsValue> {
+    let files = parse_project_files(project_sources_json)?;
+    match find_project_file(&files, path.trim()) {
+        Some(content) => to_json_string(&scenario_config_full_to_json(content)),
+        None => to_json_string(&json!({
+            "ok": false,
+            "error": "rum.toml scenario was not found in the project",
+        })),
+    }
+}
+
+pub(crate) fn set_scenario_config_impl(path: &str, config_json: &str) -> Result<String, JsValue> {
+    let config: Value = serde_json::from_str(config_json.trim())
+        .map_err(|e| JsValue::from_str(&format!("Invalid scenario config JSON: {e}")))?;
+    let content = scenario_config_text_from_json(&config).map_err(|e| JsValue::from_str(&e))?;
+    to_json_string(&json!({
+        "writes": [{ "path": path, "content": content }],
+        "result": { "ok": true },
+    }))
+}
+
+pub(crate) fn default_scenario_config_impl(
+    project_sources_json: &str,
+    model: &str,
+) -> Result<String, JsValue> {
+    let config = project_config_from_sources(project_sources_json)?;
+    let (path, content) = config
+        .default_scenario_config(model)
+        .map_err(|e| JsValue::from_str(&format!("default scenario config error: {e}")))?;
+    to_json_string(&json!({
+        "ok": true,
+        "path": path.to_string_lossy(),
+        "content": content,
+    }))
 }

--- a/crates/rumoca-bind-wasm/src/tests.rs
+++ b/crates/rumoca-bind-wasm/src/tests.rs
@@ -1951,3 +1951,64 @@ fn project_get_simulation_config_reads_in_memory_rum_toml() {
             .is_some_and(|content| content.contains("solver = \"rk-like\""))
     );
 }
+
+#[test]
+fn scenario_config_full_round_trips_interactive_io() {
+    // The config GUI reads the whole rum.toml as a JSON tree and writes it back.
+    // Nested interactive-IO sections must survive a round-trip losslessly.
+    let rum_toml = r#"[rumoca]
+version = "1"
+task = "simulate"
+
+[model]
+name = "Rover"
+file = "Rover.mo"
+
+[sim]
+solver = "auto"
+mode = "realtime"
+
+[input.keyboard.keys.ArrowUp]
+action = "set"
+target = "throttle"
+value = 1.0
+
+[signals.viewer]
+theta = "stepper:theta"
+"#;
+    let sources = serde_json::json!({ "rum.toml": rum_toml }).to_string();
+
+    let full = project_get_scenario_config_full(&sources, "rum.toml").expect("full config");
+    let parsed: serde_json::Value = serde_json::from_str(&full).expect("json");
+    assert_eq!(parsed["ok"], true);
+    let mut config = parsed["config"].clone();
+    assert_eq!(
+        config["input"]["keyboard"]["keys"]["ArrowUp"]["action"],
+        "set"
+    );
+    assert_eq!(config["signals"]["viewer"]["theta"], "stepper:theta");
+
+    // Change the solver in the tree and write it back.
+    config["sim"]["solver"] = serde_json::Value::from("bdf");
+    let write_response =
+        project_set_scenario_config("rum.toml", &config.to_string()).expect("set scenario");
+    let written: serde_json::Value = serde_json::from_str(&write_response).expect("json");
+    let content = written["writes"][0]["content"].as_str().expect("content");
+    assert!(content.contains("solver = \"bdf\""));
+    // Interactive-IO blocks preserved.
+    assert!(content.contains("[input.keyboard.keys.ArrowUp]"));
+    assert!(content.contains("theta = \"stepper:theta\""));
+    assert!(content.contains("[rumoca]"));
+}
+
+#[test]
+fn default_scenario_config_creates_minimal_rum_toml() {
+    let sources = serde_json::json!({ "models/Rover.mo": "model Rover end Rover;" }).to_string();
+    let response = project_default_scenario_config(&sources, "Rover").expect("default config");
+    let parsed: serde_json::Value = serde_json::from_str(&response).expect("json");
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["path"], "models/rum.rover.toml");
+    let content = parsed["content"].as_str().expect("content");
+    assert!(content.contains("[rumoca]"));
+    assert!(content.contains("name = \"Rover\""));
+}

--- a/crates/rumoca-bind-wasm/src/tests.rs
+++ b/crates/rumoca-bind-wasm/src/tests.rs
@@ -1920,3 +1920,34 @@ fn lower_to_solve_json_feeds_diffsol_simulation() {
         "x(1) should be ~e^-1, got {last}"
     );
 }
+
+#[test]
+fn project_get_simulation_config_reads_in_memory_rum_toml() {
+    // The browser editor passes its in-memory project files as a `path ->
+    // content` JSON map; the command reads the `rum.toml` config with no disk.
+    let sources = serde_json::json!({
+        "rum.Ball.toml": "[rumoca]\nversion = \"1\"\ntask = \"simulate\"\n\n[model]\nname = \"Ball\"\n\n[sim]\nsolver = \"bdf\"\nt_end = 9.0\n",
+        "Ball.mo": "model Ball end Ball;",
+    })
+    .to_string();
+
+    let response =
+        project_get_simulation_config(&sources, "Ball", "").expect("simulation config response");
+    let parsed: serde_json::Value = serde_json::from_str(&response).expect("valid JSON");
+    assert_eq!(parsed["effective"]["solver"], "bdf");
+    assert_eq!(parsed["effective"]["tEnd"], 9.0);
+
+    // Writing a preset returns a colocated `rum.toml` write for the editor.
+    let preset = serde_json::json!({ "solver": "rk-like", "tEnd": 3.0 }).to_string();
+    let write_response =
+        project_set_simulation_preset(&sources, "Ball", &preset).expect("set preset response");
+    let written: serde_json::Value = serde_json::from_str(&write_response).expect("valid JSON");
+    let writes = written["writes"].as_array().expect("writes array");
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0]["path"], "rum.Ball.toml");
+    assert!(
+        writes[0]["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("solver = \"rk-like\""))
+    );
+}

--- a/crates/rumoca-compile/src/lib.rs
+++ b/crates/rumoca-compile/src/lib.rs
@@ -111,8 +111,11 @@ pub mod project {
         ScenarioViewerConfig, ScenarioViewerMode, SimulationConfig, SimulationDefaults,
         SimulationModelOverride, clear_model_simulation_preset, is_rumoca_task_filename,
         load_last_simulation_result_for_model, load_plot_views_for_model, load_simulation_run,
-        load_simulation_snapshot_for_model, write_last_simulation_result_for_model,
-        write_model_simulation_preset, write_plot_views_for_model, write_simulation_run,
+        load_simulation_snapshot_for_model, parse_fallback_simulation, parse_views_payload,
+        scenario_config_response, simulation_override_from_json, simulation_preset_to_json,
+        simulation_settings_to_json, visualization_views_to_json,
+        write_last_simulation_result_for_model, write_model_simulation_preset,
+        write_plot_views_for_model, write_simulation_run,
     };
 }
 

--- a/crates/rumoca-compile/src/lib.rs
+++ b/crates/rumoca-compile/src/lib.rs
@@ -112,10 +112,10 @@ pub mod project {
         SimulationModelOverride, clear_model_simulation_preset, is_rumoca_task_filename,
         load_last_simulation_result_for_model, load_plot_views_for_model, load_simulation_run,
         load_simulation_snapshot_for_model, parse_fallback_simulation, parse_views_payload,
-        scenario_config_response, simulation_override_from_json, simulation_preset_to_json,
-        simulation_settings_to_json, visualization_views_to_json,
-        write_last_simulation_result_for_model, write_model_simulation_preset,
-        write_plot_views_for_model, write_simulation_run,
+        scenario_config_full_to_json, scenario_config_response, scenario_config_text_from_json,
+        simulation_override_from_json, simulation_preset_to_json, simulation_settings_to_json,
+        visualization_views_to_json, write_last_simulation_result_for_model,
+        write_model_simulation_preset, write_plot_views_for_model, write_simulation_run,
     };
 }
 

--- a/crates/rumoca-compile/src/project_config.rs
+++ b/crates/rumoca-compile/src/project_config.rs
@@ -12,9 +12,9 @@ use crate::parse::{parse_files_parallel_lenient, parse_source_to_ast};
 
 mod json;
 pub use json::{
-    parse_fallback_simulation, parse_views_payload, scenario_config_response,
-    simulation_override_from_json, simulation_preset_to_json, simulation_settings_to_json,
-    visualization_views_to_json,
+    parse_fallback_simulation, parse_views_payload, scenario_config_full_to_json,
+    scenario_config_response, scenario_config_text_from_json, simulation_override_from_json,
+    simulation_preset_to_json, simulation_settings_to_json, visualization_views_to_json,
 };
 
 const RUMOCA_TASK_FILE_VERSION: &str = "1";
@@ -495,6 +495,22 @@ impl ProjectConfig {
             effective,
             diagnostics: self.diagnostics.clone(),
         }
+    }
+
+    /// Default colocated `rum.<model>.toml` (path + rendered content) for a
+    /// model: a minimal `[rumoca]` + `[model]` scenario, used by the editor's
+    /// "create config" (lightning-bolt) action. The GUI fills in the rest.
+    pub fn default_scenario_config(&self, model: &str) -> Result<(PathBuf, String)> {
+        let path = self.default_config_path_for_model(model);
+        let data = ProjectConfigFile {
+            model: ModelConfig {
+                name: Some(model.to_string()),
+                file: None,
+            },
+            ..ProjectConfigFile::default()
+        };
+        let text = render_config_text("", &data)?;
+        Ok((path, text))
     }
 
     /// Plot/visualization views configured for a model (empty when none).

--- a/crates/rumoca-compile/src/project_config.rs
+++ b/crates/rumoca-compile/src/project_config.rs
@@ -8,7 +8,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::merge::collect_model_names;
-use crate::parse::parse_files_parallel_lenient;
+use crate::parse::{parse_files_parallel_lenient, parse_source_to_ast};
+
+mod json;
+pub use json::{
+    parse_fallback_simulation, parse_views_payload, scenario_config_response,
+    simulation_override_from_json, simulation_preset_to_json, simulation_settings_to_json,
+    visualization_views_to_json,
+};
 
 const RUMOCA_TASK_FILE_VERSION: &str = "1";
 const GENERATED_RESULTS_DIR: &str = ".rumoca/results";
@@ -17,6 +24,11 @@ const GENERATED_RESULTS_DIR: &str = ".rumoca/results";
 pub struct ProjectConfig {
     workspace_root: PathBuf,
     configs: BTreeMap<String, ColocatedModelConfig>,
+    /// In-memory `model name -> .mo source path` map. `Some` only when the
+    /// config was built from an in-memory file set (e.g. the browser editor,
+    /// which has no real filesystem); `None` means resolve model sources from
+    /// disk. Used to colocate newly created `rum.<model>.toml` files.
+    model_source_files: Option<BTreeMap<String, PathBuf>>,
     pub diagnostics: Vec<String>,
 }
 
@@ -193,6 +205,10 @@ pub struct PlotViewConfig {
 pub(crate) struct ColocatedModelConfig {
     path: PathBuf,
     data: ProjectConfigFile,
+    /// Original on-load file text, used to merge managed keys into a write
+    /// while preserving any unmanaged keys. Empty for configs created in
+    /// memory (no prior file).
+    raw_text: String,
 }
 
 impl ProjectConfig {
@@ -206,19 +222,56 @@ impl ProjectConfig {
     }
 
     pub fn load_or_default(workspace_root: &Path) -> Result<Self> {
+        let mut read_diagnostics = Vec::new();
+        let mut config_texts = Vec::new();
+        for path in collect_workspace_scenario_files(workspace_root)? {
+            match fs::read_to_string(&path) {
+                Ok(text) => config_texts.push((path, text)),
+                Err(error) => read_diagnostics.push(format!(
+                    "Failed to read config '{}': {error}",
+                    path.display()
+                )),
+            }
+        }
+        // Disk mode: model sources are resolved from disk on demand.
+        let mut config = Self::from_config_texts(workspace_root, config_texts, None);
+        config.diagnostics.splice(0..0, read_diagnostics);
+        Ok(config)
+    }
+
+    /// Build a project config from an in-memory file set (path + content),
+    /// without touching the filesystem. `rum.<profile>.toml` entries are parsed
+    /// as configs; `.mo` entries seed the model-source map used to colocate
+    /// newly created config files. This is the browser-editor entry point.
+    pub fn from_files(workspace_root: &Path, files: Vec<(PathBuf, String)>) -> Self {
+        let mut config_texts = Vec::new();
+        let mut modelica_files = Vec::new();
+        for (path, text) in files {
+            let is_task_file = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(is_rumoca_task_filename);
+            if is_task_file {
+                config_texts.push((path, text));
+            } else if path
+                .extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("mo"))
+            {
+                modelica_files.push((path, text));
+            }
+        }
+        let model_source_files = build_model_source_files(modelica_files);
+        Self::from_config_texts(workspace_root, config_texts, Some(model_source_files))
+    }
+
+    fn from_config_texts(
+        workspace_root: &Path,
+        config_texts: Vec<(PathBuf, String)>,
+        model_source_files: Option<BTreeMap<String, PathBuf>>,
+    ) -> Self {
         let mut diagnostics = Vec::new();
         let mut configs = BTreeMap::<String, ColocatedModelConfig>::new();
-        for path in collect_workspace_scenario_files(workspace_root)? {
-            let text = match fs::read_to_string(&path) {
-                Ok(text) => text,
-                Err(error) => {
-                    diagnostics.push(format!(
-                        "Failed to read config '{}': {error}",
-                        path.display()
-                    ));
-                    continue;
-                }
-            };
+        for (path, text) in config_texts {
             if !text_looks_like_rumoca_scenario_config(&text) {
                 continue;
             }
@@ -251,20 +304,54 @@ impl ProjectConfig {
             if data.rumoca.task != ProjectTask::Simulate {
                 continue;
             }
-            configs.insert(model_name, ColocatedModelConfig { path, data });
+            configs.insert(
+                model_name,
+                ColocatedModelConfig {
+                    path,
+                    data,
+                    raw_text: text,
+                },
+            );
         }
-        Ok(Self {
+        Self {
             workspace_root: workspace_root.to_path_buf(),
             configs,
+            model_source_files,
             diagnostics,
-        })
+        }
     }
 
     pub fn save(&self) -> Result<()> {
-        for config in self.configs.values() {
-            write_colocated_config_file(&config.path, &config.data)?;
+        for (path, text) in self.compute_writes()? {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("create {}", parent.display()))?;
+            }
+            fs::write(&path, text).with_context(|| format!("write {}", path.display()))?;
         }
         Ok(())
+    }
+
+    /// Render every tracked config to its `(path, text)` write, without touching
+    /// the filesystem. Used by `save` (disk) and by the browser editor (which
+    /// applies the writes to its in-memory project store).
+    pub fn compute_writes(&self) -> Result<Vec<(PathBuf, String)>> {
+        self.configs
+            .values()
+            .map(|config| {
+                render_config_text(&config.raw_text, &config.data)
+                    .map(|text| (config.path.clone(), text))
+            })
+            .collect()
+    }
+
+    /// Render just one model's config to its `(path, text)` write. Returns
+    /// `None` when the model has no tracked config.
+    pub fn compute_write_for_model(&self, model: &str) -> Option<Result<(PathBuf, String)>> {
+        self.configs.get(model).map(|config| {
+            render_config_text(&config.raw_text, &config.data)
+                .map(|text| (config.path.clone(), text))
+        })
     }
 
     pub fn model_override(&self, model: &str) -> Option<&SimulationModelOverride> {
@@ -272,11 +359,10 @@ impl ProjectConfig {
     }
 
     pub fn set_model_override(&mut self, model: &str, model_override: SimulationModelOverride) {
-        let path = self
-            .configs
-            .get(model)
-            .map(|config| config.path.clone())
-            .unwrap_or_else(|| default_config_path_for_model(&self.workspace_root, model));
+        let path = match self.configs.get(model) {
+            Some(config) => config.path.clone(),
+            None => self.default_config_path_for_model(model),
+        };
         let entry = self
             .configs
             .entry(model.to_string())
@@ -289,9 +375,57 @@ impl ProjectConfig {
                     },
                     ..ProjectConfigFile::default()
                 },
+                raw_text: String::new(),
             });
         entry.data.model.name = Some(model.to_string());
         entry.data.sim = model_override;
+    }
+
+    /// Normalize and set a model's simulation preset (solver/dt/t_end). Shared
+    /// by the disk writer ([`write_model_simulation_preset`]) and the in-memory
+    /// browser-editor path so normalization stays identical.
+    pub fn set_model_simulation_preset(
+        &mut self,
+        model: &str,
+        mut model_override: SimulationModelOverride,
+    ) {
+        model_override.solver = normalize_solver_opt(model_override.solver);
+        model_override.dt = normalize_dt_opt(model_override.dt);
+        if !model_override
+            .t_end
+            .map(|value| value.is_finite() && value > 0.0)
+            .unwrap_or(true)
+        {
+            model_override.t_end = None;
+        }
+        self.set_model_override(model, model_override);
+    }
+
+    /// Set the plot/visualization views for a model, creating a colocated
+    /// config entry if necessary. In-memory analogue of
+    /// [`write_plot_views_for_model`].
+    pub fn set_plot_views(&mut self, model: &str, mut views: Vec<PlotViewConfig>) {
+        normalize_plot_views(&mut views);
+        let path = match self.configs.get(model) {
+            Some(config) => config.path.clone(),
+            None => self.default_config_path_for_model(model),
+        };
+        let entry = self
+            .configs
+            .entry(model.to_string())
+            .or_insert_with(|| ColocatedModelConfig {
+                path,
+                data: ProjectConfigFile {
+                    model: ModelConfig {
+                        name: Some(model.to_string()),
+                        file: None,
+                    },
+                    ..ProjectConfigFile::default()
+                },
+                raw_text: String::new(),
+            });
+        entry.data.model.name = Some(model.to_string());
+        entry.data.plot.views = views;
     }
 
     pub fn remove_model_override(&mut self, model: &str) -> bool {
@@ -362,6 +496,40 @@ impl ProjectConfig {
             diagnostics: self.diagnostics.clone(),
         }
     }
+
+    /// Plot/visualization views configured for a model (empty when none).
+    /// In-memory analogue of [`load_plot_views_for_model`].
+    pub fn plot_views_for_model(&self, model: &str) -> Vec<PlotViewConfig> {
+        self.configs
+            .get(model)
+            .map(|config| config.data.plot.views.clone())
+            .unwrap_or_default()
+    }
+
+    /// Resolve the default colocated `rum.<model>.toml` path for a model:
+    /// next to the model's `.mo` source when known, else at the workspace root.
+    fn default_config_path_for_model(&self, model: &str) -> PathBuf {
+        let source_file = match &self.model_source_files {
+            Some(map) => map.get(model).cloned(),
+            None => find_model_source_file(&self.workspace_root, model)
+                .ok()
+                .flatten(),
+        };
+        if let Some(source_file) = source_file
+            && let Some(parent) = source_file.parent()
+        {
+            let stem = source_file
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| class_name_from_qualified_name(model));
+            return parent.join(format!("rum.{}.toml", sanitize_identifier(stem)));
+        }
+        self.workspace_root.join(format!(
+            "rum.{}.toml",
+            sanitize_identifier(class_name_from_qualified_name(model))
+        ))
+    }
 }
 
 /// Rumoca task-file naming convention: `rum.toml` (default) or
@@ -394,19 +562,10 @@ pub fn load_simulation_snapshot_for_model(
 pub fn write_model_simulation_preset(
     workspace_root: &Path,
     model: &str,
-    mut model_override: SimulationModelOverride,
+    model_override: SimulationModelOverride,
 ) -> Result<()> {
-    model_override.solver = normalize_solver_opt(model_override.solver);
-    model_override.dt = normalize_dt_opt(model_override.dt);
-    if !model_override
-        .t_end
-        .map(|value| value.is_finite() && value > 0.0)
-        .unwrap_or(true)
-    {
-        model_override.t_end = None;
-    }
     let mut config = ProjectConfig::load_or_default(workspace_root)?;
-    config.set_model_override(model, model_override);
+    config.set_model_simulation_preset(model, model_override);
     config.save()
 }
 
@@ -421,40 +580,16 @@ pub fn load_plot_views_for_model(
     model: &str,
 ) -> Result<Vec<PlotViewConfig>> {
     let config = ProjectConfig::load_or_default(workspace_root)?;
-    Ok(config
-        .configs
-        .get(model)
-        .map(|cfg| cfg.data.plot.views.clone())
-        .unwrap_or_default())
+    Ok(config.plot_views_for_model(model))
 }
 
 pub fn write_plot_views_for_model(
     workspace_root: &Path,
     model: &str,
-    mut views: Vec<PlotViewConfig>,
+    views: Vec<PlotViewConfig>,
 ) -> Result<()> {
-    normalize_plot_views(&mut views);
     let mut config = ProjectConfig::load_or_default(workspace_root)?;
-    let path = config
-        .configs
-        .get(model)
-        .map(|config| config.path.clone())
-        .unwrap_or_else(|| default_config_path_for_model(workspace_root, model));
-    let entry = config
-        .configs
-        .entry(model.to_string())
-        .or_insert_with(|| ColocatedModelConfig {
-            path,
-            data: ProjectConfigFile {
-                model: ModelConfig {
-                    name: Some(model.to_string()),
-                    file: None,
-                },
-                ..ProjectConfigFile::default()
-            },
-        });
-    entry.data.model.name = Some(model.to_string());
-    entry.data.plot.views = views;
+    config.set_plot_views(model, views);
     config.save()
 }
 
@@ -704,22 +839,30 @@ fn collect_workspace_scenario_files(workspace_root: &Path) -> Result<Vec<PathBuf
     Ok(files)
 }
 
-fn write_colocated_config_file(path: &Path, data: &ProjectConfigFile) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
-    }
-
-    let mut value = if path.is_file() {
-        let text = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-        toml::from_str::<toml::Value>(&text)
-            .unwrap_or_else(|_| toml::Value::Table(Default::default()))
-    } else {
-        toml::Value::Table(Default::default())
-    };
+/// Render a config file's text by merging managed keys into the prior file
+/// text (preserving any unmanaged keys). Pure: no filesystem access.
+fn render_config_text(existing_raw: &str, data: &ProjectConfigFile) -> Result<String> {
+    let mut value = toml::from_str::<toml::Value>(existing_raw)
+        .unwrap_or_else(|_| toml::Value::Table(Default::default()));
     merge_config_value(&mut value, data)?;
-    let text =
-        toml::to_string_pretty(&value).with_context(|| format!("serialize {}", path.display()))?;
-    fs::write(path, text).with_context(|| format!("write {}", path.display()))
+    toml::to_string_pretty(&value).context("serialize project config")
+}
+
+/// Build a `model name -> .mo source path` map from an in-memory file set, so
+/// the browser editor can colocate new config files without disk access.
+/// Files are sorted by path so the lowest path wins for a duplicated model.
+fn build_model_source_files(mut files: Vec<(PathBuf, String)>) -> BTreeMap<String, PathBuf> {
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut map = BTreeMap::new();
+    for (path, content) in files {
+        let Ok(definition) = parse_source_to_ast(&content, &path.to_string_lossy()) else {
+            continue;
+        };
+        for name in collect_model_names(&definition) {
+            map.entry(name).or_insert_with(|| path.clone());
+        }
+    }
+    map
 }
 
 fn merge_config_value(value: &mut toml::Value, data: &ProjectConfigFile) -> Result<()> {
@@ -874,23 +1017,6 @@ fn merge_optional_f64(
     } else {
         table.remove(key);
     }
-}
-
-fn default_config_path_for_model(workspace_root: &Path, model: &str) -> PathBuf {
-    if let Ok(Some(source_file)) = find_model_source_file(workspace_root, model)
-        && let Some(parent) = source_file.parent()
-    {
-        let stem = source_file
-            .file_stem()
-            .and_then(|value| value.to_str())
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| class_name_from_qualified_name(model));
-        return parent.join(format!("rum.{}.toml", sanitize_identifier(stem)));
-    }
-    workspace_root.join(format!(
-        "rum.{}.toml",
-        sanitize_identifier(class_name_from_qualified_name(model))
-    ))
 }
 
 fn find_model_source_file(workspace_root: &Path, model: &str) -> Result<Option<PathBuf>> {

--- a/crates/rumoca-compile/src/project_config/json.rs
+++ b/crates/rumoca-compile/src/project_config/json.rs
@@ -149,6 +149,70 @@ fn scenario_error(message: impl Into<String>) -> Value {
     json!({ "ok": false, "error": message.into() })
 }
 
+/// Full `rum.toml` scenario as a JSON tree for the editor's config GUI:
+/// `{ ok, config: <toml-as-json>, descriptor: <scenario_config_response> }`. The
+/// `config` tree round-trips every section losslessly (including the nested
+/// interactive-IO blocks), so the form can edit known fields and preserve the rest.
+pub fn scenario_config_full_to_json(content: &str) -> Value {
+    let raw = match toml::from_str::<toml::Value>(content) {
+        Ok(raw) => raw,
+        Err(error) => return scenario_error(format!("failed to parse scenario config: {error}")),
+    };
+    let config = serde_json::to_value(&raw).unwrap_or(Value::Null);
+    json!({
+        "ok": true,
+        "config": config,
+        "descriptor": scenario_config_response(content),
+    })
+}
+
+/// Render a `rum.toml` from the GUI's JSON config tree, ensuring the `[rumoca]`
+/// marker is present (defaulting version/task). Pure: no filesystem access.
+pub fn scenario_config_text_from_json(config: &Value) -> Result<String, String> {
+    let mut cleaned = config.clone();
+    strip_json_nulls(&mut cleaned);
+    let mut toml_value = toml::Value::try_from(&cleaned)
+        .map_err(|error| format!("config is not representable as TOML: {error}"))?;
+    ensure_rumoca_marker(&mut toml_value);
+    toml::to_string_pretty(&toml_value)
+        .map_err(|error| format!("failed to serialize scenario config: {error}"))
+}
+
+/// TOML has no `null`; drop null-valued keys so the GUI can omit unset fields.
+fn strip_json_nulls(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            map.retain(|_, entry| !entry.is_null());
+            for entry in map.values_mut() {
+                strip_json_nulls(entry);
+            }
+        }
+        Value::Array(items) => {
+            for entry in items.iter_mut() {
+                strip_json_nulls(entry);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn ensure_rumoca_marker(value: &mut toml::Value) {
+    let toml::Value::Table(root) = value else {
+        return;
+    };
+    let marker = root
+        .entry("rumoca".to_string())
+        .or_insert_with(|| toml::Value::Table(Default::default()));
+    if let toml::Value::Table(marker_table) = marker {
+        marker_table
+            .entry("version".to_string())
+            .or_insert_with(|| toml::Value::String(super::RUMOCA_TASK_FILE_VERSION.to_string()));
+        marker_table
+            .entry("task".to_string())
+            .or_insert_with(|| toml::Value::String("simulate".to_string()));
+    }
+}
+
 fn string_array(value: Option<&Value>) -> Vec<String> {
     value
         .and_then(Value::as_array)

--- a/crates/rumoca-compile/src/project_config/json.rs
+++ b/crates/rumoca-compile/src/project_config/json.rs
@@ -1,0 +1,260 @@
+//! JSON shaping for project (`rum.toml`) configuration commands.
+//!
+//! These pure converters between the `rum.toml` config types and the camelCase
+//! JSON the editors exchange are the single source of truth shared by the LSP
+//! server (`rumoca-tool-lsp`) and the browser editor bindings
+//! (`rumoca-bind-wasm`), so the two cannot drift.
+
+use serde_json::{Value, json};
+
+use super::{
+    EffectiveSimulationConfig, EffectiveSimulationPreset, PlotViewConfig, ProjectConfigFile,
+    ProjectTask, ScenarioViewerMode, SimulationModelOverride, normalize_dt_opt,
+    normalize_solver_opt,
+};
+
+/// `EffectiveSimulationConfig` -> simulation settings JSON (camelCase).
+pub fn simulation_settings_to_json(settings: &EffectiveSimulationConfig) -> Value {
+    json!({
+        "solver": settings.solver,
+        "tEnd": settings.t_end,
+        "dt": settings.dt,
+        "outputDir": settings.output_dir,
+        "sourceRootPaths": settings.source_root_paths,
+    })
+}
+
+/// `EffectiveSimulationPreset` -> preset JSON (camelCase).
+pub fn simulation_preset_to_json(preset: &EffectiveSimulationPreset) -> Value {
+    json!({
+        "solver": preset.solver,
+        "tEnd": preset.t_end,
+        "dt": preset.dt,
+        "outputDir": preset.output_dir,
+        "sourceRootOverrides": preset.source_root_overrides,
+    })
+}
+
+/// Parse the optional `fallback` simulation settings an editor supplies when
+/// asking for a model's effective config.
+pub fn parse_fallback_simulation(value: Option<&Value>) -> Option<EffectiveSimulationConfig> {
+    let obj = value?.as_object()?;
+    let solver = normalize_solver_opt(
+        obj.get("solver")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    )
+    .unwrap_or_else(|| "auto".to_string());
+    let t_end = obj
+        .get("tEnd")
+        .and_then(Value::as_f64)
+        .filter(|v| v.is_finite() && *v > 0.0)
+        .unwrap_or(10.0);
+    let dt = normalize_dt_opt(obj.get("dt").and_then(Value::as_f64));
+    let output_dir = obj
+        .get("outputDir")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let source_root_paths = string_array(obj.get("sourceRootPaths"));
+    Some(EffectiveSimulationConfig {
+        solver,
+        t_end,
+        dt,
+        output_dir,
+        source_root_paths,
+    })
+}
+
+/// Parse a simulation preset (`setSimulationPreset` payload) into a model
+/// override.
+pub fn simulation_override_from_json(value: &Value) -> Option<SimulationModelOverride> {
+    let obj = value.as_object()?;
+    Some(SimulationModelOverride {
+        solver: obj
+            .get("solver")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        t_end: obj.get("tEnd").and_then(Value::as_f64),
+        dt: obj.get("dt").and_then(Value::as_f64),
+        output_dir: obj
+            .get("outputDir")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        source_root_overrides: string_array(obj.get("sourceRootOverrides")),
+    })
+}
+
+/// Configured plot views -> `{ "views": [...] }` JSON (camelCase).
+pub fn visualization_views_to_json(views: Vec<PlotViewConfig>) -> Value {
+    let payload: Vec<VisualizationViewPayload> = views
+        .into_iter()
+        .map(VisualizationViewPayload::from)
+        .collect();
+    json!({ "views": payload })
+}
+
+/// Parse a `setVisualizationConfig` views payload into plot view configs.
+pub fn parse_views_payload(value: &Value) -> Option<Vec<PlotViewConfig>> {
+    serde_json::from_value::<Vec<VisualizationViewPayload>>(value.clone())
+        .ok()
+        .map(|views| views.into_iter().map(PlotViewConfig::from).collect())
+}
+
+/// Build the `getScenarioConfig` response for a `rum.toml` file's text. Returns
+/// `{ ok: false, error }` for any malformed/incomplete scenario.
+pub fn scenario_config_response(content: &str) -> Value {
+    let raw_config = match toml::from_str::<toml::Value>(content) {
+        Ok(config) => config,
+        Err(error) => return scenario_error(format!("failed to parse scenario config: {error}")),
+    };
+    let config = match toml::from_str::<ProjectConfigFile>(content) {
+        Ok(config) => config,
+        Err(error) => return scenario_error(format!("failed to parse scenario config: {error}")),
+    };
+    let model = config
+        .model
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("");
+    if model.is_empty() {
+        return scenario_error("scenario config is missing [model].name");
+    }
+    let target = config.codegen.target.as_deref().unwrap_or("").trim();
+    if config.rumoca.task == ProjectTask::Codegen && target.is_empty() {
+        return scenario_error("codegen scenario config is missing [codegen].target");
+    }
+    json!({
+        "ok": true,
+        "task": match config.rumoca.task {
+            ProjectTask::Simulate => "simulate",
+            ProjectTask::Codegen => "codegen",
+        },
+        "model": model,
+        "target": target,
+        "outputDir": config.codegen.output_dir,
+        "viewerMode": scenario_viewer_mode(&config, &raw_config),
+        "viewerPreferExternal": config.viewer.prefer_external,
+        "simMode": scenario_sim_mode(&raw_config),
+        "httpPort": scenario_http_port(&raw_config),
+        "websocketPort": scenario_websocket_port(&raw_config),
+        "httpScene": scenario_http_scene(&raw_config),
+        "interactive": scenario_requests_live_viewer(&raw_config),
+    })
+}
+
+fn scenario_error(message: impl Into<String>) -> Value {
+    json!({ "ok": false, "error": message.into() })
+}
+
+fn string_array(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn table_has_key(value: &toml::Value, key: &str) -> bool {
+    value
+        .as_table()
+        .is_some_and(|table| table.contains_key(key))
+}
+
+fn table_path<'a>(value: &'a toml::Value, path: &[&str]) -> Option<&'a toml::Value> {
+    let mut current = value;
+    for key in path {
+        current = current.as_table()?.get(*key)?;
+    }
+    Some(current)
+}
+
+fn scenario_requests_live_viewer(raw: &toml::Value) -> bool {
+    table_path(raw, &["transport", "http"]).is_some()
+        || table_has_key(raw, "input")
+        || table_has_key(raw, "signals")
+        || table_has_key(raw, "locals")
+        || table_has_key(raw, "derive")
+        || table_has_key(raw, "reset")
+        || table_has_key(raw, "external_interface")
+        || (table_has_key(raw, "schema")
+            && table_has_key(raw, "receive")
+            && table_has_key(raw, "send"))
+}
+
+fn scenario_viewer_mode(config: &ProjectConfigFile, raw: &toml::Value) -> &'static str {
+    match config.viewer.mode {
+        Some(ScenarioViewerMode::ResultsPanel) => "results_panel",
+        Some(ScenarioViewerMode::ExternalWeb) => "external_web",
+        None if scenario_requests_live_viewer(raw) => "external_web",
+        None => "results_panel",
+    }
+}
+
+fn scenario_http_port(raw: &toml::Value) -> Option<i64> {
+    table_path(raw, &["transport", "http", "port"]).and_then(toml::Value::as_integer)
+}
+
+fn scenario_websocket_port(raw: &toml::Value) -> Option<i64> {
+    table_path(raw, &["transport", "websocket", "port"]).and_then(toml::Value::as_integer)
+}
+
+fn scenario_http_scene(raw: &toml::Value) -> Option<&str> {
+    table_path(raw, &["transport", "http", "scene"]).and_then(toml::Value::as_str)
+}
+
+fn scenario_sim_mode(raw: &toml::Value) -> Option<&str> {
+    table_path(raw, &["sim", "mode"]).and_then(toml::Value::as_str)
+}
+
+/// camelCase wire representation of a plot view, shared with the editors.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct VisualizationViewPayload {
+    id: String,
+    title: String,
+    #[serde(rename = "type")]
+    view_type: String,
+    x: Option<String>,
+    #[serde(default)]
+    y: Vec<String>,
+    script: Option<String>,
+    script_path: Option<String>,
+}
+
+impl From<PlotViewConfig> for VisualizationViewPayload {
+    fn from(view: PlotViewConfig) -> Self {
+        Self {
+            id: view.id,
+            title: view.title,
+            view_type: view.view_type,
+            x: view.x,
+            y: view.y,
+            script: view.script,
+            script_path: view.script_path,
+        }
+    }
+}
+
+impl From<VisualizationViewPayload> for PlotViewConfig {
+    fn from(view: VisualizationViewPayload) -> Self {
+        Self {
+            id: view.id,
+            title: view.title,
+            view_type: view.view_type,
+            x: view.x,
+            y: view.y,
+            script: view.script,
+            script_path: view.script_path,
+        }
+    }
+}

--- a/crates/rumoca-compile/src/project_config/tests.rs
+++ b/crates/rumoca-compile/src/project_config/tests.rs
@@ -301,3 +301,58 @@ dt = 0.01
     assert!(!text.contains("t_end ="));
     assert!(!text.contains("dt ="));
 }
+
+#[test]
+fn from_files_reads_config_without_filesystem() {
+    // The browser editor path: parse an in-memory file set (no disk access).
+    let files = vec![
+        (
+            PathBuf::from("rum.Ball.toml"),
+            r#"
+[rumoca]
+version = "1"
+task = "simulate"
+
+[model]
+name = "Examples.Ball"
+
+[sim]
+solver = "bdf"
+t_end = 7.0
+"#
+            .to_string(),
+        ),
+        (PathBuf::from("Ball.mo"), "model Ball end Ball;".to_string()),
+    ];
+
+    let config = ProjectConfig::from_files(Path::new(""), files);
+    let effective =
+        config.effective_for_model("Examples.Ball", &EffectiveSimulationConfig::default());
+    assert_eq!(effective.solver, "bdf");
+    assert_eq!(effective.t_end, 7.0);
+}
+
+#[test]
+fn from_files_colocates_new_config_next_to_model_source() {
+    // A new preset for a model whose .mo lives in a subdirectory should write a
+    // colocated `rum.<stem>.toml` next to it, resolved from the in-memory map.
+    let files = vec![(
+        PathBuf::from("models/Ball.mo"),
+        "model Ball end Ball;".to_string(),
+    )];
+    let mut config = ProjectConfig::from_files(Path::new(""), files);
+    config.set_model_simulation_preset(
+        "Ball",
+        SimulationModelOverride {
+            solver: Some("bdf".to_string()),
+            ..SimulationModelOverride::default()
+        },
+    );
+    let (path, text) = config
+        .compute_write_for_model("Ball")
+        .expect("write exists")
+        .expect("render ok");
+    assert_eq!(path, PathBuf::from("models/rum.ball.toml"));
+    assert!(text.contains("solver = \"bdf\""));
+    assert!(text.contains("[rumoca]"));
+}

--- a/crates/rumoca-tool-lsp/src/server.rs
+++ b/crates/rumoca-tool-lsp/src/server.rs
@@ -15,10 +15,9 @@ use rumoca_compile::parsing::{
     ast, collect_compile_unit_source_files, collect_model_names, parse_source_to_ast,
 };
 use rumoca_compile::project::{
-    EffectiveSimulationConfig, EffectiveSimulationPreset, PlotViewConfig, ProjectConfig,
-    ProjectConfigFile, ProjectTask, ScenarioViewerMode, SimulationModelOverride,
-    clear_model_simulation_preset, load_plot_views_for_model, load_simulation_snapshot_for_model,
-    write_model_simulation_preset, write_plot_views_for_model,
+    EffectiveSimulationConfig, ProjectConfig, ProjectConfigFile, clear_model_simulation_preset,
+    load_plot_views_for_model, load_simulation_snapshot_for_model, write_model_simulation_preset,
+    write_plot_views_for_model,
 };
 use rumoca_compile::source_roots::{
     PackageLayoutError, SourceRootCacheStatus, SourceRootCacheTiming, canonical_path_key,

--- a/crates/rumoca-tool-lsp/src/server/project_commands.rs
+++ b/crates/rumoca-tool-lsp/src/server/project_commands.rs
@@ -13,58 +13,6 @@ fn builtin_template_descriptors() -> Vec<rumoca_compile::codegen::targets::Built
     builtin_target_descriptors_for_ir(TargetTemplateIr::Dae)
 }
 
-fn table_has_key(value: &toml::Value, key: &str) -> bool {
-    value
-        .as_table()
-        .is_some_and(|table| table.contains_key(key))
-}
-
-fn table_path<'a>(value: &'a toml::Value, path: &[&str]) -> Option<&'a toml::Value> {
-    let mut current = value;
-    for key in path {
-        current = current.as_table()?.get(*key)?;
-    }
-    Some(current)
-}
-
-fn scenario_requests_live_viewer(raw: &toml::Value) -> bool {
-    table_path(raw, &["transport", "http"]).is_some()
-        || table_has_key(raw, "input")
-        || table_has_key(raw, "signals")
-        || table_has_key(raw, "locals")
-        || table_has_key(raw, "derive")
-        || table_has_key(raw, "reset")
-        || table_has_key(raw, "external_interface")
-        || (table_has_key(raw, "schema")
-            && table_has_key(raw, "receive")
-            && table_has_key(raw, "send"))
-}
-
-fn scenario_viewer_mode(config: &ProjectConfigFile, raw: &toml::Value) -> &'static str {
-    match config.viewer.mode {
-        Some(ScenarioViewerMode::ResultsPanel) => "results_panel",
-        Some(ScenarioViewerMode::ExternalWeb) => "external_web",
-        None if scenario_requests_live_viewer(raw) => "external_web",
-        None => "results_panel",
-    }
-}
-
-fn scenario_http_port(raw: &toml::Value) -> Option<i64> {
-    table_path(raw, &["transport", "http", "port"]).and_then(toml::Value::as_integer)
-}
-
-fn scenario_websocket_port(raw: &toml::Value) -> Option<i64> {
-    table_path(raw, &["transport", "websocket", "port"]).and_then(toml::Value::as_integer)
-}
-
-fn scenario_http_scene(raw: &toml::Value) -> Option<&str> {
-    table_path(raw, &["transport", "http", "scene"]).and_then(toml::Value::as_str)
-}
-
-fn scenario_sim_mode(raw: &toml::Value) -> Option<&str> {
-    table_path(raw, &["sim", "mode"]).and_then(toml::Value::as_str)
-}
-
 impl ModelicaLanguageServer {
     pub(super) async fn simulation_request_settings_for_model_prewarm(
         &self,
@@ -151,57 +99,7 @@ impl ModelicaLanguageServer {
             Ok(source) => source,
             Err(error) => return Some(Self::simulation_error_value(error)),
         };
-        let raw_config = match toml::from_str::<toml::Value>(&source) {
-            Ok(config) => config,
-            Err(error) => {
-                return Some(Self::simulation_error_value(format!(
-                    "failed to parse scenario config: {error}",
-                )));
-            }
-        };
-        let config = match toml::from_str::<ProjectConfigFile>(&source) {
-            Ok(config) => config,
-            Err(error) => {
-                return Some(Self::simulation_error_value(format!(
-                    "failed to parse scenario config: {error}",
-                )));
-            }
-        };
-        let model = config
-            .model
-            .name
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("");
-        if model.is_empty() {
-            return Some(Self::simulation_error_value(
-                "scenario config is missing [model].name",
-            ));
-        }
-        let target = config.codegen.target.as_deref().unwrap_or("").trim();
-        if config.rumoca.task == ProjectTask::Codegen && target.is_empty() {
-            return Some(Self::simulation_error_value(
-                "codegen scenario config is missing [codegen].target",
-            ));
-        }
-        Some(json!({
-            "ok": true,
-            "task": match config.rumoca.task {
-                ProjectTask::Simulate => "simulate",
-                ProjectTask::Codegen => "codegen",
-            },
-            "model": model,
-            "target": target,
-            "outputDir": config.codegen.output_dir,
-            "viewerMode": scenario_viewer_mode(&config, &raw_config),
-            "viewerPreferExternal": config.viewer.prefer_external,
-            "simMode": scenario_sim_mode(&raw_config),
-            "httpPort": scenario_http_port(&raw_config),
-            "websocketPort": scenario_websocket_port(&raw_config),
-            "httpScene": scenario_http_scene(&raw_config),
-            "interactive": scenario_requests_live_viewer(&raw_config),
-        }))
+        Some(scenario_config_response(&source))
     }
 
     pub(super) async fn execute_render_target(&self, params: Option<Value>) -> Option<Value> {
@@ -419,11 +317,7 @@ impl ModelicaLanguageServer {
             .or(workspace_root_default)?;
         let model = obj.get("model").and_then(Value::as_str)?.to_string();
         let views = load_plot_views_for_model(&workspace_root, &model).ok()?;
-        let payload_views: Vec<VisualizationViewPayload> = views
-            .into_iter()
-            .map(VisualizationViewPayload::from)
-            .collect();
-        Some(json!({ "views": payload_views }))
+        Some(visualization_views_to_json(views))
     }
 
     pub(super) async fn execute_set_visualization_config(

--- a/crates/rumoca-tool-lsp/src/server/support.rs
+++ b/crates/rumoca-tool-lsp/src/server/support.rs
@@ -1,6 +1,13 @@
 use super::*;
 pub(super) use crate::completion_metrics::{CompletionProgressSummary, CompletionTimingSummary};
 use rumoca_compile::compile::{SessionCacheStatsSnapshot, SourceRootStatusSnapshot};
+// Project (`rum.toml`) config command JSON shaping is owned by `rumoca-compile`
+// so the LSP server and the browser editor bindings share one implementation.
+pub(super) use rumoca_compile::project::{
+    parse_fallback_simulation, parse_views_payload, scenario_config_response,
+    simulation_override_from_json, simulation_preset_to_json, simulation_settings_to_json,
+    visualization_views_to_json,
+};
 use std::fs::OpenOptions;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -414,60 +421,6 @@ pub(super) fn parse_simulation_request_settings(
     })
 }
 
-pub(super) fn parse_fallback_simulation(
-    value: Option<&Value>,
-) -> Option<EffectiveSimulationConfig> {
-    let value = value?;
-    let obj = value.as_object()?;
-    let solver = normalize_solver_opt(
-        obj.get("solver")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-    )
-    .unwrap_or_else(|| "auto".to_string());
-    let t_end = obj
-        .get("tEnd")
-        .and_then(Value::as_f64)
-        .filter(|v| v.is_finite() && *v > 0.0)
-        .unwrap_or(10.0);
-    let dt = normalize_dt_opt(obj.get("dt").and_then(Value::as_f64));
-    let output_dir = obj
-        .get("outputDir")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let source_root_paths = obj
-        .get("sourceRootPaths")
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::trim)
-                .filter(|v| !v.is_empty())
-                .map(str::to_string)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    Some(EffectiveSimulationConfig {
-        solver,
-        t_end,
-        dt,
-        output_dir,
-        source_root_paths,
-    })
-}
-
-pub(super) fn simulation_settings_to_json(settings: &EffectiveSimulationConfig) -> Value {
-    json!({
-        "solver": settings.solver,
-        "tEnd": settings.t_end,
-        "dt": settings.dt,
-        "outputDir": settings.output_dir,
-        "sourceRootPaths": settings.source_root_paths,
-    })
-}
-
 pub(super) fn find_open_workspace_document_for_model(
     snapshot: &SessionSnapshot,
     model: &str,
@@ -493,98 +446,6 @@ pub(super) fn find_open_workspace_document_for_model(
         }
     }
     None
-}
-
-pub(super) fn simulation_preset_to_json(preset: &EffectiveSimulationPreset) -> Value {
-    json!({
-        "solver": preset.solver,
-        "tEnd": preset.t_end,
-        "dt": preset.dt,
-        "outputDir": preset.output_dir,
-        "sourceRootOverrides": preset.source_root_overrides,
-    })
-}
-
-pub(super) fn simulation_override_from_json(value: &Value) -> Option<SimulationModelOverride> {
-    let obj = value.as_object()?;
-    let solver = obj
-        .get("solver")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let t_end = obj.get("tEnd").and_then(Value::as_f64);
-    let dt = obj.get("dt").and_then(Value::as_f64);
-    let output_dir = obj
-        .get("outputDir")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let source_root_overrides = obj
-        .get("sourceRootOverrides")
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_string)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    Some(SimulationModelOverride {
-        solver,
-        t_end,
-        dt,
-        output_dir,
-        source_root_overrides,
-    })
-}
-
-pub(super) fn parse_views_payload(value: &Value) -> Option<Vec<PlotViewConfig>> {
-    serde_json::from_value::<Vec<VisualizationViewPayload>>(value.clone())
-        .ok()
-        .map(|views| views.into_iter().map(PlotViewConfig::from).collect())
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(super) struct VisualizationViewPayload {
-    pub(super) id: String,
-    pub(super) title: String,
-    #[serde(rename = "type")]
-    pub(super) view_type: String,
-    pub(super) x: Option<String>,
-    #[serde(default)]
-    pub(super) y: Vec<String>,
-    pub(super) script: Option<String>,
-    pub(super) script_path: Option<String>,
-}
-
-impl From<PlotViewConfig> for VisualizationViewPayload {
-    fn from(view: PlotViewConfig) -> Self {
-        Self {
-            id: view.id,
-            title: view.title,
-            view_type: view.view_type,
-            x: view.x,
-            y: view.y,
-            script: view.script,
-            script_path: view.script_path,
-        }
-    }
-}
-
-impl From<VisualizationViewPayload> for PlotViewConfig {
-    fn from(view: VisualizationViewPayload) -> Self {
-        Self {
-            id: view.id,
-            title: view.title,
-            view_type: view.view_type,
-            x: view.x,
-            y: view.y,
-            script: view.script,
-            script_path: view.script_path,
-        }
-    }
 }
 
 pub(super) fn normalize_solver_opt(value: Option<String>) -> Option<String> {
@@ -768,24 +629,5 @@ mod tests {
         .expect("parse views payload");
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].script_path.as_deref(), Some("viewer_3d.js"));
-    }
-
-    #[test]
-    fn visualization_view_payload_serializes_script_path_as_camel_case() {
-        let payload = VisualizationViewPayload::from(PlotViewConfig {
-            id: "viewer_3d".to_string(),
-            title: "Viewer".to_string(),
-            view_type: "3d".to_string(),
-            x: None,
-            y: Vec::new(),
-            script: None,
-            script_path: Some("viewer_3d.js".to_string()),
-        });
-        let encoded = serde_json::to_value(payload).expect("serialize payload");
-        assert_eq!(
-            encoded.get("scriptPath").and_then(Value::as_str),
-            Some("viewer_3d.js")
-        );
-        assert!(encoded.get("script_path").is_none());
     }
 }

--- a/crates/rumoca-tool-lsp/src/server/tests/editor_surface_tests.rs
+++ b/crates/rumoca-tool-lsp/src/server/tests/editor_surface_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rumoca_compile::project::SimulationModelOverride;
 use std::sync::atomic::Ordering;
 
 pub(super) async fn assert_formatting_wraps_handler(

--- a/crates/rumoca-viz-web/web/visualization_shared.js
+++ b/crates/rumoca-viz-web/web/visualization_shared.js
@@ -3659,8 +3659,80 @@ ctx.onFrame = (api) => {
         }
     }
 
+    // --- Scenario config form model (rum.toml dual-view GUI) -----------------
+    // Pure transforms between a rum.toml-as-JSON config tree (from
+    // project_get_scenario_config_full) and a flat list of editable leaf fields,
+    // shared by the config form in both editors. Scalars (string/number/boolean)
+    // are editable leaves; nested tables recurse so the form can group by
+    // top-level section; arrays and other non-scalars are edited as raw JSON
+    // leaves in v1 and refined into richer widgets later.
+
+    function scenarioConfigLeafKind(value) {
+        if (typeof value === 'boolean') return 'boolean';
+        if (typeof value === 'number') return 'number';
+        if (typeof value === 'string') return 'string';
+        return 'json';
+    }
+
+    function flattenScenarioConfig(tree, basePath = []) {
+        const fields = [];
+        if (!tree || typeof tree !== 'object' || Array.isArray(tree)) {
+            return fields;
+        }
+        for (const key of Object.keys(tree)) {
+            const value = tree[key];
+            const path = [...basePath, key];
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+                fields.push(...flattenScenarioConfig(value, path));
+            } else {
+                fields.push({
+                    path,
+                    section: path[0],
+                    key,
+                    label: path.join('.'),
+                    kind: scenarioConfigLeafKind(value),
+                    value,
+                });
+            }
+        }
+        return fields;
+    }
+
+    function setScenarioConfigValue(tree, path, value) {
+        const next = tree && typeof tree === 'object' && !Array.isArray(tree)
+            ? { ...tree }
+            : {};
+        if (!Array.isArray(path) || path.length === 0) {
+            return next;
+        }
+        const [head, ...rest] = path;
+        if (rest.length === 0) {
+            if (value === undefined) {
+                delete next[head];
+            } else {
+                next[head] = value;
+            }
+        } else {
+            next[head] = setScenarioConfigValue(next[head], rest, value);
+        }
+        return next;
+    }
+
+    function applyScenarioConfigEdits(tree, edits) {
+        let next = tree && typeof tree === 'object' && !Array.isArray(tree) ? tree : {};
+        for (const edit of Array.isArray(edits) ? edits : []) {
+            if (edit && Array.isArray(edit.path)) {
+                next = setScenarioConfigValue(next, edit.path, edit.value);
+            }
+        }
+        return next;
+    }
+
     return {
         buildHostedResultsPanelState,
+        flattenScenarioConfig,
+        setScenarioConfigValue,
+        applyScenarioConfigEdits,
         buildHostedResultsPanelTitle,
         buildLatestSimulationResultsIndexDocument,
         buildVisualizationModel,

--- a/crates/rumoca-viz-web/web/visualization_shared.js
+++ b/crates/rumoca-viz-web/web/visualization_shared.js
@@ -3728,11 +3728,221 @@ ctx.onFrame = (api) => {
         return next;
     }
 
+    const SCENARIO_CONFIG_SECTION_ORDER = [
+        'rumoca',
+        'model',
+        'sim',
+        'codegen',
+        'viewer',
+        'transport',
+        'locals',
+        'input',
+        'signals',
+        'derive',
+        'reset',
+    ];
+
+    function scenarioConfigSectionRank(section) {
+        const index = SCENARIO_CONFIG_SECTION_ORDER.indexOf(section);
+        return index === -1 ? SCENARIO_CONFIG_SECTION_ORDER.length : index;
+    }
+
+    // Render one editable leaf field for the config form. `index` keys the input
+    // back to its field descriptor so the host can rebuild edits on save.
+    function scenarioConfigFieldMarkup(field, index) {
+        const subLabel = field.path.slice(1).join('.') || field.key;
+        const idAttr = `field_${index}`;
+        let control;
+        if (field.kind === 'boolean') {
+            const checked = field.value ? ' checked' : '';
+            control = `<input type="checkbox" id="${idAttr}" data-field="${index}"${checked}>`;
+        } else if (field.kind === 'number') {
+            control = `<input type="number" step="any" id="${idAttr}" data-field="${index}" value="${escapeHtml(String(field.value ?? ''))}">`;
+        } else if (field.kind === 'json') {
+            control = `<textarea id="${idAttr}" data-field="${index}" rows="2">${escapeHtml(JSON.stringify(field.value ?? null))}</textarea>`;
+        } else {
+            control = `<input type="text" id="${idAttr}" data-field="${index}" value="${escapeHtml(String(field.value ?? ''))}">`;
+        }
+        return `
+        <div class="field">
+          <label for="${idAttr}">${escapeHtml(subLabel)}</label>
+          ${control}
+        </div>`;
+    }
+
+    // Build the rum.toml config GUI document (iframe srcdoc). The form renders
+    // the flattened scalar leaves grouped by top-level section; on save it posts
+    // the collected `{path, value}` edits to the host (which holds the config
+    // tree and writes via project_set_scenario_config). Toggling switches the
+    // editor to the raw TOML view. Mirrors the simulation-settings bridge.
+    function buildScenarioConfigDocument(scenario) {
+        const data = scenario && typeof scenario === 'object' ? scenario : {};
+        const config = data.config && typeof data.config === 'object' ? data.config : {};
+        const descriptor = data.descriptor && typeof data.descriptor === 'object' ? data.descriptor : {};
+        const path = trimMaybeString(data.path) || 'rum.toml';
+        const model = trimMaybeString(descriptor.model)
+            || trimMaybeString((config.model || {}).name)
+            || trimMaybeString(data.model);
+        const task = trimMaybeString(descriptor.task) || trimMaybeString((config.rumoca || {}).task) || 'simulate';
+        const fields = flattenScenarioConfig(config);
+        fields.forEach((field, index) => {
+            field.index = index;
+        });
+        const sections = new Map();
+        for (const field of fields) {
+            if (!sections.has(field.section)) {
+                sections.set(field.section, []);
+            }
+            sections.get(field.section).push(field);
+        }
+        const sectionMarkup = [...sections.keys()]
+            .sort((a, b) => scenarioConfigSectionRank(a) - scenarioConfigSectionRank(b) || a.localeCompare(b))
+            .map((section) => {
+                const rows = sections
+                    .get(section)
+                    .map((field) => scenarioConfigFieldMarkup(field, field.index))
+                    .join('');
+                return `
+      <section class="card">
+        <h3>${escapeHtml(section)}</h3>
+        <div class="grid">${rows}</div>
+      </section>`;
+            })
+            .join('');
+        const initialStateJson = escapeInlineScriptJson(JSON.stringify({ path, fields }));
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rumoca Config: ${escapeHtml(model || path)}</title>
+  <style>
+    :root { --pad: 16px; --radius: 8px; --muted: var(--vscode-descriptionForeground, #9da5b4); --ok: var(--vscode-testing-iconPassed, #73c991); --error: var(--vscode-errorForeground, #f48771); }
+    html, body { height: 100%; }
+    body { margin: 0; font-family: var(--vscode-font-family, system-ui, sans-serif); color: var(--vscode-foreground, #d4d4d4); background: var(--vscode-editor-background, #1e1e1e); }
+    .page { padding: var(--pad); display: grid; gap: 12px; }
+    .header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+    .title { font-size: 16px; font-weight: 700; margin: 0; }
+    .subtitle { color: var(--muted); font-size: 12px; }
+    .actions { display: flex; gap: 8px; }
+    button { font: inherit; padding: 6px 12px; border-radius: 6px; border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-background, #0e639c); color: var(--vscode-button-foreground, #fff); cursor: pointer; }
+    button.ghost { background: transparent; color: var(--vscode-foreground, #d4d4d4); border-color: var(--vscode-input-border, #3c3c3c); }
+    .card { border: 1px solid var(--vscode-panel-border, #3c3c3c); border-radius: var(--radius); padding: 12px; background: var(--vscode-sideBar-background, #252526); }
+    .card h3 { margin: 0 0 10px 0; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+    .field { display: grid; gap: 4px; }
+    label { font-size: 12px; font-weight: 600; }
+    input, textarea { width: 100%; box-sizing: border-box; background: var(--vscode-input-background, #313131); color: var(--vscode-input-foreground, #ccc); border: 1px solid var(--vscode-input-border, #3c3c3c); border-radius: 6px; padding: 6px; }
+    input[type="checkbox"] { width: auto; }
+    .status { font-size: 12px; min-height: 16px; }
+    .status.ok { color: var(--ok); } .status.error { color: var(--error); }
+    .empty { color: var(--muted); font-size: 13px; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="header">
+      <div>
+        <p class="title">${escapeHtml(model || 'Scenario')} <span class="subtitle">(${escapeHtml(task)})</span></p>
+        <div class="subtitle">${escapeHtml(path)}</div>
+      </div>
+      <div class="actions">
+        <button id="saveBtn">Save</button>
+        <button id="rawBtn" class="ghost">Raw TOML</button>
+      </div>
+    </div>
+    <div id="status" class="status"></div>
+    ${sectionMarkup || '<div class="empty">This rum.toml has no editable fields yet. Use the lightning-bolt action on a model, or switch to the raw TOML view.</div>'}
+  </div>
+  <script>
+    const initialState = ${initialStateJson};
+    const fields = Array.isArray(initialState.fields) ? initialState.fields : [];
+    const path = String(initialState.path || 'rum.toml');
+    const statusEl = document.getElementById('status');
+    const vscodeApi = typeof acquireVsCodeApi === 'function' ? acquireVsCodeApi() : null;
+    const pendingRequests = new Map();
+    let nextRequestId = 1;
+    const browserHost = (() => {
+      const own = globalThis.RumocaScenarioConfigHost;
+      if (own && typeof own.request === 'function') return own;
+      try {
+        const parentHost = globalThis.parent && globalThis.parent !== globalThis
+          ? globalThis.parent.RumocaScenarioConfigHost : null;
+        if (parentHost && typeof parentHost.request === 'function') return parentHost;
+      } catch (_error) { return null; }
+      return null;
+    })();
+
+    function requestHost(method, payload) {
+      if (browserHost) return Promise.resolve(browserHost.request(method, payload));
+      if (!vscodeApi) return Promise.reject(new Error('config host unavailable'));
+      const requestId = String(nextRequestId++);
+      return new Promise((resolve, reject) => {
+        pendingRequests.set(requestId, { resolve, reject });
+        vscodeApi.postMessage({ command: 'scenarioConfig.request', requestId, method, payload });
+      });
+    }
+
+    window.addEventListener('message', (event) => {
+      const message = event && event.data ? event.data : {};
+      if (message.command !== 'scenarioConfig.response') return;
+      const pending = pendingRequests.get(String(message.requestId || ''));
+      if (!pending) return;
+      pendingRequests.delete(String(message.requestId));
+      if (message.ok === false) pending.reject(new Error(String(message.error || 'config host request failed')));
+      else pending.resolve(message.value);
+    });
+
+    function setStatus(text, level) {
+      statusEl.textContent = text || '';
+      statusEl.classList.remove('ok', 'error');
+      if (level) statusEl.classList.add(level);
+    }
+
+    function collectEdits() {
+      const edits = [];
+      for (const field of fields) {
+        const el = document.querySelector('[data-field="' + field.index + '"]');
+        if (!el) continue;
+        let value;
+        if (field.kind === 'boolean') {
+          value = el.checked;
+        } else if (field.kind === 'number') {
+          const parsed = Number(el.value);
+          value = Number.isFinite(parsed) ? parsed : field.value;
+        } else if (field.kind === 'json') {
+          try { value = JSON.parse(el.value); } catch (_error) { value = field.value; }
+        } else {
+          value = el.value;
+        }
+        edits.push({ path: field.path, value });
+      }
+      return edits;
+    }
+
+    document.getElementById('saveBtn').addEventListener('click', async () => {
+      try {
+        setStatus('Saving…');
+        await requestHost('save', { path, edits: collectEdits() });
+        setStatus('Saved', 'ok');
+      } catch (error) {
+        setStatus(String(error && error.message ? error.message : error), 'error');
+      }
+    });
+    document.getElementById('rawBtn').addEventListener('click', () => {
+      requestHost('toggleRaw', { path }).catch(() => {});
+    });
+  </script>
+</body>
+</html>`;
+    }
+
     return {
         buildHostedResultsPanelState,
         flattenScenarioConfig,
         setScenarioConfigValue,
         applyScenarioConfigEdits,
+        buildScenarioConfigDocument,
         buildHostedResultsPanelTitle,
         buildLatestSimulationResultsIndexDocument,
         buildVisualizationModel,

--- a/editors/wasm/rumoca_worker.js
+++ b/editors/wasm/rumoca_worker.js
@@ -7,6 +7,11 @@ const cacheBust = workerUrl.searchParams.get('v') || '';
 const withCacheBust = (path) =>
     cacheBust ? `${path}?v=${encodeURIComponent(cacheBust)}` : path;
 
+// WASM project-config commands take JSON-string arguments. Accept either an
+// already-stringified payload field or a structured object from the main thread.
+const jsonArg = (value, emptyDefault = '') =>
+    value == null ? emptyDefault : (typeof value === 'string' ? value : JSON.stringify(value));
+
 let init;
 let wasm_init;
 let get_version;
@@ -34,6 +39,12 @@ let lsp_semantic_token_legend;
 let list_classes;
 let get_class_info;
 let render_target;
+let project_get_simulation_config;
+let project_set_simulation_preset;
+let project_reset_simulation_preset;
+let project_get_visualization_config;
+let project_set_visualization_config;
+let project_get_scenario_config;
 let simulate_model = null;
 let simulate_model_with_project_sources = null;
 let lower_model_to_solve_json = null;
@@ -116,6 +127,12 @@ async function loadWasmModule() {
     list_classes = mod.list_classes;
     get_class_info = mod.get_class_info;
     render_target = mod.render_target;
+    project_get_simulation_config = mod.project_get_simulation_config;
+    project_set_simulation_preset = mod.project_set_simulation_preset;
+    project_reset_simulation_preset = mod.project_reset_simulation_preset;
+    project_get_visualization_config = mod.project_get_visualization_config;
+    project_set_visualization_config = mod.project_set_visualization_config;
+    project_get_scenario_config = mod.project_get_scenario_config;
     if (typeof mod.simulate_model === 'function') {
         simulate_model = mod.simulate_model;
     }
@@ -268,6 +285,45 @@ self.onmessage = async (e) => {
                 switch (command) {
                     case 'rumoca.project.getSimulationModels':
                         result = get_simulation_models(payload.source || '', payload.defaultModel || '');
+                        break;
+                    case 'rumoca.project.getSimulationConfig':
+                        result = project_get_simulation_config(
+                            jsonArg(payload.projectSources),
+                            payload.model || '',
+                            jsonArg(payload.fallback),
+                        );
+                        break;
+                    case 'rumoca.project.setSimulationPreset':
+                        result = project_set_simulation_preset(
+                            jsonArg(payload.projectSources),
+                            payload.model || '',
+                            jsonArg(payload.preset, 'null'),
+                        );
+                        break;
+                    case 'rumoca.project.resetSimulationPreset':
+                        result = project_reset_simulation_preset(
+                            jsonArg(payload.projectSources),
+                            payload.model || '',
+                        );
+                        break;
+                    case 'rumoca.project.getVisualizationConfig':
+                        result = project_get_visualization_config(
+                            jsonArg(payload.projectSources),
+                            payload.model || '',
+                        );
+                        break;
+                    case 'rumoca.project.setVisualizationConfig':
+                        result = project_set_visualization_config(
+                            jsonArg(payload.projectSources),
+                            payload.model || '',
+                            jsonArg(payload.views, 'null'),
+                        );
+                        break;
+                    case 'rumoca.project.getScenarioConfig':
+                        result = project_get_scenario_config(
+                            jsonArg(payload.projectSources),
+                            payload.path || payload.uri || '',
+                        );
                         break;
                     case 'rumoca.project.startSimulation':
                         if (!simulate_model) {

--- a/editors/wasm/rumoca_worker.js
+++ b/editors/wasm/rumoca_worker.js
@@ -45,6 +45,9 @@ let project_reset_simulation_preset;
 let project_get_visualization_config;
 let project_set_visualization_config;
 let project_get_scenario_config;
+let project_get_scenario_config_full;
+let project_set_scenario_config;
+let project_default_scenario_config;
 let simulate_model = null;
 let simulate_model_with_project_sources = null;
 let lower_model_to_solve_json = null;
@@ -133,6 +136,9 @@ async function loadWasmModule() {
     project_get_visualization_config = mod.project_get_visualization_config;
     project_set_visualization_config = mod.project_set_visualization_config;
     project_get_scenario_config = mod.project_get_scenario_config;
+    project_get_scenario_config_full = mod.project_get_scenario_config_full;
+    project_set_scenario_config = mod.project_set_scenario_config;
+    project_default_scenario_config = mod.project_default_scenario_config;
     if (typeof mod.simulate_model === 'function') {
         simulate_model = mod.simulate_model;
     }
@@ -323,6 +329,24 @@ self.onmessage = async (e) => {
                         result = project_get_scenario_config(
                             jsonArg(payload.projectSources),
                             payload.path || payload.uri || '',
+                        );
+                        break;
+                    case 'rumoca.project.getScenarioConfigFull':
+                        result = project_get_scenario_config_full(
+                            jsonArg(payload.projectSources),
+                            payload.path || payload.uri || '',
+                        );
+                        break;
+                    case 'rumoca.project.setScenarioConfig':
+                        result = project_set_scenario_config(
+                            payload.path || payload.uri || '',
+                            jsonArg(payload.config, 'null'),
+                        );
+                        break;
+                    case 'rumoca.project.defaultScenarioConfig':
+                        result = project_default_scenario_config(
+                            jsonArg(payload.projectSources),
+                            payload.model || '',
                         );
                         break;
                     case 'rumoca.project.startSimulation':

--- a/editors/wasm/tests/scenario_config_form_smoke.mjs
+++ b/editors/wasm/tests/scenario_config_form_smoke.mjs
@@ -69,7 +69,31 @@ function undefinedEditDeletesKey() {
   assert(configTree.sim.mode === "realtime", "expected original tree unchanged");
 }
 
+function documentRendersSectionsAndControls() {
+  const html = shared.buildScenarioConfigDocument({
+    path: "rum.Rover.toml",
+    config: configTree,
+    descriptor: { model: "Rover", task: "simulate" },
+  });
+  assert(typeof html === "string" && html.includes("<!DOCTYPE html>"), "expected an HTML document");
+  assert(html.includes("Rover"), "expected the model name in the header");
+  assert(html.includes(">sim<") || html.includes(">sim</h3>"), "expected a sim section card");
+  assert(html.includes(">signals<") || html.includes("signals"), "expected the interactive signals section");
+  assert(html.includes('id="saveBtn"'), "expected a Save button");
+  assert(html.includes('id="rawBtn"'), "expected a Raw TOML toggle");
+  assert(html.includes("RumocaScenarioConfigHost"), "expected the host bridge");
+  // Deeply nested IO leaf must be rendered as an editable field.
+  assert(html.includes("keyboard.keys.ArrowUp.value"), "expected nested IO leaf label");
+}
+
+function documentHandlesEmptyConfig() {
+  const html = shared.buildScenarioConfigDocument({ path: "rum.toml", config: {} });
+  assert(html.includes("no editable fields"), "expected an empty-state message");
+}
+
 flattenExposesNestedLeaves();
 editsApplyByPathAndPreserveSiblings();
 undefinedEditDeletesKey();
+documentRendersSectionsAndControls();
+documentHandlesEmptyConfig();
 console.log("scenario_config_form_smoke: ok");

--- a/editors/wasm/tests/scenario_config_form_smoke.mjs
+++ b/editors/wasm/tests/scenario_config_form_smoke.mjs
@@ -1,0 +1,75 @@
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const shared = require(
+  path.resolve("crates", "rumoca-viz-web", "web", "visualization_shared.js"),
+);
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+// A rum.toml-as-JSON tree with nested interactive-IO, like
+// project_get_scenario_config_full returns.
+const configTree = {
+  rumoca: { version: "1", task: "simulate" },
+  model: { name: "Rover", file: "Rover.mo" },
+  sim: { solver: "auto", mode: "realtime" },
+  input: { keyboard: { keys: { ArrowUp: { action: "set", target: "throttle", value: 1.0 } } } },
+  signals: { viewer: { theta: "stepper:theta" } },
+};
+
+function flattenExposesNestedLeaves() {
+  const fields = shared.flattenScenarioConfig(configTree);
+  const byLabel = new Map(fields.map((field) => [field.label, field]));
+
+  assert(byLabel.get("sim.solver")?.value === "auto", "expected sim.solver leaf");
+  assert(byLabel.get("sim.solver")?.kind === "string", "expected string kind");
+  assert(byLabel.get("sim.solver")?.section === "sim", "expected top-level section");
+  assert(
+    byLabel.get("input.keyboard.keys.ArrowUp.value")?.value === 1.0,
+    "expected deeply nested interactive-IO leaf",
+  );
+  assert(
+    byLabel.get("input.keyboard.keys.ArrowUp.value")?.kind === "number",
+    "expected number kind for numeric leaf",
+  );
+  assert(
+    byLabel.get("signals.viewer.theta")?.value === "stepper:theta",
+    "expected signal-routing leaf",
+  );
+}
+
+function editsApplyByPathAndPreserveSiblings() {
+  const updated = shared.applyScenarioConfigEdits(configTree, [
+    { path: ["sim", "solver"], value: "bdf" },
+    { path: ["sim", "t_end"], value: 5.0 },
+  ]);
+
+  assert(updated.sim.solver === "bdf", "expected solver updated");
+  assert(updated.sim.t_end === 5.0, "expected new key added");
+  assert(updated.sim.mode === "realtime", "expected sibling preserved");
+  // Deeply nested IO untouched.
+  assert(
+    updated.input.keyboard.keys.ArrowUp.target === "throttle",
+    "expected nested IO preserved through edits",
+  );
+  // Original tree not mutated (structural sharing / immutability).
+  assert(configTree.sim.solver === "auto", "expected original tree unchanged");
+}
+
+function undefinedEditDeletesKey() {
+  const updated = shared.applyScenarioConfigEdits(configTree, [
+    { path: ["sim", "mode"], value: undefined },
+  ]);
+  assert(!("mode" in updated.sim), "expected key removed when value is undefined");
+  assert(configTree.sim.mode === "realtime", "expected original tree unchanged");
+}
+
+flattenExposesNestedLeaves();
+editsApplyByPathAndPreserveSiblings();
+undefinedEditDeletesKey();
+console.log("scenario_config_form_smoke: ok");

--- a/editors/wasm/vendor/visualization_shared.js
+++ b/editors/wasm/vendor/visualization_shared.js
@@ -3659,8 +3659,80 @@ ctx.onFrame = (api) => {
         }
     }
 
+    // --- Scenario config form model (rum.toml dual-view GUI) -----------------
+    // Pure transforms between a rum.toml-as-JSON config tree (from
+    // project_get_scenario_config_full) and a flat list of editable leaf fields,
+    // shared by the config form in both editors. Scalars (string/number/boolean)
+    // are editable leaves; nested tables recurse so the form can group by
+    // top-level section; arrays and other non-scalars are edited as raw JSON
+    // leaves in v1 and refined into richer widgets later.
+
+    function scenarioConfigLeafKind(value) {
+        if (typeof value === 'boolean') return 'boolean';
+        if (typeof value === 'number') return 'number';
+        if (typeof value === 'string') return 'string';
+        return 'json';
+    }
+
+    function flattenScenarioConfig(tree, basePath = []) {
+        const fields = [];
+        if (!tree || typeof tree !== 'object' || Array.isArray(tree)) {
+            return fields;
+        }
+        for (const key of Object.keys(tree)) {
+            const value = tree[key];
+            const path = [...basePath, key];
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+                fields.push(...flattenScenarioConfig(value, path));
+            } else {
+                fields.push({
+                    path,
+                    section: path[0],
+                    key,
+                    label: path.join('.'),
+                    kind: scenarioConfigLeafKind(value),
+                    value,
+                });
+            }
+        }
+        return fields;
+    }
+
+    function setScenarioConfigValue(tree, path, value) {
+        const next = tree && typeof tree === 'object' && !Array.isArray(tree)
+            ? { ...tree }
+            : {};
+        if (!Array.isArray(path) || path.length === 0) {
+            return next;
+        }
+        const [head, ...rest] = path;
+        if (rest.length === 0) {
+            if (value === undefined) {
+                delete next[head];
+            } else {
+                next[head] = value;
+            }
+        } else {
+            next[head] = setScenarioConfigValue(next[head], rest, value);
+        }
+        return next;
+    }
+
+    function applyScenarioConfigEdits(tree, edits) {
+        let next = tree && typeof tree === 'object' && !Array.isArray(tree) ? tree : {};
+        for (const edit of Array.isArray(edits) ? edits : []) {
+            if (edit && Array.isArray(edit.path)) {
+                next = setScenarioConfigValue(next, edit.path, edit.value);
+            }
+        }
+        return next;
+    }
+
     return {
         buildHostedResultsPanelState,
+        flattenScenarioConfig,
+        setScenarioConfigValue,
+        applyScenarioConfigEdits,
         buildHostedResultsPanelTitle,
         buildLatestSimulationResultsIndexDocument,
         buildVisualizationModel,

--- a/editors/wasm/vendor/visualization_shared.js
+++ b/editors/wasm/vendor/visualization_shared.js
@@ -3728,11 +3728,221 @@ ctx.onFrame = (api) => {
         return next;
     }
 
+    const SCENARIO_CONFIG_SECTION_ORDER = [
+        'rumoca',
+        'model',
+        'sim',
+        'codegen',
+        'viewer',
+        'transport',
+        'locals',
+        'input',
+        'signals',
+        'derive',
+        'reset',
+    ];
+
+    function scenarioConfigSectionRank(section) {
+        const index = SCENARIO_CONFIG_SECTION_ORDER.indexOf(section);
+        return index === -1 ? SCENARIO_CONFIG_SECTION_ORDER.length : index;
+    }
+
+    // Render one editable leaf field for the config form. `index` keys the input
+    // back to its field descriptor so the host can rebuild edits on save.
+    function scenarioConfigFieldMarkup(field, index) {
+        const subLabel = field.path.slice(1).join('.') || field.key;
+        const idAttr = `field_${index}`;
+        let control;
+        if (field.kind === 'boolean') {
+            const checked = field.value ? ' checked' : '';
+            control = `<input type="checkbox" id="${idAttr}" data-field="${index}"${checked}>`;
+        } else if (field.kind === 'number') {
+            control = `<input type="number" step="any" id="${idAttr}" data-field="${index}" value="${escapeHtml(String(field.value ?? ''))}">`;
+        } else if (field.kind === 'json') {
+            control = `<textarea id="${idAttr}" data-field="${index}" rows="2">${escapeHtml(JSON.stringify(field.value ?? null))}</textarea>`;
+        } else {
+            control = `<input type="text" id="${idAttr}" data-field="${index}" value="${escapeHtml(String(field.value ?? ''))}">`;
+        }
+        return `
+        <div class="field">
+          <label for="${idAttr}">${escapeHtml(subLabel)}</label>
+          ${control}
+        </div>`;
+    }
+
+    // Build the rum.toml config GUI document (iframe srcdoc). The form renders
+    // the flattened scalar leaves grouped by top-level section; on save it posts
+    // the collected `{path, value}` edits to the host (which holds the config
+    // tree and writes via project_set_scenario_config). Toggling switches the
+    // editor to the raw TOML view. Mirrors the simulation-settings bridge.
+    function buildScenarioConfigDocument(scenario) {
+        const data = scenario && typeof scenario === 'object' ? scenario : {};
+        const config = data.config && typeof data.config === 'object' ? data.config : {};
+        const descriptor = data.descriptor && typeof data.descriptor === 'object' ? data.descriptor : {};
+        const path = trimMaybeString(data.path) || 'rum.toml';
+        const model = trimMaybeString(descriptor.model)
+            || trimMaybeString((config.model || {}).name)
+            || trimMaybeString(data.model);
+        const task = trimMaybeString(descriptor.task) || trimMaybeString((config.rumoca || {}).task) || 'simulate';
+        const fields = flattenScenarioConfig(config);
+        fields.forEach((field, index) => {
+            field.index = index;
+        });
+        const sections = new Map();
+        for (const field of fields) {
+            if (!sections.has(field.section)) {
+                sections.set(field.section, []);
+            }
+            sections.get(field.section).push(field);
+        }
+        const sectionMarkup = [...sections.keys()]
+            .sort((a, b) => scenarioConfigSectionRank(a) - scenarioConfigSectionRank(b) || a.localeCompare(b))
+            .map((section) => {
+                const rows = sections
+                    .get(section)
+                    .map((field) => scenarioConfigFieldMarkup(field, field.index))
+                    .join('');
+                return `
+      <section class="card">
+        <h3>${escapeHtml(section)}</h3>
+        <div class="grid">${rows}</div>
+      </section>`;
+            })
+            .join('');
+        const initialStateJson = escapeInlineScriptJson(JSON.stringify({ path, fields }));
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rumoca Config: ${escapeHtml(model || path)}</title>
+  <style>
+    :root { --pad: 16px; --radius: 8px; --muted: var(--vscode-descriptionForeground, #9da5b4); --ok: var(--vscode-testing-iconPassed, #73c991); --error: var(--vscode-errorForeground, #f48771); }
+    html, body { height: 100%; }
+    body { margin: 0; font-family: var(--vscode-font-family, system-ui, sans-serif); color: var(--vscode-foreground, #d4d4d4); background: var(--vscode-editor-background, #1e1e1e); }
+    .page { padding: var(--pad); display: grid; gap: 12px; }
+    .header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+    .title { font-size: 16px; font-weight: 700; margin: 0; }
+    .subtitle { color: var(--muted); font-size: 12px; }
+    .actions { display: flex; gap: 8px; }
+    button { font: inherit; padding: 6px 12px; border-radius: 6px; border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-background, #0e639c); color: var(--vscode-button-foreground, #fff); cursor: pointer; }
+    button.ghost { background: transparent; color: var(--vscode-foreground, #d4d4d4); border-color: var(--vscode-input-border, #3c3c3c); }
+    .card { border: 1px solid var(--vscode-panel-border, #3c3c3c); border-radius: var(--radius); padding: 12px; background: var(--vscode-sideBar-background, #252526); }
+    .card h3 { margin: 0 0 10px 0; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+    .field { display: grid; gap: 4px; }
+    label { font-size: 12px; font-weight: 600; }
+    input, textarea { width: 100%; box-sizing: border-box; background: var(--vscode-input-background, #313131); color: var(--vscode-input-foreground, #ccc); border: 1px solid var(--vscode-input-border, #3c3c3c); border-radius: 6px; padding: 6px; }
+    input[type="checkbox"] { width: auto; }
+    .status { font-size: 12px; min-height: 16px; }
+    .status.ok { color: var(--ok); } .status.error { color: var(--error); }
+    .empty { color: var(--muted); font-size: 13px; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="header">
+      <div>
+        <p class="title">${escapeHtml(model || 'Scenario')} <span class="subtitle">(${escapeHtml(task)})</span></p>
+        <div class="subtitle">${escapeHtml(path)}</div>
+      </div>
+      <div class="actions">
+        <button id="saveBtn">Save</button>
+        <button id="rawBtn" class="ghost">Raw TOML</button>
+      </div>
+    </div>
+    <div id="status" class="status"></div>
+    ${sectionMarkup || '<div class="empty">This rum.toml has no editable fields yet. Use the lightning-bolt action on a model, or switch to the raw TOML view.</div>'}
+  </div>
+  <script>
+    const initialState = ${initialStateJson};
+    const fields = Array.isArray(initialState.fields) ? initialState.fields : [];
+    const path = String(initialState.path || 'rum.toml');
+    const statusEl = document.getElementById('status');
+    const vscodeApi = typeof acquireVsCodeApi === 'function' ? acquireVsCodeApi() : null;
+    const pendingRequests = new Map();
+    let nextRequestId = 1;
+    const browserHost = (() => {
+      const own = globalThis.RumocaScenarioConfigHost;
+      if (own && typeof own.request === 'function') return own;
+      try {
+        const parentHost = globalThis.parent && globalThis.parent !== globalThis
+          ? globalThis.parent.RumocaScenarioConfigHost : null;
+        if (parentHost && typeof parentHost.request === 'function') return parentHost;
+      } catch (_error) { return null; }
+      return null;
+    })();
+
+    function requestHost(method, payload) {
+      if (browserHost) return Promise.resolve(browserHost.request(method, payload));
+      if (!vscodeApi) return Promise.reject(new Error('config host unavailable'));
+      const requestId = String(nextRequestId++);
+      return new Promise((resolve, reject) => {
+        pendingRequests.set(requestId, { resolve, reject });
+        vscodeApi.postMessage({ command: 'scenarioConfig.request', requestId, method, payload });
+      });
+    }
+
+    window.addEventListener('message', (event) => {
+      const message = event && event.data ? event.data : {};
+      if (message.command !== 'scenarioConfig.response') return;
+      const pending = pendingRequests.get(String(message.requestId || ''));
+      if (!pending) return;
+      pendingRequests.delete(String(message.requestId));
+      if (message.ok === false) pending.reject(new Error(String(message.error || 'config host request failed')));
+      else pending.resolve(message.value);
+    });
+
+    function setStatus(text, level) {
+      statusEl.textContent = text || '';
+      statusEl.classList.remove('ok', 'error');
+      if (level) statusEl.classList.add(level);
+    }
+
+    function collectEdits() {
+      const edits = [];
+      for (const field of fields) {
+        const el = document.querySelector('[data-field="' + field.index + '"]');
+        if (!el) continue;
+        let value;
+        if (field.kind === 'boolean') {
+          value = el.checked;
+        } else if (field.kind === 'number') {
+          const parsed = Number(el.value);
+          value = Number.isFinite(parsed) ? parsed : field.value;
+        } else if (field.kind === 'json') {
+          try { value = JSON.parse(el.value); } catch (_error) { value = field.value; }
+        } else {
+          value = el.value;
+        }
+        edits.push({ path: field.path, value });
+      }
+      return edits;
+    }
+
+    document.getElementById('saveBtn').addEventListener('click', async () => {
+      try {
+        setStatus('Saving…');
+        await requestHost('save', { path, edits: collectEdits() });
+        setStatus('Saved', 'ok');
+      } catch (error) {
+        setStatus(String(error && error.message ? error.message : error), 'error');
+      }
+    });
+    document.getElementById('rawBtn').addEventListener('click', () => {
+      requestHost('toggleRaw', { path }).catch(() => {});
+    });
+  </script>
+</body>
+</html>`;
+    }
+
     return {
         buildHostedResultsPanelState,
         flattenScenarioConfig,
         setScenarioConfigValue,
         applyScenarioConfigEdits,
+        buildScenarioConfigDocument,
         buildHostedResultsPanelTitle,
         buildLatestSimulationResultsIndexDocument,
         buildVisualizationModel,


### PR DESCRIPTION
## Summary
Foundation for a configurable, rum.toml-driven simulation/visualization config shared by the editor surfaces (rustbook live examples + tutorial website).

- **`rumoca-compile/project_config`**: full rum.toml scenario get/set, filesystem-agnostic (reads an in-memory `path → content` map, no disk), with a default config for the editor GUI. Models `[rumoca]` marker, `[model]`, `[codegen]`, `[sim]` defaults + per-model overrides (`solver`, `t_end`, `dt`), `[plot]`, and a viewer mode (plot vs 3D). JSON (de)serialization in `project_config/json.rs`.
- **`rumoca-bind-wasm/project_config_api`**: exposes `project_get_simulation_config` / `project_set_simulation_preset` to the browser editor (in-memory project files in, colocated `rum.toml` write out).
- **`visualization_shared.js`**: the dual-view config form (GUI ⇄ raw TOML) — `renderSimulationToml`, `renderViewsToml`, `parseViewsToml`, scenario/solver fields with validation; wired through the `RumocaSimulationSettingsHost` bridge.
- LSP `project_commands`/`support` slimmed to delegate to the shared config layer.
- Tests: `project_config` unit tests, a WASM `project_get_simulation_config_reads_in_memory_rum_toml` round-trip, and a JS `scenario_config_form_smoke.mjs`.

## Notes
- Rebased onto current `main`; resolved a tests.rs conflict by keeping both the diffsol lowering test (#248) and the new config round-trip test.
- **Known follow-up:** this currently keeps the `editors/wasm/vendor/visualization_shared.js` vendored copy alongside the canonical `crates/rumoca-viz-web/web/` one. De-forking the viz assets into a single `@cognipilot/rumoca-viz` package is the next workstream; landing this maintains the existing vendoring pattern rather than expanding scope here.