### PR TITLE
fix: align stiff DAE structural guard and solve jacobians

### DIFF
--- a/crates/rumoca-eval-solve/src/runtime.rs
+++ b/crates/rumoca-eval-solve/src/runtime.rs
@@ -647,10 +647,19 @@ impl SolveRuntime {
             self.row_eval_context(),
         )?;
         match row.assignment_target {
+            // `raw - current_target` is only valid when the row evaluates to the
+            // target's *value* (an expression in the other unknowns). A row that
+            // reads its own target is already a residual in it — e.g. a flow-sum
+            // `... + own + ... = 0` whose `raw` is affine in `own` with a +1
+            // coefficient. Subtracting `own` there cancels that dependence and
+            // leaves a residual with zero slope, so the linear solve reports the
+            // target as undeterminable. Use the bare residual in that case (same
+            // as assignment-shape rows), which Newton-solves correctly.
             Some(own)
                 if !self
                     .implicit_scalar_rhs
-                    .row_has_assignment_shape(row.row_idx) =>
+                    .row_has_assignment_shape(row.row_idx)
+                    && !self.implicit_scalar_rhs.row_reads_y(row.row_idx, own) =>
             {
                 Ok(raw - solver_y[own])
             }

--- a/crates/rumoca-phase-codegen/src/codegen/mod.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/mod.rs
@@ -1028,7 +1028,9 @@ pub fn render_template_with_dae_json(
     };
     let solve_blocks = solve_blocks_from_dae_json(dae_json)?;
     let solve_derivative_nodes = solve_derivative_nodes_from_dae_json(dae_json)?;
-    let solve_jacobian_rows = solve_jacobian_rows_from_dae_json(dae_json);
+    let solve_implicit_rows = solve_implicit_rows_from_dae_json(dae_json);
+    let solve_jacobian_rows = solve_jacobian_rows_from_dae_json(dae_json, &solve_implicit_rows);
+    let solve_full_jacobian_rows = solve_full_jacobian_rows_from_dae_json(dae_json);
     let result = tmpl.render(minijinja::context! {
         dae => dae_value.clone(),
         solve => solve_value,
@@ -1036,7 +1038,9 @@ pub fn render_template_with_dae_json(
         ir_kind => ir_kind,
         solve_blocks => solve_blocks,
         solve_derivative_nodes => solve_derivative_nodes,
+        solve_implicit_rows => Value::from_serialize(&solve_implicit_rows),
         solve_jacobian_rows => solve_jacobian_rows,
+        solve_full_jacobian_rows => solve_full_jacobian_rows,
     })?;
 
     Ok(result)
@@ -1061,7 +1065,9 @@ pub fn render_template_with_dae_json_and_name(
     };
     let solve_blocks = solve_blocks_from_dae_json(dae_json)?;
     let solve_derivative_nodes = solve_derivative_nodes_from_dae_json(dae_json)?;
-    let solve_jacobian_rows = solve_jacobian_rows_from_dae_json(dae_json);
+    let solve_implicit_rows = solve_implicit_rows_from_dae_json(dae_json);
+    let solve_jacobian_rows = solve_jacobian_rows_from_dae_json(dae_json, &solve_implicit_rows);
+    let solve_full_jacobian_rows = solve_full_jacobian_rows_from_dae_json(dae_json);
     let tmpl = env.get_template("inline")?;
     let result = tmpl.render(minijinja::context! {
         dae => dae_value.clone(),
@@ -1071,7 +1077,9 @@ pub fn render_template_with_dae_json_and_name(
         model_name => model_name,
         solve_blocks => solve_blocks,
         solve_derivative_nodes => solve_derivative_nodes,
+        solve_implicit_rows => Value::from_serialize(&solve_implicit_rows),
         solve_jacobian_rows => solve_jacobian_rows,
+        solve_full_jacobian_rows => solve_full_jacobian_rows,
     })?;
 
     Ok(result)
@@ -1143,9 +1151,22 @@ fn solve_derivative_nodes_from_dae_json(
     ))
 }
 
-fn solve_jacobian_rows_from_dae_json(dae_json: &serde_json::Value) -> Value {
+fn solve_implicit_rows_from_dae_json(dae_json: &serde_json::Value) -> serde_json::Value {
+    dae_json
+        .pointer("/solve/continuous/implicit_rhs/nodes")
+        .map(scalar_programs_from_compute_nodes)
+        .unwrap_or_else(|| serde_json::Value::Array(Vec::new()))
+}
+
+fn solve_jacobian_rows_from_dae_json(
+    dae_json: &serde_json::Value,
+    implicit_rows: &serde_json::Value,
+) -> Value {
+    if implicit_rows.as_array().is_none_or(Vec::is_empty) {
+        return Value::from_serialize(Vec::<serde_json::Value>::new());
+    }
     let rows = dae_json
-        .pointer("/solve/artifacts/continuous/full_jacobian_v/programs")
+        .pointer("/solve/artifacts/continuous/implicit_jacobian_v_scalar/programs")
         .cloned()
         .or_else(|| {
             dae_json
@@ -1154,6 +1175,14 @@ fn solve_jacobian_rows_from_dae_json(dae_json: &serde_json::Value) -> Value {
         })
         .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
     Value::from_serialize(&rows)
+}
+
+fn solve_full_jacobian_rows_from_dae_json(dae_json: &serde_json::Value) -> Value {
+    Value::from_serialize(
+        dae_json
+            .pointer("/solve/artifacts/continuous/full_jacobian_v/programs")
+            .unwrap_or(&serde_json::Value::Array(Vec::new())),
+    )
 }
 
 fn scalar_programs_from_compute_nodes(nodes: &serde_json::Value) -> serde_json::Value {
@@ -1925,6 +1954,8 @@ use solve_renderer::solve_render_context_value;
 mod codegen_tests;
 #[cfg(test)]
 mod fmi_template_tests;
+#[cfg(test)]
+mod solve_template_context_tests;
 #[cfg(test)]
 mod stencil_codegen_tests;
 #[cfg(test)]

--- a/crates/rumoca-phase-codegen/src/codegen/solve_renderer.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/solve_renderer.rs
@@ -139,20 +139,30 @@ fn solve_render_context_value_with_dae(
     ));
     let implicit_rows =
         rumoca_eval_solve::to_scalar_program_block(&solve_problem.continuous.implicit_rhs);
-    // Jacobian rows prefer the full AD jacobian (state + parameter seed
-    // columns, needed e.g. for FMI directional derivatives w.r.t.
-    // parameters); the implicit state-only block is the fallback.
-    let jacobian_rows = if artifacts.continuous.full_jacobian_v.programs.is_empty() {
+    let has_implicit_rows = !implicit_rows.programs.is_empty();
+    let implicit_jacobian_rows = if !has_implicit_rows {
+        solve::ScalarProgramBlock::default()
+    } else if artifacts
+        .continuous
+        .implicit_jacobian_v_scalar
+        .programs
+        .is_empty()
+    {
         rumoca_eval_solve::to_scalar_program_block(&artifacts.continuous.implicit_jacobian_v)
     } else {
-        artifacts.continuous.full_jacobian_v.clone()
+        artifacts.continuous.implicit_jacobian_v_scalar.clone()
     };
+    let full_jacobian_rows = artifacts.continuous.full_jacobian_v.clone();
     // Row arrays (matching the historical `.programs` shape) as typed
     // objects so the row renderers take the typed fast path.
     let implicit_rows =
         Value::from_object(render_solve::SolveRowsValue::new(implicit_rows.programs));
-    let jacobian_rows =
-        Value::from_object(render_solve::SolveRowsValue::new(jacobian_rows.programs));
+    let implicit_jacobian_rows = Value::from_object(render_solve::SolveRowsValue::new(
+        implicit_jacobian_rows.programs,
+    ));
+    let full_jacobian_rows = Value::from_object(render_solve::SolveRowsValue::new(
+        full_jacobian_rows.programs,
+    ));
     Ok(match model_name {
         Some(name) => minijinja::context! {
             dae => dae_entry.clone(),
@@ -164,7 +174,8 @@ fn solve_render_context_value_with_dae(
             solve_blocks => solve_blocks,
             solve_derivative_nodes => derivative_nodes,
             solve_implicit_rows => implicit_rows,
-            solve_jacobian_rows => jacobian_rows,
+            solve_jacobian_rows => implicit_jacobian_rows,
+            solve_full_jacobian_rows => full_jacobian_rows,
         },
         None => minijinja::context! {
             dae => dae_entry.clone(),
@@ -175,7 +186,8 @@ fn solve_render_context_value_with_dae(
             solve_blocks => solve_blocks,
             solve_derivative_nodes => derivative_nodes,
             solve_implicit_rows => implicit_rows,
-            solve_jacobian_rows => jacobian_rows,
+            solve_jacobian_rows => implicit_jacobian_rows,
+            solve_full_jacobian_rows => full_jacobian_rows,
         },
     })
 }

--- a/crates/rumoca-phase-codegen/src/codegen/solve_template_context_tests.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/solve_template_context_tests.rs
@@ -1,0 +1,107 @@
+use super::*;
+use rumoca_ir_solve as solve;
+
+fn builtin_template(target: &str, template: &str) -> &'static str {
+    crate::templates::builtin_target(target)
+        .and_then(|target| target.template_source(template))
+        .expect("built-in target template must exist")
+}
+
+fn single_slot_row() -> Vec<solve::LinearOp> {
+    vec![
+        solve::LinearOp::LoadY { dst: 0, index: 0 },
+        solve::LinearOp::StoreOutput { src: 0 },
+    ]
+}
+
+fn implicit_problem_with_artifacts() -> (solve::SolveProblem, solve::SolveArtifacts) {
+    let row = single_slot_row();
+    let mut problem = solve::SolveProblem::default();
+    problem.continuous.derivative_rhs =
+        solve::ComputeBlock::from_scalar_program_block(solve::ScalarProgramBlock::new(vec![
+            row.clone(),
+        ]));
+    problem.continuous.implicit_rhs =
+        solve::ComputeBlock::from_scalar_program_block(solve::ScalarProgramBlock::new(vec![
+            row.clone(),
+        ]));
+
+    let mut artifacts = solve::SolveArtifacts::default();
+    artifacts.continuous.implicit_jacobian_v_scalar =
+        solve::ScalarProgramBlock::new(vec![row.clone()]);
+    artifacts.continuous.full_jacobian_v = solve::ScalarProgramBlock::new(vec![row]);
+    (problem, artifacts)
+}
+
+fn explicit_problem() -> solve::SolveProblem {
+    let mut problem = solve::SolveProblem::default();
+    problem.continuous.derivative_rhs =
+        solve::ComputeBlock::from_scalar_program_block(solve::ScalarProgramBlock::new(vec![
+            single_slot_row(),
+        ]));
+    problem
+}
+
+#[test]
+fn test_solve_template_context_exposes_optional_rows_as_sequences() {
+    let (problem, artifacts) = implicit_problem_with_artifacts();
+
+    let rendered = render_solve_template_with_name(
+        &problem,
+        &artifacts,
+        "{{ solve_implicit_rows | length }} {{ solve_jacobian_rows | length }} {{ solve_full_jacobian_rows | length }}",
+        "ImplicitDemo",
+    )
+    .expect("solve template should render direct optional row sequences");
+    assert_eq!(rendered, "1 1 1");
+
+    let mlir = render_solve_template_with_name(
+        &problem,
+        &artifacts,
+        builtin_template("mlir", "mlir.mlir.jinja"),
+        "ImplicitDemo",
+    )
+    .expect("mlir template should render optional functions");
+    assert!(mlir.contains("func.func @eval_implicit_rhs"));
+    assert!(mlir.contains("func.func @eval_jacobian_v"));
+
+    let rendered = render_solve_template_with_name(
+        &explicit_problem(),
+        &artifacts,
+        "{{ solve_implicit_rows | length }} {{ solve_jacobian_rows | length }} {{ solve_full_jacobian_rows | length }}",
+        "ExplicitOnlyDemo",
+    )
+    .expect("implicit JVP rows should be empty without an implicit residual");
+    assert_eq!(rendered, "0 0 1");
+}
+
+#[test]
+fn test_serialized_solve_template_context_exposes_optional_rows_as_sequences() {
+    let (problem, artifacts) = implicit_problem_with_artifacts();
+
+    let mut solve_json = serde_json::to_value(&problem).expect("serialize solve problem");
+    solve_json["artifacts"] = serde_json::to_value(&artifacts).expect("serialize artifacts");
+    let dae_json = serde_json::json!({
+        "__ir_kind": "solve",
+        "solve": solve_json,
+    });
+    let rendered = render_template_with_dae_json(
+        &dae_json,
+        "{{ solve_implicit_rows | length }} {{ solve_jacobian_rows | length }} {{ solve_full_jacobian_rows | length }}",
+    )
+    .expect("serialized solve context should render direct optional row sequences");
+    assert_eq!(rendered, "1 1 1");
+
+    let mut solve_json = serde_json::to_value(explicit_problem()).expect("serialize solve problem");
+    solve_json["artifacts"] = serde_json::to_value(&artifacts).expect("serialize artifacts");
+    let dae_json = serde_json::json!({
+        "__ir_kind": "solve",
+        "solve": solve_json,
+    });
+    let rendered = render_template_with_dae_json(
+        &dae_json,
+        "{{ solve_implicit_rows | length }} {{ solve_jacobian_rows | length }} {{ solve_full_jacobian_rows | length }}",
+    )
+    .expect("serialized implicit JVP rows should be empty without implicit residual");
+    assert_eq!(rendered, "0 0 1");
+}

--- a/crates/rumoca-phase-codegen/src/templates/fmi3/model.c.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/fmi3/model.c.jinja
@@ -34,7 +34,7 @@
 {% set solve_pre_param_bindings = solve.solve_layout.pre_param_bindings if solve is defined and solve.solve_layout is defined and solve.solve_layout.pre_param_bindings is defined else [] %}
 {% set solve_derivative_rows = solve.continuous.derivative_rhs.programs if solve is defined and solve.continuous is defined and solve.continuous.derivative_rhs is defined and solve.continuous.derivative_rhs.programs is defined else [] %}
 {% set solve_derivative_nodes = solve_derivative_nodes if solve_derivative_nodes is defined else (solve.continuous.derivative_rhs.nodes if solve is defined and solve.continuous is defined and solve.continuous.derivative_rhs is defined and solve.continuous.derivative_rhs.nodes is defined else []) %}
-{% set solve_jacobian_rows = solve_jacobian_rows if solve_jacobian_rows is defined else (solve.artifacts.continuous.implicit_jacobian_v.programs if solve is defined and solve.artifacts is defined and solve.artifacts.continuous is defined and solve.artifacts.continuous.implicit_jacobian_v is defined and solve.artifacts.continuous.implicit_jacobian_v.programs is defined else (solve.artifacts.continuous.full_jacobian_v.programs if solve is defined and solve.artifacts is defined and solve.artifacts.continuous is defined and solve.artifacts.continuous.full_jacobian_v is defined and solve.artifacts.continuous.full_jacobian_v.programs is defined else [])) %}
+{% set solve_full_jacobian_rows = solve_full_jacobian_rows if solve_full_jacobian_rows is defined else (solve.artifacts.continuous.full_jacobian_v.programs if solve is defined and solve.artifacts is defined and solve.artifacts.continuous is defined and solve.artifacts.continuous.full_jacobian_v is defined and solve.artifacts.continuous.full_jacobian_v.programs is defined else []) %}
 {% set solve_row_c_cfg = {"time": "m->time", "y": "__rumoca_solve_y(m, {})", "p": "__rumoca_solve_p(m, {})"} %}
 {% set solve_slot_assign_c_cfg = {"y_set": "__rumoca_solve_set_y(m, {}, {})", "p_set": "__rumoca_solve_set_p(m, {}, {})"} %}
 {% set solve_jacobian_c_cfg = {"time": "m->time", "y": "__rumoca_solve_y(m, {})", "p": "__rumoca_solve_p(m, {})", "seed": "seed[{}]"} %}
@@ -307,7 +307,7 @@ static double Modelica_Blocks_Types_ExternalCombiTimeTable() { return 0.0; }
 #define N_SOLVE_Y        (N_STATES + N_ALGEBRAICS + N_OUTPUTS)
 #define N_SOLVE_P        (N_PARAMETERS + N_INPUTS + N_DISCRETE_REAL + N_DISCRETE_VAL)
 #define N_SOLVE_SEEDS    (N_SOLVE_Y + N_SOLVE_P)
-#define N_SOLVE_JACOBIAN_ROWS {{ solve_jacobian_rows | length }}
+#define N_SOLVE_JACOBIAN_ROWS {{ solve_full_jacobian_rows | length }}
 
 /* Per-variable counts (FMI 3.0 native arrays: one VR per variable) */
 #define NVAR_X  {{ dae.x | length }}
@@ -1264,9 +1264,9 @@ static int solve_seed_offset_for_vr_element(fmi3ValueReference vr, int elem) {
 }
 
 static void compute_solve_jacobian_v(ModelInstance* m, const fmi3Float64 seed[], fmi3Float64 out[]) {
-{% if solve_jacobian_rows | length > 0 %}
+{% if solve_full_jacobian_rows | length > 0 %}
     compute_derivatives(m);
-{% for row in solve_jacobian_rows %}
+{% for row in solve_full_jacobian_rows %}
     out[{{ loop.index0 }}] = {{ render_solve_row_c(row, solve_jacobian_c_cfg) }};
 {% endfor %}
 {% else %}

--- a/crates/rumoca-phase-codegen/src/templates/mlir/mlir.mlir.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/mlir/mlir.mlir.jinja
@@ -26,10 +26,15 @@
          if solve is defined and solve.continuous is defined
             and solve.continuous.derivative_rhs is defined
             and solve.continuous.derivative_rhs.programs is defined else []) %}
-{%- set impl_rows = solve_implicit_rows.programs
-      if solve_implicit_rows is defined and solve_implicit_rows.programs is defined else [] %}
-{%- set jac_rows = solve_jacobian_rows.programs
-      if solve_jacobian_rows is defined and solve_jacobian_rows.programs is defined else [] %}
+{%- set impl_rows = solve_implicit_rows
+      if solve_implicit_rows is defined else (
+         solve_blocks.continuous.implicit_rhs.scalar_programs.programs
+         if solve_blocks is defined and solve_blocks.continuous is defined
+            and solve_blocks.continuous.implicit_rhs is defined
+            and solve_blocks.continuous.implicit_rhs.scalar_programs is defined
+            and solve_blocks.continuous.implicit_rhs.scalar_programs.programs is defined else []) %}
+{%- set jac_rows = solve_jacobian_rows
+      if solve_jacobian_rows is defined else [] %}
 {%- set root_rows = solve.events.root_conditions.programs
       if solve is defined and solve.events is defined
          and solve.events.root_conditions is defined

--- a/crates/rumoca-phase-structural/src/dae_prepare/dae_prepare_demotion_tests.rs
+++ b/crates/rumoca-phase-structural/src/dae_prepare/dae_prepare_demotion_tests.rs
@@ -389,6 +389,42 @@ fn test_constrained_dummy_reduction_keeps_state_with_direct_output_alias() {
 }
 
 #[test]
+fn test_constrained_dummy_state_names_skip_self_integrating_output_transform() {
+    let mut dae = Dae::new();
+    for name in ["occB", "manHours"] {
+        dae.variables
+            .states
+            .insert(VarName::new(name), Variable::new(VarName::new(name)));
+    }
+    dae.variables
+        .outputs
+        .insert(VarName::new("occA"), Variable::new(VarName::new("occA")));
+
+    dae.continuous
+        .equations
+        .push(eq(sub(der("occB"), sub(real(0.5), var("occB")))));
+    dae.continuous
+        .equations
+        .push(eq(sub(var("occA"), sub(real(1.0), var("occB")))));
+    dae.continuous
+        .equations
+        .push(eq(sub(der("manHours"), var("occA"))));
+
+    let dummy_states = constrained_dummy_state_names(&dae);
+    assert!(
+        dummy_states.is_empty(),
+        "a self-integrating state transformed through an output must not be classified as dummy"
+    );
+
+    let demoted = reduce_constrained_dummy_derivatives(&mut dae);
+    assert_eq!(
+        demoted, 0,
+        "a self-integrating output transform must not be demoted later"
+    );
+    assert!(dae.variables.states.contains_key(&VarName::new("occB")));
+}
+
+#[test]
 fn test_demote_direct_assigned_states_keeps_state_with_other_state_in_alias_closure() {
     let mut dae = Dae::new();
     dae.variables

--- a/crates/rumoca-phase-structural/src/dae_prepare/dummy_state_metadata.rs
+++ b/crates/rumoca-phase-structural/src/dae_prepare/dummy_state_metadata.rs
@@ -6,7 +6,8 @@ use rumoca_ir_dae::expr_contains_var;
 use super::{
     Dae, Equation, Expression, Literal, OpBinary, OpUnary, Subscript, VarName, add_expr,
     direct_demotion_round_context, expression_contains_any_der_call,
-    extract_state_direct_assignment_equation, state_select_rank, sub_expr,
+    extract_state_direct_assignment_equation, state_has_standalone_der_equation, state_select_rank,
+    sub_expr,
 };
 
 const LINEAR_EPSILON: f64 = 1.0e-12;
@@ -140,6 +141,29 @@ fn expression_is_plain_var_ref(expr: &Expression, expected: &VarName) -> bool {
         Expression::VarRef { name, subscripts, .. }
             if subscripts.is_empty() && name.var_name() == expected
     )
+}
+
+/// True when the constrained-dummy defining expression for `state_name`
+/// references another state, i.e. the defining constraint genuinely couples
+/// differential states (a high-index DAE such as `w1 = ratio * w2`).
+fn defining_expr_couples_other_state(
+    defining_expr: &Expression,
+    state_name: &VarName,
+    state_names: &[VarName],
+) -> bool {
+    state_names
+        .iter()
+        .any(|other| other != state_name && expr_contains_var(defining_expr, other))
+}
+
+fn candidate_is_self_integrating_non_state_alias(
+    dae: &Dae,
+    state_name: &VarName,
+    definition: &ConstrainedDummyDefinition,
+    state_names: &[VarName],
+) -> bool {
+    state_has_standalone_der_equation(dae, state_name, state_names).unwrap_or(false)
+        && !defining_expr_couples_other_state(&definition.defining_expr, state_name, state_names)
 }
 
 fn numeric_constant(expr: &Expression) -> Option<f64> {
@@ -621,6 +645,13 @@ pub fn constrained_dummy_state_defining_exprs(
         &state_name_set,
         &when_assigned_states,
     ));
+    // A state with its own assignable `der(state) = ...` row genuinely
+    // integrates unless the defining constraint couples it to another state.
+    // Filter that case here, at constrained-dummy classification time, so
+    // metadata (`constrained_dummy_state_names`) and actual demotion agree.
+    definitions.retain(|(state_name, definition)| {
+        !candidate_is_self_integrating_non_state_alias(dae, state_name, definition, &state_names)
+    });
 
     definitions.sort_by(|(a, _), (b, _)| {
         let a_var = &dae.variables.states[a];

--- a/crates/rumoca-solver-diffsol/src/stepper.rs
+++ b/crates/rumoca-solver-diffsol/src/stepper.rs
@@ -5,10 +5,7 @@
 use diffsol::{OdeSolverMethod, VectorHost};
 use rumoca_eval_solve::{self as solve_eval, SolveRuntime};
 use rumoca_ir_solve as solve;
-use rumoca_solver::{
-    SimOptions, event_solver_step_cap, implicit_residual_is_zero_through_interval,
-    runtime_root_event_application_time,
-};
+use rumoca_solver::{SimOptions, event_solver_step_cap, runtime_root_event_application_time};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -488,9 +485,9 @@ where
 
 fn step_solver_by<Eqn, S>(
     solver: &Rc<RefCell<S>>,
-    model: &OdeModel,
-    params: &RuntimeParameters,
-    opts: &SimOptions,
+    _model: &OdeModel,
+    _params: &RuntimeParameters,
+    _opts: &SimOptions,
     dt: f64,
 ) -> Result<StepAdvance, SimError>
 where
@@ -506,32 +503,60 @@ where
         solver.state().t
     };
     let target = current_t + dt;
-    {
-        let solver_ref = solver.borrow();
-        let params_ref = params.borrow();
-        if implicit_residual_is_zero_through_interval(
-            model,
-            solver_ref.state().y.as_slice(),
-            params_ref.as_slice(),
-            current_t,
-            target,
-            opts.atol.max(1.0e-12),
-        )? {
-            drop(solver_ref);
-            *solver.borrow_mut().state_mut().t = target;
+    // NOTE: deliberately no `implicit_residual_is_zero_through_interval`
+    // fast-path here. Bumping `state_mut().t = target` to skip a "steady"
+    // interval jumps the solver clock forward while leaving the BDF multistep
+    // history at the old time, so the history times go inconsistent the moment
+    // the model leaves equilibrium — exactly the kind of corruption that makes
+    // a stiff long-horizon solve collapse at the next transition. The batch
+    // dense-output path (`advance_output_interval` in `lib.rs`) has no such
+    // shortcut and completes the full horizon; mirror it.
+    let mut solver = solver.borrow_mut();
+    // Advance with the solver's own adaptive steps and land on `target` via
+    // dense output (`state_mut_back`), rather than pinning a stop time at every
+    // output sample. `set_stop_time(target)` forces a shortened, awkward final
+    // step onto each output instant; on stiff models (e.g. the rover thermal
+    // system at its lunar louver/thermostat crossings) that constrained step
+    // repeatedly fails the Newton iteration and the solve collapses
+    // (~"nonlinear solver failures" at the same instant every run). Free-running
+    // the step and rewinding into the just-completed step keeps the natural step
+    // size, which is exactly what the batch dense-output path does
+    // (`advance_output_interval` / `state_mut_back` in `lib.rs`) and why the
+    // batch path completes the full horizon where the interactive stepper used
+    // to collapse.
+    loop {
+        if solver.state().t >= target {
+            solver
+                .state_mut_back(target)
+                .map_err(|err| SimError::SolverError(format!("state_mut_back: {err}")))?;
             return Ok(StepAdvance::default());
         }
-    }
-    let mut solver = solver.borrow_mut();
-    solver
-        .set_stop_time(target)
-        .map_err(|err| SimError::SolverError(format!("Failed to set stop time: {err}")))?;
-    loop {
         match solver_call("BDF step", || solver.step()) {
-            Ok(diffsol::OdeSolverStopReason::TstopReached) => return Ok(StepAdvance::default()),
-            Ok(diffsol::OdeSolverStopReason::InternalTimestep) => continue,
-            Ok(diffsol::OdeSolverStopReason::RootFound(_, _)) => {
-                return Ok(StepAdvance { hit_root: true });
+            Ok(
+                diffsol::OdeSolverStopReason::TstopReached
+                | diffsol::OdeSolverStopReason::InternalTimestep,
+            ) => continue,
+            Ok(diffsol::OdeSolverStopReason::RootFound(t_root, _)) => {
+                // The free-running step overshoots the root (the solver state
+                // sits at the natural step end, past `t_root`). The caller's
+                // event handling assumes the solver is *at* the event instant,
+                // so rewind onto it via dense output before signalling — exactly
+                // what the batch path does in `handle_root_crossing`. Without
+                // this the projection and event reset run against a post-root
+                // state at the wrong time and the next solve diverges to NaN.
+                if t_root <= target {
+                    solver
+                        .state_mut_back(t_root)
+                        .map_err(|err| SimError::SolverError(format!("state_mut_back: {err}")))?;
+                    return Ok(StepAdvance { hit_root: true });
+                }
+                // Root lies beyond the requested interval: land on `target` and
+                // defer the crossing to the next step, which resumes from
+                // `target` and re-detects it.
+                solver
+                    .state_mut_back(target)
+                    .map_err(|err| SimError::SolverError(format!("state_mut_back: {err}")))?;
+                return Ok(StepAdvance::default());
             }
             Err(err) => return Err(err),
         }

--- a/crates/rumoca-solver/src/runtime/event.rs
+++ b/crates/rumoca-solver/src/runtime/event.rs
@@ -61,7 +61,14 @@ pub fn runtime_event_horizon(event: RuntimeEventStop, target: f64, horizon: f64)
 }
 
 pub fn runtime_root_event_application_time(root_t: f64, target_t: f64) -> f64 {
-    if sample_time_match_with_tol(root_t, target_t) {
+    // A non-finite `target_t` (e.g. `f64::INFINITY` used by the interactive
+    // stepper as an "unbounded next sample" sentinel) must never be reported as
+    // the application time: `sample_time_match_with_tol(finite, INF)` is
+    // spuriously true (its relative tolerance is itself infinite, so
+    // `INF <= INF`), which would jump the event clock to infinity and NaN the
+    // rebuilt solver. Guard the match on a finite target; the `.min(target_t)`
+    // below is already a no-op for `INF`, leaving the right-limit of the root.
+    if target_t.is_finite() && sample_time_match_with_tol(root_t, target_t) {
         target_t
     } else {
         event_right_limit_time(root_t).min(target_t)

--- a/crates/rumoca/src/main.rs
+++ b/crates/rumoca/src/main.rs
@@ -426,6 +426,17 @@ struct SimCommandArgs {
     #[arg(long)]
     dt: Option<f64>,
 
+    /// Absolute solver tolerance (overrides the model's `experiment(Tolerance=…)`
+    /// and the backend default). Pair with --rtol to match a host's tolerance
+    /// policy exactly (e.g. lunica's 1e-4 atol/rtol).
+    #[arg(long)]
+    atol: Option<f64>,
+
+    /// Relative solver tolerance (overrides the model's `experiment(Tolerance=…)`
+    /// and the backend default).
+    #[arg(long)]
+    rtol: Option<f64>,
+
     /// Output file path for simulation report (default: <MODEL>_results.html)
     #[arg(short, long)]
     output: Option<String>,
@@ -920,6 +931,8 @@ fn run_configured_simulation(args: SimCommandArgs) -> Result<()> {
             model: &compiled_model,
             t_end: args.t_end.unwrap_or(config.sim.t_end),
             dt: args.dt.or(Some(config.sim.dt)),
+            atol: args.atol,
+            rtol: args.rtol,
             solver_mode,
             solver_label: &solver_label,
             output: args.output.as_deref().or(config.sim.output.as_deref()),
@@ -1196,6 +1209,8 @@ fn run_direct_simulation(args: SimCommandArgs) -> Result<()> {
         model: &model,
         t_end: args.t_end.unwrap_or(1.0),
         dt: args.dt,
+        atol: args.atol,
+        rtol: args.rtol,
         solver_mode: solver.into(),
         solver_label: solver.as_label(),
         output: args.output.as_deref(),
@@ -1789,6 +1804,8 @@ struct SimulationRun<'a> {
     model: &'a str,
     t_end: f64,
     dt: Option<f64>,
+    atol: Option<f64>,
+    rtol: Option<f64>,
     solver_mode: SimSolverMode,
     solver_label: &'a str,
     output: Option<&'a str>,
@@ -1808,7 +1825,7 @@ fn run_simulation(run: SimulationRun<'_>) -> Result<()> {
         );
     }
 
-    let opts = SimOptions {
+    let mut opts = SimOptions {
         t_end: run.t_end,
         dt: run.dt,
         solver_mode: run.solver_mode,
@@ -1817,6 +1834,14 @@ fn run_simulation(run: SimulationRun<'_>) -> Result<()> {
         diffsol_method: DiffsolMethod::from_external_name(run.solver_label).unwrap_or_default(),
         ..SimOptions::default()
     };
+    // Explicit --atol/--rtol override the backend default so a host's tolerance
+    // policy can be reproduced exactly from the CLI.
+    if let Some(atol) = run.atol {
+        opts.atol = atol;
+    }
+    if let Some(rtol) = run.rtol {
+        opts.rtol = rtol;
+    }
 
     eprintln!("Simulating {} to t={}...", run.model, run.t_end);
     // On a non-finite-suggestive failure (e.g. a model divide-by-zero showing up


### PR DESCRIPTION
## Summary

This supersedes #253 while preserving credit for the original work by `0xIonRod`.

- Keeps the original stiff-DAE solver/stepper/CLI tolerance commits from PR #253.
- Moves the self-integrating dummy-state guard up into constrained-dummy metadata classification, so `constrained_dummy_state_names` and actual demotion agree before later compiler phases consume the structure.
- Splits the solve Jacobian template context into two intended paths: implicit residual JVP rows for MLIR `eval_jacobian_v`, and full derivative RHS JVP rows for FMI directional derivative APIs.
- Adds focused regression coverage for the metadata-level guard and the two Jacobian template contexts.

## Attribution

The first two commits are authored by Rod from #253. The corrective commit also includes:

`Co-authored-by: 0xIonRod <101790821+0xIonRod@users.noreply.github.com>`

## Deferred Follow-up

`rumoca sim --atol/--rtol` is retained from #253, but `rum.toml` / `rum.<profile>.toml` support for `[sim].atol` and `[sim].rtol` is not in this PR. That is tracked separately in #260.

## Validation

- `cargo xtask verify quick`
- `cargo xtask verify full`

Full verification passed after this final shape, including the MSL gates, MLIR checks, template/runtime checks, coverage gate, docs, VS Code, WASM, and LSP/MSL timing gates.