### PR TITLE
Improve Python API bindings

### DIFF
--- a/crates/rumoca-bind-python/rumoca.pyi
+++ b/crates/rumoca-bind-python/rumoca.pyi
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Sequence
+
+ScenarioTask = Literal["simulate", "codegen"]
+Solver = Literal["auto", "rk-like", "bdf"]
+
+__all__: Sequence[str]
+
+
+class ParseResult:
+    success: bool
+    error: str | None
+
+    def __bool__(self) -> bool: ...
+    def __repr__(self) -> str: ...
+
+
+class LintMessage:
+    rule: str
+    level: Literal["error", "warning", "note", "help"]
+    message: str
+    file: str
+    line: int
+    column: int
+    suggestion: str | None
+
+    def __repr__(self) -> str: ...
+
+
+class SimulationOptions:
+    t_start: float
+    t_end: float
+    dt: float | None
+    solver: str | None
+    rtol: float | None
+    atol: float | None
+    max_wall_seconds: float | None
+
+    def __init__(
+        self,
+        t_end: float = 1.0,
+        dt: float | None = None,
+        solver: Solver | str | None = None,
+        t_start: float = 0.0,
+        rtol: float | None = None,
+        atol: float | None = None,
+        max_wall_seconds: float | None = None,
+    ) -> None: ...
+    def __repr__(self) -> str: ...
+
+
+class CompileResult:
+    model_name: str
+
+    def __repr__(self) -> str: ...
+    def __getitem__(self, key: str) -> Any: ...
+    def to_dict(self) -> dict[str, Any]: ...
+    def to_json(self, pretty: bool = True) -> str: ...
+    def save_json(self, path: str, pretty: bool = True) -> None: ...
+
+
+class SimulationResult:
+    model_name: str
+    metrics: dict[str, Any]
+    data: dict[str, Any]
+
+    def __repr__(self) -> str: ...
+    def __getitem__(self, key: str) -> Any: ...
+    def to_dict(self) -> dict[str, Any]: ...
+    def to_json(self, pretty: bool = True) -> str: ...
+    def save_json(self, path: str, pretty: bool = True) -> None: ...
+
+
+class CodegenResult:
+    model_name: str
+    target: str
+    paths: list[str]
+
+    def __repr__(self) -> str: ...
+    def to_dict(self) -> list[dict[str, Any]]: ...
+    def to_json(self, pretty: bool = True) -> str: ...
+    def save_json(self, path: str, pretty: bool = True) -> None: ...
+    def save_all(self, output_dir: str) -> list[str]: ...
+
+
+class Project:
+    workspace_root: str
+    model_name: str | None
+    model_file: str | None
+
+    @classmethod
+    def open(
+        cls,
+        workspace_root: str = ".",
+        model_name: str | None = None,
+        model_file: str | None = None,
+        focus_path: str | None = None,
+        source_roots: list[str] | None = None,
+    ) -> Project: ...
+
+    def __repr__(self) -> str: ...
+    def source_roots(self) -> list[str]: ...
+    def load_source_roots(self) -> str: ...
+    def compile_file(
+        self,
+        path: str | None = None,
+        model_name: str | None = None,
+    ) -> CompileResult: ...
+    def compile_source(
+        self,
+        source: str,
+        model_name: str | None = None,
+        filename: str | None = None,
+    ) -> CompileResult: ...
+    def simulate_file(
+        self,
+        path: str | None = None,
+        model_name: str | None = None,
+        options: SimulationOptions | None = None,
+    ) -> SimulationResult: ...
+    def simulate_source(
+        self,
+        source: str,
+        model_name: str | None = None,
+        filename: str | None = None,
+        options: SimulationOptions | None = None,
+    ) -> SimulationResult: ...
+    def codegen_file(
+        self,
+        path: str | None = None,
+        target: str | None = None,
+        model_name: str | None = None,
+    ) -> CodegenResult: ...
+
+
+class ProjectSession:
+    """Reusable compiler session with source-root and compile caches."""
+
+    @classmethod
+    def from_project(
+        cls,
+        workspace_root: str,
+        focus_path: str | None = None,
+        model_name: str | None = None,
+        task: ScenarioTask = "simulate",
+        source_roots: list[str] | None = None,
+    ) -> ProjectSession: ...
+
+    def __init__(self, source_roots: list[str] | None = None) -> None: ...
+    def __repr__(self) -> str: ...
+    def clear(self) -> None: ...
+    def configure_source_roots(self, source_roots: list[str]) -> None: ...
+    def configure_project(
+        self,
+        workspace_root: str,
+        focus_path: str | None = None,
+        model_name: str | None = None,
+        task: ScenarioTask = "simulate",
+        source_roots: list[str] | None = None,
+    ) -> None: ...
+    def get_source_roots(self) -> list[str]: ...
+    def load_source_roots(self) -> str: ...
+    def source_root_statuses(self) -> str: ...
+    def compile(
+        self,
+        source: str,
+        model_name: str | None = None,
+        filename: str | None = None,
+    ) -> str: ...
+    def compile_to_json(
+        self,
+        source: str,
+        model_name: str | None = None,
+        filename: str | None = None,
+    ) -> str: ...
+    def compile_file(self, path: str, model_name: str | None = None) -> str: ...
+    def compile_file_to_json(self, path: str, model_name: str | None = None) -> str: ...
+    def render_model(
+        self,
+        source: str,
+        template: str,
+        model_name: str | None = None,
+        filename: str | None = None,
+    ) -> str: ...
+    def render_model_file(
+        self,
+        path: str,
+        template: str,
+        model_name: str | None = None,
+    ) -> str: ...
+    def render_target_model(
+        self,
+        source: str,
+        target: str,
+        model_name: str | None = None,
+        filename: str | None = None,
+    ) -> str: ...
+    def render_target_file(
+        self,
+        path: str,
+        target: str,
+        model_name: str | None = None,
+    ) -> str: ...
+    def simulate(
+        self,
+        source: str,
+        model_name: str | None = None,
+        filename: str | None = None,
+        options: SimulationOptions | None = None,
+    ) -> str: ...
+    def simulate_file(
+        self,
+        path: str,
+        model_name: str | None = None,
+        options: SimulationOptions | None = None,
+    ) -> str: ...
+
+
+def version() -> str: ...
+def parse(source: str, filename: str | None = None) -> ParseResult: ...
+def lint(source: str, filename: str | None = None) -> list[LintMessage]: ...
+def check(source: str, filename: str | None = None) -> list[LintMessage]: ...
+def format(source: str, filename: str | None = None) -> str: ...
+def format_or_original(source: str, filename: str | None = None) -> str: ...
+def get_builtin_targets() -> str: ...
+def effective_source_roots(
+    source_roots: list[str] | None = None,
+    workspace_root: str | None = None,
+    focus_path: str | None = None,
+    model_name: str | None = None,
+    task: ScenarioTask = "simulate",
+) -> str: ...
+def workspace_source_roots(workspace_root: str, focus_path: str | None = None) -> str: ...
+def scenario_simulation_config(
+    workspace_root: str,
+    model_name: str,
+    solver: Solver | str | None = None,
+    t_end: float | None = None,
+    dt: float | None = None,
+    output_dir: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def scenario_codegen_config(workspace_root: str, model_name: str) -> str: ...
+def compile(
+    source: str,
+    model_name: str | None = None,
+    filename: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def compile_source(
+    source: str,
+    model_name: str | None = None,
+    filename: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def compile_to_json(
+    source: str,
+    model_name: str | None = None,
+    filename: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def compile_file(
+    path: str,
+    model_name: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def compile_file_to_json(
+    path: str,
+    model_name: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def render_model(
+    source: str,
+    template: str,
+    model_name: str | None = None,
+    filename: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def render_model_file(
+    path: str,
+    template: str,
+    model_name: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def render_target_model(
+    source: str,
+    target: str,
+    model_name: str | None = None,
+    filename: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def render_target_file(
+    path: str,
+    target: str,
+    model_name: str | None = None,
+    source_roots: list[str] | None = None,
+) -> str: ...
+def simulate(
+    source: str,
+    model_name: str | None = None,
+    filename: str | None = None,
+    source_roots: list[str] | None = None,
+    options: SimulationOptions | None = None,
+) -> str: ...
+def simulate_file(
+    path: str,
+    model_name: str | None = None,
+    source_roots: list[str] | None = None,
+    options: SimulationOptions | None = None,
+) -> str: ...

--- a/crates/rumoca-bind-python/src/lib.rs
+++ b/crates/rumoca-bind-python/src/lib.rs
@@ -12,6 +12,7 @@
 
 use ::rumoca::CompilationResult as HighLevelCompilationResult;
 use pyo3::prelude::*;
+use pyo3::types::PyType;
 use pyo3::{PyErr, exceptions::PyRuntimeError};
 use rumoca_compile::codegen::targets::{
     TargetBundle, render_dae_target_files, validate_dae_target_capabilities,
@@ -20,10 +21,12 @@ use rumoca_compile::compile::{FailedPhase, PhaseResult, Session, SessionConfig, 
 use rumoca_compile::parsing::{
     collect_compile_unit_source_files, collect_model_names, validate_source_syntax,
 };
+use rumoca_compile::scenario::{EffectiveSimulationConfig, ScenarioConfig, ScenarioTask};
 use rumoca_compile::source_roots::{
     canonical_path_key, merge_source_root_paths, plan_source_root_loads,
     referenced_unloaded_source_root_paths, source_root_source_set_key,
 };
+use rumoca_compile::workspace::WorkspaceConfig;
 use rumoca_sim::simulate_dae;
 use rumoca_sim::{SimOptions, SimSolverMode as RuntimeSimSolverMode};
 use rumoca_sim::{
@@ -35,11 +38,20 @@ use rumoca_tool_lint::{LintLevel, LintOptions, lint as lint_source};
 use serde_json::{Value, json};
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+mod python_result;
+#[cfg(test)]
+mod tests;
+
+use python_result::{
+    CodegenResult, CompileResult, SimulationResult, codegen_result_from_json,
+    compile_result_from_compilation, simulation_result_from_json,
+};
+
 #[derive(Debug)]
-struct PyRuntimeStringError(String);
+pub(crate) struct PyRuntimeStringError(String);
 
 impl From<PyRuntimeStringError> for PyErr {
     fn from(value: PyRuntimeStringError) -> Self {
@@ -105,6 +117,71 @@ impl LintMessage {
     }
 }
 
+#[pyclass]
+#[derive(Clone)]
+pub struct SimulationOptions {
+    #[pyo3(get)]
+    t_start: f64,
+    #[pyo3(get)]
+    t_end: f64,
+    #[pyo3(get)]
+    dt: Option<f64>,
+    #[pyo3(get)]
+    solver: Option<String>,
+    #[pyo3(get)]
+    rtol: Option<f64>,
+    #[pyo3(get)]
+    atol: Option<f64>,
+    #[pyo3(get)]
+    max_wall_seconds: Option<f64>,
+}
+
+#[pymethods]
+impl SimulationOptions {
+    #[new]
+    #[pyo3(signature = (t_end=1.0, dt=None, solver=None, t_start=0.0, rtol=None, atol=None, max_wall_seconds=None))]
+    fn new(
+        t_end: f64,
+        dt: Option<f64>,
+        solver: Option<String>,
+        t_start: f64,
+        rtol: Option<f64>,
+        atol: Option<f64>,
+        max_wall_seconds: Option<f64>,
+    ) -> Self {
+        Self {
+            t_start,
+            t_end,
+            dt,
+            solver,
+            rtol,
+            atol,
+            max_wall_seconds,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SimulationOptions(t_start={}, t_end={}, dt={:?}, solver={:?})",
+            self.t_start, self.t_end, self.dt, self.solver
+        )
+    }
+}
+
+impl Default for SimulationOptions {
+    fn default() -> Self {
+        Self {
+            t_start: 0.0,
+            t_end: 1.0,
+            dt: None,
+            solver: None,
+            rtol: None,
+            atol: None,
+            max_wall_seconds: None,
+        }
+    }
+}
+
 #[pyclass(unsendable)]
 struct ProjectSession {
     session: Session,
@@ -124,6 +201,26 @@ impl ProjectSession {
             source_root_paths,
             effective_source_root_paths,
         }
+    }
+
+    #[classmethod]
+    #[pyo3(signature = (workspace_root, focus_path=None, model_name=None, task="simulate", source_roots=None))]
+    fn from_project(
+        _cls: &Bound<'_, PyType>,
+        workspace_root: &str,
+        focus_path: Option<&str>,
+        model_name: Option<&str>,
+        task: &str,
+        source_roots: Option<Vec<String>>,
+    ) -> Result<Self, PyRuntimeStringError> {
+        let source_root_paths = project_configured_source_roots(
+            source_roots.unwrap_or_default(),
+            Some(workspace_root),
+            focus_path,
+            model_name,
+            task,
+        )?;
+        Ok(Self::new(Some(source_root_paths)))
     }
 
     fn __repr__(&self) -> String {
@@ -154,6 +251,25 @@ impl ProjectSession {
 
     fn get_source_roots(&self) -> Vec<String> {
         self.source_root_paths.clone()
+    }
+
+    #[pyo3(signature = (workspace_root, focus_path=None, model_name=None, task="simulate", source_roots=None))]
+    fn configure_project(
+        &mut self,
+        workspace_root: &str,
+        focus_path: Option<&str>,
+        model_name: Option<&str>,
+        task: &str,
+        source_roots: Option<Vec<String>>,
+    ) -> Result<(), PyRuntimeStringError> {
+        let source_root_paths = project_configured_source_roots(
+            source_roots.unwrap_or_default(),
+            Some(workspace_root),
+            focus_path,
+            model_name,
+            task,
+        )?;
+        self.configure_source_roots(source_root_paths)
     }
 
     fn load_source_roots(&mut self) -> Result<String, PyRuntimeStringError> {
@@ -317,15 +433,13 @@ impl ProjectSession {
         render_compiled_target(&result, &actual_model_name, target)
     }
 
-    #[pyo3(signature = (source, model_name=None, filename=None, t_end=1.0, dt=None, solver=None))]
+    #[pyo3(signature = (source, model_name=None, filename=None, options=None))]
     fn simulate(
         &mut self,
         source: &str,
         model_name: Option<&str>,
         filename: Option<&str>,
-        t_end: f64,
-        dt: Option<f64>,
-        solver: Option<&str>,
+        options: Option<PyRef<'_, SimulationOptions>>,
     ) -> Result<String, PyRuntimeStringError> {
         self.sync_source_root_paths()?;
         let filename = filename.unwrap_or("input.mo");
@@ -335,18 +449,16 @@ impl ProjectSession {
             model_name,
             filename,
             &self.effective_source_root_paths,
-            SimRequest { t_end, dt, solver },
+            sim_request(options.as_deref()),
         )
     }
 
-    #[pyo3(signature = (path, model_name=None, t_end=1.0, dt=None, solver=None))]
+    #[pyo3(signature = (path, model_name=None, options=None))]
     fn simulate_file(
         &mut self,
         path: &str,
         model_name: Option<&str>,
-        t_end: f64,
-        dt: Option<f64>,
-        solver: Option<&str>,
+        options: Option<PyRef<'_, SimulationOptions>>,
     ) -> Result<String, PyRuntimeStringError> {
         self.sync_source_root_paths()?;
         simulate_file_in_session(
@@ -354,7 +466,7 @@ impl ProjectSession {
             path,
             model_name,
             &self.effective_source_root_paths,
-            SimRequest { t_end, dt, solver },
+            sim_request(options.as_deref()),
         )
     }
 }
@@ -367,6 +479,229 @@ impl ProjectSession {
             &mut self.effective_source_root_paths,
         );
         Ok(())
+    }
+}
+
+#[pyclass(unsendable)]
+pub struct Project {
+    session: ProjectSession,
+    workspace_root: String,
+    model_name: Option<String>,
+    model_file: Option<String>,
+    focus_path: Option<String>,
+}
+
+#[pymethods]
+impl Project {
+    #[classmethod]
+    #[pyo3(signature = (workspace_root=".", model_name=None, model_file=None, focus_path=None, source_roots=None))]
+    fn open(
+        _cls: &Bound<'_, PyType>,
+        workspace_root: &str,
+        model_name: Option<&str>,
+        model_file: Option<&str>,
+        focus_path: Option<&str>,
+        source_roots: Option<Vec<String>>,
+    ) -> Result<Self, PyRuntimeStringError> {
+        let focus = focus_path.or(model_file);
+        let source_root_paths = project_configured_source_roots(
+            source_roots.unwrap_or_default(),
+            Some(workspace_root),
+            focus,
+            model_name,
+            "simulate",
+        )?;
+        let session = ProjectSession::new(Some(source_root_paths));
+        Ok(Self {
+            session,
+            workspace_root: workspace_root.to_string(),
+            model_name: model_name.map(str::to_string),
+            model_file: model_file.map(str::to_string),
+            focus_path: focus_path.map(str::to_string),
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Project(workspace_root='{}', model_name={:?}, model_file={:?})",
+            self.workspace_root, self.model_name, self.model_file
+        )
+    }
+
+    #[getter]
+    fn workspace_root(&self) -> String {
+        self.workspace_root.clone()
+    }
+
+    #[getter]
+    fn model_name(&self) -> Option<String> {
+        self.model_name.clone()
+    }
+
+    #[getter]
+    fn model_file(&self) -> Option<String> {
+        self.model_file.clone()
+    }
+
+    fn source_roots(&self) -> Vec<String> {
+        self.session.get_source_roots()
+    }
+
+    fn load_source_roots(&mut self) -> Result<String, PyRuntimeStringError> {
+        self.session.load_source_roots()
+    }
+
+    #[pyo3(signature = (path=None, model_name=None))]
+    fn compile_file(
+        &mut self,
+        path: Option<&str>,
+        model_name: Option<&str>,
+    ) -> Result<CompileResult, PyRuntimeStringError> {
+        let path = self.resolve_model_file(path)?;
+        let model_name = self.resolve_model_name(model_name);
+        self.session.sync_source_root_paths()?;
+        let (result, actual_model_name) = compile_file_in_session(
+            &mut self.session.session,
+            &path,
+            model_name.as_deref(),
+            &self.session.effective_source_root_paths,
+        )?;
+        compile_result_from_compilation(result, actual_model_name)
+    }
+
+    #[pyo3(signature = (source, model_name=None, filename=None))]
+    fn compile_source(
+        &mut self,
+        source: &str,
+        model_name: Option<&str>,
+        filename: Option<&str>,
+    ) -> Result<CompileResult, PyRuntimeStringError> {
+        self.session.sync_source_root_paths()?;
+        let filename = filename
+            .map(str::to_string)
+            .or_else(|| self.model_file.clone())
+            .unwrap_or_else(|| "input.mo".to_string());
+        let model_name = self.resolve_model_name(model_name);
+        let (result, actual_model_name) = compile_source_in_session(
+            &mut self.session.session,
+            source,
+            model_name.as_deref(),
+            &filename,
+            &self.session.effective_source_root_paths,
+        )?;
+        compile_result_from_compilation(result, actual_model_name)
+    }
+
+    #[pyo3(signature = (path=None, model_name=None, options=None))]
+    fn simulate_file(
+        &mut self,
+        path: Option<&str>,
+        model_name: Option<&str>,
+        options: Option<PyRef<'_, SimulationOptions>>,
+    ) -> Result<SimulationResult, PyRuntimeStringError> {
+        let path = self.resolve_model_file(path)?;
+        let model_name = self.resolve_model_name(model_name);
+        self.session.sync_source_root_paths()?;
+        let json = simulate_file_in_session(
+            &mut self.session.session,
+            &path,
+            model_name.as_deref(),
+            &self.session.effective_source_root_paths,
+            sim_request(options.as_deref()),
+        )?;
+        simulation_result_from_json(&json)
+    }
+
+    #[pyo3(signature = (source, model_name=None, filename=None, options=None))]
+    fn simulate_source(
+        &mut self,
+        source: &str,
+        model_name: Option<&str>,
+        filename: Option<&str>,
+        options: Option<PyRef<'_, SimulationOptions>>,
+    ) -> Result<SimulationResult, PyRuntimeStringError> {
+        self.session.sync_source_root_paths()?;
+        let filename = filename
+            .map(str::to_string)
+            .or_else(|| self.model_file.clone())
+            .unwrap_or_else(|| "input.mo".to_string());
+        let model_name = self.resolve_model_name(model_name);
+        let json = simulate_source_in_session(
+            &mut self.session.session,
+            source,
+            model_name.as_deref(),
+            &filename,
+            &self.session.effective_source_root_paths,
+            sim_request(options.as_deref()),
+        )?;
+        simulation_result_from_json(&json)
+    }
+
+    #[pyo3(signature = (path=None, target=None, model_name=None))]
+    fn codegen_file(
+        &mut self,
+        path: Option<&str>,
+        target: Option<&str>,
+        model_name: Option<&str>,
+    ) -> Result<CodegenResult, PyRuntimeStringError> {
+        let path = self.resolve_model_file(path)?;
+        let model_name = self.resolve_model_name(model_name);
+        let target = self.resolve_codegen_target(target, model_name.as_deref())?;
+        self.session.sync_source_root_paths()?;
+        let (result, actual_model_name) = compile_file_in_session(
+            &mut self.session.session,
+            &path,
+            model_name.as_deref(),
+            &self.session.effective_source_root_paths,
+        )?;
+        let json = render_compiled_target(&result, &actual_model_name, &target)?;
+        codegen_result_from_json(&json, actual_model_name, target)
+    }
+}
+
+impl Project {
+    fn resolve_model_name(&self, model_name: Option<&str>) -> Option<String> {
+        model_name
+            .map(str::to_string)
+            .or_else(|| self.model_name.clone())
+    }
+
+    fn resolve_model_file(&self, path: Option<&str>) -> Result<String, PyRuntimeStringError> {
+        path.map(str::to_string)
+            .or_else(|| self.model_file.clone())
+            .or_else(|| self.focus_path.clone())
+            .ok_or_else(|| {
+                PyRuntimeStringError(
+                    "model file required: pass path=... or open Project with model_file=..."
+                        .to_string(),
+                )
+            })
+    }
+
+    fn resolve_codegen_target(
+        &self,
+        target: Option<&str>,
+        model_name: Option<&str>,
+    ) -> Result<String, PyRuntimeStringError> {
+        if let Some(target) = target {
+            return Ok(target.to_string());
+        }
+        let Some(model_name) = model_name else {
+            return Err(PyRuntimeStringError(
+                "codegen target required when project has no model_name".to_string(),
+            ));
+        };
+        let config = ScenarioConfig::load_or_default(Path::new(&self.workspace_root))
+            .map_err(|e| PyRuntimeStringError(format!("Scenario config error: {e}")))?;
+        config
+            .codegen_config_for_model(model_name)
+            .target
+            .ok_or_else(|| {
+                PyRuntimeStringError(
+                    "codegen target required: pass target=... or configure [codegen].target"
+                        .to_string(),
+                )
+            })
     }
 }
 
@@ -465,6 +800,77 @@ fn check(source: &str, filename: Option<&str>) -> Vec<LintMessage> {
 #[pyfunction]
 fn get_builtin_targets() -> Result<String, PyRuntimeStringError> {
     serde_json::to_string(&builtin_targets_json())
+        .map_err(|e| PyRuntimeStringError(format!("JSON error: {e}")))
+}
+
+/// Resolve source roots from MODELICAPATH, workspace config, scenario config, and explicit paths.
+#[pyfunction]
+#[pyo3(signature = (source_roots=None, workspace_root=None, focus_path=None, model_name=None, task="simulate"))]
+fn effective_source_roots(
+    source_roots: Option<Vec<String>>,
+    workspace_root: Option<&str>,
+    focus_path: Option<&str>,
+    model_name: Option<&str>,
+    task: &str,
+) -> Result<String, PyRuntimeStringError> {
+    let configured = project_configured_source_roots(
+        source_roots.unwrap_or_default(),
+        workspace_root,
+        focus_path,
+        model_name,
+        task,
+    )?;
+    serde_json::to_string(&resolve_source_root_paths(&configured))
+        .map_err(|e| PyRuntimeStringError(format!("JSON error: {e}")))
+}
+
+/// Return effective `rumoca-workspace.toml` source roots for a focused path as JSON.
+#[pyfunction]
+#[pyo3(signature = (workspace_root, focus_path=None))]
+fn workspace_source_roots(
+    workspace_root: &str,
+    focus_path: Option<&str>,
+) -> Result<String, PyRuntimeStringError> {
+    let roots = workspace_configured_source_roots(workspace_root, focus_path)?;
+    serde_json::to_string(&roots).map_err(|e| PyRuntimeStringError(format!("JSON error: {e}")))
+}
+
+/// Return the effective simulation config for a model from `rumoca-scenario*.toml`.
+#[pyfunction]
+#[pyo3(signature = (workspace_root, model_name, solver=None, t_end=None, dt=None, output_dir=None, source_roots=None))]
+fn scenario_simulation_config(
+    workspace_root: &str,
+    model_name: &str,
+    solver: Option<&str>,
+    t_end: Option<f64>,
+    dt: Option<f64>,
+    output_dir: Option<&str>,
+    source_roots: Option<Vec<String>>,
+) -> Result<String, PyRuntimeStringError> {
+    let snapshot = load_scenario_simulation_snapshot(
+        workspace_root,
+        model_name,
+        solver,
+        t_end,
+        dt,
+        output_dir,
+        source_roots.unwrap_or_default(),
+    )?;
+    serde_json::to_string_pretty(&snapshot)
+        .map_err(|e| PyRuntimeStringError(format!("JSON error: {e}")))
+}
+
+/// Return the codegen target config for a model from `rumoca-scenario*.toml`.
+#[pyfunction]
+#[pyo3(signature = (workspace_root, model_name))]
+fn scenario_codegen_config(
+    workspace_root: &str,
+    model_name: &str,
+) -> Result<String, PyRuntimeStringError> {
+    let config = ScenarioConfig::load_or_default(Path::new(workspace_root))
+        .map_err(|e| PyRuntimeStringError(format!("Scenario config error: {e}")))?;
+    let codegen = config.codegen_config_for_model(model_name);
+    serde_json::to_string_pretty(&codegen)
         .map_err(|e| PyRuntimeStringError(format!("JSON error: {e}")))
 }
 
@@ -586,33 +992,45 @@ fn render_target_file(
 
 /// Compile and simulate inline Modelica source.
 #[pyfunction]
-#[pyo3(signature = (source, model_name=None, filename=None, source_roots=None, t_end=1.0, dt=None, solver=None))]
+#[pyo3(signature = (source, model_name=None, filename=None, source_roots=None, options=None))]
 fn simulate(
     source: &str,
     model_name: Option<&str>,
     filename: Option<&str>,
     source_roots: Option<Vec<String>>,
-    t_end: f64,
-    dt: Option<f64>,
-    solver: Option<&str>,
+    options: Option<PyRef<'_, SimulationOptions>>,
 ) -> Result<String, PyRuntimeStringError> {
     let mut session = ProjectSession::new(source_roots);
-    session.simulate(source, model_name, filename, t_end, dt, solver)
+    session.sync_source_root_paths()?;
+    let filename = filename.unwrap_or("input.mo");
+    simulate_source_in_session(
+        &mut session.session,
+        source,
+        model_name,
+        filename,
+        &session.effective_source_root_paths,
+        sim_request(options.as_deref()),
+    )
 }
 
 /// Compile and simulate a Modelica file.
 #[pyfunction]
-#[pyo3(signature = (path, model_name=None, source_roots=None, t_end=1.0, dt=None, solver=None))]
+#[pyo3(signature = (path, model_name=None, source_roots=None, options=None))]
 fn simulate_file(
     path: &str,
     model_name: Option<&str>,
     source_roots: Option<Vec<String>>,
-    t_end: f64,
-    dt: Option<f64>,
-    solver: Option<&str>,
+    options: Option<PyRef<'_, SimulationOptions>>,
 ) -> Result<String, PyRuntimeStringError> {
     let mut session = ProjectSession::new(source_roots);
-    session.simulate_file(path, model_name, t_end, dt, solver)
+    session.sync_source_root_paths()?;
+    simulate_file_in_session(
+        &mut session.session,
+        path,
+        model_name,
+        &session.effective_source_root_paths,
+        sim_request(options.as_deref()),
+    )
 }
 
 fn builtin_targets_json() -> Value {
@@ -628,6 +1046,125 @@ fn builtin_targets_json() -> Value {
             })
             .collect(),
     )
+}
+
+fn project_configured_source_roots(
+    explicit_source_roots: Vec<String>,
+    workspace_root: Option<&str>,
+    focus_path: Option<&str>,
+    model_name: Option<&str>,
+    task: &str,
+) -> Result<Vec<String>, PyRuntimeStringError> {
+    let mut roots = match workspace_root {
+        Some(root) => workspace_configured_source_roots(root, focus_path)?,
+        None => Vec::new(),
+    };
+    if let (Some(root), Some(model)) = (workspace_root, model_name) {
+        extend_scenario_source_roots(&mut roots, root, model, task)?;
+    }
+    roots.extend(explicit_source_roots);
+    Ok(dedup_source_roots(roots))
+}
+
+fn workspace_configured_source_roots(
+    workspace_root: &str,
+    focus_path: Option<&str>,
+) -> Result<Vec<String>, PyRuntimeStringError> {
+    let workspace_root = Path::new(workspace_root);
+    let focus_path = focus_path
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root.to_path_buf());
+    let config = WorkspaceConfig::load(workspace_root, &focus_path)
+        .map_err(|e| PyRuntimeStringError(format!("Workspace config error: {e}")))?;
+    Ok(config.effective_source_roots_for(&focus_path))
+}
+
+fn extend_scenario_source_roots(
+    roots: &mut Vec<String>,
+    workspace_root: &str,
+    model_name: &str,
+    task: &str,
+) -> Result<(), PyRuntimeStringError> {
+    let task = parse_scenario_task(task)?;
+    let config = ScenarioConfig::load_or_default(Path::new(workspace_root))
+        .map_err(|e| PyRuntimeStringError(format!("Scenario config error: {e}")))?;
+    match task {
+        ScenarioTask::Simulate => {
+            let fallback = EffectiveSimulationConfig {
+                source_root_paths: roots.clone(),
+                ..EffectiveSimulationConfig::default()
+            };
+            *roots = config
+                .simulation_snapshot_for_model(model_name, &fallback)
+                .effective
+                .source_root_paths;
+        }
+        ScenarioTask::Codegen => roots.extend(config.resolve_all_source_root_paths()),
+    }
+    Ok(())
+}
+
+fn parse_scenario_task(task: &str) -> Result<ScenarioTask, PyRuntimeStringError> {
+    match task {
+        "simulate" => Ok(ScenarioTask::Simulate),
+        "codegen" => Ok(ScenarioTask::Codegen),
+        other => Err(PyRuntimeStringError(format!(
+            "unknown scenario task '{other}', expected 'simulate' or 'codegen'"
+        ))),
+    }
+}
+
+fn sim_request(options: Option<&SimulationOptions>) -> SimRequest {
+    let options = options.cloned().unwrap_or_default();
+    SimRequest {
+        t_start: options.t_start,
+        t_end: options.t_end,
+        dt: options.dt,
+        solver: options.solver,
+        rtol: options.rtol,
+        atol: options.atol,
+        max_wall_seconds: options.max_wall_seconds,
+    }
+}
+
+fn load_scenario_simulation_snapshot(
+    workspace_root: &str,
+    model_name: &str,
+    solver: Option<&str>,
+    t_end: Option<f64>,
+    dt: Option<f64>,
+    output_dir: Option<&str>,
+    source_roots: Vec<String>,
+) -> Result<rumoca_compile::scenario::ScenarioSimulationSnapshot, PyRuntimeStringError> {
+    let mut fallback = EffectiveSimulationConfig {
+        source_root_paths: source_roots,
+        ..EffectiveSimulationConfig::default()
+    };
+    if let Some(solver) = solver {
+        fallback.solver = solver.to_string();
+    }
+    if let Some(t_end) = t_end {
+        fallback.t_end = t_end;
+    }
+    fallback.dt = dt;
+    if let Some(output_dir) = output_dir {
+        fallback.output_dir = output_dir.to_string();
+    }
+    let config = ScenarioConfig::load_or_default(Path::new(workspace_root))
+        .map_err(|e| PyRuntimeStringError(format!("Scenario config error: {e}")))?;
+    Ok(config.simulation_snapshot_for_model(model_name, &fallback))
+}
+
+fn dedup_source_roots(paths: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut deduped = Vec::new();
+    for path in paths {
+        let key = canonical_path_key(&path);
+        if seen.insert(key) {
+            deduped.push(path);
+        }
+    }
+    deduped
 }
 
 fn split_env_modelicapath() -> Vec<String> {
@@ -979,26 +1516,39 @@ fn seconds_since(started: Instant) -> f64 {
     started.elapsed().as_secs_f64()
 }
 
-#[derive(Clone, Copy)]
-struct SimRequest<'a> {
+#[derive(Clone)]
+struct SimRequest {
+    t_start: f64,
     t_end: f64,
     dt: Option<f64>,
-    solver: Option<&'a str>,
+    solver: Option<String>,
+    rtol: Option<f64>,
+    atol: Option<f64>,
+    max_wall_seconds: Option<f64>,
 }
 
 fn simulate_compiled_model(
     result: &HighLevelCompilationResult,
     model_name: &str,
     compile_seconds: f64,
-    request: SimRequest<'_>,
+    request: SimRequest,
 ) -> Result<String, PyRuntimeStringError> {
-    let (solver_mode, solver_label) = RuntimeSimSolverMode::parse_request(request.solver);
-    let opts = SimOptions {
+    let (solver_mode, solver_label) =
+        RuntimeSimSolverMode::parse_request(request.solver.as_deref());
+    let mut opts = SimOptions {
+        t_start: request.t_start,
         t_end: request.t_end,
         dt: request.dt,
         solver_mode,
         ..SimOptions::default()
     };
+    if let Some(rtol) = request.rtol {
+        opts.rtol = rtol;
+    }
+    if let Some(atol) = request.atol {
+        opts.atol = atol;
+    }
+    opts.max_wall_seconds = request.max_wall_seconds;
     let sim_started = Instant::now();
     let sim = simulate_dae(&result.dae, &opts)
         .map_err(|e| PyRuntimeStringError(format!("Simulation error: {e}")))?;
@@ -1029,7 +1579,7 @@ fn simulate_source_in_session(
     model_name: Option<&str>,
     file_name: &str,
     source_root_paths: &[String],
-    request: SimRequest<'_>,
+    request: SimRequest,
 ) -> Result<String, PyRuntimeStringError> {
     let compile_started = Instant::now();
     let (result, actual_model_name) =
@@ -1047,7 +1597,7 @@ fn simulate_file_in_session(
     path: &str,
     model_name: Option<&str>,
     source_root_paths: &[String],
-    request: SimRequest<'_>,
+    request: SimRequest,
 ) -> Result<String, PyRuntimeStringError> {
     let compile_started = Instant::now();
     let (result, actual_model_name) =
@@ -1079,261 +1629,19 @@ fn rumoca(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(render_target_model, m)?)?;
     m.add_function(wrap_pyfunction!(render_target_file, m)?)?;
     m.add_function(wrap_pyfunction!(get_builtin_targets, m)?)?;
+    m.add_function(wrap_pyfunction!(effective_source_roots, m)?)?;
+    m.add_function(wrap_pyfunction!(workspace_source_roots, m)?)?;
+    m.add_function(wrap_pyfunction!(scenario_simulation_config, m)?)?;
+    m.add_function(wrap_pyfunction!(scenario_codegen_config, m)?)?;
     m.add_function(wrap_pyfunction!(simulate, m)?)?;
     m.add_function(wrap_pyfunction!(simulate_file, m)?)?;
     m.add_class::<ParseResult>()?;
     m.add_class::<LintMessage>()?;
+    m.add_class::<SimulationOptions>()?;
+    m.add_class::<CompileResult>()?;
+    m.add_class::<SimulationResult>()?;
+    m.add_class::<CodegenResult>()?;
     m.add_class::<ProjectSession>()?;
+    m.add_class::<Project>()?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn assert_dae_model_class_type(dae: &Value) {
-        assert_eq!(
-            dae.get("metadata")
-                .and_then(|metadata| metadata.get("class_type"))
-                .and_then(Value::as_str),
-            Some("Model")
-        );
-    }
-
-    #[test]
-    fn test_version() {
-        let v = version();
-        assert!(!v.is_empty());
-    }
-
-    #[test]
-    fn test_parse_valid() {
-        let result = parse("model M Real x; end M;", None);
-        assert!(result.success);
-        assert!(result.error.is_none());
-    }
-
-    #[test]
-    fn test_parse_invalid() {
-        let result = parse("model M Real x end M;", None);
-        assert!(!result.success);
-        assert!(result.error.is_some());
-    }
-
-    #[test]
-    fn test_lint() {
-        let messages = lint("model m Real x; end m;", None);
-        assert!(!messages.is_empty());
-    }
-
-    #[test]
-    fn test_format_valid() {
-        let source = "model M Real x; end M;";
-        let formatted = format_source(source, None).expect("format");
-        assert_eq!(formatted, "model M Real x; end M;\n");
-    }
-
-    #[test]
-    fn test_format_or_original_invalid() {
-        let source = "model M Real x end M;";
-        let out = format_or_original(source, None);
-        assert_eq!(out, source);
-    }
-
-    #[test]
-    fn test_get_builtin_targets_includes_sympy() {
-        let targets = get_builtin_targets().expect("targets");
-        let parsed: Value = serde_json::from_str(&targets).expect("json");
-        assert!(parsed.as_array().is_some_and(|items| {
-            items
-                .iter()
-                .any(|item| item.get("id").and_then(Value::as_str) == Some("sympy"))
-        }));
-    }
-
-    #[test]
-    fn test_compile_inline_source() {
-        let dae_json = compile(
-            "model Ball\n  Real x(start=0);\nequation\n  der(x) = -x;\nend Ball;\n",
-            Some("Ball"),
-            Some("Ball.mo"),
-            None,
-        )
-        .expect("compile inline");
-        let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
-        assert_dae_model_class_type(&dae);
-        assert!(
-            dae.get("x")
-                .and_then(|v| v.as_object())
-                .is_some_and(|state_map| state_map.contains_key("x"))
-        );
-    }
-
-    #[test]
-    fn test_compile_to_json_returns_canonical_payload() {
-        let dae_json = compile_to_json(
-            "model Ball\n  Real x(start=0);\nequation\n  der(x) = -x;\nend Ball;\n",
-            Some("Ball"),
-            Some("Ball.mo"),
-            None,
-        )
-        .expect("compile to json");
-        let dae: Value = serde_json::from_str(&dae_json).expect("valid JSON");
-        assert!(dae.get("x").is_some(), "canonical payload should contain x");
-        assert!(
-            dae.get("f_x").is_some(),
-            "canonical payload should contain f_x"
-        );
-    }
-
-    #[test]
-    fn test_compile_file_reads_source_from_path() {
-        let temp_dir = unique_temp_model_dir("rumoca_bind_python_ball");
-        fs::create_dir(&temp_dir).expect("create temp model dir");
-        let temp_file = temp_dir.join("Ball.mo");
-        fs::write(
-            &temp_file,
-            "model Ball\n  Real x(start=0);\nequation\n  der(x) = -x;\nend Ball;\n",
-        )
-        .expect("write temp model");
-
-        let dae_json = compile_file(temp_file.to_string_lossy().as_ref(), Some("Ball"), None)
-            .expect("compile from file");
-        let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
-        assert_dae_model_class_type(&dae);
-
-        let _ = fs::remove_dir_all(temp_dir);
-    }
-
-    #[test]
-    fn test_compile_file_fixture_loads_source_root_and_infers_model() {
-        let fixture = fixture_path("UsesLib.mo");
-        let source_root = fixture_path("Lib");
-
-        let dae_json = compile_file(
-            fixture.to_string_lossy().as_ref(),
-            None,
-            Some(vec![source_root.to_string_lossy().to_string()]),
-        )
-        .expect("compile from fixture");
-        let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
-        assert_dae_model_class_type(&dae);
-        assert!(
-            dae.get("x")
-                .and_then(|v| v.as_object())
-                .is_some_and(|state_map| state_map.contains_key("x"))
-        );
-    }
-
-    #[test]
-    fn test_project_session_reuses_fixture_source_root_for_simulation() {
-        let fixture = fixture_path("UsesLib.mo");
-        let source_root = fixture_path("Lib");
-        let mut session =
-            ProjectSession::new(Some(vec![source_root.to_string_lossy().to_string()]));
-
-        let dae_json = session
-            .compile_file(fixture.to_string_lossy().as_ref(), None)
-            .expect("compile from project session");
-        let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
-        assert_dae_model_class_type(&dae);
-
-        let statuses = session.source_root_statuses().expect("statuses");
-        let parsed: Value = serde_json::from_str(&statuses).expect("status json");
-        assert!(
-            parsed.as_array().is_some_and(|items| !items.is_empty()),
-            "expected loaded source root status after compile"
-        );
-
-        let sim_json = session
-            .simulate_file(
-                fixture.to_string_lossy().as_ref(),
-                None,
-                0.2,
-                Some(0.1),
-                Some("auto"),
-            )
-            .expect("simulate fixture");
-        let sim: Value = serde_json::from_str(&sim_json).expect("valid sim JSON");
-        assert!(
-            sim.get("metrics")
-                .and_then(|value| value.get("points"))
-                .and_then(Value::as_u64)
-                .is_some_and(|points| points >= 2)
-        );
-    }
-
-    #[test]
-    fn test_render_target_file_uses_native_dae_template() {
-        let fixture = fixture_path("UsesLib.mo");
-        let source_root = fixture_path("Lib");
-        let rendered_json = render_target_file(
-            fixture.to_string_lossy().as_ref(),
-            "dae-modelica",
-            None,
-            Some(vec![source_root.to_string_lossy().to_string()]),
-        )
-        .expect("render target");
-        let rendered_files: Value = serde_json::from_str(&rendered_json).expect("target JSON");
-        let rendered = rendered_files[0]["content"].as_str().expect("content");
-        assert!(rendered.contains("class UsesLib"));
-    }
-
-    #[test]
-    fn test_compile_source_alias_matches_compile() {
-        let dae_json = compile_source(
-            "model Ball\n  Real x(start=0);\nequation\n  der(x) = -x;\nend Ball;\n",
-            Some("Ball"),
-            Some("Ball.mo"),
-            None,
-        )
-        .expect("compile via alias");
-        let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
-        assert_dae_model_class_type(&dae);
-    }
-
-    #[test]
-    fn test_compile_rejects_empty_source() {
-        let err =
-            compile("", Some("Ball"), Some("Ball.mo"), None).expect_err("empty source should fail");
-        assert!(!err.0.is_empty());
-    }
-
-    #[test]
-    fn test_compile_file_rejects_missing_file() {
-        let err =
-            compile_file("missing.mo", Some("Ball"), None).expect_err("missing file should fail");
-        assert!(err.0.contains("Failed to read"));
-    }
-
-    #[test]
-    fn test_load_source_roots_reports_fixture_load() {
-        let source_root = fixture_path("Lib");
-        let mut session =
-            ProjectSession::new(Some(vec![source_root.to_string_lossy().to_string()]));
-        let summary = session.load_source_roots().expect("load roots");
-        let parsed: Value = serde_json::from_str(&summary).expect("summary json");
-        assert!(
-            parsed
-                .get("reports")
-                .and_then(Value::as_array)
-                .is_some_and(|reports| !reports.is_empty())
-        );
-    }
-
-    fn fixture_path(relative: &str) -> std::path::PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("fixtures")
-            .join(relative)
-    }
-
-    fn unique_temp_model_dir(stem: &str) -> std::path::PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{stem}_{nanos}"))
-    }
 }

--- a/crates/rumoca-bind-python/src/python_result.rs
+++ b/crates/rumoca-bind-python/src/python_result.rs
@@ -1,0 +1,273 @@
+use ::rumoca::CompilationResult as HighLevelCompilationResult;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use pyo3::{PyObject, Python, exceptions::PyKeyError};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+use crate::PyRuntimeStringError;
+
+#[pyclass]
+#[derive(Clone)]
+pub(crate) struct CompileResult {
+    #[pyo3(get)]
+    model_name: String,
+    payload: Value,
+}
+
+#[pymethods]
+impl CompileResult {
+    fn __repr__(&self) -> String {
+        format!("CompileResult(model_name='{}')", self.model_name)
+    }
+
+    fn __getitem__(&self, py: Python<'_>, key: &str) -> PyResult<PyObject> {
+        json_object_item(py, &self.payload, key)
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyObject {
+        json_value_to_py(py, &self.payload)
+    }
+
+    #[pyo3(signature = (pretty=true))]
+    fn to_json(&self, pretty: bool) -> Result<String, PyRuntimeStringError> {
+        json_value_to_string(&self.payload, pretty)
+    }
+
+    #[pyo3(signature = (path, pretty=true))]
+    fn save_json(&self, path: &str, pretty: bool) -> Result<(), PyRuntimeStringError> {
+        save_json_value(path, &self.payload, pretty)
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub(crate) struct SimulationResult {
+    #[pyo3(get)]
+    model_name: String,
+    payload: Value,
+}
+
+#[pymethods]
+impl SimulationResult {
+    fn __repr__(&self) -> String {
+        format!("SimulationResult(model_name='{}')", self.model_name)
+    }
+
+    fn __getitem__(&self, py: Python<'_>, key: &str) -> PyResult<PyObject> {
+        json_object_item(py, &self.payload, key)
+    }
+
+    #[getter]
+    fn metrics(&self, py: Python<'_>) -> PyObject {
+        json_nested_object_item(py, &self.payload, "metrics")
+    }
+
+    #[getter]
+    fn data(&self, py: Python<'_>) -> PyObject {
+        json_nested_object_item(py, &self.payload, "payload")
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyObject {
+        json_value_to_py(py, &self.payload)
+    }
+
+    #[pyo3(signature = (pretty=true))]
+    fn to_json(&self, pretty: bool) -> Result<String, PyRuntimeStringError> {
+        json_value_to_string(&self.payload, pretty)
+    }
+
+    #[pyo3(signature = (path, pretty=true))]
+    fn save_json(&self, path: &str, pretty: bool) -> Result<(), PyRuntimeStringError> {
+        save_json_value(path, &self.payload, pretty)
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub(crate) struct CodegenResult {
+    #[pyo3(get)]
+    model_name: String,
+    #[pyo3(get)]
+    target: String,
+    files: Value,
+}
+
+#[pymethods]
+impl CodegenResult {
+    fn __repr__(&self) -> String {
+        let count = self.files.as_array().map_or(0, std::vec::Vec::len);
+        format!(
+            "CodegenResult(model_name='{}', target='{}', files={})",
+            self.model_name, self.target, count
+        )
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyObject {
+        json_value_to_py(py, &self.files)
+    }
+
+    #[getter]
+    fn paths(&self) -> Vec<String> {
+        rendered_file_entries(&self.files)
+            .into_iter()
+            .map(|(path, _)| path)
+            .collect()
+    }
+
+    #[pyo3(signature = (pretty=true))]
+    fn to_json(&self, pretty: bool) -> Result<String, PyRuntimeStringError> {
+        json_value_to_string(&self.files, pretty)
+    }
+
+    #[pyo3(signature = (path, pretty=true))]
+    fn save_json(&self, path: &str, pretty: bool) -> Result<(), PyRuntimeStringError> {
+        save_json_value(path, &self.files, pretty)
+    }
+
+    fn save_all(&self, output_dir: &str) -> Result<Vec<String>, PyRuntimeStringError> {
+        let output_dir = Path::new(output_dir);
+        let mut written = Vec::new();
+        for (relative_path, content) in rendered_file_entries(&self.files) {
+            written.push(write_rendered_file(output_dir, &relative_path, &content)?);
+        }
+        Ok(written)
+    }
+}
+
+pub(crate) fn compile_result_from_compilation(
+    result: HighLevelCompilationResult,
+    model_name: String,
+) -> Result<CompileResult, PyRuntimeStringError> {
+    let payload = serde_json::to_value(result.dae)
+        .map_err(|e| PyRuntimeStringError(format!("JSON error: {e}")))?;
+    Ok(CompileResult {
+        model_name,
+        payload,
+    })
+}
+
+pub(crate) fn simulation_result_from_json(
+    json: &str,
+) -> Result<SimulationResult, PyRuntimeStringError> {
+    let payload: Value =
+        serde_json::from_str(json).map_err(|e| PyRuntimeStringError(format!("JSON error: {e}")))?;
+    let model_name = payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    Ok(SimulationResult {
+        model_name,
+        payload,
+    })
+}
+
+pub(crate) fn codegen_result_from_json(
+    json: &str,
+    model_name: String,
+    target: String,
+) -> Result<CodegenResult, PyRuntimeStringError> {
+    let files: Value =
+        serde_json::from_str(json).map_err(|e| PyRuntimeStringError(format!("JSON error: {e}")))?;
+    Ok(CodegenResult {
+        model_name,
+        target,
+        files,
+    })
+}
+
+fn json_value_to_py(py: Python<'_>, value: &Value) -> PyObject {
+    match value {
+        Value::Null => py.None(),
+        Value::Bool(value) => value.into_py(py),
+        Value::Number(value) => json_number_to_py(py, value),
+        Value::String(value) => value.into_py(py),
+        Value::Array(values) => {
+            let items = values
+                .iter()
+                .map(|value| json_value_to_py(py, value))
+                .collect::<Vec<_>>();
+            PyList::new_bound(py, items).into_py(py)
+        }
+        Value::Object(values) => {
+            let dict = PyDict::new_bound(py);
+            for (key, value) in values {
+                dict.set_item(key, json_value_to_py(py, value))
+                    .expect("serde_json object keys and values convert to Python");
+            }
+            dict.into_py(py)
+        }
+    }
+}
+
+fn json_number_to_py(py: Python<'_>, value: &serde_json::Number) -> PyObject {
+    if let Some(value) = value.as_i64() {
+        return value.into_py(py);
+    }
+    if let Some(value) = value.as_u64() {
+        return value.into_py(py);
+    }
+    if let Some(value) = value.as_f64() {
+        return value.into_py(py);
+    }
+    py.None()
+}
+
+fn json_object_item(py: Python<'_>, value: &Value, key: &str) -> PyResult<PyObject> {
+    match value.get(key) {
+        Some(value) => Ok(json_value_to_py(py, value)),
+        None => Err(PyKeyError::new_err(key.to_string())),
+    }
+}
+
+fn json_nested_object_item(py: Python<'_>, value: &Value, key: &str) -> PyObject {
+    value.get(key).map_or_else(
+        || PyDict::new_bound(py).into_py(py),
+        |value| json_value_to_py(py, value),
+    )
+}
+
+fn json_value_to_string(value: &Value, pretty: bool) -> Result<String, PyRuntimeStringError> {
+    if pretty {
+        serde_json::to_string_pretty(value)
+    } else {
+        serde_json::to_string(value)
+    }
+    .map_err(|e| PyRuntimeStringError(format!("JSON error: {e}")))
+}
+
+fn save_json_value(path: &str, value: &Value, pretty: bool) -> Result<(), PyRuntimeStringError> {
+    let text = json_value_to_string(value, pretty)?;
+    fs::write(path, text).map_err(|e| PyRuntimeStringError(format!("Failed to write {path}: {e}")))
+}
+
+fn rendered_file_entries(files: &Value) -> Vec<(String, String)> {
+    files
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|file| {
+            let path = file.get("path")?.as_str()?;
+            let content = file.get("content")?.as_str()?;
+            Some((path.to_string(), content.to_string()))
+        })
+        .collect()
+}
+
+fn write_rendered_file(
+    output_dir: &Path,
+    relative_path: &str,
+    content: &str,
+) -> Result<String, PyRuntimeStringError> {
+    let path = output_dir.join(relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            PyRuntimeStringError(format!("Failed to create {}: {e}", parent.display()))
+        })?;
+    }
+    fs::write(&path, content)
+        .map_err(|e| PyRuntimeStringError(format!("Failed to write {}: {e}", path.display())))?;
+    Ok(path.to_string_lossy().to_string())
+}

--- a/crates/rumoca-bind-python/src/tests.rs
+++ b/crates/rumoca-bind-python/src/tests.rs
@@ -1,0 +1,319 @@
+use super::*;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn assert_dae_model_class_type(dae: &Value) {
+    assert_eq!(
+        dae.get("metadata")
+            .and_then(|metadata| metadata.get("class_type"))
+            .and_then(Value::as_str),
+        Some("Model")
+    );
+}
+
+#[test]
+fn test_version() {
+    let v = version();
+    assert!(!v.is_empty());
+}
+
+#[test]
+fn test_parse_valid() {
+    let result = parse("model M Real x; end M;", None);
+    assert!(result.success);
+    assert!(result.error.is_none());
+}
+
+#[test]
+fn test_parse_invalid() {
+    let result = parse("model M Real x end M;", None);
+    assert!(!result.success);
+    assert!(result.error.is_some());
+}
+
+#[test]
+fn test_lint() {
+    let messages = lint("model m Real x; end m;", None);
+    assert!(!messages.is_empty());
+}
+
+#[test]
+fn test_format_valid() {
+    let source = "model M Real x; end M;";
+    let formatted = format_source(source, None).expect("format");
+    assert_eq!(formatted, "model M Real x; end M;\n");
+}
+
+#[test]
+fn test_format_or_original_invalid() {
+    let source = "model M Real x end M;";
+    let out = format_or_original(source, None);
+    assert_eq!(out, source);
+}
+
+#[test]
+fn test_get_builtin_targets_includes_sympy() {
+    let targets = get_builtin_targets().expect("targets");
+    let parsed: Value = serde_json::from_str(&targets).expect("json");
+    assert!(parsed.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|item| item.get("id").and_then(Value::as_str) == Some("sympy"))
+    }));
+}
+
+#[test]
+fn test_compile_inline_source() {
+    let dae_json = compile(
+        "model Ball\n  Real x(start=0);\nequation\n  der(x) = -x;\nend Ball;\n",
+        Some("Ball"),
+        Some("Ball.mo"),
+        None,
+    )
+    .expect("compile inline");
+    let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
+    assert_dae_model_class_type(&dae);
+    assert!(
+        dae.get("x")
+            .and_then(|v| v.as_object())
+            .is_some_and(|state_map| state_map.contains_key("x"))
+    );
+}
+
+#[test]
+fn test_compile_to_json_returns_canonical_payload() {
+    let dae_json = compile_to_json(
+        "model Ball\n  Real x(start=0);\nequation\n  der(x) = -x;\nend Ball;\n",
+        Some("Ball"),
+        Some("Ball.mo"),
+        None,
+    )
+    .expect("compile to json");
+    let dae: Value = serde_json::from_str(&dae_json).expect("valid JSON");
+    assert!(dae.get("x").is_some(), "canonical payload should contain x");
+    assert!(
+        dae.get("f_x").is_some(),
+        "canonical payload should contain f_x"
+    );
+}
+
+#[test]
+fn test_compile_file_reads_source_from_path() {
+    let temp_dir = unique_temp_model_dir("rumoca_bind_python_ball");
+    fs::create_dir(&temp_dir).expect("create temp model dir");
+    let temp_file = temp_dir.join("Ball.mo");
+    fs::write(
+        &temp_file,
+        "model Ball\n  Real x(start=0);\nequation\n  der(x) = -x;\nend Ball;\n",
+    )
+    .expect("write temp model");
+
+    let dae_json = compile_file(temp_file.to_string_lossy().as_ref(), Some("Ball"), None)
+        .expect("compile from file");
+    let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
+    assert_dae_model_class_type(&dae);
+
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+#[test]
+fn test_compile_file_fixture_loads_source_root_and_infers_model() {
+    let fixture = fixture_path("UsesLib.mo");
+    let source_root = fixture_path("Lib");
+
+    let dae_json = compile_file(
+        fixture.to_string_lossy().as_ref(),
+        None,
+        Some(vec![source_root.to_string_lossy().to_string()]),
+    )
+    .expect("compile from fixture");
+    let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
+    assert_dae_model_class_type(&dae);
+    assert!(
+        dae.get("x")
+            .and_then(|v| v.as_object())
+            .is_some_and(|state_map| state_map.contains_key("x"))
+    );
+}
+
+#[test]
+fn test_project_session_reuses_fixture_source_root_for_simulation() {
+    let fixture = fixture_path("UsesLib.mo");
+    let source_root = fixture_path("Lib");
+    let mut session = ProjectSession::new(Some(vec![source_root.to_string_lossy().to_string()]));
+
+    let dae_json = session
+        .compile_file(fixture.to_string_lossy().as_ref(), None)
+        .expect("compile from project session");
+    let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
+    assert_dae_model_class_type(&dae);
+
+    let statuses = session.source_root_statuses().expect("statuses");
+    let parsed: Value = serde_json::from_str(&statuses).expect("status json");
+    assert!(
+        parsed.as_array().is_some_and(|items| !items.is_empty()),
+        "expected loaded source root status after compile"
+    );
+
+    let sim_json = simulate_file_in_session(
+        &mut session.session,
+        fixture.to_string_lossy().as_ref(),
+        None,
+        &session.effective_source_root_paths,
+        SimRequest {
+            t_start: 0.0,
+            t_end: 0.2,
+            dt: Some(0.1),
+            solver: Some("auto".to_string()),
+            rtol: None,
+            atol: None,
+            max_wall_seconds: None,
+        },
+    )
+    .expect("simulate fixture");
+    let sim: Value = serde_json::from_str(&sim_json).expect("valid sim JSON");
+    assert!(
+        sim.get("metrics")
+            .and_then(|value| value.get("points"))
+            .and_then(Value::as_u64)
+            .is_some_and(|points| points >= 2)
+    );
+}
+
+#[test]
+fn test_render_target_file_uses_native_dae_template() {
+    let fixture = fixture_path("UsesLib.mo");
+    let source_root = fixture_path("Lib");
+    let rendered_json = render_target_file(
+        fixture.to_string_lossy().as_ref(),
+        "dae-modelica",
+        None,
+        Some(vec![source_root.to_string_lossy().to_string()]),
+    )
+    .expect("render target");
+    let rendered_files: Value = serde_json::from_str(&rendered_json).expect("target JSON");
+    let rendered = rendered_files[0]["content"].as_str().expect("content");
+    assert!(rendered.contains("class UsesLib"));
+}
+
+#[test]
+fn test_compile_source_alias_matches_compile() {
+    let dae_json = compile_source(
+        "model Ball\n  Real x(start=0);\nequation\n  der(x) = -x;\nend Ball;\n",
+        Some("Ball"),
+        Some("Ball.mo"),
+        None,
+    )
+    .expect("compile via alias");
+    let dae: Value = serde_json::from_str(&dae_json).expect("valid DAE JSON");
+    assert_dae_model_class_type(&dae);
+}
+
+#[test]
+fn test_compile_rejects_empty_source() {
+    let err =
+        compile("", Some("Ball"), Some("Ball.mo"), None).expect_err("empty source should fail");
+    assert!(!err.0.is_empty());
+}
+
+#[test]
+fn test_compile_file_rejects_missing_file() {
+    let err = compile_file("missing.mo", Some("Ball"), None).expect_err("missing file should fail");
+    assert!(err.0.contains("Failed to read"));
+}
+
+#[test]
+fn test_load_source_roots_reports_fixture_load() {
+    let source_root = fixture_path("Lib");
+    let mut session = ProjectSession::new(Some(vec![source_root.to_string_lossy().to_string()]));
+    let summary = session.load_source_roots().expect("load roots");
+    let parsed: Value = serde_json::from_str(&summary).expect("summary json");
+    assert!(
+        parsed
+            .get("reports")
+            .and_then(Value::as_array)
+            .is_some_and(|reports| !reports.is_empty())
+    );
+}
+
+#[test]
+fn test_workspace_source_roots_reads_project_config() {
+    let temp_dir = unique_temp_model_dir("rumoca_bind_python_workspace_config");
+    fs::create_dir(&temp_dir).expect("create temp dir");
+    let lib_dir = temp_dir.join("Lib");
+    fs::create_dir(&lib_dir).expect("create lib dir");
+    fs::write(
+        temp_dir.join("rumoca-workspace.toml"),
+        "source_roots = [\"Lib\"]\n",
+    )
+    .expect("write workspace config");
+
+    let focus = temp_dir.join("M.mo");
+    let roots = workspace_source_roots(
+        temp_dir.to_string_lossy().as_ref(),
+        Some(focus.to_string_lossy().as_ref()),
+    )
+    .expect("workspace roots");
+    let parsed: Value = serde_json::from_str(&roots).expect("valid roots JSON");
+    assert!(parsed.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|item| item.as_str().is_some_and(|path| path.ends_with("Lib")))
+    }));
+
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+#[test]
+fn test_scenario_simulation_config_applies_toml_settings() {
+    let temp_dir = unique_temp_model_dir("rumoca_bind_python_scenario_config");
+    fs::create_dir(&temp_dir).expect("create temp dir");
+    fs::write(
+        temp_dir.join("rumoca-scenario.ball.toml"),
+        r#"
+[rumoca]
+version = "1"
+task = "simulate"
+
+[model]
+name = "Ball"
+
+[sim]
+solver = "rk-like"
+t_end = 2.5
+dt = 0.25
+"#,
+    )
+    .expect("write scenario config");
+
+    let config = scenario_simulation_config(
+        temp_dir.to_string_lossy().as_ref(),
+        "Ball",
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("scenario config");
+    let parsed: Value = serde_json::from_str(&config).expect("valid config JSON");
+    assert_eq!(parsed["effective"]["solver"], "rk-like");
+    assert_eq!(parsed["effective"]["t_end"], 2.5);
+    assert_eq!(parsed["effective"]["dt"], 0.25);
+
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+fn fixture_path(relative: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(relative)
+}
+
+fn unique_temp_model_dir(stem: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{stem}_{nanos}"))
+}

--- a/crates/rumoca-bind-python/tests/smoke_test.py
+++ b/crates/rumoca-bind-python/tests/smoke_test.py
@@ -46,9 +46,28 @@ def main() -> None:
     statuses = json.loads(session.source_root_statuses())
     assert statuses
 
-    sim = json.loads(session.simulate_file(str(MODEL_FILE), t_end=0.2, dt=0.1, solver="auto"))
+    sim_options = rumoca.SimulationOptions(t_end=0.2, dt=0.1, solver="auto")
+    sim = json.loads(session.simulate_file(str(MODEL_FILE), options=sim_options))
     assert sim["model"] == "UsesLib"
     assert sim["metrics"]["points"] >= 2
+
+    project = rumoca.Project.open(
+        str(FIXTURE_ROOT),
+        model_name="UsesLib",
+        model_file=str(MODEL_FILE),
+        source_roots=[str(SOURCE_ROOT)],
+    )
+    project_compile = project.compile_file()
+    assert project_compile.model_name == "UsesLib"
+    assert_raw_dae_model(project_compile.to_dict())
+
+    project_sim = project.simulate_file(options=sim_options)
+    assert project_sim.model_name == "UsesLib"
+    assert project_sim.metrics["points"] >= 2
+
+    project_codegen = project.codegen_file(target="dae-modelica")
+    assert project_codegen.paths
+    assert "class UsesLib" in project_codegen.to_dict()[0]["content"]
 
 
 if __name__ == "__main__":

--- a/crates/rumoca-compile/src/scenario_config/json.rs
+++ b/crates/rumoca-compile/src/scenario_config/json.rs
@@ -315,6 +315,12 @@ struct VisualizationViewPayload {
     x: Option<String>,
     #[serde(default)]
     y: Vec<String>,
+    #[serde(
+        default,
+        rename = "scatterSeries",
+        skip_serializing_if = "Option::is_none"
+    )]
+    _scatter_series: Option<Vec<Value>>,
     script: Option<String>,
     script_path: Option<String>,
 }
@@ -327,6 +333,7 @@ impl From<PlotViewConfig> for VisualizationViewPayload {
             view_type: view.view_type,
             x: view.x,
             y: view.y,
+            _scatter_series: None,
             script: view.script,
             script_path: view.script_path,
         }

--- a/crates/rumoca-compile/src/scenario_config/tests.rs
+++ b/crates/rumoca-compile/src/scenario_config/tests.rs
@@ -226,6 +226,27 @@ mode = "auto"
 }
 
 #[test]
+fn parse_views_payload_accepts_scatter_series_from_editor() {
+    let payload = serde_json::json!([
+        {
+            "id": "scatter_main",
+            "title": "Phase",
+            "type": "scatter",
+            "x": "time",
+            "y": ["x"],
+            "scatterSeries": [
+                { "name": "x vs time", "x": "time", "y": "x" }
+            ]
+        }
+    ]);
+
+    let views = parse_views_payload(&payload).expect("scatter view payload parses");
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].id, "scatter_main");
+    assert_eq!(views[0].view_type, "scatter");
+}
+
+#[test]
 fn input_enabled_scenario_defaults_to_results_panel_viewer() {
     let descriptor = scenario_config_response(
         r#"

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1164,7 +1164,7 @@ interface ScenarioConfigFullResponse {
 }
 
 function scenarioNeedsInputRunner(scenario: ScenarioConfigResponse): boolean {
-    return scenario.inputEnabled === true;
+    return scenario.viewerMode === 'external_web';
 }
 
 const DEFAULT_CODEGEN_TARGET_ID = 'sympy';

--- a/packages/vscode/tests/simulation_command_resync.test.mjs
+++ b/packages/vscode/tests/simulation_command_resync.test.mjs
@@ -75,6 +75,26 @@ test("simulate command publishes failures to Problems diagnostics", () => {
   );
 });
 
+test("input-enabled results-panel scenarios stay on batch results path", () => {
+  const source = readExtensionSource();
+  const predicateBlock = sliceFrom(
+    source,
+    "function scenarioNeedsInputRunner(",
+    "const DEFAULT_CODEGEN_TARGET_ID",
+  );
+
+  assert.equal(
+    predicateBlock.includes("scenario.viewerMode === 'external_web'"),
+    true,
+    "external viewer routing should be selected by viewerMode",
+  );
+  assert.equal(
+    predicateBlock.includes("inputEnabled"),
+    false,
+    "input routing alone should not bypass the results-panel simulation path",
+  );
+});
+
 test("interactive viewer launch waits for runner ready output", () => {
   const source = readExtensionSource();
   const startInteractiveScenarioBlock = sliceFrom(


### PR DESCRIPTION
## Summary
- add a typed `Project` API, result wrapper classes, and `.pyi` autocomplete coverage for the Python binding
- keep existing string-returning `ProjectSession`/module functions compatible while adding project-aware source-root and simulation options
- fix review issues by accepting editor `scatterSeries` visualization payloads and routing input-enabled `results_panel` scenarios through the batch results path

## Validation
- `cargo fmt --check`
- `cargo check -p rumoca-bind-python`
- `cargo test -p rumoca-bind-python`
- `cargo test -p rumoca-compile scenario_config --lib`
- `node --test packages/vscode/tests/simulation_command_resync.test.mjs`
- `python3 -m py_compile crates/rumoca-bind-python/rumoca.pyi crates/rumoca-bind-python/tests/smoke_test.py`
- `git diff --check`
- `maturin build --release --out dist`
- install built wheel in `target/python-smoke-venv` and run `crates/rumoca-bind-python/tests/smoke_test.py`