### PR TITLE
fix: matrix column-slice shape inference + multi-viewer WebSocket server

### DIFF
--- a/crates/rumoca-contracts/tests/arr_contracts.rs
+++ b/crates/rumoca-contracts/tests/arr_contracts.rs
@@ -636,6 +636,31 @@ fn arr_037_cross_of_2_vectors_rejected() {
     );
 }
 
+// Regression: a column slice `m[:, i]` of a `[3, n]` matrix is a 3-vector, so
+// `cross` must accept it. The shape walk previously dropped dimension 0 on the
+// scalar subscript (yielding `[n]`) instead of dimension 1, spuriously firing
+// ET009 for `n != 3`.
+#[test]
+fn arr_037_cross_of_matrix_column_slice_accepted() {
+    expect_success(
+        r#"
+        model Test
+            parameter Integer n = 4;
+            Real m[3, n] = zeros(3, n);
+            Real omega[3] = {0, 0, 1};
+            Real v[3, n];
+            Real x(start = 0, fixed = true);
+        equation
+            for i in 1:n loop
+                v[:, i] = cross(omega, m[:, i]);
+            end for;
+            der(x) = v[1, 1];
+        end Test;
+    "#,
+        "Test",
+    );
+}
+
 // =============================================================================
 // ARR-038: transpose needs at least two dimensions (MLS §10.3.2)
 // =============================================================================

--- a/crates/rumoca-eval-ast/src/eval/dimension_inference.rs
+++ b/crates/rumoca-eval-ast/src/eval/dimension_inference.rs
@@ -120,13 +120,19 @@ fn apply_component_subscripts_to_dims(
     ctx: &TypeCheckEvalContext,
     scope: &str,
 ) -> Vec<usize> {
+    // `pos` tracks the dimension the next subscript applies to. Scalar
+    // indexing removes that dimension (so the cursor stays put, now pointing
+    // at the following dimension); slice/colon indexing keeps it and advances
+    // the cursor. This positional walk is what lets `a[:, i]` on `[3, 4]`
+    // drop dimension 1 and yield `[3]` rather than removing dimension 0.
+    let mut pos = 0usize;
     for part in &cr.parts {
         let Some(subs) = &part.subs else { continue };
         for sub in subs {
-            if dims.is_empty() {
-                return Vec::new();
+            if pos >= dims.len() {
+                return dims;
             }
-            apply_subscript_to_dims(sub, &mut dims, ctx, scope);
+            apply_subscript_to_dims(sub, &mut dims, &mut pos, ctx, scope);
         }
     }
     dims
@@ -135,21 +141,23 @@ fn apply_component_subscripts_to_dims(
 fn apply_subscript_to_dims(
     sub: &Subscript,
     dims: &mut Vec<usize>,
+    pos: &mut usize,
     ctx: &TypeCheckEvalContext,
     scope: &str,
 ) {
     match sub {
         Subscript::Expression(expr) if matches!(expr, Expression::Range { .. }) => {
-            if let Some(first_dim) = dims.first_mut() {
-                *first_dim = infer_range_length(expr, ctx, scope).unwrap_or(*first_dim);
-            }
+            dims[*pos] = infer_range_length(expr, ctx, scope).unwrap_or(dims[*pos]);
+            *pos += 1;
         }
-        // Scalar indexing consumes one dimension.
+        // Scalar indexing consumes the dimension at the cursor.
         Subscript::Expression(_) => {
-            dims.remove(0);
+            dims.remove(*pos);
         }
         // `:` keeps the current dimension unchanged.
-        Subscript::Range { .. } | Subscript::Empty => {}
+        Subscript::Range { .. } | Subscript::Empty => {
+            *pos += 1;
+        }
     }
 }
 

--- a/crates/rumoca-transport-websocket/src/lib.rs
+++ b/crates/rumoca-transport-websocket/src/lib.rs
@@ -8,7 +8,7 @@
 use std::io::{ErrorKind, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, mpsc};
+use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread;
 use std::time::Duration;
 
@@ -23,9 +23,22 @@ pub struct WsConfig {
 
 type WsStream = WebSocket<TcpStream>;
 
-/// Run a broadcast WS server on `port`. Consumes `state_rx` — forwards each
-/// message to the currently-connected client (keeping only the latest if the
-/// loop produces faster than the browser consumes).
+/// Latest simulation frame, shared across every connected viewer. `generation`
+/// bumps on each new frame so a client only resends when there's something new;
+/// `closed` is set when the sim's state channel ends.
+#[derive(Default)]
+struct Latest {
+    generation: u64,
+    frame: Option<String>,
+    closed: bool,
+}
+
+/// Shared latest-frame slot plus a condvar clients block on for new frames.
+type SharedLatest = Arc<(Mutex<Latest>, Condvar)>;
+
+/// Run a broadcast WS server on `port`. Consumes `state_rx` and fans the latest
+/// message out to *all* connected viewers, keeping only the latest if the loop
+/// produces faster than the browsers consume.
 ///
 /// Accepts client→server JSON commands:
 /// - `{"realtime": true|false}` — flips the shared `realtime` flag
@@ -53,15 +66,47 @@ pub fn run_broadcast_server(
     if let Some(tx) = ready_tx {
         let _ = tx.send(Ok(()));
     }
+    // Fan the single-consumer state channel out to a shared latest-frame slot,
+    // so every connected viewer can read it (not just the first one).
+    let shared: SharedLatest = Arc::new((Mutex::new(Latest::default()), Condvar::new()));
+    {
+        let shared = Arc::clone(&shared);
+        thread::spawn(move || {
+            for json in state_rx.iter() {
+                let (lock, cvar) = &*shared;
+                let mut latest = lock.lock().unwrap();
+                latest.generation = latest.generation.wrapping_add(1);
+                latest.frame = Some(json);
+                cvar.notify_all();
+            }
+            // Sender dropped (sim ended): wake clients so they can exit.
+            let (lock, cvar) = &*shared;
+            lock.lock().unwrap().closed = true;
+            cvar.notify_all();
+        });
+    }
+
+    // One thread per connection. The handshake and per-client streaming run off
+    // the accept path, so a slow, half-open, or stale viewer can neither block
+    // the accept loop nor starve any other viewer.
     for stream in listener.incoming().flatten() {
-        if let Some(ws) = accept_ws(stream) {
-            log_status("viewer connected");
-            serve_client(ws, &state_rx, control_tx.as_ref(), &realtime, &quit);
-            log_status("viewer disconnected");
-        }
         if quit.load(Ordering::Relaxed) {
             return;
         }
+        let shared = Arc::clone(&shared);
+        let control_tx = control_tx.clone();
+        let realtime = Arc::clone(&realtime);
+        let quit = Arc::clone(&quit);
+        thread::spawn(move || {
+            // Bound the handshake: a connection that never upgrades (port scan,
+            // browser probe, half-open socket) is dropped instead of hanging.
+            stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+            if let Some(ws) = accept_ws(stream) {
+                log_status("viewer connected");
+                serve_client(ws, &shared, control_tx.as_ref(), &realtime, &quit);
+                log_status("viewer disconnected");
+            }
+        });
     }
 }
 
@@ -86,11 +131,12 @@ fn accept_ws(stream: TcpStream) -> Option<WsStream> {
 
 fn serve_client(
     mut ws: WsStream,
-    state_rx: &mpsc::Receiver<String>,
+    shared: &SharedLatest,
     control_tx: Option<&mpsc::Sender<String>>,
     realtime: &Arc<AtomicBool>,
     quit: &Arc<AtomicBool>,
 ) {
+    let mut last_sent = 0u64;
     loop {
         if !drain_inbound(&mut ws, control_tx, realtime, quit) {
             return;
@@ -98,10 +144,52 @@ fn serve_client(
         if quit.load(Ordering::Relaxed) {
             return;
         }
-        if !push_latest(&mut ws, state_rx) {
-            return;
+        match next_frame(shared, &mut last_sent) {
+            FrameWait::Closed => return,
+            FrameWait::None => {}
+            FrameWait::New(json) => {
+                if ws.send(Message::Text(json.into())).is_err() {
+                    return;
+                }
+            }
         }
-        thread::sleep(Duration::from_millis(16)); // ~60 fps
+    }
+}
+
+enum FrameWait {
+    /// A frame newer than the client's last is ready to send.
+    New(String),
+    /// No new frame within this tick; loop to re-check inbound/quit.
+    None,
+    /// The sim's state channel closed; the client should stop.
+    Closed,
+}
+
+/// Block up to ~16 ms (≈60 fps) for a frame newer than `last_sent`, advancing
+/// `last_sent` when one is found. Holds only the shared lock, never the socket.
+fn next_frame(shared: &SharedLatest, last_sent: &mut u64) -> FrameWait {
+    let (lock, cvar) = &**shared;
+    let mut latest = lock.lock().unwrap();
+    while latest.generation == *last_sent && !latest.closed {
+        let (guard, timeout) = cvar
+            .wait_timeout(latest, Duration::from_millis(16))
+            .unwrap();
+        latest = guard;
+        if timeout.timed_out() {
+            break;
+        }
+    }
+    if latest.generation != *last_sent {
+        *last_sent = latest.generation;
+        // Cloned so every other connected viewer still sees this frame.
+        match latest.frame.clone() {
+            Some(json) => FrameWait::New(json),
+            None => FrameWait::None,
+        }
+    } else if latest.closed {
+        FrameWait::Closed
+    } else {
+        FrameWait::None
     }
 }
 
@@ -153,19 +241,6 @@ fn apply_command(
     if cmd.get("quit").and_then(|v| v.as_bool()) == Some(true) && !forwarded_to_runner {
         quit.store(true, Ordering::Relaxed);
         log_status("quit requested by viewer");
-    }
-}
-
-/// Drain the state channel and push only the latest JSON. Returns `false` if
-/// the send failed.
-fn push_latest(ws: &mut WsStream, state_rx: &mpsc::Receiver<String>) -> bool {
-    let mut latest: Option<String> = None;
-    while let Ok(json) = state_rx.try_recv() {
-        latest = Some(json);
-    }
-    match latest {
-        Some(json) => ws.send(Message::Text(json.into())).is_ok(),
-        None => true,
     }
 }
 


### PR DESCRIPTION
Two independent fixes surfaced while building an interactive quadrotor SIL example.

## fix(eval): matrix column-slice shape inference

Subscript shape inference applied every index to dimension 0: a scalar index did `dims.remove(0)`, a range edited `dims.first_mut()`, and `:` was a no-op. For `m[:, i]` on `[3, n]` this dropped the leading `3` and yielded `[n]`, so `cross()`/`skew()` on a column slice spuriously failed **ET009** when `n != 3` (e.g. a top-level `QuadrotorSIL` plant with `leg_r_b[3, 4]`).

Thread a positional cursor through the subscripts: slice/colon keeps the dimension and advances the cursor; scalar removes the dimension at the cursor (which stays put as the next dim shifts in). `m[:, i]` on `[3, n]` now correctly yields `[3]`. Adds **ARR-037** regression covering `cross()` of a matrix column slice.

## fix(transport-websocket): fan latest frame to all viewers

The broadcast server consumed the single-consumer state channel directly in the accept loop and served one client at a time. A second viewer couldn't connect while the first was streaming, and a slow or half-open client blocked the accept loop entirely — viewers froze or "never worked".

Fan the state channel into a shared latest-frame slot (`Mutex` + `Condvar`, generation-stamped) and spawn one thread per connection. Each viewer reads the latest frame independently and only resends when the generation bumps; a 5s handshake read timeout drops connections that never upgrade so they can't starve the accept loop.

## Testing
- Affected crates build clean; clippy clean.
- `ARR-037` regression added and passing.
- WebSocket fix validated with 3 stale non-handshaking sockets + 2 real viewers concurrently: both real viewers receive a steady ~60 fps stream, none starved.
