### PR TITLE
feat(embedded-c): discrete/sampled model export + input-alias orientation fix

### DIFF
--- a/crates/rumoca-phase-codegen/src/templates/embedded-c/model.c.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/embedded-c/model.c.jinja
@@ -1,45 +1,282 @@
-{#- Embedded C implementation over prepared Solve IR. -#}
+{#- Embedded C implementation over prepared Solve IR.
+
+    Handles continuous ODE models (forward-Euler integration of the derivative
+    RHS) and discrete/sampled models (`when`/`sample`/`pre`). The discrete and
+    event machinery mirrors the FMI 2.0 backend, evaluated over the same Solve
+    IR, but is exposed through a minimal init()/step() API over the flat y[]/p[]
+    vectors.
+-#}
 {%- if ir_kind != "solve" -%}
 {{ fail("embedded-c target requires Solve IR") }}
 {%- endif -%}
 {%- set model_name = model_name | default("model") | sanitize -%}
-{%- set rows = solve_blocks.continuous.derivative_rhs.scalar_programs.programs -%}
-{%- set cfg = {"time": "m->time", "y": "m->y[{}]", "p": "m->p[{}]"} -%}
+{%- set MODEL = model_name | upper -%}
+{%- set dae = dae if dae is defined else {} -%}
+
+{#- Symbol policy so render_expr() can emit start expressions that reference
+    constants/parameters by their (sanitized) names as local C aliases. -#}
+{%- set c_symbol_policy = {
+    "separator": "_",
+    "generated_prefixes": ["pre_", "der_"],
+    "reserved": [
+        "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else",
+        "enum", "extern", "float", "for", "goto", "if", "int", "long", "register", "return",
+        "short", "signed", "sizeof", "static", "struct", "switch", "typedef", "union",
+        "unsigned", "void", "volatile", "while", "inline", "restrict",
+        "m", "t", "time", "i", "n", "real_t", "pre", "der"
+    ]
+} -%}
+{%- set symbols = target_symbols(dae.symbol_refs | default([]), c_symbol_policy, dae.symbol_aliases | default([])) -%}
+{%- set cfg = {"prefix": "", "power": "pow", "and_op": "&&", "or_op": "||", "not_op": "!", "true_val": "1", "false_val": "0", "if_style": "ternary", "array_start": "(real_t[]){", "array_end": "}", "subscript_underscore": true, "sum_fn": "__rumoca_sum_d", "symbols": symbols} -%}
+
+{#- Solve IR row renderers operate directly on the flat y[]/p[] vectors. -#}
+{%- set row_cfg = {"time": "m->time", "y": "m->y[{}]", "p": "m->p[{}]"} -%}
+{%- set assign_cfg = {"y_set": "m->y[{}] = {}", "p_set": "m->p[{}] = {}"} -%}
+
+{%- set derivative_rows = solve_blocks.continuous.derivative_rhs.scalar_programs.programs
+    if solve_blocks is defined and solve_blocks.continuous is defined
+       and solve_blocks.continuous.derivative_rhs is defined
+       and solve_blocks.continuous.derivative_rhs.scalar_programs is defined
+       and solve_blocks.continuous.derivative_rhs.scalar_programs.programs is defined else [] -%}
+{%- set discrete_rows = solve.discrete.rhs.programs
+    if solve is defined and solve.discrete is defined and solve.discrete.rhs is defined
+       and solve.discrete.rhs.programs is defined else [] -%}
+{%- set discrete_targets = solve.discrete.update_targets
+    if solve is defined and solve.discrete is defined
+       and solve.discrete.update_targets is defined else [] -%}
+{%- set runtime_rows = solve.discrete.runtime_assignment_rhs.programs
+    if solve is defined and solve.discrete is defined
+       and solve.discrete.runtime_assignment_rhs is defined
+       and solve.discrete.runtime_assignment_rhs.programs is defined else [] -%}
+{%- set runtime_targets = solve.discrete.runtime_assignment_targets
+    if solve is defined and solve.discrete is defined
+       and solve.discrete.runtime_assignment_targets is defined else [] -%}
+{%- set pre_bindings = solve.solve_layout.pre_param_bindings
+    if solve is defined and solve.solve_layout is defined
+       and solve.solve_layout.pre_param_bindings is defined else [] -%}
+{%- set initial_event_index = solve.solve_layout.initial_event_parameter_index
+    if solve is defined and solve.solve_layout is defined else none -%}
+{%- set bindings = solve.layout.bindings -%}
+{#- Flat p[] slots of the auto-generated `when`-clause condition variables
+    (origin == "generated" discrete-valued vars). Their pre() memory is reset to
+    the inactive state on every tick so each step() is treated as a fresh sample
+    /event edge — the embedded "one step == one control tick" contract. -#}
+{%- set ns_cond = namespace(slots=[]) -%}
+{%- for name, var in dae.m | default({}) | items -%}
+{%- if var.origin == "generated" -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) -%}
+{%- set slot = bindings[source_ref(name, var.dims, i + 1)] -%}
+{%- if slot and slot.P is defined -%}{%- set ns_cond.slots = ns_cond.slots + [slot.P.index] -%}{%- endif -%}
+{%- endfor -%}
+{%- else -%}
+{%- set slot = bindings[name] -%}
+{%- if slot and slot.P is defined -%}{%- set ns_cond.slots = ns_cond.slots + [slot.P.index] -%}{%- endif -%}
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
 #include "{{ model_name }}.h"
 
 #include <math.h>
 #include <string.h>
+
+{# Vector-sum builtin used by some scalarized array reductions. #}
+static real_t __rumoca_sum_d(const real_t *v, int n) {
+    real_t s = 0.0;
+    for (int i = 0; i < n; i++) {
+        s += v[i];
+    }
+    return s;
+}
+
+{#- Macro: declare local C aliases (initialised to 0) for a variable map. -#}
+{%- macro decl_locals(vars) -%}
+{%- for name, var in vars | items -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) %}
+    real_t {{ symbol(symbols, source_ref(name, var.dims, i + 1)) }} = 0.0; (void){{ symbol(symbols, source_ref(name, var.dims, i + 1)) }};
+{%- endfor -%}
+{%- else %}
+    real_t {{ symbol(symbols, name) }} = 0.0; (void){{ symbol(symbols, name) }};
+{%- endif -%}
+{%- endfor -%}
+{%- endmacro -%}
+
+{#- Macro: evaluate start expressions into the local aliases. -#}
+{%- macro eval_starts(vars) -%}
+{%- for name, var in vars | items -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) -%}
+{%- if var.start and is_string_literal(var.start) != "yes" %}
+    {{ symbol(symbols, source_ref(name, var.dims, i + 1)) }} = {{ render_expr_at_index(var.start, i + 1, cfg) }};
+{%- endif -%}
+{%- endfor -%}
+{%- else -%}
+{%- if var.start and is_string_literal(var.start) != "yes" %}
+    {{ symbol(symbols, name) }} = {{ render_expr(var.start, cfg) }};
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endmacro -%}
+
+{#- Macro: store the local aliases into their flat Solve IR slot. -#}
+{%- macro store_slots(vars) -%}
+{%- for name, var in vars | items -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) -%}
+{%- set key = source_ref(name, var.dims, i + 1) -%}
+{%- set slot = bindings[key] -%}
+{%- if slot and (slot.Y is defined or slot.P is defined) %}
+    {{ render_solve_slot_assign_c(slot, symbol(symbols, key), assign_cfg) }}
+{%- endif -%}
+{%- endfor -%}
+{%- else -%}
+{%- set slot = bindings[name] -%}
+{%- if slot and (slot.Y is defined or slot.P is defined) %}
+    {{ render_solve_slot_assign_c(slot, symbol(symbols, name), assign_cfg) }}
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endmacro -%}
+
+{# Snapshot pre() parameters: copy current values into their __pre__ slots. #}
+static void {{ model_name }}_snapshot_pre({{ model_name }}_t *m) {
+{%- if pre_bindings | length > 0 %}
+{%- for binding in pre_bindings %}
+{%- if binding.source.P is defined and binding.source.P.index in ns_cond.slots %}
+    m->p[{{ binding.dest_p_index }}] = 0.0;  /* when-condition pre reset */
+{%- else %}
+    {{ render_solve_pre_param_binding_c(binding, row_cfg, assign_cfg) }}
+{%- endif %}
+{%- endfor %}
+{%- else %}
+    (void)m;
+{%- endif %}
+}
+
+{# Evaluate one pass of the runtime-assignment + discrete (when) update rows
+   into their targets. Returns nonzero if any slot changed this pass. #}
+static int {{ model_name }}_event_pass({{ model_name }}_t *m) {
+{%- if (discrete_rows | length > 0) or (runtime_rows | length > 0) %}
+    real_t __p_prev[{{ MODEL }}_P_LEN > 0 ? {{ MODEL }}_P_LEN : 1];
+    memcpy(__p_prev, m->p, sizeof(m->p));
+{%- if (solve.layout.y_scalars | default(0)) > 0 %}
+    real_t __y_prev[{{ MODEL }}_Y_LEN > 0 ? {{ MODEL }}_Y_LEN : 1];
+    memcpy(__y_prev, m->y, sizeof(m->y));
+{%- endif %}
+{%- if runtime_rows | length > 0 %}
+    real_t __rt[{{ runtime_rows | length }}];
+{%- for row in runtime_rows %}
+    __rt[{{ loop.index0 }}] = {{ render_solve_row_c(row, row_cfg) }};
+{%- endfor %}
+{%- for target in runtime_targets %}
+    {{ render_solve_slot_assign_c(target, "__rt[" ~ loop.index0 ~ "]", assign_cfg) }}
+{%- endfor %}
+{%- endif %}
+{%- if discrete_rows | length > 0 %}
+    real_t __dv[{{ discrete_rows | length }}];
+{%- for row in discrete_rows %}
+    __dv[{{ loop.index0 }}] = {{ render_solve_row_c(row, row_cfg) }};
+{%- endfor %}
+{%- for target in discrete_targets %}
+    {{ render_solve_slot_assign_c(target, "__dv[" ~ loop.index0 ~ "]", assign_cfg) }}
+{%- endfor %}
+{%- endif %}
+    if (memcmp(__p_prev, m->p, sizeof(m->p)) != 0) {
+        return 1;
+    }
+{%- if (solve.layout.y_scalars | default(0)) > 0 %}
+    if (memcmp(__y_prev, m->y, sizeof(m->y)) != 0) {
+        return 1;
+    }
+{%- endif %}
+    return 0;
+{%- else %}
+    (void)m;
+    return 0;
+{%- endif %}
+}
+
+{# Iterate the runtime/discrete update rows to a fixed point. The rows self-gate
+   on the sample/event condition derived from m->time; iterating resolves the
+   intra-tick dependency between condition rows and the equations that read
+   them (mirrors the reference event iteration). #}
+static void {{ model_name }}_discrete_updates({{ model_name }}_t *m) {
+    for (int __it = 0; __it < 100; __it++) {
+        if (!{{ model_name }}_event_pass(m)) {
+            break;
+        }
+    }
+}
 
 void {{ model_name }}_init({{ model_name }}_t *m) {
     if (!m) {
         return;
     }
     memset(m, 0, sizeof(*m));
+
+    /* Evaluate start expressions into local aliases (constants first, then
+       parameters/discretes/inputs/states which may reference them), then store
+       each into its flat Solve IR slot. */
+{{ decl_locals(dae.constants | default({})) }}
+{{ decl_locals(dae.p | default({})) }}
+{{ decl_locals(dae.z | default({})) }}
+{{ decl_locals(dae.m | default({})) }}
+{{ decl_locals(dae.u | default({})) }}
+{{ decl_locals(dae.x | default({})) }}
+{{ eval_starts(dae.constants | default({})) }}
+{{ eval_starts(dae.p | default({})) }}
+{{ eval_starts(dae.z | default({})) }}
+{{ eval_starts(dae.m | default({})) }}
+{{ eval_starts(dae.u | default({})) }}
+{{ eval_starts(dae.x | default({})) }}
+{{ store_slots(dae.p | default({})) }}
+{{ store_slots(dae.z | default({})) }}
+{{ store_slots(dae.m | default({})) }}
+{{ store_slots(dae.u | default({})) }}
+{{ store_slots(dae.x | default({})) }}
+{%- if initial_event_index is not none and discrete_rows | length > 0 %}
+
+    /* Run the initialization (`initial()`) event. */
+    m->p[{{ initial_event_index }}] = 1.0;
+    {{ model_name }}_snapshot_pre(m);
+    {{ model_name }}_discrete_updates(m);
+    m->p[{{ initial_event_index }}] = 0.0;
+{%- endif %}
 }
 
 void {{ model_name }}_derivative_rhs(const {{ model_name }}_t *m, real_t *out) {
     if (!m || !out) {
         return;
     }
-{%- set solve_body = render_solve_block_c(rows, cfg, "out[{}] = {}") %}
-{%- if solve_body %}
-{{ solve_body }}
+{%- for row in derivative_rows %}
+    out[{{ loop.index0 }}] = {{ render_solve_row_c(row, row_cfg) }};
 {%- else %}
     (void)m;
     (void)out;
-{%- endif %}
+{%- endfor %}
 }
 
 void {{ model_name }}_step({{ model_name }}_t *m, real_t dt) {
     if (!m) {
         return;
     }
-    real_t dx[{{ rows | length if rows | length > 0 else 1 }}] = {0};
+{%- if derivative_rows | length > 0 %}
+    /* Continuous states: explicit forward-Euler over [t, t+dt]. */
+    real_t dx[{{ derivative_rows | length }}] = {0};
     {{ model_name }}_derivative_rhs(m, dx);
-{%- for _row in rows %}
-    if ({{ loop.index0 }} < {{ model_name | upper }}_STATE_LEN) {
+{%- for _row in derivative_rows %}
+    if ({{ loop.index0 }} < {{ MODEL }}_STATE_LEN) {
         m->y[{{ loop.index0 }}] += dt * dx[{{ loop.index0 }}];
     }
 {%- endfor %}
+{%- endif %}
+
     m->time += dt;
+
+{%- if discrete_rows | length > 0 %}
+    /* Discrete/sample tick at the new time. */
+    {{ model_name }}_snapshot_pre(m);
+    {{ model_name }}_discrete_updates(m);
+{%- endif %}
 }

--- a/crates/rumoca-phase-codegen/src/templates/embedded-c/model.h.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/embedded-c/model.h.jinja
@@ -1,11 +1,23 @@
-{#- Embedded C header over prepared Solve IR. -#}
+{#- Embedded C header over prepared Solve IR.
+
+    Supports both continuous (forward-Euler ODE) and discrete/sampled
+    (`when`/`sample`/`pre`) models. State and parameter vectors are the flat
+    Solve IR layout:
+      y[] = [continuous states | algebraics | outputs]
+      p[] = [parameters | inputs | discrete reals | discrete valued]
+    Index macros below name the user-visible slots so callers do not hard-code
+    positions (e.g. `m.p[{{ model_name | upper }}_P_u] = 1.0;`).
+-#}
 {%- if ir_kind != "solve" -%}
 {{ fail("embedded-c target requires Solve IR") }}
 {%- endif -%}
 {%- set model_name = model_name | default("model") | sanitize -%}
+{%- set dae = dae if dae is defined else {} -%}
 {%- set y_len = solve.layout.y_scalars -%}
 {%- set p_len = solve.layout.p_scalars -%}
 {%- set derivative_len = solve_blocks.continuous.derivative_rhs.output_count -%}
+{%- set bindings = solve.layout.bindings -%}
+{%- set MODEL = model_name | upper -%}
 #pragma once
 
 #include <stddef.h>
@@ -13,11 +25,43 @@
 typedef double real_t;
 
 enum {
-    {{ model_name | upper }}_Y_LEN = {{ y_len }},
-    {{ model_name | upper }}_P_LEN = {{ p_len }},
-    {{ model_name | upper }}_STATE_LEN = {{ solve.solve_layout.state_scalar_count }},
-    {{ model_name | upper }}_DERIVATIVE_LEN = {{ derivative_len }}
+    {{ MODEL }}_Y_LEN = {{ y_len }},
+    {{ MODEL }}_P_LEN = {{ p_len }},
+    {{ MODEL }}_STATE_LEN = {{ solve.solve_layout.state_scalar_count }},
+    {{ MODEL }}_DERIVATIVE_LEN = {{ derivative_len }}
 };
+
+{#- Emit slot-index macros for user-visible scalars. `vars` come from the DAE
+    IR; their flat slot is resolved through the Solve layout bindings. -#}
+{%- macro index_macros(vars, kind) -%}
+{%- for name, var in vars | items -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) -%}
+{%- set key = source_ref(name, var.dims, i + 1) -%}
+{%- set slot = bindings[key] -%}
+{%- if slot and slot.Y is defined %}
+#define {{ MODEL }}_Y_{{ key | sanitize }} {{ slot.Y.index }}  /* {{ kind }} {{ key }} */
+{%- elif slot and slot.P is defined %}
+#define {{ MODEL }}_P_{{ key | sanitize }} {{ slot.P.index }}  /* {{ kind }} {{ key }} */
+{%- endif -%}
+{%- endfor -%}
+{%- else -%}
+{%- set slot = bindings[name] -%}
+{%- if slot and slot.Y is defined %}
+#define {{ MODEL }}_Y_{{ name | sanitize }} {{ slot.Y.index }}  /* {{ kind }} {{ name }} */
+{%- elif slot and slot.P is defined %}
+#define {{ MODEL }}_P_{{ name | sanitize }} {{ slot.P.index }}  /* {{ kind }} {{ name }} */
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endmacro -%}
+/* ---- Variable slot indices (name -> flat array position) ---- */
+{{ index_macros(dae.u | default({}), "input") }}
+{{ index_macros(dae.x | default({}), "state") }}
+{{ index_macros(dae.z | default({}), "discrete") }}
+{{ index_macros(dae.m | default({}), "discrete") }}
+{{ index_macros(dae.y | default({}), "algebraic") }}
+{{ index_macros(dae.w | default({}), "output") }}
 
 typedef struct {
     real_t time;
@@ -25,6 +69,13 @@ typedef struct {
     real_t p[{{ p_len if p_len > 0 else 1 }}];
 } {{ model_name }}_t;
 
+/* Initialise to start values and run the initialization (`initial()`) event. */
 void {{ model_name }}_init({{ model_name }}_t *m);
+
+/* Continuous derivative RHS: writes dy/dt for the state block into out[]. */
 void {{ model_name }}_derivative_rhs(const {{ model_name }}_t *m, real_t *out);
+
+/* Advance one step of size dt: forward-Euler for continuous states, then one
+   discrete/sample tick (snapshot pre(), evaluate when-equations). Call once per
+   control period for a fixed-rate discrete controller. */
 void {{ model_name }}_step({{ model_name }}_t *m, real_t dt);

--- a/crates/rumoca-phase-codegen/src/templates/embedded-c/target.toml
+++ b/crates/rumoca-phase-codegen/src/templates/embedded-c/target.toml
@@ -9,8 +9,8 @@ Compile: cc -O2 -Wall -c {{ out_dir }}/{{ model_name }}.c"""
 
 [capabilities]
 scalar_fallback = true
-events = false
-runtime_events = false
+events = true
+runtime_events = true
 forward_ad = false
 reverse_ad = false
 dynamic_control_flow = false

--- a/crates/rumoca-phase-solve/src/lower/array_values.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values.rs
@@ -237,6 +237,22 @@ fn expr_span_from_subscripts(subscripts: &[rumoca_core::Subscript]) -> rumoca_co
         .unwrap_or(rumoca_core::Span::DUMMY)
 }
 
+/// True when every subscript selects a single element (no `:` and no range),
+/// i.e. the access reduces to one scalar array element. Such selections — even
+/// with a runtime (non-constant) index like `wp[current_wp, 1]` — must use the
+/// scalar VarRef path (which lowers runtime indices to indexed loads), not the
+/// compile-time slice enumeration which would try to fold the index.
+fn subscripts_select_single_element(subscripts: &[rumoca_core::Subscript]) -> bool {
+    !subscripts.is_empty()
+        && subscripts.iter().all(|subscript| match subscript {
+            rumoca_core::Subscript::Colon { .. } => false,
+            rumoca_core::Subscript::Expr { expr, .. } => {
+                !matches!(&**expr, rumoca_core::Expression::Range { .. })
+            }
+            _ => true,
+        })
+}
+
 fn collect_indexed_record_field_keys(
     base_key: &str,
     field: &str,
@@ -1332,6 +1348,21 @@ impl<'a> LowerBuilder<'a> {
         match self.local_shadowed_subscript_values(name, subscripts, scope, call_depth)? {
             LocalSubscriptResolution::Values(values) => return Ok(values),
             LocalSubscriptResolution::NotLocal => {}
+        }
+        // A single-element selection (no `:`/range) yields one scalar element.
+        // Route it through the scalar VarRef path, which supports runtime
+        // (non-constant) subscripts via indexed loads. The compile-time slice
+        // enumeration below only handles constant indices/ranges, so sending a
+        // runtime index like `wp[current_wp, 1]` (e.g. as a function argument)
+        // through it would fail trying to fold the index.
+        if subscripts_select_single_element(subscripts) {
+            return Ok(vec![self.lower_var_ref(
+                name,
+                subscripts,
+                expr_span_from_subscripts(subscripts),
+                scope,
+                call_depth,
+            )?]);
         }
         if let Some(values) = self.lower_indexed_reference_slice_values(
             name,

--- a/crates/rumoca-phase-solve/src/lower/array_values/inference.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/inference.rs
@@ -717,6 +717,15 @@ impl<'a> LowerBuilder<'a> {
             rumoca_core::Expression::VarRef {
                 name, subscripts, ..
             } => {
+                // MLS §3.7.5/§8.6: `pre(x)` lowers to the synthetic `__pre__.x`
+                // parameter that *holds the previous-event value* of a discrete
+                // (or state) variable. Folding it would pin a runtime array
+                // subscript such as `wp[pre(k), 1]` to its start index, so a
+                // `__pre__.` reference must take the runtime dynamic-selection
+                // path instead of compile-time subscript folding.
+                if name.as_str().starts_with("__pre__.") {
+                    return false;
+                }
                 if subscripts.is_empty() && const_scope.contains_key(name.as_str()) {
                     return true;
                 }

--- a/crates/rumoca-phase-solve/src/lower/discrete_updates.rs
+++ b/crates/rumoca-phase-solve/src/lower/discrete_updates.rs
@@ -55,6 +55,7 @@ pub(crate) fn normalized_discrete_update_equations(
         )?;
     }
     normalized_equations.extend(oriented_discrete_alias_equations(
+        dae_model,
         &alias_edges,
         &protected_lhs_names,
     )?);
@@ -433,6 +434,7 @@ fn discrete_alias_edges(
 }
 
 fn oriented_discrete_alias_equations(
+    dae_model: &dae::Dae,
     edges: &[DiscreteAliasEdge],
     protected_lhs_names: &IndexSet<rumoca_core::VarName>,
 ) -> Result<Vec<dae::Equation>, LowerError> {
@@ -468,7 +470,7 @@ fn oriented_discrete_alias_equations(
             continue;
         }
         let component = collect_alias_component(&root_candidate, &adjacency);
-        let roots = alias_component_roots(&component, protected_lhs_names);
+        let roots = alias_component_roots(dae_model, &component, protected_lhs_names);
         for root in &roots {
             visited.insert(root.clone());
         }
@@ -552,16 +554,22 @@ fn collect_alias_component(
 }
 
 fn alias_component_roots(
+    dae_model: &dae::Dae,
     component: &[rumoca_core::VarName],
     protected_lhs_names: &IndexSet<rumoca_core::VarName>,
 ) -> Vec<rumoca_core::VarName> {
-    let protected = component
+    // Inputs are read-only sources: force them to be roots so alias edges always
+    // orient *away* from them (`state := input`), never toward them. Protected
+    // names (non-alias update targets) are likewise forced roots.
+    let forced = component
         .iter()
-        .filter(|name| protected_lhs_names.contains(*name))
+        .filter(|name| {
+            protected_lhs_names.contains(*name) || is_discrete_input_name(dae_model, name)
+        })
         .cloned()
         .collect::<Vec<_>>();
-    if !protected.is_empty() {
-        return protected;
+    if !forced.is_empty() {
+        return forced;
     }
     component.first().cloned().into_iter().collect::<Vec<_>>()
 }
@@ -714,6 +722,20 @@ fn should_reorient_discrete_alias(
 ) -> Result<bool, LowerError> {
     let lhs_names = discrete_update_lhs_names(dae_model, lhs, scalar_count)?;
     let target_names = discrete_update_lhs_names(dae_model, alias_target, scalar_count)?;
+
+    // Inputs are read-only: never reorient an alias so an input becomes the write
+    // target, and always reorient away from one if the current target is an input.
+    let lhs_is_input = lhs_names.iter().any(|n| is_discrete_input_name(dae_model, n));
+    let target_is_input = target_names
+        .iter()
+        .any(|n| is_discrete_input_name(dae_model, n));
+    if target_is_input {
+        return Ok(false);
+    }
+    if lhs_is_input {
+        return Ok(true);
+    }
+
     let lhs_protected = any_name_in_set(&lhs_names, protected_lhs_names);
     let target_protected = any_name_in_set(&target_names, protected_lhs_names);
     if lhs_protected != target_protected {
@@ -1087,6 +1109,20 @@ fn is_discrete_update_name(dae_model: &dae::Dae, name: &rumoca_core::VarName) ->
             dae_model.variables.discrete_reals.contains_key(&base)
                 || dae_model.variables.discrete_valued.contains_key(&base)
                 || dae_model.variables.inputs.contains_key(&base)
+        })
+}
+
+/// An input variable is known externally each tick and is read-only inside the
+/// model: it can be an alias *endpoint* (the read side of `state := input`) but
+/// must never be selected as an update target. Orienting an alias edge so an
+/// input is written would clobber the caller's per-tick input every step.
+fn is_discrete_input_name(dae_model: &dae::Dae, name: &rumoca_core::VarName) -> bool {
+    dae_model.variables.inputs.contains_key(name)
+        || dae::component_base_name(name.as_str()).is_some_and(|base| {
+            dae_model
+                .variables
+                .inputs
+                .contains_key(&rumoca_core::VarName::new(base))
         })
 }
 

--- a/crates/rumoca-phase-solve/src/lower/tests/event_intrinsics.rs
+++ b/crates/rumoca-phase-solve/src/lower/tests/event_intrinsics.rs
@@ -1,6 +1,55 @@
 use super::*;
 
 #[test]
+fn discrete_history_update_from_input_keeps_state_as_target() {
+    // A sampled controller's end-of-step history update `prev_x := x`, where `x`
+    // is an external input, must orient with the discrete state as the write
+    // target. Reorienting it to `x := prev_x` would make the read-only input an
+    // assignment target and clobber the caller's per-tick input every step,
+    // leaving the controller blind to its live pose. Regression for the
+    // discrete-alias orientation that ignored input causality.
+    let mut dae_model = dae::Dae::default();
+    dae_model
+        .variables
+        .inputs
+        .insert(rumoca_core::VarName::new("x"), scalar_var("x"));
+    dae_model
+        .variables
+        .discrete_reals
+        .insert(rumoca_core::VarName::new("prev_x"), scalar_var("prev_x"));
+    dae_model.discrete.real_updates.push(dae::Equation {
+        lhs: Some(rumoca_core::VarName::new("prev_x").into()),
+        rhs: rumoca_core::Expression::VarRef {
+            name: rumoca_core::VarName::new("x").into(),
+            subscripts: vec![],
+            span: rumoca_core::Span::DUMMY,
+        },
+        span: Default::default(),
+        origin: "prev_x := x history update".to_string(),
+        scalar_count: 1,
+    });
+
+    let equations = crate::lower::normalized_discrete_update_equations(&dae_model)
+        .expect("history update should lower");
+
+    assert_eq!(equations.len(), 1, "expected a single oriented update");
+    let eq = &equations[0];
+    assert_eq!(
+        eq.lhs.as_ref().map(|lhs| lhs.var_name().as_str()),
+        Some("prev_x"),
+        "discrete state (not the input) must be the update target"
+    );
+    let rumoca_core::Expression::VarRef { name, .. } = &eq.rhs else {
+        panic!("history update RHS should read the input directly: {:?}", eq.rhs);
+    };
+    assert_eq!(
+        name.var_name().as_str(),
+        "x",
+        "history update must read the live input on the RHS"
+    );
+}
+
+#[test]
 fn lower_discrete_rhs_keeps_edge_initial_as_runtime_event_flag() {
     let mut dae_model = dae::Dae::default();
     dae_model


### PR DESCRIPTION
## Summary

Restores discrete/sampled-model code generation to the **embedded-c** target and
fixes a discrete-alias orientation bug that made externally-driven sampled
controllers ignore their live inputs.

## Embedded-C discrete/sampled export (`3e4e274f`)

The embedded-c target had regressed to continuous-only. Over the same Solve IR the
FMI backend uses, it now emits a plain `init()`/`step()` C API for
`when`/`sample`/`pre` models:

- parameter-start initialization plus the `initial()` event,
- `pre()` snapshotting, with when-clause condition memory reset each tick so one
  `step()` is one control tick,
- fixed-point iteration of the discrete update rows, alongside the existing
  forward-Euler continuous path.

Capability flags `events`/`runtime_events` are enabled and the header emits
name→slot index macros for the flat `y[]`/`p[]` vectors. Two phase-solve lowering
paths are generalized so a runtime array index survives into the contexts a
discrete controller uses (`__pre__.x` no longer folded as a compile-time
subscript; single-element selection routes to the scalar VarRef path).

## Fix: never orient a discrete alias to write an input (`b8ab6ef1`)

A discrete history update `prev_x := x` whose RHS is an external **input** was
lowered with target/RHS swapped, emitting `x := prev_x` — writing the read-only
input slot inside the discrete event pass. The fixed-point event loop then
clobbered the caller's per-tick input with stale `pre` data, so every
externally-driven sampled controller (e.g. a fixed-wing SIL outer loop) went
blind to its live inputs.

`prev_x := x` is an explicit-LHS algorithm assignment, but inputs are valid
discrete-alias endpoints (they may be read on an alias RHS), so it became a
`DiscreteAliasEdge` and the orientation graph picked the first-seen node as the
component root — orienting the edge toward the input.

The invariant **inputs are never alias write targets** is now enforced: inputs
are forced to be alias component roots (orienting edges away from them) and an
alias is never reoriented onto an input. Adds `is_discrete_input_name` and a
regression test.

## Verification

- Generated C for the affected update flips from `x := prev_x` back to
  `prev_x := x`; no input slot is written inside `event_pass`.
- New regression test `discrete_history_update_from_input_keeps_state_as_target`
  fails without the fix, passes with it.
- Full `rumoca-phase-solve` (371) and `rumoca-phase-codegen` (133) suites pass;
  clippy clean.
