### PR TITLE
build(python): abi3 wheels + expand the wheel platform matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1048,21 +1048,50 @@ jobs:
     # Built on PRs and on the release tag only (see Build WASM note).
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ${{ matrix.os }}
+    # The natively-built/tested wheels (x86_64 glibc, macOS x2, Windows) gate the
+    # PR; the cross-compiled aarch64 and musllinux targets are best-effort
+    # (non-blocking) until CI proves them green, then flip them to required.
+    continue-on-error: ${{ !matrix.native }}
     strategy:
+      # One target's build failure (e.g. a cross target) must not cancel the
+      # others — abi3 + the mainstream wheels still publish.
+      fail-fast: false
       matrix:
         include:
+          # Linux glibc (manylinux) — abi3, one wheel per arch for Python >= 3.10.
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-            name: linux-x86_64
+            manylinux: auto
+            name: linux-x86_64-gnu
+            native: true
+          - os: ubuntu-24.04
+            target: aarch64-unknown-linux-gnu
+            manylinux: auto
+            name: linux-aarch64-gnu
+            native: false
+          # Linux musl (musllinux) — Alpine / musl Docker base images.
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            manylinux: musllinux_1_2
+            name: linux-x86_64-musl
+            native: false
+          - os: ubuntu-24.04
+            target: aarch64-unknown-linux-musl
+            manylinux: musllinux_1_2
+            name: linux-aarch64-musl
+            native: false
           - os: macos-15-intel
             target: x86_64-apple-darwin
             name: macos-x86_64
+            native: true
           - os: macos-15
             target: aarch64-apple-darwin
             name: macos-aarch64
+            native: true
           - os: windows-2025
             target: x86_64-pc-windows-msvc
             name: windows-x64
+            native: true
     steps:
       - uses: actions/checkout@v5
         with:
@@ -1073,43 +1102,32 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libudev-dev
-
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-        shell: bash
-
-      - name: Add target
-        if: matrix.target != 'x86_64-pc-windows-msvc'
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Install maturin
-        run: pip install maturin
-
+      # maturin-action builds Linux wheels inside manylinux/musllinux containers
+      # (and cross-compiles aarch64), so it handles the platform tags and the
+      # cross toolchain. abi3 is picked up from the crate's pyo3 feature, giving
+      # one wheel per platform for all CPython >= 3.10.
       - name: Build wheels
-        shell: bash
-        run: |
-          cd crates/rumoca-bind-python
-          rm -rf dist
-          mkdir -p dist
-          if [ "${{ matrix.target }}" = "x86_64-pc-windows-msvc" ]; then
-            maturin build --release --out dist
-          else
-            maturin build --release --out dist --target ${{ matrix.target }}
-          fi
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          args: --release --out dist --manifest-path crates/rumoca-bind-python/Cargo.toml
+          # libudev (pulled in via the `rumoca` crate) inside the Linux build
+          # containers: systemd-devel on manylinux (yum), eudev-dev on musllinux
+          # (apk). No-op on macOS/Windows runners.
+          before-script-linux: |
+            if command -v yum >/dev/null 2>&1; then yum install -y systemd-devel; fi
+            if command -v apk >/dev/null 2>&1; then apk add --no-cache eudev-dev; fi
 
+      # The wheel is only installable/runnable on a host matching its arch+libc,
+      # so smoke-test just the native rows; cross/musl rows build-and-upload.
       - name: Smoke test installed wheel
+        if: matrix.native
         shell: bash
         run: |
           # Install with the `notebook` extra so the %%modelica magic smoke test
           # exercises the real IPython integration (not the import-only fallback).
-          WHEEL=$(ls crates/rumoca-bind-python/dist/*.whl | head -1)
+          WHEEL=$(ls dist/*.whl | head -1)
           python -m pip install --force-reinstall "${WHEEL}[notebook]"
           python crates/rumoca-bind-python/tests/smoke_test.py
           python crates/rumoca-bind-python/tests/magic_test.py
@@ -1118,7 +1136,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: wheels-${{ matrix.name }}
-          path: crates/rumoca-bind-python/dist
+          path: dist
 
   build-python-sdist:
     name: Build Python sdist

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 /target
 /crates/rumoca/target/rumoca-library-cache
 __pycache__/
-tests/notebooks/python/.venv/
+# Python virtual environments — any name, any location (.venv, venv, .venv-*).
+.venv/
+.venv-*/
+venv/
 tests/notebooks/python/poetry.lock
-examples/.venv/
 res
 .vscode/ros_path
 build/

--- a/crates/rumoca-bind-python/Cargo.toml
+++ b/crates/rumoca-bind-python/Cargo.toml
@@ -21,7 +21,11 @@ rumoca-sim = { workspace = true, features = ["solver-diffsol"] }
 rumoca-compile = { workspace = true }
 rumoca-tool-fmt = { workspace = true }
 rumoca-tool-lint = { workspace = true }
-pyo3 = { version = "0.22", features = ["extension-module"] }
+# `abi3-py310` builds against CPython's stable ABI: one wheel per platform works
+# on every CPython >= 3.10 (and future releases), instead of one wheel per
+# Python minor version. Cuts the wheel matrix and avoids source builds when a
+# user is on a Python version we didn't pre-build.
+pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 serde_json = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary

Two distribution fixes so users download a prebuilt wheel instead of compiling the Rust stack from source (the cause of slow `pip install` on platforms we don't pre-build).

**abi3** — build against CPython's stable ABI (pyo3 `abi3-py310`). One wheel per platform now works on every CPython ≥ 3.10 (and future releases), instead of one per Python minor version. A user on a Python version we didn't pre-build no longer falls back to a source build. Verified locally: `maturin` emits `rumoca-<v>-cp310-abi3-*.whl`.

**Wheel matrix** — replace the hand-rolled four-target build with `PyO3/maturin-action` and add the platforms that currently compile from source:
- Linux glibc (manylinux) **x86_64 + aarch64**
- Linux musl (musllinux_1_2) **x86_64 + aarch64** (Alpine / musl Docker images)
- macOS x86_64 + arm64, Windows x64 (unchanged)

maturin-action builds Linux wheels in manylinux/musllinux containers and cross-compiles aarch64; `libudev` (via the `rumoca` crate) is installed inside the containers (`systemd-devel` on manylinux, `eudev-dev` on musllinux). The natively build-and-run targets (x86_64 glibc, macOS, Windows) smoke-test the wheel and **gate** the PR; the cross/musl targets build-and-upload and are **non-blocking** (`continue-on-error`) until CI proves them green, then we flip them to required.

## Out of scope
Android/termux uses bionic libc, so **none** of these Linux wheels load there — it needs a separate NDK build, tracked as a future stretch item.

## Testing
- abi3 build verified locally (correct `cp310-abi3` wheel tag).
- The expanded cross/musl targets are exercised by CI (can't be cross-built/verified locally); they're non-blocking until green.
