### PR TITLE
feat(sim): discrete/sampled model support — embedded-C export, pure-discrete stepper, multirate & Zenoh SITL transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +55,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -118,6 +140,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +171,45 @@ name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -219,10 +295,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 dependencies = [
  "serde",
 ]
@@ -238,6 +329,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "blake3"
@@ -260,6 +354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -346,6 +449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-expr"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +475,18 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "chunked_transfer"
@@ -450,6 +571,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +597,33 @@ checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
  "cfg-if",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -470,6 +637,22 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_affinity"
@@ -779,8 +962,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -798,12 +991,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.114",
 ]
@@ -840,12 +1057,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -874,7 +1117,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -921,6 +1164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -967,6 +1211,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dyn-stack"
@@ -1097,6 +1347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "faer"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1407,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.2",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1458,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1480,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1228,6 +1519,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1249,6 +1541,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1454,8 +1757,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1467,9 +1772,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1513,8 +1829,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 2.13.0",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1628,9 +1964,19 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1638,7 +1984,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
 ]
 
@@ -1647,6 +1993,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1661,12 +2012,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1690,6 +2056,36 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1801,6 +2197,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1873,6 +2280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +2299,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1915,6 +2340,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,6 +2404,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jwalk"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,6 +2423,39 @@ dependencies = [
  "crossbeam",
  "rayon",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "keyed-set"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d255a6b6ecd77bb93ce91de984d7039bff7503f500eb4851a1269732f22baf"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lalry"
@@ -1955,6 +2468,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -2062,6 +2578,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2594,15 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -2183,9 +2714,15 @@ version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ea9ac0a51fb5112607099560fdf0f90366ab088a2a9e6e8ae176794e9806aa"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2335,6 +2872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2902,31 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nonempty-collections"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e216d0e8cf9d54fa66e5780f6e1d5dc96d1c1b3c25aeba3b6758548bcbbd8b9d"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2422,6 +2993,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +3031,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2508,6 +3106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +3127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +3143,12 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2636,6 +3255,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,8 +3330,51 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2729,10 +3410,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "pnet_base"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_datalink"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
+dependencies = [
+ "ipnetwork",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2946,6 +3680,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "fastbloom",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,11 +3752,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2975,8 +3774,18 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2994,6 +3803,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -3062,6 +3874,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,6 +3920,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3166,6 +4012,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ringbuffer-spsc"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3e7aa0a681b232e7cd7f856a53b10603df88ca74b79a8d8088845185492e35"
+dependencies = [
+ "array-init",
+ "crossbeam",
+]
+
+[[package]]
+name = "ron"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
+dependencies = [
+ "bitflags 2.10.0",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "typeid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rumoca"
 version = "0.9.9"
 dependencies = [
@@ -3175,7 +4065,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "flate2",
- "indexmap",
+ "indexmap 2.13.0",
  "miette",
  "mimalloc",
  "minijinja",
@@ -3208,7 +4098,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "tungstenite",
+ "tungstenite 0.26.2",
  "ureq",
  "walkdir",
  "zip",
@@ -3237,7 +4127,7 @@ dependencies = [
  "bincode",
  "console_error_panic_hook",
  "getrandom 0.3.4",
- "indexmap",
+ "indexmap 2.13.0",
  "js-sys",
  "lsp-types",
  "rumoca-compile",
@@ -3294,7 +4184,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "blake3",
- "indexmap",
+ "indexmap 2.13.0",
  "miette",
  "rayon",
  "rumoca-core",
@@ -3320,7 +4210,7 @@ dependencies = [
 name = "rumoca-contracts"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-compile",
  "rumoca-phase-dae",
  "rumoca-sim",
@@ -3334,7 +4224,7 @@ dependencies = [
 name = "rumoca-core"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "miette",
  "serde",
 ]
@@ -3343,7 +4233,7 @@ dependencies = [
 name = "rumoca-eval-ast"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rumoca-ir-ast",
  "rustc-hash",
@@ -3354,7 +4244,7 @@ name = "rumoca-eval-dae"
 version = "0.9.9"
 dependencies = [
  "blake3",
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rumoca-ir-dae",
  "rustc-hash",
@@ -3365,7 +4255,7 @@ dependencies = [
 name = "rumoca-eval-flat"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rumoca-ir-flat",
  "rustc-hash",
@@ -3377,7 +4267,7 @@ dependencies = [
 name = "rumoca-eval-solve"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rumoca-eval-dae",
  "rumoca-ir-dae",
@@ -3404,7 +4294,7 @@ dependencies = [
 name = "rumoca-exec-mlir"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "libloading",
  "rumoca-core",
  "rumoca-eval-solve",
@@ -3432,7 +4322,7 @@ name = "rumoca-input"
 version = "0.9.9"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-signal-frame",
  "serde",
  "serde_json",
@@ -3461,7 +4351,7 @@ dependencies = [
 name = "rumoca-ir-ast"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rustc-hash",
  "serde",
@@ -3472,7 +4362,7 @@ name = "rumoca-ir-dae"
 version = "0.9.9"
 dependencies = [
  "bincode",
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "serde",
  "serde_json",
@@ -3482,7 +4372,7 @@ dependencies = [
 name = "rumoca-ir-flat"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rumoca-ir-ast",
  "rustc-hash",
@@ -3494,7 +4384,7 @@ name = "rumoca-ir-solve"
 version = "0.9.9"
 dependencies = [
  "bincode",
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "serde",
  "serde_json",
@@ -3504,7 +4394,7 @@ dependencies = [
 name = "rumoca-phase-codegen"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "miette",
  "minijinja",
  "rumoca-core",
@@ -3521,7 +4411,7 @@ dependencies = [
 name = "rumoca-phase-dae"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "miette",
  "rumoca-core",
  "rumoca-eval-dae",
@@ -3537,7 +4427,7 @@ dependencies = [
 name = "rumoca-phase-flatten"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "miette",
  "rumoca-core",
  "rumoca-eval-ast",
@@ -3553,7 +4443,7 @@ dependencies = [
 name = "rumoca-phase-instantiate"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "miette",
  "rumoca-core",
  "rumoca-eval-ast",
@@ -3568,7 +4458,7 @@ name = "rumoca-phase-parse"
 version = "0.9.9"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "miette",
  "parol",
  "parol_runtime",
@@ -3582,7 +4472,7 @@ name = "rumoca-phase-resolve"
 version = "0.9.9"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "miette",
  "rumoca-core",
  "rumoca-ir-ast",
@@ -3595,7 +4485,7 @@ dependencies = [
 name = "rumoca-phase-solve"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rumoca-eval-dae",
  "rumoca-eval-solve",
@@ -3609,7 +4499,7 @@ dependencies = [
 name = "rumoca-phase-structural"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rumoca-ir-dae",
  "thiserror 2.0.17",
@@ -3634,7 +4524,7 @@ dependencies = [
 name = "rumoca-signal-frame"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -3642,7 +4532,7 @@ name = "rumoca-sim"
 version = "0.9.9"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "libc",
  "rumoca-codec",
  "rumoca-compile",
@@ -3661,6 +4551,7 @@ dependencies = [
  "rumoca-solver-rk45",
  "rumoca-transport-udp",
  "rumoca-transport-websocket",
+ "rumoca-transport-zenoh",
  "serde",
  "serde_json",
  "signal-hook",
@@ -3689,7 +4580,7 @@ name = "rumoca-solver-diffsol"
 version = "0.9.9"
 dependencies = [
  "diffsol",
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rumoca-eval-solve",
  "rumoca-ir-solve",
@@ -3702,7 +4593,7 @@ dependencies = [
 name = "rumoca-solver-rk45"
 version = "0.9.9"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "rumoca-core",
  "rumoca-eval-solve",
  "rumoca-ir-solve",
@@ -3719,7 +4610,7 @@ dependencies = [
  "clap",
  "dirs",
  "flate2",
- "indexmap",
+ "indexmap 2.13.0",
  "mimalloc",
  "ntest",
  "rayon",
@@ -3805,7 +4696,17 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "tungstenite",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "rumoca-transport-zenoh"
+version = "0.9.9"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "zenoh",
 ]
 
 [[package]]
@@ -3833,6 +4734,24 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustix"
@@ -3876,13 +4795,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3902,6 +4870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3917,6 +4891,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "either",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3963,6 +4984,39 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -4018,12 +5072,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -4052,6 +5117,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4074,12 +5184,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -4120,6 +5255,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "sigpipe"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4148,6 +5293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,6 +5312,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -4168,6 +5329,21 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spindle"
@@ -4183,10 +5359,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "stabby"
+version = "72.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b834ec7ced12095fea1e4b07dcb7e8cf2b59b18afa3eac52494d835965a5ec"
+dependencies = [
+ "rustversion",
+ "stabby-abi",
+]
+
+[[package]]
+name = "stabby-abi"
+version = "72.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1a4f477858a5bdf927c9fab7f579899de9b13e39f8b3b3b300c89fbab632f4"
+dependencies = [
+ "rustc_version",
+ "rustversion",
+ "sha2-const-stable",
+ "stabby-macros",
+]
+
+[[package]]
+name = "stabby-macros"
+version = "72.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b31c4b2434980b67ad83f300a58088ba14d59454dcd79ba3d87419bbd924d31e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -4426,10 +5652,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4437,6 +5665,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny_http"
@@ -4461,6 +5699,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls-listener"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1461056cc1ef47003f7ee16e4cef3741068d4c7f6b627bfce49b7c00c120a530"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "token-cell"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb48920ae769b58126c8c93269805011c793201f95fde28b479b81a9a531bbde"
+dependencies = [
+ "paste",
+ "portable-atomic",
+ "rustversion",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4472,7 +5749,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4489,6 +5766,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,6 +5796,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -4537,7 +5837,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -4551,7 +5851,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -4638,6 +5938,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4676,6 +5977,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4685,12 +5996,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4717,6 +6031,24 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -4733,6 +6065,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4743,6 +6091,20 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uhlc"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62a645e3e4e6c85b7abe49b086aa3204119431f42b6123b0070419fb6e9d24e"
+dependencies = [
+ "humantime",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "spin 0.10.0",
+]
 
 [[package]]
 name = "ume"
@@ -4775,16 +6137,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unzip-n"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5bb2756c16fb66f80cfbf5fb0e0c09a7001e739f453c9ec241b9c8b1556fda"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "ureq"
@@ -4839,8 +6224,33 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validated_struct"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869a93e8a7286e339e1128630051d82babbcd75d585975af07b9f3327220e60e"
+dependencies = [
+ "json5",
+ "serde",
+ "serde_json",
+ "validated_struct_macros",
+]
+
+[[package]]
+name = "validated_struct_macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c44ce98e7227a04eeb4cf9c784109a5c9710e54849ceb4f09f8597247897f1e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "unzip-n",
 ]
 
 [[package]]
@@ -5001,7 +6411,7 @@ checksum = "46d90019b1afd4b808c263e428de644f3003691f243387d30d673211ee0cb8e8"
 dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
  "serde",
 ]
@@ -5035,6 +6445,25 @@ checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5214,6 +6643,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5246,6 +6684,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5507,6 +6960,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5533,7 +7004,7 @@ dependencies = [
  "clap_complete",
  "dirs",
  "flate2",
- "indexmap",
+ "indexmap 2.13.0",
  "lsp-types",
  "mimalloc",
  "nix 0.29.0",
@@ -5565,6 +7036,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5585,6 +7066,516 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "synstructure",
+]
+
+[[package]]
+name = "zenoh"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e22d7002ac149ef17fe400bb40a267ebbba40a83413bab03da7762256fa94e"
+dependencies = [
+ "ahash",
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "const_format",
+ "flate2",
+ "flume",
+ "futures",
+ "git-version",
+ "itertools",
+ "json5",
+ "lazy_static",
+ "nonempty-collections",
+ "once_cell",
+ "petgraph",
+ "phf",
+ "rand 0.8.5",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uhlc",
+ "vec_map",
+ "zenoh-buffers",
+ "zenoh-codec",
+ "zenoh-collections",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-keyexpr",
+ "zenoh-link",
+ "zenoh-link-commons",
+ "zenoh-macros",
+ "zenoh-plugin-trait",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+ "zenoh-sync",
+ "zenoh-task",
+ "zenoh-transport",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-buffers"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89c9e2427102e8efd533716f0935389a3900a818e7334004dd647ac0bd029dc"
+dependencies = [
+ "zenoh-collections",
+]
+
+[[package]]
+name = "zenoh-codec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31930531a8e387160bc3680c6d62f80a201020cf4d8aa36bd46988b425a66306"
+dependencies = [
+ "tracing",
+ "uhlc",
+ "zenoh-buffers",
+ "zenoh-protocol",
+]
+
+[[package]]
+name = "zenoh-collections"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc5195efe3ad44786275f559bbd6f13c6612470e9706c9a9a8b5b47388d51e1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "zenoh-config"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8672f4eaf88fd486f0503c59d19edfc25e7dd689bccd90d3cb731a5f627e0df"
+dependencies = [
+ "json5",
+ "nonempty-collections",
+ "num_cpus",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "serde_yaml",
+ "tracing",
+ "uhlc",
+ "validated_struct",
+ "zenoh-core",
+ "zenoh-keyexpr",
+ "zenoh-macros",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1525319e4d9ef2af54fc9c74abf419236e32e6535081339321f3f55e2f34ce2f"
+dependencies = [
+ "lazy_static",
+ "tokio",
+ "zenoh-result",
+ "zenoh-runtime",
+]
+
+[[package]]
+name = "zenoh-crypto"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44b80a042fc71419fc4952a90c9cbcfb323c0ced048125d8b44fd362f184045f"
+dependencies = [
+ "aes",
+ "hmac",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "sha3",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-keyexpr"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f04c82f0728f6704a1a397a04b38de5b2fd5a9a886a232cf650c9af294ba5d"
+dependencies = [
+ "getrandom 0.2.17",
+ "hashbrown 0.16.1",
+ "keyed-set",
+ "rand 0.8.5",
+ "schemars 1.2.1",
+ "serde",
+ "token-cell",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71103cfe96a851ef5ff781d64dda95c70e70208f74e186d6d294ba21e89cc64"
+dependencies = [
+ "zenoh-config",
+ "zenoh-link-commons",
+ "zenoh-link-quic",
+ "zenoh-link-quic_datagram",
+ "zenoh-link-tcp",
+ "zenoh-link-tls",
+ "zenoh-link-udp",
+ "zenoh-link-unixsock_stream",
+ "zenoh-link-ws",
+ "zenoh-protocol",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link-commons"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc91a5163793f842b4b016b2d50640db5a3533370348eb796e7078c576e87cf"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "flume",
+ "futures",
+ "quinn",
+ "quinn-proto",
+ "rcgen",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "secrecy",
+ "serde",
+ "socket2 0.5.10",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "webpki-roots 1.0.5",
+ "x509-parser",
+ "zenoh-buffers",
+ "zenoh-codec",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-quic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d065833147be895b7091cc3e505433c2c8b3172e36c9e06e84a5779a4aa655"
+dependencies = [
+ "async-trait",
+ "rustls-webpki",
+ "time",
+ "tracing",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-link-quic_datagram",
+ "zenoh-protocol",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link-quic_datagram"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e81b15df31a3d0ddde9a4fb3fbc928e9a2a6d6a4de38bcf55badd3a5208947a4"
+dependencies = [
+ "async-trait",
+ "rustls-webpki",
+ "time",
+ "tokio-util",
+ "tracing",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link-tcp"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e912ac36902173dfc295317e001dc630e5ac9a70c2780f2d2eac500b205a700"
+dependencies = [
+ "async-trait",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link-tls"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f6b308ae2599f9c1344fbcd3418b2c3a3a9fe287ec39501ba834168493ba37"
+dependencies = [
+ "async-trait",
+ "base64",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "secrecy",
+ "socket2 0.5.10",
+ "time",
+ "tls-listener",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "webpki-roots 1.0.5",
+ "x509-parser",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+]
+
+[[package]]
+name = "zenoh-link-udp"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca106ca8c3b7625e7071b9d7408955726e994c8f35fd68e00de8ac58b185d52d"
+dependencies = [
+ "async-trait",
+ "libc",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "windows-sys 0.61.2",
+ "zenoh-buffers",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-link-quic_datagram",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-sync",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-unixsock_stream"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2b7f60cdb5ad771d1a4f8e2eda15529e96dbe81c0ad2c1015b4c194347676"
+dependencies = [
+ "async-trait",
+ "nix 0.29.0",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+]
+
+[[package]]
+name = "zenoh-link-ws"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7fb54899f7fbdfc4fd02e647f9bba0d6e089cca4355acafb9499c510ebea79"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "url",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-macros"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9310b02a8f6dc4bd04d9ce6b318b9d00182aeeeeca60410003307d63a2569a3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "zenoh-keyexpr",
+]
+
+[[package]]
+name = "zenoh-plugin-trait"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e235815d14b22448aa1db948560328761530932fa7a2f9a3c14853b3f0267941"
+dependencies = [
+ "git-version",
+ "libloading",
+ "serde",
+ "stabby",
+ "tracing",
+ "zenoh-config",
+ "zenoh-keyexpr",
+ "zenoh-macros",
+ "zenoh-result",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-protocol"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeab45020bbecc077f14f06ee8f5aee65ce760af72481e663cac58b5dbfa66dd"
+dependencies = [
+ "const_format",
+ "rand 0.8.5",
+ "serde",
+ "uhlc",
+ "zenoh-buffers",
+ "zenoh-keyexpr",
+ "zenoh-macros",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-result"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca8e65b08f211833fe31cf38d73a48c6e1d6d900914e1ddd8cb176b3355b75b"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "zenoh-runtime"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd3d0c1558f909c9a74bde5e398c5733f81eb954818451baac2a6c09f48d6a5e"
+dependencies = [
+ "lazy_static",
+ "ron",
+ "serde",
+ "tokio",
+ "tracing",
+ "zenoh-macros",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-sync"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9588f87db82b414a3e73d13312026be826332f53d270966e3e19f77f7fa1f06d"
+dependencies = [
+ "arc-swap",
+ "event-listener",
+ "futures",
+ "tokio",
+ "zenoh-buffers",
+ "zenoh-collections",
+ "zenoh-core",
+]
+
+[[package]]
+name = "zenoh-task"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2ac601598a27152b366ba1c6825216f01f77bb898f719b7752099a3594ce72"
+dependencies = [
+ "futures",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zenoh-core",
+ "zenoh-runtime",
+]
+
+[[package]]
+name = "zenoh-transport"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80800c4adc26dbe81418735068541cf39820a95ec988114f04dd014775ba7c97"
+dependencies = [
+ "async-trait",
+ "crossbeam-utils",
+ "flume",
+ "futures",
+ "lazy_static",
+ "lz4_flex",
+ "rand 0.8.5",
+ "ringbuffer-spsc",
+ "rsa",
+ "serde",
+ "sha3",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zenoh-buffers",
+ "zenoh-codec",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-crypto",
+ "zenoh-link",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+ "zenoh-sync",
+ "zenoh-task",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-util"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b10369df18a781a3e675c9a2cbf54adb44c9dc2a376c1014c5e488410df2179"
+dependencies = [
+ "async-trait",
+ "const_format",
+ "flume",
+ "home",
+ "humantime",
+ "lazy_static",
+ "libc",
+ "libloading",
+ "pnet_datalink",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "winapi",
+ "zenoh-core",
+ "zenoh-result",
 ]
 
 [[package]]
@@ -5708,7 +7699,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "hmac",
- "indexmap",
+ "indexmap 2.13.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/rumoca-codec",
     "crates/rumoca-codec-flatbuffers",
     "crates/rumoca-transport-udp",
+    "crates/rumoca-transport-zenoh",
     "crates/rumoca-transport-websocket",
     "crates/rumoca-input",
     "crates/rumoca-input-gamepad",
@@ -90,6 +91,7 @@ rumoca-signal-frame = { path = "crates/rumoca-signal-frame" }
 rumoca-codec = { path = "crates/rumoca-codec" }
 rumoca-codec-flatbuffers = { path = "crates/rumoca-codec-flatbuffers" }
 rumoca-transport-udp = { path = "crates/rumoca-transport-udp" }
+rumoca-transport-zenoh = { path = "crates/rumoca-transport-zenoh" }
 rumoca-transport-websocket = { path = "crates/rumoca-transport-websocket" }
 rumoca-input = { path = "crates/rumoca-input" }
 rumoca-input-gamepad = { path = "crates/rumoca-input-gamepad" }
@@ -148,6 +150,7 @@ lsp-types = "0.94"
 # LSP server (native only)
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
+zenoh = "1.9.0"
 # WASM bindings
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"

--- a/crates/rumoca-bind-wasm/src/tests.rs
+++ b/crates/rumoca-bind-wasm/src/tests.rs
@@ -486,6 +486,53 @@ fn test_compile_to_json_valid_model() {
     );
 }
 
+#[cfg(any(feature = "sim-diffsol", feature = "sim-rk45"))]
+#[test]
+fn test_interactive_stepper_runs_pure_discrete_model_with_guarded_dynamic_subscript() {
+    let _guard = session_test_guard();
+    clear_source_root_cache().expect("clear source-root cache");
+
+    let source = r#"
+    model DiscreteController
+      input Real u;
+      parameter Real table[2] = {2.0, 4.0};
+      discrete output Real y(start = 0.0);
+      discrete Integer k(start = 1);
+    protected
+      discrete Real prev(start = 0.0);
+    algorithm
+      if pre(k) == 1 then
+        prev := 0.0;
+      else
+        prev := table[pre(k) - 1];
+      end if;
+      y := u + prev;
+      k := if pre(k) >= 2 then 1 else pre(k) + 1;
+    end DiscreteController;
+    "#;
+
+    let mut session = Session::default();
+    session.update_document("input.mo", source);
+    let result = session
+        .compile_model_dae_strict_reachable_uncached_with_recovery("DiscreteController")
+        .expect("pure discrete model should compile");
+    let mut stepper = rumoca_sim::SimStepper::new_with_diagnostics(
+        &result.dae,
+        rumoca_sim::SimOptions::default(),
+    )
+    .expect("pure discrete stepper should build");
+    stepper.set_input("u", 1.5).expect("set input u");
+    stepper.step(0.02).expect("first discrete tick");
+    assert_eq!(stepper.time(), 0.02);
+    assert_eq!(stepper.get("y").expect("read y"), Some(1.5));
+
+    stepper.set_input("u", 2.0).expect("set input u");
+    stepper.step(0.02).expect("second discrete tick");
+    assert_eq!(stepper.get("y").expect("read y"), Some(4.0));
+
+    clear_source_root_cache().expect("clear source-root cache");
+}
+
 #[test]
 fn test_compile_to_json_matches_compile_wrapper_output() {
     let _guard = session_test_guard();

--- a/crates/rumoca-phase-codegen/src/templates/embedded-c/model.c.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/embedded-c/model.c.jinja
@@ -1,31 +1,263 @@
-{#- Embedded C implementation over prepared Solve IR. -#}
+{#- Embedded C implementation over prepared Solve IR.
+
+    Handles continuous ODE models (forward-Euler integration of the derivative
+    RHS) and discrete/sampled models (`when`/`sample`/`pre`). The discrete and
+    event machinery mirrors the FMI 2.0 backend, evaluated over the same Solve
+    IR, but is exposed through a minimal init()/step() API over the flat y[]/p[]
+    vectors.
+-#}
 {%- if ir_kind != "solve" -%}
 {{ fail("embedded-c target requires Solve IR") }}
 {%- endif -%}
 {%- set model_name = model_name | default("model") | sanitize -%}
-{%- set rows = solve_blocks.continuous.derivative_rhs.scalar_programs.programs -%}
-{%- set output_indices = solve_blocks.continuous.derivative_rhs.scalar_programs.output_indices -%}
-{%- set cfg = {"time": "m->time", "y": "m->y[{}]", "p": "m->p[{}]"} -%}
+{%- set MODEL = model_name | upper -%}
+{%- set dae = dae if dae is defined else {} -%}
+
+{#- Symbol policy so render_expr() can emit start expressions that reference
+    constants/parameters by their (sanitized) names as local C aliases. -#}
+{%- set c_symbol_policy = {
+    "separator": "_",
+    "generated_prefixes": ["pre_", "der_"],
+    "reserved": [
+        "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else",
+        "enum", "extern", "float", "for", "goto", "if", "int", "long", "register", "return",
+        "short", "signed", "sizeof", "static", "struct", "switch", "typedef", "union",
+        "unsigned", "void", "volatile", "while", "inline", "restrict",
+        "m", "t", "time", "i", "n", "real_t", "pre", "der"
+    ]
+} -%}
+{%- set symbols = target_symbols(dae.symbol_refs | default([]), c_symbol_policy, dae.symbol_aliases | default([])) -%}
+{%- set cfg = {"prefix": "", "power": "pow", "and_op": "&&", "or_op": "||", "not_op": "!", "true_val": "1", "false_val": "0", "if_style": "ternary", "array_start": "(real_t[]){", "array_end": "}", "subscript_underscore": true, "sum_fn": "__rumoca_sum_d", "symbols": symbols} -%}
+
+{#- Solve IR row renderers operate directly on the flat y[]/p[] vectors. -#}
+{%- set row_cfg = {"time": "m->time", "y": "m->y[{}]", "p": "m->p[{}]"} -%}
+{%- set assign_cfg = {"y_set": "m->y[{}] = {}", "p_set": "m->p[{}] = {}"} -%}
+
+{%- set derivative_rows = solve_blocks.continuous.derivative_rhs.scalar_programs.programs
+    if solve_blocks is defined and solve_blocks.continuous is defined
+       and solve_blocks.continuous.derivative_rhs is defined
+       and solve_blocks.continuous.derivative_rhs.scalar_programs is defined
+       and solve_blocks.continuous.derivative_rhs.scalar_programs.programs is defined else [] -%}
+{%- set derivative_output_indices = solve_blocks.continuous.derivative_rhs.scalar_programs.output_indices
+    if solve_blocks is defined and solve_blocks.continuous is defined
+       and solve_blocks.continuous.derivative_rhs is defined
+       and solve_blocks.continuous.derivative_rhs.scalar_programs is defined
+       and solve_blocks.continuous.derivative_rhs.scalar_programs.output_indices is defined else [] -%}
+{%- set discrete_rows = solve.discrete.rhs.programs
+    if solve is defined and solve.discrete is defined and solve.discrete.rhs is defined
+       and solve.discrete.rhs.programs is defined else [] -%}
+{%- set discrete_targets = solve.discrete.update_targets
+    if solve is defined and solve.discrete is defined
+       and solve.discrete.update_targets is defined else [] -%}
+{%- set runtime_rows = solve.discrete.runtime_assignment_rhs.programs
+    if solve is defined and solve.discrete is defined
+       and solve.discrete.runtime_assignment_rhs is defined
+       and solve.discrete.runtime_assignment_rhs.programs is defined else [] -%}
+{%- set runtime_targets = solve.discrete.runtime_assignment_targets
+    if solve is defined and solve.discrete is defined
+       and solve.discrete.runtime_assignment_targets is defined else [] -%}
+{%- set pre_bindings = solve.solve_layout.pre_param_bindings
+    if solve is defined and solve.solve_layout is defined
+       and solve.solve_layout.pre_param_bindings is defined else [] -%}
+{%- set initial_event_index = solve.solve_layout.initial_event_parameter_index
+    if solve is defined and solve.solve_layout is defined else none -%}
+{%- set bindings = solve.layout.bindings -%}
+{#- Flat p[] slots of the auto-generated `when`-clause condition variables
+    (origin == "generated" discrete-valued vars). Their pre() memory is reset to
+    the inactive state on every tick so each step() is treated as a fresh sample
+    /event edge — the embedded "one step == one control tick" contract. -#}
+{%- set ns_cond = namespace(slots=[]) -%}
+{%- for name, var in dae.m | default({}) | items -%}
+{%- if var.origin == "generated" -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) -%}
+{%- set slot = bindings[source_ref(name, var.dims, i + 1)] -%}
+{%- if slot and slot.P is defined -%}{%- set ns_cond.slots = ns_cond.slots + [slot.P.index] -%}{%- endif -%}
+{%- endfor -%}
+{%- else -%}
+{%- set slot = bindings[name] -%}
+{%- if slot and slot.P is defined -%}{%- set ns_cond.slots = ns_cond.slots + [slot.P.index] -%}{%- endif -%}
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
 #include "{{ model_name }}.h"
 
 #include <math.h>
 #include <string.h>
+
+{# Vector-sum builtin used by some scalarized array reductions. #}
+static real_t __rumoca_sum_d(const real_t *v, int n) {
+    real_t s = 0.0;
+    for (int i = 0; i < n; i++) {
+        s += v[i];
+    }
+    return s;
+}
+
+{#- Macro: declare local C aliases (initialised to 0) for a variable map. -#}
+{%- macro decl_locals(vars) -%}
+{%- for name, var in vars | items -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) %}
+    real_t {{ symbol(symbols, source_ref(name, var.dims, i + 1)) }} = 0.0; (void){{ symbol(symbols, source_ref(name, var.dims, i + 1)) }};
+{%- endfor -%}
+{%- else %}
+    real_t {{ symbol(symbols, name) }} = 0.0; (void){{ symbol(symbols, name) }};
+{%- endif -%}
+{%- endfor -%}
+{%- endmacro -%}
+
+{#- Macro: evaluate start expressions into the local aliases. -#}
+{%- macro eval_starts(vars) -%}
+{%- for name, var in vars | items -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) -%}
+{%- if var.start and is_string_literal(var.start) != "yes" %}
+    {{ symbol(symbols, source_ref(name, var.dims, i + 1)) }} = {{ render_expr_at_index(var.start, i + 1, cfg) }};
+{%- endif -%}
+{%- endfor -%}
+{%- else -%}
+{%- if var.start and is_string_literal(var.start) != "yes" %}
+    {{ symbol(symbols, name) }} = {{ render_expr(var.start, cfg) }};
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endmacro -%}
+
+{#- Macro: store the local aliases into their flat Solve IR slot. -#}
+{%- macro store_slots(vars) -%}
+{%- for name, var in vars | items -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) -%}
+{%- set key = source_ref(name, var.dims, i + 1) -%}
+{%- set slot = bindings[key] -%}
+{%- if slot and (slot.Y is defined or slot.P is defined) %}
+    {{ render_solve_slot_assign_c(slot, symbol(symbols, key), assign_cfg) }}
+{%- endif -%}
+{%- endfor -%}
+{%- else -%}
+{%- set slot = bindings[name] -%}
+{%- if slot and (slot.Y is defined or slot.P is defined) %}
+    {{ render_solve_slot_assign_c(slot, symbol(symbols, name), assign_cfg) }}
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endmacro -%}
+
+{# Snapshot pre() parameters: copy current values into their __pre__ slots. #}
+static void {{ model_name }}_snapshot_pre({{ model_name }}_t *m) {
+{%- if pre_bindings | length > 0 %}
+{%- for binding in pre_bindings %}
+{%- if binding.source.P is defined and binding.source.P.index in ns_cond.slots %}
+    m->p[{{ binding.dest_p_index }}] = 0.0;  /* when-condition pre reset */
+{%- else %}
+    {{ render_solve_pre_param_binding_c(binding, row_cfg, assign_cfg) }}
+{%- endif %}
+{%- endfor %}
+{%- else %}
+    (void)m;
+{%- endif %}
+}
+
+{# Evaluate one pass of the runtime-assignment + discrete (when) update rows
+   into their targets. Returns nonzero if any slot changed this pass. #}
+static int {{ model_name }}_event_pass({{ model_name }}_t *m) {
+{%- if (discrete_rows | length > 0) or (runtime_rows | length > 0) %}
+    real_t __p_prev[{{ MODEL }}_P_LEN > 0 ? {{ MODEL }}_P_LEN : 1];
+    memcpy(__p_prev, m->p, sizeof(m->p));
+{%- if (solve.layout.y_scalars | default(0)) > 0 %}
+    real_t __y_prev[{{ MODEL }}_Y_LEN > 0 ? {{ MODEL }}_Y_LEN : 1];
+    memcpy(__y_prev, m->y, sizeof(m->y));
+{%- endif %}
+{%- if runtime_rows | length > 0 %}
+    real_t __rt[{{ runtime_rows | length }}];
+{%- for row in runtime_rows %}
+    __rt[{{ loop.index0 }}] = {{ render_solve_row_c(row, row_cfg) }};
+{%- endfor %}
+{%- for target in runtime_targets %}
+    {{ render_solve_slot_assign_c(target, "__rt[" ~ loop.index0 ~ "]", assign_cfg) }}
+{%- endfor %}
+{%- endif %}
+{%- if discrete_rows | length > 0 %}
+    real_t __dv[{{ discrete_rows | length }}];
+{%- for row in discrete_rows %}
+    __dv[{{ loop.index0 }}] = {{ render_solve_row_c(row, row_cfg) }};
+{%- endfor %}
+{%- for target in discrete_targets %}
+    {{ render_solve_slot_assign_c(target, "__dv[" ~ loop.index0 ~ "]", assign_cfg) }}
+{%- endfor %}
+{%- endif %}
+    if (memcmp(__p_prev, m->p, sizeof(m->p)) != 0) {
+        return 1;
+    }
+{%- if (solve.layout.y_scalars | default(0)) > 0 %}
+    if (memcmp(__y_prev, m->y, sizeof(m->y)) != 0) {
+        return 1;
+    }
+{%- endif %}
+    return 0;
+{%- else %}
+    (void)m;
+    return 0;
+{%- endif %}
+}
+
+{# Iterate the runtime/discrete update rows to a fixed point. The rows self-gate
+   on the sample/event condition derived from m->time; iterating resolves the
+   intra-tick dependency between condition rows and the equations that read
+   them (mirrors the reference event iteration). #}
+static void {{ model_name }}_discrete_updates({{ model_name }}_t *m) {
+    for (int __it = 0; __it < 100; __it++) {
+        if (!{{ model_name }}_event_pass(m)) {
+            break;
+        }
+    }
+}
 
 void {{ model_name }}_init({{ model_name }}_t *m) {
     if (!m) {
         return;
     }
     memset(m, 0, sizeof(*m));
+
+    /* Evaluate start expressions into local aliases (constants first, then
+       parameters/discretes/inputs/states which may reference them), then store
+       each into its flat Solve IR slot. */
+{{ decl_locals(dae.constants | default({})) }}
+{{ decl_locals(dae.p | default({})) }}
+{{ decl_locals(dae.z | default({})) }}
+{{ decl_locals(dae.m | default({})) }}
+{{ decl_locals(dae.u | default({})) }}
+{{ decl_locals(dae.x | default({})) }}
+{{ eval_starts(dae.constants | default({})) }}
+{{ eval_starts(dae.p | default({})) }}
+{{ eval_starts(dae.z | default({})) }}
+{{ eval_starts(dae.m | default({})) }}
+{{ eval_starts(dae.u | default({})) }}
+{{ eval_starts(dae.x | default({})) }}
+{{ store_slots(dae.p | default({})) }}
+{{ store_slots(dae.z | default({})) }}
+{{ store_slots(dae.m | default({})) }}
+{{ store_slots(dae.u | default({})) }}
+{{ store_slots(dae.x | default({})) }}
+{%- if initial_event_index is not none and discrete_rows | length > 0 %}
+
+    /* Run the initialization (`initial()`) event. */
+    m->p[{{ initial_event_index }}] = 1.0;
+    {{ model_name }}_snapshot_pre(m);
+    {{ model_name }}_discrete_updates(m);
+    m->p[{{ initial_event_index }}] = 0.0;
+{%- endif %}
 }
 
 void {{ model_name }}_derivative_rhs(const {{ model_name }}_t *m, real_t *out) {
     if (!m || !out) {
         return;
     }
-    for (int i = 0; i < {{ model_name | upper }}_DERIVATIVE_LEN; ++i) {
+    for (int i = 0; i < {{ MODEL }}_DERIVATIVE_LEN; ++i) {
         out[i] = 0.0;
     }
-{%- set solve_body = render_solve_block_c(rows, cfg, "out[{}] = {}", output_indices) %}
+{%- set solve_body = render_solve_block_c(derivative_rows, row_cfg, "out[{}] = {}", derivative_output_indices) %}
 {%- if solve_body %}
 {{ solve_body }}
 {%- else %}
@@ -38,12 +270,22 @@ void {{ model_name }}_step({{ model_name }}_t *m, real_t dt) {
     if (!m) {
         return;
     }
-    real_t dx[{{ model_name | upper }}_DERIVATIVE_LEN > 0 ? {{ model_name | upper }}_DERIVATIVE_LEN : 1] = {0};
+{%- if derivative_rows | length > 0 %}
+    /* Continuous states: explicit forward-Euler over [t, t+dt]. */
+    real_t dx[{{ MODEL }}_DERIVATIVE_LEN > 0 ? {{ MODEL }}_DERIVATIVE_LEN : 1] = {0};
     {{ model_name }}_derivative_rhs(m, dx);
-    for (int i = 0; i < {{ model_name | upper }}_STATE_LEN; ++i) {
-        if (i < {{ model_name | upper }}_DERIVATIVE_LEN) {
+    for (int i = 0; i < {{ MODEL }}_STATE_LEN; ++i) {
+        if (i < {{ MODEL }}_DERIVATIVE_LEN) {
             m->y[i] += dt * dx[i];
         }
     }
+{%- endif %}
+
     m->time += dt;
+
+{%- if discrete_rows | length > 0 %}
+    /* Discrete/sample tick at the new time. */
+    {{ model_name }}_snapshot_pre(m);
+    {{ model_name }}_discrete_updates(m);
+{%- endif %}
 }

--- a/crates/rumoca-phase-codegen/src/templates/embedded-c/model.c.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/embedded-c/model.c.jinja
@@ -207,6 +207,12 @@ static int {{ model_name }}_event_pass({{ model_name }}_t *m) {
    intra-tick dependency between condition rows and the equations that read
    them (mirrors the reference event iteration). #}
 static void {{ model_name }}_discrete_updates({{ model_name }}_t *m) {
+    /* Bound on fixed-point passes. `event_pass` returns 0 once a pass changes
+       nothing, which is the normal exit; the cap only guards against a model
+       whose discrete rows never settle (e.g. an ill-posed algebraic loop). It is
+       sized well above the longest real dependency chain so a converging model
+       always breaks out first; if the cap is ever hit the last computed state is
+       used as-is rather than looping forever. */
     for (int __it = 0; __it < 100; __it++) {
         if (!{{ model_name }}_event_pass(m)) {
             break;

--- a/crates/rumoca-phase-codegen/src/templates/embedded-c/model.h.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/embedded-c/model.h.jinja
@@ -1,11 +1,23 @@
-{#- Embedded C header over prepared Solve IR. -#}
+{#- Embedded C header over prepared Solve IR.
+
+    Supports both continuous (forward-Euler ODE) and discrete/sampled
+    (`when`/`sample`/`pre`) models. State and parameter vectors are the flat
+    Solve IR layout:
+      y[] = [continuous states | algebraics | outputs]
+      p[] = [parameters | inputs | discrete reals | discrete valued]
+    Index macros below name the user-visible slots so callers do not hard-code
+    positions (e.g. `m.p[{{ model_name | upper }}_P_u] = 1.0;`).
+-#}
 {%- if ir_kind != "solve" -%}
 {{ fail("embedded-c target requires Solve IR") }}
 {%- endif -%}
 {%- set model_name = model_name | default("model") | sanitize -%}
+{%- set dae = dae if dae is defined else {} -%}
 {%- set y_len = solve.layout.y_scalars -%}
 {%- set p_len = solve.layout.p_scalars -%}
 {%- set derivative_len = solve_blocks.continuous.derivative_rhs.output_count -%}
+{%- set bindings = solve.layout.bindings -%}
+{%- set MODEL = model_name | upper -%}
 #pragma once
 
 #include <stddef.h>
@@ -13,11 +25,43 @@
 typedef double real_t;
 
 enum {
-    {{ model_name | upper }}_Y_LEN = {{ y_len }},
-    {{ model_name | upper }}_P_LEN = {{ p_len }},
-    {{ model_name | upper }}_STATE_LEN = {{ solve.solve_layout.state_scalar_count }},
-    {{ model_name | upper }}_DERIVATIVE_LEN = {{ derivative_len }}
+    {{ MODEL }}_Y_LEN = {{ y_len }},
+    {{ MODEL }}_P_LEN = {{ p_len }},
+    {{ MODEL }}_STATE_LEN = {{ solve.solve_layout.state_scalar_count }},
+    {{ MODEL }}_DERIVATIVE_LEN = {{ derivative_len }}
 };
+
+{#- Emit slot-index macros for user-visible scalars. `vars` come from the DAE
+    IR; their flat slot is resolved through the Solve layout bindings. -#}
+{%- macro index_macros(vars, kind) -%}
+{%- for name, var in vars | items -%}
+{%- if var.dims -%}
+{%- for i in range(var.dims | product) -%}
+{%- set key = source_ref(name, var.dims, i + 1) -%}
+{%- set slot = bindings[key] -%}
+{%- if slot and slot.Y is defined %}
+#define {{ MODEL }}_Y_{{ key | sanitize }} {{ slot.Y.index }}  /* {{ kind }} {{ key }} */
+{%- elif slot and slot.P is defined %}
+#define {{ MODEL }}_P_{{ key | sanitize }} {{ slot.P.index }}  /* {{ kind }} {{ key }} */
+{%- endif -%}
+{%- endfor -%}
+{%- else -%}
+{%- set slot = bindings[name] -%}
+{%- if slot and slot.Y is defined %}
+#define {{ MODEL }}_Y_{{ name | sanitize }} {{ slot.Y.index }}  /* {{ kind }} {{ name }} */
+{%- elif slot and slot.P is defined %}
+#define {{ MODEL }}_P_{{ name | sanitize }} {{ slot.P.index }}  /* {{ kind }} {{ name }} */
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endmacro -%}
+/* ---- Variable slot indices (name -> flat array position) ---- */
+{{ index_macros(dae.u | default({}), "input") }}
+{{ index_macros(dae.x | default({}), "state") }}
+{{ index_macros(dae.z | default({}), "discrete") }}
+{{ index_macros(dae.m | default({}), "discrete") }}
+{{ index_macros(dae.y | default({}), "algebraic") }}
+{{ index_macros(dae.w | default({}), "output") }}
 
 typedef struct {
     real_t time;
@@ -25,6 +69,13 @@ typedef struct {
     real_t p[{{ p_len if p_len > 0 else 1 }}];
 } {{ model_name }}_t;
 
+/* Initialise to start values and run the initialization (`initial()`) event. */
 void {{ model_name }}_init({{ model_name }}_t *m);
+
+/* Continuous derivative RHS: writes dy/dt for the state block into out[]. */
 void {{ model_name }}_derivative_rhs(const {{ model_name }}_t *m, real_t *out);
+
+/* Advance one step of size dt: forward-Euler for continuous states, then one
+   discrete/sample tick (snapshot pre(), evaluate when-equations). Call once per
+   control period for a fixed-rate discrete controller. */
 void {{ model_name }}_step({{ model_name }}_t *m, real_t dt);

--- a/crates/rumoca-phase-codegen/src/templates/embedded-c/target.toml
+++ b/crates/rumoca-phase-codegen/src/templates/embedded-c/target.toml
@@ -9,8 +9,8 @@ Compile: cc -O2 -Wall -c {{ out_dir }}/{{ model_name }}.c"""
 
 [capabilities]
 scalar_fallback = true
-events = false
-runtime_events = false
+events = true
+runtime_events = true
 forward_ad = false
 reverse_ad = false
 dynamic_control_flow = false

--- a/crates/rumoca-phase-solve/src/lower/array_values.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values.rs
@@ -254,6 +254,22 @@ fn single_usize_vec(
     Ok(values)
 }
 
+/// True when every subscript selects a single element (no `:` and no range),
+/// i.e. the access reduces to one scalar array element. Such selections — even
+/// with a runtime (non-constant) index like `wp[current_wp, 1]` — must use the
+/// scalar VarRef path (which lowers runtime indices to indexed loads), not the
+/// compile-time slice enumeration which would try to fold the index.
+fn subscripts_select_single_element(subscripts: &[rumoca_core::Subscript]) -> bool {
+    !subscripts.is_empty()
+        && subscripts.iter().all(|subscript| match subscript {
+            rumoca_core::Subscript::Colon { .. } => false,
+            rumoca_core::Subscript::Expr { expr, .. } => {
+                !matches!(&**expr, rumoca_core::Expression::Range { .. })
+            }
+            _ => true,
+        })
+}
+
 fn collect_indexed_record_field_keys(
     base_key: &str,
     field: &str,
@@ -1520,6 +1536,17 @@ impl<'a> LowerBuilder<'a> {
             Some(span) => span,
             None => self.required_reference_or_context_span(name, "array slice lowering")?,
         };
+        // A single-element selection (no `:`/range) yields one scalar element.
+        // Route it through the scalar VarRef path, which supports runtime
+        // (non-constant) subscripts via indexed loads. The compile-time slice
+        // enumeration below only handles constant indices/ranges, so sending a
+        // runtime index like `wp[current_wp, 1]` (e.g. as a function argument)
+        // through it would fail trying to fold the index.
+        if subscripts_select_single_element(subscripts) {
+            return Ok(vec![
+                self.lower_var_ref(name, subscripts, span, scope, call_depth)?,
+            ]);
+        }
         if let Some(values) =
             self.lower_indexed_reference_slice_values(name, subscripts, span, scope)?
         {

--- a/crates/rumoca-phase-solve/src/lower/array_values/dynamic_selection.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/dynamic_selection.rs
@@ -1658,6 +1658,18 @@ impl<'a> LowerBuilder<'a> {
         subscripts: &[rumoca_core::Subscript],
     ) -> bool {
         let key = name.as_str();
+        // `__pre__.X` is the previous-step memory of a discrete state, not a
+        // constant. The DAE registers it as a non-tunable parameter (and seeds
+        // its `start` value into `structural_bindings`) purely as a
+        // representational artifact, but `snapshot_pre` rewrites the slot every
+        // step. Folding an if-branch on it would bake in the state's start value
+        // (e.g. `if pre(current_wp) == 1` collapsing to the wp==1 branch),
+        // silently producing the wrong dynamics — exactly what scalar `lower_if`
+        // already refuses to do. Treat it as run-time state so lowering keeps a
+        // `Select`.
+        if key.starts_with("__pre__.") {
+            return false;
+        }
         // Loop indices and projected function parameters bound to constants.
         if subscripts.is_empty() && self.local_const_bindings.contains_key(key) {
             return true;

--- a/crates/rumoca-phase-solve/src/lower/array_values/inference.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/inference.rs
@@ -927,6 +927,12 @@ impl<'a> LowerBuilder<'a> {
                 if subscripts.is_empty() && const_scope.contains_key(name.as_str()) {
                     return true;
                 }
+                if self
+                    .dae_variables
+                    .is_some_and(|variables| !var_ref_is_translation_constant(variables, name))
+                {
+                    return false;
+                }
                 compile_time_var_key(name, subscripts, const_scope, *span)
                     .ok()
                     .is_some_and(|key| {
@@ -1098,6 +1104,20 @@ impl<'a> LowerBuilder<'a> {
             _ => Vec::new(),
         })
     }
+}
+
+fn var_ref_is_translation_constant(
+    variables: &dae::DaeVariables,
+    name: &rumoca_core::Reference,
+) -> bool {
+    let var_name = name.var_name();
+    if variables.constants.contains_key(var_name) {
+        return true;
+    }
+    if let Some(parameter) = variables.parameters.get(var_name) {
+        return !parameter.is_tunable;
+    }
+    false
 }
 
 fn required_arg<'a>(

--- a/crates/rumoca-phase-solve/src/lower/array_values/inference.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/inference.rs
@@ -915,6 +915,15 @@ impl<'a> LowerBuilder<'a> {
                 span,
                 ..
             } => {
+                // MLS §3.7.5/§8.6: `pre(x)` lowers to the synthetic `__pre__.x`
+                // parameter that *holds the previous-event value* of a discrete
+                // (or state) variable. Folding it would pin a runtime array
+                // subscript such as `wp[pre(k), 1]` to its start index, so a
+                // `__pre__.` reference must take the runtime dynamic-selection
+                // path instead of compile-time subscript folding.
+                if name.as_str().starts_with("__pre__.") {
+                    return false;
+                }
                 if subscripts.is_empty() && const_scope.contains_key(name.as_str()) {
                     return true;
                 }

--- a/crates/rumoca-phase-solve/src/lower/discrete_updates.rs
+++ b/crates/rumoca-phase-solve/src/lower/discrete_updates.rs
@@ -139,7 +139,8 @@ pub(crate) fn normalized_discrete_update_equations(
             true,
         )?;
     }
-    let alias_equations = oriented_discrete_alias_equations(&alias_edges, &protected_lhs_names)?;
+    let alias_equations =
+        oriented_discrete_alias_equations(dae_model, &alias_edges, &protected_lhs_names)?;
     reserve_discrete_capacity(
         &mut normalized_equations,
         alias_equations.len(),
@@ -599,6 +600,7 @@ fn discrete_alias_edges(
 // components, and emits equations in deterministic order.
 #[allow(clippy::too_many_lines)]
 fn oriented_discrete_alias_equations(
+    dae_model: &dae::Dae,
     edges: &[DiscreteAliasEdge],
     protected_lhs_names: &IndexSet<rumoca_core::VarName>,
 ) -> Result<Vec<dae::Equation>, LowerError> {
@@ -664,7 +666,7 @@ fn oriented_discrete_alias_equations(
             continue;
         }
         let component = collect_alias_component(&root_candidate, &adjacency, span)?;
-        let roots = alias_component_roots(&component, protected_lhs_names, span)?;
+        let roots = alias_component_roots(dae_model, &component, protected_lhs_names, span)?;
         for root in &roots {
             if !visited.contains(root) {
                 reserve_discrete_index_set_capacity(
@@ -794,22 +796,23 @@ fn collect_alias_component(
 }
 
 fn alias_component_roots(
+    dae_model: &dae::Dae,
     component: &[rumoca_core::VarName],
     protected_lhs_names: &IndexSet<rumoca_core::VarName>,
     span: rumoca_core::Span,
 ) -> Result<Vec<rumoca_core::VarName>, LowerError> {
-    let mut protected = discrete_vec_with_capacity(
-        component.len(),
-        "alias component protected root count",
-        span,
-    )?;
+    // Inputs are read-only sources: force them to be roots so alias edges always
+    // orient *away* from them (`state := input`), never toward them. Protected
+    // names (non-alias update targets) are likewise forced roots.
+    let mut forced =
+        discrete_vec_with_capacity(component.len(), "alias component forced root count", span)?;
     for name in component {
-        if protected_lhs_names.contains(name) {
-            protected.push(name.clone());
+        if protected_lhs_names.contains(name) || is_discrete_input_name(dae_model, name) {
+            forced.push(name.clone());
         }
     }
-    if !protected.is_empty() {
-        return Ok(protected);
+    if !forced.is_empty() {
+        return Ok(forced);
     }
     let mut roots = discrete_vec_with_capacity(1, "alias component root count", span)?;
     if let Some(name) = component.first() {
@@ -999,6 +1002,22 @@ fn should_reorient_discrete_alias(
 ) -> Result<bool, LowerError> {
     let lhs_names = discrete_update_lhs_names(dae_model, lhs, scalar_count, span)?;
     let target_names = discrete_update_lhs_names(dae_model, alias_target, scalar_count, span)?;
+
+    // Inputs are read-only: never reorient an alias so an input becomes the write
+    // target, and always reorient away from one if the current target is an input.
+    let lhs_is_input = lhs_names
+        .iter()
+        .any(|n| is_discrete_input_name(dae_model, n));
+    let target_is_input = target_names
+        .iter()
+        .any(|n| is_discrete_input_name(dae_model, n));
+    if target_is_input {
+        return Ok(false);
+    }
+    if lhs_is_input {
+        return Ok(true);
+    }
+
     let lhs_protected = any_name_in_set(&lhs_names, protected_lhs_names);
     let target_protected = any_name_in_set(&target_names, protected_lhs_names);
     if lhs_protected != target_protected {
@@ -1425,6 +1444,20 @@ fn is_discrete_update_name(dae_model: &dae::Dae, name: &rumoca_core::VarName) ->
             dae_model.variables.discrete_reals.contains_key(&base)
                 || dae_model.variables.discrete_valued.contains_key(&base)
                 || dae_model.variables.inputs.contains_key(&base)
+        })
+}
+
+/// An input variable is known externally each tick and is read-only inside the
+/// model: it can be an alias *endpoint* (the read side of `state := input`) but
+/// must never be selected as an update target. Orienting an alias edge so an
+/// input is written would clobber the caller's per-tick input every step.
+fn is_discrete_input_name(dae_model: &dae::Dae, name: &rumoca_core::VarName) -> bool {
+    dae_model.variables.inputs.contains_key(name)
+        || dae::component_base_name(name.as_str()).is_some_and(|base| {
+            dae_model
+                .variables
+                .inputs
+                .contains_key(&rumoca_core::VarName::new(base))
         })
 }
 

--- a/crates/rumoca-phase-solve/src/lower/tests.rs
+++ b/crates/rumoca-phase-solve/src/lower/tests.rs
@@ -1275,3 +1275,91 @@ fn named_arg(name: &str, value: rumoca_core::Expression) -> rumoca_core::Express
         span: lower_test_span(),
     }
 }
+
+#[test]
+fn lower_discrete_rhs_keeps_pre_selector_branch_as_runtime_select() {
+    // Regression: an inner `if pre(s) == 1` nested inside an array-valued update
+    // must lower to a run-time `Select` reading `__pre__.s`, never collapse to
+    // the selector's start-value branch. `__pre__.s` is the previous-step memory
+    // of a discrete state (mutable, rewritten every tick) even though the DAE
+    // registers it as a non-tunable parameter with a `start`. The array lowering
+    // path used to treat that parameter as a translation-time constant and fold
+    // the branch, while the scalar path kept the `Select` -- so the same selector
+    // resolved two different ways across an equation (cross-track guidance bug).
+    let mut dae_model = dae::Dae::default();
+    dae_model.variables.parameters.insert(
+        rumoca_core::VarName::new("__pre__.s"),
+        dae::Variable {
+            start: Some(rumoca_core::Expression::Literal {
+                value: rumoca_core::Literal::Real(1.0),
+                span: lower_test_span(),
+            }),
+            fixed: Some(true),
+            is_tunable: false,
+            ..dae::Variable::new(rumoca_core::VarName::new("__pre__.s"), lower_test_span())
+        },
+    );
+    dae_model
+        .variables
+        .discrete_reals
+        .insert(rumoca_core::VarName::new("u"), scalar_var("u"));
+    dae_model.variables.discrete_reals.insert(
+        rumoca_core::VarName::new("y"),
+        dae::Variable {
+            dims: vec![2],
+            ..dae::Variable::new(rumoca_core::VarName::new("y"), lower_test_span())
+        },
+    );
+    dae_model.discrete.real_updates.push(dae::Equation {
+        lhs: Some(rumoca_core::VarName::new("y").into()),
+        rhs: rumoca_core::Expression::Array {
+            elements: vec![
+                rumoca_core::Expression::If {
+                    branches: vec![(
+                        rumoca_core::Expression::Binary {
+                            op: rumoca_core::OpBinary::Eq,
+                            lhs: Box::new(var("__pre__.s")),
+                            rhs: Box::new(rumoca_core::Expression::Literal {
+                                value: rumoca_core::Literal::Integer(1),
+                                span: lower_test_span(),
+                            }),
+                            span: lower_test_span(),
+                        },
+                        rumoca_core::Expression::Literal {
+                            value: rumoca_core::Literal::Real(100.0),
+                            span: lower_test_span(),
+                        },
+                    )],
+                    else_branch: Box::new(var("u")),
+                    span: lower_test_span(),
+                },
+                rumoca_core::Expression::Literal {
+                    value: rumoca_core::Literal::Real(7.0),
+                    span: lower_test_span(),
+                },
+            ],
+            is_matrix: false,
+            span: lower_test_span(),
+        },
+        span: lower_test_span(),
+        origin: "pre-selector array if".to_string(),
+        scalar_count: 2,
+    });
+
+    let layout = build_var_layout(&dae_model).expect("test DAE layout should build");
+    let rows = lower_discrete_rhs(&dae_model, &layout).expect("pre-selector branch should lower");
+    assert_eq!(rows.len(), 2);
+
+    // pre(s) == 1 at runtime -> then-branch constant.
+    let mut p = vec![0.0; layout.p_scalars()];
+    set_p_value(&layout, &mut p, "__pre__.s", 1.0);
+    set_p_value(&layout, &mut p, "u", 42.0);
+    let (_, then_value) = eval_linear_ops(&rows[0], &[], &p, 0.0);
+    assert_eq!(then_value, Some(100.0));
+
+    // pre(s) advances to 2 -> else-branch reads `u`. A folded branch would still
+    // return 100.0 here, ignoring the run-time selector.
+    set_p_value(&layout, &mut p, "__pre__.s", 2.0);
+    let (_, else_value) = eval_linear_ops(&rows[0], &[], &p, 0.0);
+    assert_eq!(else_value, Some(42.0));
+}

--- a/crates/rumoca-phase-solve/src/lower/tests/event_intrinsics.rs
+++ b/crates/rumoca-phase-solve/src/lower/tests/event_intrinsics.rs
@@ -1,6 +1,58 @@
 use super::*;
 
 #[test]
+fn discrete_history_update_from_input_keeps_state_as_target() {
+    // A sampled controller's end-of-step history update `prev_x := x`, where `x`
+    // is an external input, must orient with the discrete state as the write
+    // target. Reorienting it to `x := prev_x` would make the read-only input an
+    // assignment target and clobber the caller's per-tick input every step,
+    // leaving the controller blind to its live pose. Regression for the
+    // discrete-alias orientation that ignored input causality.
+    let mut dae_model = dae::Dae::default();
+    dae_model
+        .variables
+        .inputs
+        .insert(rumoca_core::VarName::new("x"), scalar_var("x"));
+    dae_model
+        .variables
+        .discrete_reals
+        .insert(rumoca_core::VarName::new("prev_x"), scalar_var("prev_x"));
+    dae_model.discrete.real_updates.push(dae::Equation {
+        lhs: Some(rumoca_core::VarName::new("prev_x").into()),
+        rhs: rumoca_core::Expression::VarRef {
+            name: rumoca_core::VarName::new("x").into(),
+            subscripts: vec![],
+            span: lower_test_span(),
+        },
+        span: lower_test_span(),
+        origin: "prev_x := x history update".to_string(),
+        scalar_count: 1,
+    });
+
+    let equations = crate::lower::normalized_discrete_update_equations(&dae_model)
+        .expect("history update should lower");
+
+    assert_eq!(equations.len(), 1, "expected a single oriented update");
+    let eq = &equations[0];
+    assert_eq!(
+        eq.lhs.as_ref().map(|lhs| lhs.var_name().as_str()),
+        Some("prev_x"),
+        "discrete state (not the input) must be the update target"
+    );
+    let rumoca_core::Expression::VarRef { name, .. } = &eq.rhs else {
+        panic!(
+            "history update RHS should read the input directly: {:?}",
+            eq.rhs
+        );
+    };
+    assert_eq!(
+        name.var_name().as_str(),
+        "x",
+        "history update must read the live input on the RHS"
+    );
+}
+
+#[test]
 fn lower_discrete_rhs_keeps_edge_initial_as_runtime_event_flag() {
     let mut dae_model = dae::Dae::default();
     dae_model

--- a/crates/rumoca-sim/Cargo.toml
+++ b/crates/rumoca-sim/Cargo.toml
@@ -31,6 +31,7 @@ runner = [
     "dep:rumoca-input-gamepad",
     "dep:rumoca-input-keyboard",
     "dep:rumoca-transport-udp",
+    "dep:rumoca-transport-zenoh",
     "dep:rumoca-transport-websocket",
     "dep:rumoca-compile",
     "dep:signal-hook",
@@ -61,6 +62,7 @@ rumoca-codec = { workspace = true, optional = true }
 rumoca-input = { workspace = true, optional = true }
 rumoca-input-keyboard = { workspace = true, optional = true }
 rumoca-transport-udp = { workspace = true, optional = true }
+rumoca-transport-zenoh = { workspace = true, optional = true }
 rumoca-transport-websocket = { workspace = true, optional = true }
 rumoca-compile = { workspace = true, optional = true }
 signal-hook = { version = "0.3", optional = true }

--- a/crates/rumoca-sim/src/diffsol.rs
+++ b/crates/rumoca-sim/src/diffsol.rs
@@ -168,6 +168,16 @@ impl SimStepper {
             &opts,
             true,
         )?;
+        Self::from_solve_model(solve_model, opts)
+    }
+
+    /// Build directly from an already-lowered, override-applied solve model, so
+    /// callers that lowered once (e.g. the auto-stepper dispatch that first
+    /// probes for a pure-discrete model) do not lower the model a second time.
+    pub(crate) fn from_solve_model(
+        solve_model: solve::SolveModel,
+        opts: rumoca_solver::SimOptions,
+    ) -> Result<Self, SimulationDiagnosticError> {
         let inner = rumoca_solver_diffsol::stepper::SimStepper::new(&solve_model, opts)
             .map_err(|err| SimulationDiagnosticError::Solver(err.to_string()))?;
         Ok(Self { inner })

--- a/crates/rumoca-sim/src/discrete_stepper.rs
+++ b/crates/rumoca-sim/src/discrete_stepper.rs
@@ -1,0 +1,206 @@
+use indexmap::IndexMap;
+use rumoca_eval_solve::{SolveRuntime, apply_discrete_slot_values};
+use rumoca_ir_solve as solve;
+use rumoca_solver::{RuntimeSolveError, commit_pre_params_after_event};
+
+use crate::solve_lowering::SimulationDiagnosticError;
+
+const UPDATE_TOL: f64 = 1.0e-9;
+const UPDATE_MAX_ITERS: usize = 64;
+
+#[derive(Debug, Clone)]
+pub(crate) struct StepperState {
+    pub(crate) time: f64,
+    pub(crate) values: IndexMap<String, f64>,
+}
+
+pub(crate) struct SimStepper {
+    runtime: &'static SolveRuntime,
+    reset_y: Vec<f64>,
+    reset_params: Vec<f64>,
+    y: Vec<f64>,
+    params: Vec<f64>,
+    input_values: IndexMap<String, f64>,
+    time: f64,
+}
+
+impl SimStepper {
+    /// Build a pure-discrete stepper from an already-lowered solve model. The
+    /// caller (the auto/rk-like dispatch) lowers the model once and routes it
+    /// here only when it has zero continuous states, so nothing is lowered
+    /// twice.
+    pub(crate) fn from_solve_model(
+        solve_model: solve::SolveModel,
+    ) -> Result<Self, SimulationDiagnosticError> {
+        let runtime = Box::leak(Box::new(
+            SolveRuntime::new(&solve_model)
+                .map_err(|err| SimulationDiagnosticError::Solver(err.to_string()))?,
+        ));
+        let mut y = runtime.model.initial_y.clone();
+        let mut params = runtime.model.parameters.clone();
+        runtime
+            .apply_initialization_updates(&mut y, &mut params, 0.0, UPDATE_TOL, UPDATE_MAX_ITERS)
+            .map_err(runtime_error)?;
+        runtime
+            .update_relation_memory_from_state(0.0, &[], &mut params, UPDATE_TOL, UPDATE_MAX_ITERS)
+            .map_err(runtime_error)?;
+        runtime
+            .refresh_algebraic_and_output_slots(0.0, &mut y, &params, UPDATE_TOL, UPDATE_MAX_ITERS)
+            .map_err(runtime_error)?;
+        commit_pre_params_after_event(&runtime.model, &y, &mut params, UPDATE_TOL);
+        Ok(Self {
+            runtime,
+            reset_y: y.clone(),
+            reset_params: params.clone(),
+            y,
+            params,
+            input_values: IndexMap::new(),
+            time: 0.0,
+        })
+    }
+
+    pub(crate) fn set_input(
+        &mut self,
+        name: &str,
+        value: f64,
+    ) -> Result<(), SimulationDiagnosticError> {
+        let Some(param_idx) = self
+            .runtime
+            .model
+            .problem
+            .solve_layout
+            .input_parameter_index(name)
+        else {
+            return Err(SimulationDiagnosticError::Solver(format!(
+                "unknown input '{name}'"
+            )));
+        };
+        self.input_values.insert(name.to_string(), value);
+        if let Some(slot) = self.params.get_mut(param_idx) {
+            *slot = value;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn reset(&mut self, t_start: f64) -> Result<(), SimulationDiagnosticError> {
+        self.y.clone_from(&self.reset_y);
+        self.params.clone_from(&self.reset_params);
+        self.input_values.clear();
+        self.time = t_start;
+        Ok(())
+    }
+
+    pub(crate) fn step(&mut self, dt: f64) -> Result<(), SimulationDiagnosticError> {
+        if dt <= 0.0 {
+            return Ok(());
+        }
+        self.time += dt;
+        let values = self
+            .runtime
+            .eval_scalar_program_block(
+                &self.runtime.model.problem.discrete.rhs,
+                &self.y,
+                &self.params,
+                self.time,
+            )
+            .map_err(runtime_error)?;
+        apply_discrete_slot_values(
+            &self.runtime.model.problem.discrete.update_targets,
+            &values,
+            &mut self.y,
+            &mut self.params,
+            UPDATE_TOL,
+        )
+        .map_err(runtime_error)?;
+        self.runtime
+            .apply_runtime_assignments_once(&mut self.y, &mut self.params, self.time)
+            .map_err(runtime_error)?;
+        commit_pre_params_after_event(&self.runtime.model, &self.y, &mut self.params, UPDATE_TOL);
+        Ok(())
+    }
+
+    pub(crate) fn time(&self) -> f64 {
+        self.time
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Result<Option<f64>, SimulationDiagnosticError> {
+        if let Some(value) = self.input_values.get(name).copied() {
+            return Ok(Some(value));
+        }
+        let Some(idx) = self
+            .runtime
+            .model
+            .visible_names
+            .iter()
+            .position(|visible| visible == name)
+        else {
+            return Ok(None);
+        };
+        let values = self
+            .runtime
+            .visible_values(&self.y, &self.params, self.time)
+            .map_err(runtime_error)?;
+        values.get(idx).copied().map(Some).ok_or_else(|| {
+            SimulationDiagnosticError::Solver(format!(
+                "visible value '{name}' resolved to index {idx}, but runtime returned {} values",
+                values.len()
+            ))
+        })
+    }
+
+    pub(crate) fn state(&self) -> Result<StepperState, SimulationDiagnosticError> {
+        Ok(StepperState {
+            time: self.time(),
+            values: self.stepper_visible_values()?,
+        })
+    }
+
+    pub(crate) fn values_for(
+        &self,
+        names: &[String],
+    ) -> Result<IndexMap<String, f64>, SimulationDiagnosticError> {
+        self.runtime
+            .visible_values_for_names(&self.y, &self.params, self.time, names)
+            .map_err(runtime_error)
+    }
+
+    pub(crate) fn input_names(&self) -> &[String] {
+        self.runtime.model.problem.solve_layout.input_scalar_names()
+    }
+
+    pub(crate) fn variable_names(&self) -> &[String] {
+        &self.runtime.model.visible_names
+    }
+
+    fn stepper_visible_values(&self) -> Result<IndexMap<String, f64>, SimulationDiagnosticError> {
+        let visible_values = self
+            .runtime
+            .visible_values(&self.y, &self.params, self.time)
+            .map_err(runtime_error)?;
+        if self.runtime.model.visible_names.len() != visible_values.len() {
+            return Err(SimulationDiagnosticError::Solver(format!(
+                "runtime returned {} visible values for {} visible names",
+                visible_values.len(),
+                self.runtime.model.visible_names.len()
+            )));
+        }
+        let mut values: IndexMap<String, f64> = self
+            .runtime
+            .model
+            .visible_names
+            .iter()
+            .cloned()
+            .zip(visible_values)
+            .collect();
+        values.extend(
+            self.input_values
+                .iter()
+                .map(|(name, value)| (name.clone(), *value)),
+        );
+        Ok(values)
+    }
+}
+
+fn runtime_error(error: RuntimeSolveError) -> SimulationDiagnosticError {
+    SimulationDiagnosticError::Solver(error.to_string())
+}

--- a/crates/rumoca-sim/src/lib.rs
+++ b/crates/rumoca-sim/src/lib.rs
@@ -27,6 +27,8 @@ pub use rumoca_solver::{
 };
 
 pub mod bulk;
+#[cfg(any(feature = "solver-diffsol", feature = "solver-rk45"))]
+mod discrete_stepper;
 mod interactive_stepper;
 #[cfg(any(feature = "solver-diffsol", feature = "solver-rk45"))]
 mod sim_stepper;

--- a/crates/rumoca-sim/src/rk45.rs
+++ b/crates/rumoca-sim/src/rk45.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use rumoca_ir_dae as dae;
+use rumoca_ir_solve as solve;
 
 use crate::InteractiveStepper;
 use crate::solve_lowering::{SimulationDiagnosticError, lower_dae_for_simulation};
@@ -55,6 +56,16 @@ impl SimStepper {
             &opts,
             true,
         )?;
+        Self::from_solve_model(solve_model, opts)
+    }
+
+    /// Build directly from an already-lowered, override-applied solve model, so
+    /// callers that lowered once (e.g. the auto-stepper dispatch that first
+    /// probes for a pure-discrete model) do not lower the model a second time.
+    pub(crate) fn from_solve_model(
+        solve_model: solve::SolveModel,
+        opts: rumoca_solver::SimOptions,
+    ) -> Result<Self, SimulationDiagnosticError> {
         let inner = rumoca_solver_rk45::SimStepper::new(&solve_model, opts)
             .map_err(|err| SimulationDiagnosticError::Solver(err.to_string()))?;
         Ok(Self { inner })

--- a/crates/rumoca-sim/src/runner/config.rs
+++ b/crates/rumoca-sim/src/runner/config.rs
@@ -14,6 +14,7 @@ use rumoca_codec::config::{
 use rumoca_input::config::{DeriveSpec, InputConfig, LocalDef, SignalsConfig};
 use rumoca_solver::SimPacingMode;
 use rumoca_transport_udp::UdpConfig;
+use rumoca_transport_zenoh::ZenohConfig;
 
 // ── Top-level ──────────────────────────────────────────────────────────────
 
@@ -84,6 +85,13 @@ pub struct SimulationConfig {
     controller: Option<toml::Value>,
     #[serde(default)]
     pub transport: Option<TransportConfig>,
+    /// Message-name to Zenoh key mapping. Message names may be `send`,
+    /// `receive`, a FlatBuffer root type, or the root type's snake_case leaf.
+    #[serde(default)]
+    pub publish: HashMap<String, String>,
+    /// Message-name to Zenoh key mapping for inbound command messages.
+    #[serde(default)]
+    pub subscribe: HashMap<String, String>,
     #[serde(default)]
     pub locals: HashMap<String, LocalDef>,
     #[serde(default)]
@@ -191,6 +199,8 @@ pub struct ModelConfig {
 pub struct TransportConfig {
     #[serde(default)]
     pub udp: Option<UdpConfig>,
+    #[serde(default)]
+    pub zenoh: Option<ZenohConfig>,
     #[serde(default, rename = "websocket")]
     pub websocket: Option<WebSocketConfig>,
     #[serde(default)]
@@ -450,6 +460,13 @@ impl SimulationConfig {
         Ok(config)
     }
 
+    /// True when a `[transport.zenoh]` section is configured.
+    fn has_zenoh_transport(&self) -> bool {
+        self.transport
+            .as_ref()
+            .is_some_and(|transport| transport.zenoh.is_some())
+    }
+
     /// The three FB sections must all be present (external coupling) or all
     /// absent (standalone). Any mix is a user error.
     fn validate(&self) -> anyhow::Result<()> {
@@ -493,6 +510,12 @@ impl SimulationConfig {
                  Provide all three ([schema], [receive], [send]) to enable \
                  external-interface coupling, or omit all three for standalone mode."
             );
+        }
+        if !self.publish.is_empty() && !self.has_zenoh_transport() {
+            anyhow::bail!("[publish] requires a [transport.zenoh] section");
+        }
+        if !self.subscribe.is_empty() && !self.has_zenoh_transport() {
+            anyhow::bail!("[subscribe] requires a [transport.zenoh] section");
         }
         if self.controller.is_some() {
             anyhow::bail!(

--- a/crates/rumoca-sim/src/runner/config.rs
+++ b/crates/rumoca-sim/src/runner/config.rs
@@ -55,6 +55,8 @@ pub struct SimulationConfig {
     pub rumoca: Option<RumocaMarker>,
 
     pub sim: SimConfig,
+    #[serde(default)]
+    pub lockstep: Option<LockstepConfig>,
 
     /// Additional Modelica package roots loaded before the requested model.
     /// Paths are resolved relative to the config file by the CLI.
@@ -143,6 +145,26 @@ pub struct SimConfig {
     /// - `lockstep`: wait for each inbound external-interface packet before stepping.
     #[serde(default)]
     pub mode: Option<SimPacingMode>,
+    /// Number of `dt` runner steps to advance after each received lockstep
+    /// packet. Values greater than 1 are useful for a slower external
+    /// controller driving a faster plant integration rate.
+    #[serde(default = "default_steps_per_packet")]
+    pub steps_per_packet: usize,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockstepConfig {
+    /// Outbound sample stream rate. With the current runner this is the single
+    /// configured `[send]` FlatBuffer message, e.g. fake mocap.
+    pub send_rate_hz: f64,
+    /// Inbound control barrier rate. The runner waits for one received packet
+    /// before advancing beyond each interval.
+    pub receive_rate_hz: f64,
+    /// Maximum plant integration step used while advancing between scheduled
+    /// send/control boundaries. Defaults to `[sim].dt`.
+    #[serde(default)]
+    pub max_step_dt: Option<f64>,
 }
 
 fn default_dt() -> f64 {
@@ -150,6 +172,9 @@ fn default_dt() -> f64 {
 }
 fn default_t_end() -> f64 {
     1.0
+}
+fn default_steps_per_packet() -> usize {
+    1
 }
 
 // ── Model ──────────────────────────────────────────────────────────────────
@@ -428,6 +453,22 @@ impl SimulationConfig {
     /// The three FB sections must all be present (external coupling) or all
     /// absent (standalone). Any mix is a user error.
     fn validate(&self) -> anyhow::Result<()> {
+        if self.sim.steps_per_packet == 0 {
+            anyhow::bail!("[sim] steps_per_packet must be at least 1");
+        }
+        if let Some(lockstep) = &self.lockstep {
+            if lockstep.send_rate_hz <= 0.0 || !lockstep.send_rate_hz.is_finite() {
+                anyhow::bail!("[lockstep] send_rate_hz must be a positive finite number");
+            }
+            if lockstep.receive_rate_hz <= 0.0 || !lockstep.receive_rate_hz.is_finite() {
+                anyhow::bail!("[lockstep] receive_rate_hz must be a positive finite number");
+            }
+            if let Some(max_step_dt) = lockstep.max_step_dt
+                && (max_step_dt <= 0.0 || !max_step_dt.is_finite())
+            {
+                anyhow::bail!("[lockstep] max_step_dt must be a positive finite number");
+            }
+        }
         let present = [
             ("schema", self.schema.is_some()),
             ("receive", self.receive.is_some()),
@@ -641,6 +682,73 @@ mode = "{raw}"
             let cfg = toml::from_str::<SimulationConfig>(&text).unwrap();
             assert_eq!(cfg.effective_pacing_mode(), expected);
         }
+    }
+
+    #[test]
+    fn parses_lockstep_steps_per_packet() {
+        let text = r#"
+[sim]
+dt = 0.01
+mode = "lockstep"
+steps_per_packet = 4
+"#;
+        let cfg = toml::from_str::<SimulationConfig>(text).unwrap();
+        assert_eq!(cfg.sim.steps_per_packet, 4);
+        cfg.validate()
+            .expect("positive steps_per_packet should validate");
+    }
+
+    #[test]
+    fn rejects_zero_steps_per_packet() {
+        let text = r#"
+[sim]
+dt = 0.01
+steps_per_packet = 0
+"#;
+        let cfg = toml::from_str::<SimulationConfig>(text).unwrap();
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("steps_per_packet"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parses_multirate_lockstep_config() {
+        let text = r#"
+[sim]
+dt = 0.002
+mode = "lockstep"
+
+[lockstep]
+send_rate_hz = 240
+receive_rate_hz = 50
+max_step_dt = 0.002
+"#;
+        let cfg = toml::from_str::<SimulationConfig>(text).unwrap();
+        let lockstep = cfg.lockstep.as_ref().expect("lockstep config");
+        assert_eq!(lockstep.send_rate_hz, 240.0);
+        assert_eq!(lockstep.receive_rate_hz, 50.0);
+        assert_eq!(lockstep.max_step_dt, Some(0.002));
+        cfg.validate().expect("multirate lockstep validates");
+    }
+
+    #[test]
+    fn rejects_invalid_multirate_lockstep_rates() {
+        let text = r#"
+[sim]
+dt = 0.002
+
+[lockstep]
+send_rate_hz = 0
+receive_rate_hz = 50
+"#;
+        let cfg = toml::from_str::<SimulationConfig>(text).unwrap();
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("send_rate_hz"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/rumoca-sim/src/runner/executor.rs
+++ b/crates/rumoca-sim/src/runner/executor.rs
@@ -27,7 +27,9 @@ use rumoca_input::{
 };
 use rumoca_transport_udp::{UdpConfig, UdpTransport};
 use rumoca_transport_websocket::run_broadcast_server;
+use rumoca_transport_zenoh::ZenohTransport;
 use serde::Deserialize;
+use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::runner::devices::{self, Devices};
 
@@ -235,6 +237,51 @@ fn resolve_udp(cfg: &SimulationConfig) -> Option<&UdpConfig> {
     cfg.transport.as_ref().and_then(|t| t.udp.as_ref())
 }
 
+fn resolve_zenoh(cfg: &SimulationConfig) -> Option<&rumoca_transport_zenoh::ZenohConfig> {
+    cfg.transport.as_ref().and_then(|t| t.zenoh.as_ref())
+}
+
+fn insert_u64(obj: &mut JsonMap<String, JsonValue>, key: &str, value: u64) {
+    obj.insert(key.to_string(), JsonValue::from(value));
+}
+
+fn snake_case_type_leaf(root_type: &str) -> String {
+    // `root_type` is a FlatBuffer fully-qualified type (e.g. `cerebri2.topic.Foo`);
+    // take the segment after the last dot without string tokenization. `.` is
+    // ASCII so byte-index slicing is safe.
+    let leaf = match root_type.rfind('.') {
+        Some(dot) => &root_type[dot + 1..],
+        None => root_type,
+    };
+    let mut out = String::new();
+    let mut prev_lower_or_digit = false;
+    for ch in leaf.chars() {
+        if ch.is_ascii_uppercase() {
+            if prev_lower_or_digit {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+            prev_lower_or_digit = false;
+        } else {
+            prev_lower_or_digit = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn map_message_name(
+    messages: &std::collections::HashMap<String, String>,
+    alias: &str,
+    root_type: &str,
+) -> Option<String> {
+    let leaf = snake_case_type_leaf(root_type);
+    [alias, root_type, leaf.as_str()]
+        .into_iter()
+        .find(|name| messages.contains_key(*name))
+        .map(str::to_owned)
+}
+
 #[derive(Deserialize)]
 struct ViewerInputCommand {
     key: Option<ViewerKeyCommand>,
@@ -360,10 +407,14 @@ fn browser_key_to_event(key: &ViewerKeyCommand) -> Option<KeyboardEvent> {
 /// `[receive]` + `[send]` are configured (external coupling). Absent in
 /// standalone mode (e.g. rover demo).
 struct FbTransport {
-    udp: UdpTransport,
+    udp: Option<UdpTransport>,
+    zenoh: Option<ZenohTransport>,
     pack: Box<dyn PackCodec>,
     unpack: Box<dyn UnpackCodec>,
     recv_expected: usize,
+    send_publish: Option<String>,
+    receive_publish: Option<String>,
+    receive_subscribe: Option<String>,
 }
 
 /// Immutable per-frame context: FB transport (if any), mapper, and channels.
@@ -387,6 +438,7 @@ struct FrameCtx<'a> {
 struct FrameState {
     recv_buf: [u8; 512],
     pkt_count: u64,
+    send_count: u64,
     frame_num: u64,
     last_poll: Instant,
     trace: Option<TraceLogger>,
@@ -450,6 +502,43 @@ enum FrameControl {
 /// Run the interactive simulation app. Blocks the calling thread. In standalone
 /// mode (no `[schema]`/`[receive]`/`[send]` in config) the UDP socket and
 /// codecs are not created and no external-interface coupling happens.
+fn log_pacing_status(
+    mode: SimPacingMode,
+    lockstep_schedule: Option<LockstepSchedule>,
+    steps_per_packet: usize,
+    dt: f64,
+) {
+    status_line(&format!(
+        "  Pacing: {}",
+        match mode {
+            SimPacingMode::AsFastAsPossible => "as_fast_as_possible",
+            SimPacingMode::Realtime => "realtime",
+            SimPacingMode::Lockstep if lockstep_schedule.is_some() => {
+                "lockstep (multirate scheduled)"
+            }
+            SimPacingMode::Lockstep if steps_per_packet > 1 => {
+                "lockstep (input-packet-paced, multistep)"
+            }
+            SimPacingMode::Lockstep => "lockstep (input-packet-paced)",
+        }
+    ));
+    if matches!(mode, SimPacingMode::Lockstep)
+        && let Some(schedule) = lockstep_schedule
+    {
+        status_line(&format!(
+            "  Lockstep send: {:.3} Hz, receive barrier: {:.3} Hz, max step dt: {} s",
+            1.0 / schedule.send_dt,
+            1.0 / schedule.receive_dt,
+            schedule.max_step_dt
+        ));
+    } else if matches!(mode, SimPacingMode::Lockstep) && steps_per_packet > 1 {
+        status_line(&format!(
+            "  Lockstep steps/packet: {steps_per_packet} ({} s simulated per packet)",
+            dt * steps_per_packet as f64
+        ));
+    }
+}
+
 pub fn run_sim_loop<S>(stepper: &mut S, args: SimLoopArgs<'_>) -> Result<()>
 where
     S: InteractiveStepper,
@@ -520,35 +609,7 @@ where
         .lockstep
         .as_ref()
         .map(|lockstep| LockstepSchedule::from_config(lockstep, cfg.sim.dt));
-    status_line(&format!(
-        "  Pacing: {}",
-        match mode {
-            SimPacingMode::AsFastAsPossible => "as_fast_as_possible",
-            SimPacingMode::Realtime => "realtime",
-            SimPacingMode::Lockstep if lockstep_schedule.is_some() => {
-                "lockstep (multirate scheduled)"
-            }
-            SimPacingMode::Lockstep if steps_per_packet > 1 => {
-                "lockstep (input-packet-paced, multistep)"
-            }
-            SimPacingMode::Lockstep => "lockstep (input-packet-paced)",
-        }
-    ));
-    if matches!(mode, SimPacingMode::Lockstep)
-        && let Some(schedule) = lockstep_schedule
-    {
-        status_line(&format!(
-            "  Lockstep send: {:.3} Hz, receive barrier: {:.3} Hz, max step dt: {} s",
-            1.0 / schedule.send_dt,
-            1.0 / schedule.receive_dt,
-            schedule.max_step_dt
-        ));
-    } else if matches!(mode, SimPacingMode::Lockstep) && steps_per_packet > 1 {
-        status_line(&format!(
-            "  Lockstep steps/packet: {steps_per_packet} ({} s simulated per packet)",
-            cfg.sim.dt * steps_per_packet as f64
-        ));
-    }
+    log_pacing_status(mode, lockstep_schedule, steps_per_packet, cfg.sim.dt);
     status_line("");
     status_line("Ready. Simulation running.");
     status_line(&format!(
@@ -576,6 +637,7 @@ where
     let mut state = FrameState {
         recv_buf: [0u8; 512],
         pkt_count: 0,
+        send_count: 0,
         frame_num: 0,
         last_poll: Instant::now(),
         trace,
@@ -631,16 +693,61 @@ fn setup_fb_transport(cfg: &SimulationConfig) -> Result<Option<FbTransport>> {
     let pack = rumoca_codec::build_pack(schema_cfg, send_cfg).context("Build pack codec")?;
     let unpack = rumoca_codec::build_unpack(schema_cfg, recv_cfg).context("Build unpack codec")?;
     let recv_expected = unpack.expected_size();
-    let udp_cfg = resolve_udp(cfg).context("FB config present but no [transport.udp] section")?;
-    eprintln!("  UDP listen: {}", udp_cfg.listen);
-    eprintln!("  UDP send:   {}", udp_cfg.send);
     eprintln!("  Expecting {recv_expected}-byte receive packets");
-    let udp = UdpTransport::bind(udp_cfg)?;
+    let udp = match resolve_udp(cfg) {
+        Some(udp_cfg) => {
+            eprintln!("  UDP listen: {}", udp_cfg.listen);
+            eprintln!("  UDP send:   {}", udp_cfg.send);
+            Some(UdpTransport::bind(udp_cfg)?)
+        }
+        None => None,
+    };
+    let send_publish = map_message_name(&cfg.publish, "send", &send_cfg.root_type);
+    let receive_publish = map_message_name(&cfg.publish, "receive", &recv_cfg.root_type);
+    let receive_subscribe = map_message_name(&cfg.subscribe, "receive", &recv_cfg.root_type);
+    let zenoh = match resolve_zenoh(cfg) {
+        Some(zenoh_cfg) => {
+            let transport = ZenohTransport::open(zenoh_cfg, &cfg.publish, &cfg.subscribe)?;
+            if let Some(name) = &send_publish
+                && let Some(key) = transport.publish_key_for(name)
+            {
+                eprintln!("  Zenoh publish send '{name}': {key}");
+            }
+            if let Some(name) = &receive_publish
+                && let Some(key) = transport.publish_key_for(name)
+            {
+                eprintln!("  Zenoh publish receive '{name}': {key}");
+            }
+            if let Some(name) = &receive_subscribe
+                && let Some(key) = transport.subscribe_key_for(name)
+            {
+                eprintln!("  Zenoh subscribe receive '{name}': {key}");
+            }
+            Some(transport)
+        }
+        None => None,
+    };
+    if udp.is_none() && receive_subscribe.is_none() {
+        anyhow::bail!(
+            "FB config needs an inbound command transport: configure [transport.udp] or \
+             [transport.zenoh] plus [subscribe] for the [receive] message"
+        );
+    }
+    if udp.is_none() && send_publish.is_none() {
+        anyhow::bail!(
+            "FB config without [transport.udp] needs an outbound sensor transport: \
+             configure [publish] for the [send] message"
+        );
+    }
     Ok(Some(FbTransport {
         udp,
+        zenoh,
         pack,
         unpack,
         recv_expected,
+        send_publish,
+        receive_publish,
+        receive_subscribe,
     }))
 }
 
@@ -757,7 +864,7 @@ impl FrameCtx<'_> {
         if !state.lockstep_schedule_initialized {
             state.lockstep_schedule_initialized = true;
             state.next_lockstep_control_time = now + schedule.receive_dt;
-            state.next_lockstep_send_time = now;
+            state.next_lockstep_send_time = now + schedule.send_dt;
         }
 
         let control_time = state.next_lockstep_control_time;
@@ -768,7 +875,7 @@ impl FrameCtx<'_> {
         }
         self.apply_stepper_inputs(state, stepper, engine, input_runtime)?;
 
-        while state.next_lockstep_send_time <= control_time + EPS {
+        while state.next_lockstep_send_time < control_time - EPS {
             let target = state.next_lockstep_send_time;
             let step_dt = target - stepper.time();
             if step_dt > EPS {
@@ -858,10 +965,54 @@ impl FrameCtx<'_> {
             (send_frame, json)
         };
         if let (Some(fb), Some(frame)) = (self.fb, send_frame) {
-            fb.udp.send(&fb.pack.pack(&frame));
+            let bytes = fb.pack.pack(&frame);
+            if let Some(udp) = &fb.udp {
+                udp.send(&bytes);
+            }
+            if let (Some(zenoh), Some(message)) = (&fb.zenoh, &fb.send_publish) {
+                zenoh.publish(message, &bytes);
+            }
+            state.send_count += 1;
         }
+        let json = self.with_runtime_transport_fields(json, state, stepper.time())?;
         let _ = self.state_tx.send(json);
         Ok(())
+    }
+
+    fn with_runtime_transport_fields(
+        &self,
+        json: String,
+        state: &FrameState,
+        stepper_time: f64,
+    ) -> Result<String> {
+        let mut value: JsonValue =
+            serde_json::from_str(&json).context("parse viewer JSON for runtime fields")?;
+        let obj = value
+            .as_object_mut()
+            .context("viewer JSON root must be an object")?;
+        insert_u64(obj, "runtime_tx_count", state.send_count);
+        insert_u64(obj, "runtime_rx_count", state.pkt_count);
+        if stepper_time > 0.0 {
+            obj.insert(
+                "runtime_tx_actual_hz".to_string(),
+                JsonValue::from(state.send_count as f64 / stepper_time),
+            );
+            obj.insert(
+                "runtime_rx_actual_hz".to_string(),
+                JsonValue::from(state.pkt_count as f64 / stepper_time),
+            );
+        }
+        if let Some(schedule) = self.lockstep_schedule {
+            obj.insert(
+                "runtime_tx_target_hz".to_string(),
+                JsonValue::from(1.0 / schedule.send_dt),
+            );
+            obj.insert(
+                "runtime_rx_target_hz".to_string(),
+                JsonValue::from(1.0 / schedule.receive_dt),
+            );
+        }
+        Ok(value.to_string())
     }
 
     fn emit_status(&self, state: &FrameState, stepper: &impl InteractiveStepper) {
@@ -889,11 +1040,27 @@ impl FrameCtx<'_> {
         let Some(fb) = self.fb else {
             return Ok(false);
         };
-        let Some(n) = fb.udp.recv_blocking(&mut state.recv_buf) else {
+        if let (Some(zenoh), Some(message)) = (&fb.zenoh, &fb.receive_subscribe) {
+            let Some(datagram) = zenoh.recv_latest_blocking(message, Duration::from_millis(100))
+            else {
+                return Ok(false);
+            };
+            state.pkt_count += 1;
+            apply_fb_datagram(fb, &datagram, stepper, engine)?;
+            return Ok(true);
+        }
+        let Some(udp) = &fb.udp else {
+            return Ok(false);
+        };
+        let Some(n) = udp.recv_blocking(&mut state.recv_buf) else {
             return Ok(false);
         };
         state.pkt_count += 1;
-        apply_fb_datagram(fb, &state.recv_buf[..n], stepper, engine)?;
+        let datagram = &state.recv_buf[..n];
+        if let (Some(zenoh), Some(message)) = (&fb.zenoh, &fb.receive_publish) {
+            zenoh.publish(message, datagram);
+        }
+        apply_fb_datagram(fb, datagram, stepper, engine)?;
         Ok(true)
     }
 
@@ -942,11 +1109,20 @@ impl FrameCtx<'_> {
             return Ok(());
         };
         let expected = fb.recv_expected;
+        if let (Some(zenoh), Some(message)) = (&fb.zenoh, &fb.receive_subscribe) {
+            return drain_zenoh_subscribe(fb, zenoh, message, expected, state, stepper, engine);
+        }
+        let Some(udp) = &fb.udp else {
+            return Ok(());
+        };
         let mut error = None;
-        fb.udp.drain(&mut state.recv_buf, |datagram| {
+        udp.drain(&mut state.recv_buf, |datagram| {
             state.pkt_count += 1;
             if datagram.len() != expected || error.is_some() {
                 return;
+            }
+            if let (Some(zenoh), Some(message)) = (&fb.zenoh, &fb.receive_publish) {
+                zenoh.publish(message, datagram);
             }
             error = apply_fb_datagram(fb, datagram, stepper, engine).err();
         });
@@ -955,6 +1131,32 @@ impl FrameCtx<'_> {
         }
         Ok(())
     }
+}
+
+/// Drain the Zenoh subscribe key, applying each datagram to the stepper. Split
+/// out of `drain_udp` so the receive closure isn't nested under the transport
+/// match arm.
+fn drain_zenoh_subscribe(
+    fb: &FbTransport,
+    zenoh: &ZenohTransport,
+    message: &str,
+    expected: usize,
+    state: &mut FrameState,
+    stepper: &mut impl InteractiveStepper,
+    engine: &mut InputEngine,
+) -> Result<()> {
+    let mut error = None;
+    zenoh.drain(message, |datagram| {
+        state.pkt_count += 1;
+        if datagram.len() != expected || error.is_some() {
+            return;
+        }
+        error = apply_fb_datagram(fb, datagram, stepper, engine).err();
+    });
+    if let Some(error) = error {
+        return Err(error);
+    }
+    Ok(())
 }
 
 fn start_external_interface_into(

--- a/crates/rumoca-sim/src/runner/executor.rs
+++ b/crates/rumoca-sim/src/runner/executor.rs
@@ -747,6 +747,10 @@ impl FrameCtx<'_> {
         input_runtime: &mut Devices,
         viewer_input: ViewerInputDrain,
     ) -> Result<FrameControl> {
+        // Slack for comparing accumulated send/control times against each other:
+        // the schedule advances `next_lockstep_send_time` by `send_dt` each send,
+        // so exact `==` would be defeated by float rounding. 1 ns is far below any
+        // realistic sim dt yet large enough to absorb that accumulation drift.
         const EPS: f64 = 1e-9;
 
         let now = stepper.time();
@@ -771,6 +775,10 @@ impl FrameCtx<'_> {
                 step_with_max_dt(stepper, step_dt, schedule.max_step_dt)?;
             }
             self.emit_payloads(state, stepper, engine, input_runtime)?;
+            // In this scheduled path `frame_num` counts *sends* (one per emitted
+            // payload), whereas the packet-paced path counts internal solver
+            // steps. The viewer only needs a monotonic frame counter, so the
+            // differing units are intentional.
             state.frame_num += 1;
             self.emit_status(state, stepper);
             state.next_lockstep_send_time += schedule.send_dt;

--- a/crates/rumoca-sim/src/runner/executor.rs
+++ b/crates/rumoca-sim/src/runner/executor.rs
@@ -31,7 +31,7 @@ use serde::Deserialize;
 
 use crate::runner::devices::{self, Devices};
 
-use crate::runner::config::{ResetConfig, SimulationConfig};
+use crate::runner::config::{LockstepConfig, ResetConfig, SimulationConfig};
 
 fn wall_ms_since_unix_epoch() -> Result<f64> {
     Ok(SystemTime::now()
@@ -379,6 +379,8 @@ struct FrameCtx<'a> {
     debug: bool,
     dt: f64,
     mode: SimPacingMode,
+    steps_per_packet: usize,
+    lockstep_schedule: Option<LockstepSchedule>,
 }
 
 /// Mutable per-frame state that carries across iterations.
@@ -388,6 +390,26 @@ struct FrameState {
     frame_num: u64,
     last_poll: Instant,
     trace: Option<TraceLogger>,
+    lockstep_schedule_initialized: bool,
+    next_lockstep_send_time: f64,
+    next_lockstep_control_time: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LockstepSchedule {
+    send_dt: f64,
+    receive_dt: f64,
+    max_step_dt: f64,
+}
+
+impl LockstepSchedule {
+    fn from_config(lockstep: &LockstepConfig, sim_dt: f64) -> Self {
+        Self {
+            send_dt: 1.0 / lockstep.send_rate_hz,
+            receive_dt: 1.0 / lockstep.receive_rate_hz,
+            max_step_dt: lockstep.max_step_dt.unwrap_or(sim_dt),
+        }
+    }
 }
 
 pub struct SimLoopArgs<'a> {
@@ -493,14 +515,40 @@ where
         anyhow::bail!(error);
     }
 
+    let steps_per_packet = cfg.sim.steps_per_packet;
+    let lockstep_schedule = cfg
+        .lockstep
+        .as_ref()
+        .map(|lockstep| LockstepSchedule::from_config(lockstep, cfg.sim.dt));
     status_line(&format!(
         "  Pacing: {}",
         match mode {
             SimPacingMode::AsFastAsPossible => "as_fast_as_possible",
             SimPacingMode::Realtime => "realtime",
+            SimPacingMode::Lockstep if lockstep_schedule.is_some() => {
+                "lockstep (multirate scheduled)"
+            }
+            SimPacingMode::Lockstep if steps_per_packet > 1 => {
+                "lockstep (input-packet-paced, multistep)"
+            }
             SimPacingMode::Lockstep => "lockstep (input-packet-paced)",
         }
     ));
+    if matches!(mode, SimPacingMode::Lockstep)
+        && let Some(schedule) = lockstep_schedule
+    {
+        status_line(&format!(
+            "  Lockstep send: {:.3} Hz, receive barrier: {:.3} Hz, max step dt: {} s",
+            1.0 / schedule.send_dt,
+            1.0 / schedule.receive_dt,
+            schedule.max_step_dt
+        ));
+    } else if matches!(mode, SimPacingMode::Lockstep) && steps_per_packet > 1 {
+        status_line(&format!(
+            "  Lockstep steps/packet: {steps_per_packet} ({} s simulated per packet)",
+            cfg.sim.dt * steps_per_packet as f64
+        ));
+    }
     status_line("");
     status_line("Ready. Simulation running.");
     status_line(&format!(
@@ -521,6 +569,8 @@ where
         debug,
         dt: cfg.sim.dt,
         mode,
+        steps_per_packet,
+        lockstep_schedule,
     };
     let trace = open_trace_logger(cfg)?;
     let mut state = FrameState {
@@ -529,6 +579,9 @@ where
         frame_num: 0,
         last_poll: Instant::now(),
         trace,
+        lockstep_schedule_initialized: false,
+        next_lockstep_send_time: 0.0,
+        next_lockstep_control_time: 0.0,
     };
     while let FrameControl::Continue =
         ctx.run_one_frame(&mut state, stepper, &mut engine, &mut input_runtime)?
@@ -619,6 +672,19 @@ impl FrameCtx<'_> {
             return Ok(FrameControl::Break);
         }
 
+        if matches!(self.mode, SimPacingMode::Lockstep)
+            && let Some(schedule) = self.lockstep_schedule
+        {
+            return self.run_scheduled_lockstep_frame(
+                schedule,
+                state,
+                stepper,
+                engine,
+                input_runtime,
+                viewer_input,
+            );
+        }
+
         // Pacing-specific receive + step gate.
         match self.mode {
             SimPacingMode::AsFastAsPossible | SimPacingMode::Realtime => {
@@ -634,8 +700,13 @@ impl FrameCtx<'_> {
             }
         }
 
+        let steps_this_frame = if matches!(self.mode, SimPacingMode::Lockstep) {
+            self.steps_per_packet
+        } else {
+            1
+        };
         let poll_dt = if matches!(self.mode, SimPacingMode::Lockstep | SimPacingMode::Realtime) {
-            self.dt
+            self.dt * steps_this_frame as f64
         } else {
             let elapsed = state.last_poll.elapsed().as_secs_f64();
             state.last_poll = Instant::now();
@@ -646,21 +717,13 @@ impl FrameCtx<'_> {
             return Ok(FrameControl::Break);
         }
         self.apply_stepper_inputs(state, stepper, engine, input_runtime)?;
-        step_substeps(stepper, self.dt)?;
+        for _ in 0..steps_this_frame {
+            step_substeps(stepper, self.dt)?;
+        }
 
         self.emit_payloads(state, stepper, engine, input_runtime)?;
 
-        // Status line (~1 Hz). In lockstep the period is approximate because
-        // frame rate depends on external input pacing.
-        let status_period = (1.0_f64 / self.dt).max(1.0) as u64;
-        if state.frame_num.is_multiple_of(status_period) {
-            eprint!(
-                "\r[sim] t={:.1}s frame={} pkts={}            ",
-                stepper.time(),
-                state.frame_num,
-                state.pkt_count
-            );
-        }
+        self.emit_status(state, stepper);
 
         // Realtime pacing is an explicit mode. Lockstep is paced by input
         // arrival, and as-fast-as-possible intentionally never sleeps here.
@@ -671,7 +734,57 @@ impl FrameCtx<'_> {
                 thread::sleep(target - elapsed);
             }
         }
-        state.frame_num += 1;
+        state.frame_num += steps_this_frame as u64;
+        Ok(FrameControl::Continue)
+    }
+
+    fn run_scheduled_lockstep_frame(
+        &self,
+        schedule: LockstepSchedule,
+        state: &mut FrameState,
+        stepper: &mut impl InteractiveStepper,
+        engine: &mut InputEngine,
+        input_runtime: &mut Devices,
+        viewer_input: ViewerInputDrain,
+    ) -> Result<FrameControl> {
+        const EPS: f64 = 1e-9;
+
+        let now = stepper.time();
+        if !state.lockstep_schedule_initialized {
+            state.lockstep_schedule_initialized = true;
+            state.next_lockstep_control_time = now + schedule.receive_dt;
+            state.next_lockstep_send_time = now;
+        }
+
+        let control_time = state.next_lockstep_control_time;
+        let poll_dt = (control_time - now).max(0.0);
+        input_runtime.poll_with_keyboard_events(engine, poll_dt, viewer_input.keys);
+        if let FrameControl::Break = self.handle_signals(engine, stepper)? {
+            return Ok(FrameControl::Break);
+        }
+        self.apply_stepper_inputs(state, stepper, engine, input_runtime)?;
+
+        while state.next_lockstep_send_time <= control_time + EPS {
+            let target = state.next_lockstep_send_time;
+            let step_dt = target - stepper.time();
+            if step_dt > EPS {
+                step_with_max_dt(stepper, step_dt, schedule.max_step_dt)?;
+            }
+            self.emit_payloads(state, stepper, engine, input_runtime)?;
+            state.frame_num += 1;
+            self.emit_status(state, stepper);
+            state.next_lockstep_send_time += schedule.send_dt;
+        }
+
+        let remaining_dt = control_time - stepper.time();
+        if remaining_dt > EPS {
+            step_with_max_dt(stepper, remaining_dt, schedule.max_step_dt)?;
+        }
+
+        let transport_packet = self.wait_for_command(state, stepper, engine)?;
+        if transport_packet {
+            state.next_lockstep_control_time += schedule.receive_dt;
+        }
         Ok(FrameControl::Continue)
     }
 
@@ -741,6 +854,20 @@ impl FrameCtx<'_> {
         }
         let _ = self.state_tx.send(json);
         Ok(())
+    }
+
+    fn emit_status(&self, state: &FrameState, stepper: &impl InteractiveStepper) {
+        // Status line (~1 Hz). In lockstep the period is approximate because
+        // frame rate depends on external input pacing.
+        let status_period = (1.0_f64 / self.dt).max(1.0) as u64;
+        if state.frame_num.is_multiple_of(status_period) {
+            eprint!(
+                "\r[sim] t={:.1}s frame={} pkts={}            ",
+                stepper.time(),
+                state.frame_num,
+                state.pkt_count
+            );
+        }
     }
 
     /// Lockstep receive: consume one transport packet, apply to stepper/locals.
@@ -976,12 +1103,25 @@ where
 // ── Step helper ────────────────────────────────────────────────────────────
 
 fn step_substeps(stepper: &mut impl InteractiveStepper, dt: f64) -> Result<()> {
+    let max_step_dt = stepper.max_runner_step_dt().unwrap_or(dt);
+    step_with_max_dt(stepper, dt, max_step_dt)
+}
+
+fn step_with_max_dt(
+    stepper: &mut impl InteractiveStepper,
+    dt: f64,
+    max_step_dt: f64,
+) -> Result<()> {
     let target = stepper.time() + dt;
     let step_dt = target - stepper.time();
     if step_dt <= 0.0 {
         return Ok(());
     }
-    let max_sub_dt = stepper.max_runner_step_dt().unwrap_or(step_dt);
+    let max_sub_dt = stepper
+        .max_runner_step_dt()
+        .map(|stepper_dt| stepper_dt.min(max_step_dt))
+        .unwrap_or(max_step_dt)
+        .min(step_dt);
     let n_steps = ((step_dt / max_sub_dt).ceil() as usize).max(1);
     let sub_dt = step_dt / n_steps as f64;
     for i in 0..n_steps {

--- a/crates/rumoca-sim/src/runner/template.toml
+++ b/crates/rumoca-sim/src/runner/template.toml
@@ -78,6 +78,17 @@ scene = "my_scene.js"  # relative to this scenario
 # [transport.udp]
 # listen = "0.0.0.0:4244"
 # send   = "127.0.0.1:4242"
+#
+# [transport.zenoh]
+# mode = "peer"
+# endpoint = "tcp/192.168.10.50:7447" # optional router/peer to connect to
+#
+# [publish]
+# sim_input = "synapse/sim_input"
+# motor_output = "synapse/motor_output"
+#
+# [subscribe]
+# motor_output = "synapse/motor_output"
 
 # [external_interface]
 # command = "/path/to/external-process"

--- a/crates/rumoca-sim/src/runner/template.toml
+++ b/crates/rumoca-sim/src/runner/template.toml
@@ -52,6 +52,17 @@ mode = "realtime"  # Optional runner pacing:
                    #   "realtime"            — zero-order-hold inputs and sleep to wall-clock dt.
                    #   "lockstep"            — wait for each external packet before stepping.
                    # Defaults to "lockstep" with external coupling and "realtime" standalone.
+steps_per_packet = 1
+                   # Lockstep only: advance this many dt steps after each packet.
+                   # Use e.g. 4 for a 25 Hz controller with a 100 Hz plant dt.
+
+# Optional multirate lockstep scheduler. When present, this supersedes
+# steps_per_packet: the runner streams [send] at send_rate_hz and waits for one
+# [receive] packet at each receive_rate_hz barrier before advancing further.
+# [lockstep]
+# send_rate_hz = 240
+# receive_rate_hz = 50
+# max_step_dt = 0.002
 
 # ── Transports ────────────────────────────────────────────────────────────
 # HTTP + WebSocket always needed for the viewer.

--- a/crates/rumoca-sim/src/sim_stepper.rs
+++ b/crates/rumoca-sim/src/sim_stepper.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use rumoca_ir_dae as dae;
+use rumoca_ir_solve as solve;
 
 use crate::{InteractiveStepper, SimOptions, SimSolverMode, SimulationDiagnosticError};
 
@@ -14,6 +15,7 @@ pub struct SimStepper {
 }
 
 enum SimStepperInner {
+    Discrete(Box<crate::discrete_stepper::SimStepper>),
     #[cfg(feature = "solver-diffsol")]
     Bdf(Box<crate::diffsol::SimStepper>),
     #[cfg(feature = "solver-rk45")]
@@ -41,6 +43,7 @@ impl SimStepper {
 
     pub fn set_input(&mut self, name: &str, value: f64) -> Result<(), SimulationDiagnosticError> {
         match &mut self.inner {
+            SimStepperInner::Discrete(stepper) => stepper.set_input(name, value),
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(stepper) => stepper
                 .set_input(name, value)
@@ -54,6 +57,7 @@ impl SimStepper {
 
     pub fn reset(&mut self, t_start: f64) -> Result<(), SimulationDiagnosticError> {
         match &mut self.inner {
+            SimStepperInner::Discrete(stepper) => stepper.reset(t_start),
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(stepper) => stepper
                 .reset(t_start)
@@ -74,6 +78,7 @@ impl SimStepper {
 
     pub fn step(&mut self, dt: f64) -> Result<(), SimulationDiagnosticError> {
         match &mut self.inner {
+            SimStepperInner::Discrete(stepper) => stepper.step(dt),
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(stepper) => stepper
                 .step(dt)
@@ -87,6 +92,7 @@ impl SimStepper {
 
     pub fn time(&self) -> f64 {
         match &self.inner {
+            SimStepperInner::Discrete(stepper) => stepper.time(),
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(stepper) => stepper.time(),
             #[cfg(feature = "solver-rk45")]
@@ -96,6 +102,7 @@ impl SimStepper {
 
     pub fn get(&self, name: &str) -> Result<Option<f64>, SimulationDiagnosticError> {
         match &self.inner {
+            SimStepperInner::Discrete(stepper) => stepper.get(name),
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(stepper) => stepper
                 .get(name)
@@ -109,6 +116,13 @@ impl SimStepper {
 
     pub fn state(&self) -> Result<StepperState, SimulationDiagnosticError> {
         match &self.inner {
+            SimStepperInner::Discrete(stepper) => {
+                let state = stepper.state()?;
+                Ok(StepperState {
+                    time: state.time,
+                    values: state.values,
+                })
+            }
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(stepper) => {
                 let state = stepper
@@ -134,6 +148,7 @@ impl SimStepper {
 
     pub fn input_names(&self) -> &[String] {
         match &self.inner {
+            SimStepperInner::Discrete(stepper) => stepper.input_names(),
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(stepper) => stepper.input_names(),
             #[cfg(feature = "solver-rk45")]
@@ -143,6 +158,7 @@ impl SimStepper {
 
     pub fn variable_names(&self) -> &[String] {
         match &self.inner {
+            SimStepperInner::Discrete(stepper) => stepper.variable_names(),
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(stepper) => stepper.variable_names(),
             #[cfg(feature = "solver-rk45")]
@@ -184,6 +200,7 @@ impl InteractiveStepper for SimStepper {
 
     fn values_for(&self, names: &[String]) -> Result<Option<IndexMap<String, f64>>, Self::Error> {
         match &self.inner {
+            SimStepperInner::Discrete(stepper) => stepper.values_for(names).map(Some),
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(stepper) => stepper
                 .values_for(names)
@@ -199,6 +216,7 @@ impl InteractiveStepper for SimStepper {
 
     fn max_runner_step_dt(&self) -> Option<f64> {
         match &self.inner {
+            SimStepperInner::Discrete(_) => None,
             #[cfg(feature = "solver-diffsol")]
             SimStepperInner::Bdf(_) => Some(0.002),
             #[cfg(feature = "solver-rk45")]
@@ -207,21 +225,54 @@ impl InteractiveStepper for SimStepper {
     }
 }
 
+/// Lower the DAE and apply simulation overrides exactly once. The interactive
+/// steppers share this result: the pure-discrete probe and the ODE backend it
+/// falls through to both consume the same solve model, so a model is never
+/// lowered twice per stepper construction.
+fn lower_for_interactive_stepper(
+    dae_model: &dae::Dae,
+    opts: &rumoca_solver::SimOptions,
+) -> Result<solve::SolveModel, SimulationDiagnosticError> {
+    let mut solve_model = crate::solve_lowering::lower_dae_for_simulation(dae_model, opts)
+        .map_err(SimulationDiagnosticError::SolveLowering)?;
+    crate::solve_lowering::apply_simulation_overrides(&mut solve_model, dae_model, opts, true)?;
+    Ok(solve_model)
+}
+
+fn discrete_stepper_from_solve_model(
+    solve_model: solve::SolveModel,
+) -> Result<SimStepper, SimulationDiagnosticError> {
+    let stepper = crate::discrete_stepper::SimStepper::from_solve_model(solve_model)?;
+    Ok(SimStepper {
+        inner: SimStepperInner::Discrete(Box::new(stepper)),
+    })
+}
+
 fn new_auto_stepper(
     dae_model: &dae::Dae,
     opts: rumoca_solver::SimOptions,
 ) -> Result<SimStepper, SimulationDiagnosticError> {
+    let solve_model = lower_for_interactive_stepper(dae_model, &opts)?;
+    // A model with no continuous states integrates nothing: run it on the
+    // discrete stepper instead of spinning up an ODE solver.
+    if solve_model.state_scalar_count() == 0 {
+        return discrete_stepper_from_solve_model(solve_model);
+    }
     #[cfg(feature = "solver-diffsol")]
     {
-        new_bdf_stepper(dae_model, opts)
+        crate::diffsol::SimStepper::from_solve_model(solve_model, opts).map(|stepper| SimStepper {
+            inner: SimStepperInner::Bdf(Box::new(stepper)),
+        })
     }
     #[cfg(all(not(feature = "solver-diffsol"), feature = "solver-rk45"))]
     {
-        new_rk_like_stepper(dae_model, opts)
+        crate::rk45::SimStepper::from_solve_model(solve_model, opts).map(|stepper| SimStepper {
+            inner: SimStepperInner::RkLike(Box::new(stepper)),
+        })
     }
     #[cfg(not(any(feature = "solver-diffsol", feature = "solver-rk45")))]
     {
-        let _ = (dae_model, opts);
+        let _ = (solve_model, opts);
         Err(SimulationDiagnosticError::Solver(
             "no interactive solver backend is enabled".to_string(),
         ))
@@ -253,15 +304,19 @@ fn new_rk_like_stepper(
     dae_model: &dae::Dae,
     opts: rumoca_solver::SimOptions,
 ) -> Result<SimStepper, SimulationDiagnosticError> {
+    let solve_model = lower_for_interactive_stepper(dae_model, &opts)?;
+    if solve_model.state_scalar_count() == 0 {
+        return discrete_stepper_from_solve_model(solve_model);
+    }
     #[cfg(feature = "solver-rk45")]
     {
-        crate::rk45::SimStepper::new_with_diagnostics(dae_model, opts).map(|stepper| SimStepper {
+        crate::rk45::SimStepper::from_solve_model(solve_model, opts).map(|stepper| SimStepper {
             inner: SimStepperInner::RkLike(Box::new(stepper)),
         })
     }
     #[cfg(not(feature = "solver-rk45"))]
     {
-        let _ = (dae_model, opts);
+        let _ = (solve_model, opts);
         Err(SimulationDiagnosticError::Solver(
             "rk-like solver requested, but this build does not include the rk45 backend"
                 .to_string(),

--- a/crates/rumoca-transport-zenoh/Cargo.toml
+++ b/crates/rumoca-transport-zenoh/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rumoca-transport-zenoh"
+description = "Zenoh publish transport for Rumoca"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+zenoh = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rumoca-transport-zenoh/src/lib.rs
+++ b/crates/rumoca-transport-zenoh/src/lib.rs
@@ -1,0 +1,127 @@
+//! Zenoh packet transport.
+//!
+//! The runner hands this crate already-packed FlatBuffer bytes. This transport
+//! owns the Zenoh session, declared publishers, and declared subscribers.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::Deserialize;
+use zenoh::handlers::{FifoChannel, FifoChannelHandler};
+use zenoh::{
+    Wait,
+    pubsub::{Publisher, Subscriber},
+    sample::Sample,
+};
+
+/// Configuration deserialized from `[transport.zenoh]`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ZenohConfig {
+    /// Zenoh mode: `peer`, `client`, or `router`. Defaults to Zenoh's default.
+    #[serde(default)]
+    pub mode: Option<String>,
+    /// Endpoint to connect to, e.g. `tcp/192.168.10.50:7447`.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+}
+
+/// Live Zenoh transport with declared publishers for configured messages.
+#[derive(Debug)]
+pub struct ZenohTransport {
+    _session: zenoh::Session,
+    publishers: HashMap<String, Publisher<'static>>,
+    subscribers: HashMap<String, Subscriber<FifoChannelHandler<Sample>>>,
+    publish_keys: HashMap<String, String>,
+    subscribe_keys: HashMap<String, String>,
+}
+
+impl ZenohTransport {
+    /// Open a Zenoh session and declare one publisher per `publish` entry.
+    pub fn open(
+        cfg: &ZenohConfig,
+        publish: &HashMap<String, String>,
+        subscribe: &HashMap<String, String>,
+    ) -> Result<Self> {
+        let mut zcfg = zenoh::Config::default();
+        if let Some(mode) = &cfg.mode {
+            zcfg.insert_json5("mode", &serde_json::to_string(mode)?)
+                .map_err(|err| anyhow::anyhow!("Set Zenoh mode '{mode}': {err}"))?;
+        }
+        if let Some(endpoint) = &cfg.endpoint {
+            let endpoints = serde_json::to_string(&[endpoint])?;
+            zcfg.insert_json5("connect/endpoints", &endpoints)
+                .map_err(|err| anyhow::anyhow!("Set Zenoh endpoint '{endpoint}': {err}"))?;
+        }
+
+        let session = zenoh::open(zcfg)
+            .wait()
+            .map_err(|err| anyhow::anyhow!("Open Zenoh session: {err}"))?;
+        let mut publishers = HashMap::new();
+        let mut publish_keys = HashMap::new();
+        for (message, key) in publish {
+            let publisher = session
+                .declare_publisher(key.to_owned())
+                .wait()
+                .map_err(|err| anyhow::anyhow!("Declare Zenoh publisher '{key}': {err}"))?;
+            publishers.insert(message.to_owned(), publisher);
+            publish_keys.insert(message.to_owned(), key.to_owned());
+        }
+        let mut subscribers = HashMap::new();
+        let mut subscribe_keys = HashMap::new();
+        for (message, key) in subscribe {
+            let subscriber = session
+                .declare_subscriber(key.to_owned())
+                .with(FifoChannel::default())
+                .wait()
+                .map_err(|err| anyhow::anyhow!("Declare Zenoh subscriber '{key}': {err}"))?;
+            subscribers.insert(message.to_owned(), subscriber);
+            subscribe_keys.insert(message.to_owned(), key.to_owned());
+        }
+        Ok(Self {
+            _session: session,
+            publishers,
+            subscribers,
+            publish_keys,
+            subscribe_keys,
+        })
+    }
+
+    /// Publish one byte payload for the configured message name.
+    pub fn publish(&self, message: &str, data: &[u8]) {
+        if let Some(publisher) = self.publishers.get(message) {
+            let _ = publisher.put(data.to_vec()).wait();
+        }
+    }
+
+    /// Drain queued samples for a subscribed message.
+    pub fn drain<F: FnMut(&[u8])>(&self, message: &str, mut handle: F) {
+        let Some(subscriber) = self.subscribers.get(message) else {
+            return;
+        };
+        for sample in subscriber.handler().drain() {
+            let bytes = sample.payload().to_bytes();
+            handle(bytes.as_ref());
+        }
+    }
+
+    /// Wait for a subscribed message, then collapse any queued backlog to the
+    /// latest sample. Returns `None` on timeout or receive error.
+    pub fn recv_latest_blocking(&self, message: &str, timeout: Duration) -> Option<Vec<u8>> {
+        let subscriber = self.subscribers.get(message)?;
+        let sample = subscriber.handler().recv_timeout(timeout).ok()??;
+        let mut latest = sample.payload().to_bytes().into_owned();
+        for sample in subscriber.handler().drain() {
+            latest = sample.payload().to_bytes().into_owned();
+        }
+        Some(latest)
+    }
+
+    pub fn publish_key_for(&self, message: &str) -> Option<&str> {
+        self.publish_keys.get(message).map(String::as_str)
+    }
+
+    pub fn subscribe_key_for(&self, message: &str) -> Option<&str> {
+        self.subscribe_keys.get(message).map(String::as_str)
+    }
+}

--- a/packages/rumoca-web/viz/viewer.html
+++ b/packages/rumoca-web/viz/viewer.html
@@ -70,6 +70,8 @@
     <span class="label">hud:</span> <span class="val" id="v-hud-visible">OFF</span><br>
     <span class="label">ws:</span> <span class="val" id="v-ws-state">pending</span>
     <span class="label">hz:</span> <span class="val" id="v-wsHz">—</span><br>
+    <span class="label">tx:</span> <span class="val" id="v-txHz">—</span>
+    <span class="label">rx:</span> <span class="val" id="v-rxHz">—</span><br>
     <span class="label">msgs:</span> <span class="val" id="v-msgs">0</span>
     <span class="label">frames:</span> <span class="val" id="v-frames">0</span>
     <span id="debug-hud"><br><span class="label">render:</span> <span class="val" id="v-fps">—</span> fps</span>
@@ -806,6 +808,18 @@ function animate() {
   }
   document.getElementById("v-fps").textContent = renderFps.toFixed(0);
   document.getElementById("v-wsHz").textContent = wsHz.toFixed(0);
+  const fmtTransportHz = (actual, target) => {
+    const a = Number(actual);
+    const t = Number(target);
+    if (Number.isFinite(t) && t > 0 && Number.isFinite(a) && a >= 0) {
+      return `${a.toFixed(0)}/${t.toFixed(0)}`;
+    }
+    if (Number.isFinite(a) && a >= 0) return a.toFixed(0);
+    if (Number.isFinite(t) && t > 0) return `—/${t.toFixed(0)}`;
+    return "—";
+  };
+  document.getElementById("v-txHz").textContent = fmtTransportHz(s.runtime_tx_actual_hz, s.runtime_tx_target_hz);
+  document.getElementById("v-rxHz").textContent = fmtTransportHz(s.runtime_rx_actual_hz, s.runtime_rx_target_hz);
   const inputMode = s.input_mode ?? "keyboard";
   document.getElementById("v-input").textContent = inputMode;
   document.getElementById("ctrl-keyboard").style.display = inputMode === "keyboard" ? "" : "none";


### PR DESCRIPTION
## Summary

Adds first-class discrete/sampled-model support to the simulation and codegen
paths, two solve-lowering correctness fixes that unblock sampled controllers,
and two new SITL transport paths. User-facing changes:

- **embedded-C export of discrete/sampled models** over the Solve IR (event
  pass, `pre()` snapshots, fixed-point settle), reusing the FMI backend layout.
- **Pure-discrete interactive stepper** — models with zero continuous states run
  without spinning up an ODE integrator; the auto/rk-like builders lower once
  and dispatch on continuous-state count.
- **Multirate lockstep scheduler** — decouples send/receive rates for SITL.
- **Zenoh SITL transport** — publish/subscribe transport alongside UDP.
- **Solve fixes:** never orient a discrete alias so an external input becomes a
  write target; keep `pre()`-of-discrete-state `if`-branches as runtime selects
  instead of folding to the start value (fixed a cross-track guidance bug).

Addresses the sampled-controller SIL workflow; solve fixes anchored to MLS
`pre()`/discrete semantics.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0021 (complexity), SPEC_0025 (this
  process), SPEC_0029 (crate boundaries).
- Relevant MLS section(s): §3.7.5 / §8.6 — `pre(x)` lowers to the synthetic
  `__pre__.x` parameter holding the previous-event value of a discrete/state
  variable; it is runtime state, not a translation constant. Discrete history
  update orientation follows input causality (inputs are read-only endpoints).
- Crate/phase owner: `rumoca-phase-solve` (lowering fixes), `rumoca-sim`
  (steppers, scheduler, runner), `rumoca-phase-codegen` (embedded-C templates),
  `rumoca-transport-zenoh` (new transport).

## Risk and Design Notes

- Main correctness risk: the pure-discrete stepper is selected purely by
  `state_scalar_count() == 0`; a mislowered model could take the wrong path.
  Covered by an end-to-end wasm stepper test and 5453 workspace tests.
- Main maintenance risk: the new `rumoca-transport-zenoh` crate pulls in Zenoh
  (~2050 Cargo.lock lines) — a heavyweight networking/supply-chain dependency.
- Why the change belongs in these crates: lowering fixes live in the solve
  phase; stepper/scheduler/transport wiring lives in the sim runner; the Zenoh
  transport is isolated in its own crate mirroring `rumoca-transport-udp`.
- New abstraction / public API: `rumoca-transport-zenoh` exposes
  `ZenohTransport` + `ZenohConfig` (~8 public items); `from_solve_model`
  constructors on the diffsol/rk45 steppers (crate-internal).

## Testing

- Commands run locally (all green): `cargo fmt --all -- --check`;
  `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
  `cargo test --workspace --exclude rumoca-bind-python --exclude rumoca-bind-wasm`
  (5453 passed); `cargo doc --no-deps`; architecture/`spec_budget`/
  `code_size_budget`/`history_policy` gates.
- Behavior covered: end-to-end discrete-controller stepper test; solve-lowering
  regression tests for both fixes; config validation for the new transport.
- Commands NOT run and why:
  - **MSL gate + ModelicaTest semantic gate — NOT run locally.** Local OMC
    version differs from the baseline and reports spurious deltas; relying on CI
    to run these against the resolved `msl_quality_baseline.json`.
  - **`rumoca-transport-zenoh` has no unit tests yet** — the transport is
    exercised only via config validation and manual SITL. Test coverage for the
    crate is a known follow-up gap.

## Code Size Budget (required)

```
production_lines_added:  1414
production_lines_deleted: 65
test_lines_added:        187
test_lines_deleted:      0
public_items_added:      ~8   (ZenohTransport, ZenohConfig + methods)
public_items_removed:    0
files_touched:           24   (incl. Cargo.lock)
net_added_lines:         3527 total  (1349 excluding generated Cargo.lock +2050)
```

Positive net diff justification:

- Net growth is three new capabilities (embedded-C discrete export, pure-discrete
  stepper, Zenoh transport) plus a new isolated crate; there is no equivalent
  code to delete.
- Compression already applied: the discrete stepper reuses the ODE steppers'
  lowering (single lowering, `from_solve_model` shared path — removed a
  double-lowering); config `has_zenoh_transport()` and `log_pacing_status` /
  `drain_zenoh_subscribe` helpers dedupe and de-nest the runner.
- Follow-up: add `rumoca-transport-zenoh` unit tests.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [ ] Tests prove behavior or explain the remaining gap — solve/stepper covered;
      `rumoca-transport-zenoh` has no unit tests (disclosed above).
- [x] Standard CI gates pass locally (`fmt`, `clippy -D warnings`, `cargo test`,
      `cargo doc`).
- [ ] MSL gate run for compiler/simulator changes — not run locally (OMC version
      mismatch); needs CI.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.
