### PR TITLE
Improve MSL coverage for scoped modifiers and DAE lowering

### DIFF
--- a/crates/rumoca-eval-ast/src/eval_instantiate/component_params.rs
+++ b/crates/rumoca-eval-ast/src/eval_instantiate/component_params.rs
@@ -68,13 +68,24 @@ pub fn eval_state_select_expr(
     ctx: &InstantiateEvalCtx,
     expr: &ast::Expression,
 ) -> Option<rumoca_core::StateSelect> {
+    eval_state_select_expr_with_source_scope(ctx, expr, None)
+}
+
+/// Evaluate an MLS predefined `StateSelect` attribute expression in the lexical
+/// scope where a modifier was written.
+pub fn eval_state_select_expr_with_source_scope(
+    ctx: &InstantiateEvalCtx,
+    expr: &ast::Expression,
+    source_scope: Option<&ast::QualifiedName>,
+) -> Option<rumoca_core::StateSelect> {
     let env = ConditionEvalEnv {
         mod_env: ctx.mod_env,
         effective_components: ctx.effective_components,
         tree: ctx.tree,
         resolve_class_components: ctx.resolve_class_components,
     };
-    eval_state_select_expr_with_depth(expr, env, None, 0)
+    let scope_prefix = source_scope.map(ast::QualifiedName::to_flat_string);
+    eval_state_select_expr_with_depth(expr, env, scope_prefix.as_deref(), 0)
 }
 
 fn eval_state_select_expr_with_depth(

--- a/crates/rumoca-eval-ast/src/eval_instantiate/function_eval.rs
+++ b/crates/rumoca-eval-ast/src/eval_instantiate/function_eval.rs
@@ -1471,6 +1471,36 @@ mod tests {
     }
 
     #[test]
+    fn evaluate_component_condition_unknown_modifier_blocks_declaration_default() {
+        let mut components = IndexMap::default();
+        components.insert(
+            "condition".to_string(),
+            ast::Component {
+                name: "condition".to_string(),
+                type_name: ast::Name::from_string("Boolean"),
+                binding: Some(bool_expr(true)),
+                has_explicit_binding: true,
+                ..ast::Component::empty_with_span(test_span())
+            },
+        );
+        let mut mod_env = ast::ModificationEnvironment::new();
+        mod_env.add(
+            ast::QualifiedName::from_ident("condition"),
+            ast::ModificationValue::simple(ast::Expression::ComponentReference(cref("start"))),
+        );
+
+        let condition = ast::Expression::ComponentReference(cref("condition"));
+        let ctx = InstantiateEvalCtx {
+            tree: &ast::ClassTree::new(),
+            mod_env: &mod_env,
+            effective_components: &components,
+            resolve_class_components: no_op_resolve_class_components,
+        };
+
+        assert_eq!(evaluate_component_condition(&ctx, &condition), None);
+    }
+
+    #[test]
     fn evaluate_component_condition_with_unresolved_enum_ref_is_unknown() {
         let mut components = IndexMap::default();
         let model_structure = ast::Component {

--- a/crates/rumoca-eval-ast/src/eval_instantiate/mod.rs
+++ b/crates/rumoca-eval-ast/src/eval_instantiate/mod.rs
@@ -14,6 +14,24 @@ use rumoca_ir_ast as ast;
 use rumoca_ir_ast::AstIndexMap as IndexMap;
 use rustc_hash::FxHashMap;
 
+mod component_params;
+mod function_eval;
+mod scoped_condition;
+
+pub(super) use component_params::{
+    component_expr_for_structural_eval, component_ref_to_dotted_no_subscripts,
+    enclosing_scope_candidates,
+};
+pub use component_params::{
+    eval_state_select_expr, eval_state_select_expr_with_source_scope, expr_to_string,
+    extract_binding, extract_bool_params_with_mods, extract_int_params_with_mods,
+    parse_state_select, propagate_record_alias_integer_params, try_eval_string_expr,
+};
+pub use function_eval::{
+    evaluate_array_dimensions, generate_array_indices, try_eval_integer_shape_expr,
+};
+use scoped_condition::eval_scoped_string_condition_with_depth;
+
 /// Maximum recursion depth for condition evaluation (prevents stack overflow)
 const MAX_CONDITION_DEPTH: usize = 10;
 
@@ -199,6 +217,46 @@ fn evaluate_component_condition_with_depth(
         return Some(val);
     }
 
+    // Case 6: Boolean if-expression
+    if let ast::Expression::If {
+        branches,
+        else_branch,
+        ..
+    } = condition
+    {
+        for (branch_condition, branch_value) in branches {
+            match evaluate_component_condition_with_depth(
+                branch_condition,
+                mod_env,
+                effective_components,
+                tree,
+                resolve_class_components,
+                depth + 1,
+            ) {
+                Some(true) => {
+                    return evaluate_component_condition_with_depth(
+                        branch_value,
+                        mod_env,
+                        effective_components,
+                        tree,
+                        resolve_class_components,
+                        depth + 1,
+                    );
+                }
+                Some(false) => continue,
+                None => return None,
+            }
+        }
+        return evaluate_component_condition_with_depth(
+            else_branch,
+            mod_env,
+            effective_components,
+            tree,
+            resolve_class_components,
+            depth + 1,
+        );
+    }
+
     None
 }
 
@@ -222,6 +280,22 @@ fn eval_param_ref(
         if let Some(val) = expr_to_bool(&mod_value.value) {
             return Some(val);
         }
+        if let Some(source_scope) = mod_value.source_scope.as_ref() {
+            let scope_prefix = source_scope.to_flat_string();
+            if let Some(val) = eval_scoped_string_condition_with_depth(
+                &mod_value.value,
+                ConditionEvalEnv {
+                    mod_env,
+                    effective_components,
+                    tree,
+                    resolve_class_components,
+                },
+                Some(scope_prefix.as_str()),
+                depth + 1,
+            ) {
+                return Some(val);
+            }
+        }
         // Recursively evaluate only if mod_env value is a ast::ComponentReference
         // (another parameter ref like smpmData.useDamperCage → false)
         if matches!(&mod_value.value, ast::Expression::ComponentReference(_))
@@ -236,6 +310,7 @@ fn eval_param_ref(
         {
             return Some(val);
         }
+        return None;
     }
 
     // Look up the parameter's default value from effective components (single-part only)
@@ -822,153 +897,6 @@ fn transparent_self_modifier(candidate: &str, value: &ast::Expression) -> bool {
         return false;
     };
     comp_ref.parts[0].ident.text.as_ref() == name
-}
-
-fn eval_scoped_string_condition_with_depth(
-    condition: &ast::Expression,
-    env: ConditionEvalEnv<'_>,
-    scope_prefix: Option<&str>,
-    depth: usize,
-) -> Option<bool> {
-    if depth > MAX_CONDITION_DEPTH {
-        return None;
-    }
-
-    if let Some(val) = expr_to_bool(condition) {
-        return Some(val);
-    }
-
-    let recurse = |expr: &ast::Expression| {
-        eval_scoped_string_condition_with_depth(expr, env, scope_prefix, depth + 1)
-    };
-
-    match condition {
-        ast::Expression::Unary {
-            op: rumoca_core::OpUnary::Not,
-            rhs,
-            ..
-        } => recurse(rhs).map(|v| !v),
-        ast::Expression::Parenthesized { inner, .. } => recurse(inner),
-        ast::Expression::Binary { op, lhs, rhs, .. } => eval_scoped_string_binary_condition(
-            op,
-            lhs,
-            rhs,
-            env,
-            ScopedEvalState {
-                scope_prefix,
-                depth: depth + 1,
-            },
-        )
-        .or_else(|| {
-            evaluate_component_condition_with_depth(
-                condition,
-                env.mod_env,
-                env.effective_components,
-                env.tree,
-                env.resolve_class_components,
-                depth + 1,
-            )
-        }),
-        _ => evaluate_component_condition_with_depth(
-            condition,
-            env.mod_env,
-            env.effective_components,
-            env.tree,
-            env.resolve_class_components,
-            depth + 1,
-        ),
-    }
-}
-
-struct ScopedEvalState<'a> {
-    scope_prefix: Option<&'a str>,
-    depth: usize,
-}
-
-fn eval_scoped_string_binary_condition(
-    op: &rumoca_core::OpBinary,
-    lhs: &ast::Expression,
-    rhs: &ast::Expression,
-    env: ConditionEvalEnv<'_>,
-    state: ScopedEvalState<'_>,
-) -> Option<bool> {
-    match op {
-        rumoca_core::OpBinary::Or => eval_scoped_or(lhs, rhs, env, state.scope_prefix, state.depth),
-        rumoca_core::OpBinary::And => {
-            eval_scoped_and(lhs, rhs, env, state.scope_prefix, state.depth)
-        }
-        rumoca_core::OpBinary::Eq => {
-            eval_scoped_enum_equality(lhs, rhs, env, state.scope_prefix, state.depth)
-        }
-        rumoca_core::OpBinary::Neq => {
-            eval_scoped_enum_equality(lhs, rhs, env, state.scope_prefix, state.depth).map(|v| !v)
-        }
-        _ => None,
-    }
-}
-
-fn eval_scoped_or(
-    lhs: &ast::Expression,
-    rhs: &ast::Expression,
-    env: ConditionEvalEnv<'_>,
-    scope_prefix: Option<&str>,
-    depth: usize,
-) -> Option<bool> {
-    let recurse = |expr| eval_scoped_string_condition_with_depth(expr, env, scope_prefix, depth);
-    let (l, r) = (recurse(lhs), recurse(rhs));
-    if l == Some(true) || r == Some(true) {
-        return Some(true);
-    }
-    if l == Some(false) && r == Some(false) {
-        return Some(false);
-    }
-    None
-}
-
-fn eval_scoped_and(
-    lhs: &ast::Expression,
-    rhs: &ast::Expression,
-    env: ConditionEvalEnv<'_>,
-    scope_prefix: Option<&str>,
-    depth: usize,
-) -> Option<bool> {
-    let recurse = |expr| eval_scoped_string_condition_with_depth(expr, env, scope_prefix, depth);
-    let (l, r) = (recurse(lhs), recurse(rhs));
-    if l == Some(false) || r == Some(false) {
-        return Some(false);
-    }
-    if l == Some(true) && r == Some(true) {
-        return Some(true);
-    }
-    None
-}
-
-fn eval_scoped_enum_equality(
-    lhs: &ast::Expression,
-    rhs: &ast::Expression,
-    env: ConditionEvalEnv<'_>,
-    scope_prefix: Option<&str>,
-    depth: usize,
-) -> Option<bool> {
-    let lhs_val = enum_value_for_comparison_with_depth(
-        lhs,
-        env.mod_env,
-        env.effective_components,
-        env.tree,
-        env.resolve_class_components,
-        scope_prefix,
-        depth,
-    )?;
-    let rhs_val = enum_value_for_comparison_with_depth(
-        rhs,
-        env.mod_env,
-        env.effective_components,
-        env.tree,
-        env.resolve_class_components,
-        scope_prefix,
-        depth,
-    )?;
-    Some(enum_values_equal(&lhs_val, &rhs_val))
 }
 
 fn resolve_scoped_record_field_expr(
@@ -1939,18 +1867,3 @@ fn eval_user_defined_integer_function(
 
     local_values.get(&output_name).copied()
 }
-
-mod component_params;
-mod function_eval;
-pub(super) use component_params::{
-    component_expr_for_structural_eval, component_ref_to_dotted_no_subscripts,
-    enclosing_scope_candidates,
-};
-pub use component_params::{
-    eval_state_select_expr, expr_to_string, extract_binding, extract_bool_params_with_mods,
-    extract_int_params_with_mods, parse_state_select, propagate_record_alias_integer_params,
-    try_eval_string_expr,
-};
-pub use function_eval::{
-    evaluate_array_dimensions, generate_array_indices, try_eval_integer_shape_expr,
-};

--- a/crates/rumoca-eval-ast/src/eval_instantiate/scoped_condition.rs
+++ b/crates/rumoca-eval-ast/src/eval_instantiate/scoped_condition.rs
@@ -1,0 +1,188 @@
+use super::*;
+
+pub(super) fn eval_scoped_string_condition_with_depth(
+    condition: &ast::Expression,
+    env: ConditionEvalEnv<'_>,
+    scope_prefix: Option<&str>,
+    depth: usize,
+) -> Option<bool> {
+    if depth > MAX_CONDITION_DEPTH {
+        return None;
+    }
+
+    if let Some(val) = expr_to_bool(condition) {
+        return Some(val);
+    }
+
+    let recurse = |expr: &ast::Expression| {
+        eval_scoped_string_condition_with_depth(expr, env, scope_prefix, depth + 1)
+    };
+
+    match condition {
+        ast::Expression::ComponentReference(comp_ref) => resolve_component_ref_expr(
+            comp_ref,
+            env.mod_env,
+            env.effective_components,
+            env.tree,
+            env.resolve_class_components,
+            scope_prefix,
+        )
+        .and_then(|(resolved_expr, next_scope)| {
+            eval_scoped_string_condition_with_depth(
+                &resolved_expr,
+                env,
+                next_scope.as_deref(),
+                depth + 1,
+            )
+        })
+        .or_else(|| {
+            evaluate_component_condition_with_depth(
+                condition,
+                env.mod_env,
+                env.effective_components,
+                env.tree,
+                env.resolve_class_components,
+                depth + 1,
+            )
+        }),
+        ast::Expression::Unary {
+            op: rumoca_core::OpUnary::Not,
+            rhs,
+            ..
+        } => recurse(rhs).map(|v| !v),
+        ast::Expression::Parenthesized { inner, .. } => recurse(inner),
+        ast::Expression::If {
+            branches,
+            else_branch,
+            ..
+        } => {
+            for (branch_condition, branch_value) in branches {
+                match recurse(branch_condition) {
+                    Some(true) => return recurse(branch_value),
+                    Some(false) => continue,
+                    None => return None,
+                }
+            }
+            recurse(else_branch)
+        }
+        ast::Expression::Binary { op, lhs, rhs, .. } => eval_scoped_string_binary_condition(
+            op,
+            lhs,
+            rhs,
+            env,
+            ScopedEvalState {
+                scope_prefix,
+                depth: depth + 1,
+            },
+        )
+        .or_else(|| {
+            evaluate_component_condition_with_depth(
+                condition,
+                env.mod_env,
+                env.effective_components,
+                env.tree,
+                env.resolve_class_components,
+                depth + 1,
+            )
+        }),
+        _ => evaluate_component_condition_with_depth(
+            condition,
+            env.mod_env,
+            env.effective_components,
+            env.tree,
+            env.resolve_class_components,
+            depth + 1,
+        ),
+    }
+}
+
+struct ScopedEvalState<'a> {
+    scope_prefix: Option<&'a str>,
+    depth: usize,
+}
+
+fn eval_scoped_string_binary_condition(
+    op: &rumoca_core::OpBinary,
+    lhs: &ast::Expression,
+    rhs: &ast::Expression,
+    env: ConditionEvalEnv<'_>,
+    state: ScopedEvalState<'_>,
+) -> Option<bool> {
+    match op {
+        rumoca_core::OpBinary::Or => eval_scoped_or(lhs, rhs, env, state.scope_prefix, state.depth),
+        rumoca_core::OpBinary::And => {
+            eval_scoped_and(lhs, rhs, env, state.scope_prefix, state.depth)
+        }
+        rumoca_core::OpBinary::Eq => {
+            eval_scoped_enum_equality(lhs, rhs, env, state.scope_prefix, state.depth)
+        }
+        rumoca_core::OpBinary::Neq => {
+            eval_scoped_enum_equality(lhs, rhs, env, state.scope_prefix, state.depth).map(|v| !v)
+        }
+        _ => None,
+    }
+}
+
+fn eval_scoped_or(
+    lhs: &ast::Expression,
+    rhs: &ast::Expression,
+    env: ConditionEvalEnv<'_>,
+    scope_prefix: Option<&str>,
+    depth: usize,
+) -> Option<bool> {
+    let recurse = |expr| eval_scoped_string_condition_with_depth(expr, env, scope_prefix, depth);
+    let (l, r) = (recurse(lhs), recurse(rhs));
+    if l == Some(true) || r == Some(true) {
+        return Some(true);
+    }
+    if l == Some(false) && r == Some(false) {
+        return Some(false);
+    }
+    None
+}
+
+fn eval_scoped_and(
+    lhs: &ast::Expression,
+    rhs: &ast::Expression,
+    env: ConditionEvalEnv<'_>,
+    scope_prefix: Option<&str>,
+    depth: usize,
+) -> Option<bool> {
+    let recurse = |expr| eval_scoped_string_condition_with_depth(expr, env, scope_prefix, depth);
+    let (l, r) = (recurse(lhs), recurse(rhs));
+    if l == Some(false) || r == Some(false) {
+        return Some(false);
+    }
+    if l == Some(true) && r == Some(true) {
+        return Some(true);
+    }
+    None
+}
+
+fn eval_scoped_enum_equality(
+    lhs: &ast::Expression,
+    rhs: &ast::Expression,
+    env: ConditionEvalEnv<'_>,
+    scope_prefix: Option<&str>,
+    depth: usize,
+) -> Option<bool> {
+    let lhs_val = enum_value_for_comparison_with_depth(
+        lhs,
+        env.mod_env,
+        env.effective_components,
+        env.tree,
+        env.resolve_class_components,
+        scope_prefix,
+        depth,
+    )?;
+    let rhs_val = enum_value_for_comparison_with_depth(
+        rhs,
+        env.mod_env,
+        env.effective_components,
+        env.tree,
+        env.resolve_class_components,
+        scope_prefix,
+        depth,
+    )?;
+    Some(enum_values_equal(&lhs_val, &rhs_val))
+}

--- a/crates/rumoca-ir-ast/src/visitor/rewrite.rs
+++ b/crates/rumoca-ir-ast/src/visitor/rewrite.rs
@@ -7,9 +7,14 @@ use std::sync::Arc;
 /// Default implementations recursively transform children.
 pub trait ExpressionTransformer {
     /// Transform any expression.
+    fn transform_expression(&mut self, expr: Expression) -> Expression {
+        self.walk_expression(expr)
+    }
+
+    /// Recursively transform an expression using the default traversal.
     // SPEC_0021: Exception - exhaustive visitor transform over AST expression variants.
     #[allow(clippy::too_many_lines)]
-    fn transform_expression(&mut self, expr: Expression) -> Expression {
+    fn walk_expression(&mut self, expr: Expression) -> Expression {
         match expr {
             Expression::Empty { span } => Expression::Empty { span },
             Expression::Terminal {

--- a/crates/rumoca-phase-dae/src/algorithm_lowering.rs
+++ b/crates/rumoca-phase-dae/src/algorithm_lowering.rs
@@ -4,6 +4,7 @@ use crate::{
     dae_to_flat_expression, dae_to_flat_var_name, flat_to_dae_expression,
     flat_to_dae_expression_with_refs, flat_to_dae_var_name,
 };
+mod alias_canonicalization;
 mod current_value_rewrite;
 mod for_lowering;
 mod guarded_expr;
@@ -12,6 +13,10 @@ mod rewrite_discrete;
 mod slice_lowering;
 mod substitution;
 mod target_names;
+use alias_canonicalization::{
+    defined_target_reroute_alias_rhs_target, is_binding_equation_origin,
+    is_connection_equation_origin, reroutable_alias_rhs_target,
+};
 use current_value_rewrite::{
     algorithm_variable_dims, current_value_subscript_expr, rewrite_algorithm_current_refs,
 };
@@ -237,10 +242,6 @@ pub(super) fn route_discrete_event_equations(
     Ok(())
 }
 
-fn is_connection_equation_origin(origin: &str) -> bool {
-    origin.contains("connection equation:")
-}
-
 fn anchored_collision_targets(
     grouped: &IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
 ) -> std::collections::HashSet<VarName> {
@@ -249,7 +250,7 @@ fn anchored_collision_targets(
         .filter(|(_, equations)| {
             equations
                 .iter()
-                .any(|equation| !is_connection_equation_origin(&equation.origin))
+                .any(|equation| reroutable_alias_rhs_target(equation).is_none())
         })
         .map(|(lhs, _)| lhs.clone())
         .collect()
@@ -270,8 +271,7 @@ fn choose_collision_keep_index(
     flipped_once: &std::collections::HashSet<(String, String, String)>,
 ) -> Option<usize> {
     for (idx, equation) in equations.iter().enumerate() {
-        let rhs_expr = dae_to_flat_expression(&equation.rhs);
-        let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
+        let Some(rhs_target) = reroutable_alias_rhs_target(equation) else {
             continue;
         };
         let reverse_key = flip_edge_key(&equation.origin, &rhs_target, lhs);
@@ -281,8 +281,7 @@ fn choose_collision_keep_index(
     }
 
     for (idx, equation) in equations.iter().enumerate() {
-        let rhs_expr = dae_to_flat_expression(&equation.rhs);
-        let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
+        let Some(rhs_target) = reroutable_alias_rhs_target(equation) else {
             continue;
         };
         if anchored_targets.contains(&rhs_target) {
@@ -299,11 +298,7 @@ fn has_reverse_connection_alias(
 ) -> bool {
     grouped.get(rhs_target).is_some_and(|rhs_equations| {
         rhs_equations.iter().any(|rhs_equation| {
-            if !is_connection_equation_origin(&rhs_equation.origin) {
-                return false;
-            }
-            let rhs_expr = dae_to_flat_expression(&rhs_equation.rhs);
-            discrete_assignment_rhs_var_name(&rhs_expr)
+            reroutable_alias_rhs_target(rhs_equation)
                 .as_ref()
                 .is_some_and(|candidate| candidate == lhs)
         })
@@ -343,8 +338,7 @@ fn process_collision_equation(
     flipped_once: &mut std::collections::HashSet<(String, String, String)>,
     debug_canonicalize: bool,
 ) -> Result<bool, ToDaeError> {
-    let rhs_expr = dae_to_flat_expression(&equation.rhs);
-    let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
+    let Some(rhs_target) = reroutable_alias_rhs_target(&equation) else {
         if debug_canonicalize {
             crate::log_fm_canon_debug(format!(
                 "f_m canonicalize no-rhs-var lhs={} origin={}",
@@ -435,7 +429,7 @@ fn resolve_connection_alias_target_collisions(
             }
             if equations
                 .iter()
-                .any(|equation| !is_connection_equation_origin(&equation.origin))
+                .any(|equation| reroutable_alias_rhs_target(equation).is_none())
             {
                 continue;
             }
@@ -486,7 +480,7 @@ pub(super) fn canonicalize_discrete_assignment_equations(dae: &mut Dae) -> Resul
     {
         let (mut grouped, passthrough) =
             drain_grouped_discrete_assignments(&mut dae.discrete.valued_updates);
-        reroute_connection_aliases_for_defined_targets(&mut grouped, dae)?;
+        reroute_aliases_for_defined_targets(&mut grouped, dae)?;
         resolve_connection_alias_target_collisions(&mut grouped, dae)?;
         debug_log_grouped_target_collisions(debug_canonicalize, "f_m", &grouped);
         dae.discrete.valued_updates =
@@ -537,29 +531,38 @@ fn rebuild_canonicalized_discrete_assignments(
     Ok(rebuilt)
 }
 
-fn reroute_connection_aliases_for_defined_targets(
+fn reroute_aliases_for_defined_targets(
     grouped: &mut IndexMap<VarName, Vec<rumoca_ir_dae::Equation>>,
     dae: &Dae,
 ) -> Result<(), ToDaeError> {
     let mut rerouted: IndexMap<VarName, Vec<rumoca_ir_dae::Equation>> = IndexMap::new();
     for (lhs, equations) in grouped.iter_mut() {
-        if equations.len() <= 1
-            || !equations
-                .iter()
-                .any(|equation| !is_connection_equation_origin(&equation.origin))
-        {
+        if equations.len() <= 1 {
+            continue;
+        }
+        let has_binding_anchor = equations
+            .iter()
+            .any(|equation| is_binding_equation_origin(&equation.origin));
+        let has_non_alias_anchor = equations
+            .iter()
+            .any(|equation| reroutable_alias_rhs_target(equation).is_none());
+        if !has_non_alias_anchor {
             continue;
         }
 
-        for equation in equations
-            .iter()
-            .filter(|equation| is_connection_equation_origin(&equation.origin))
-        {
-            let rhs_expr = dae_to_flat_expression(&equation.rhs);
-            let Some(rhs_target) = discrete_assignment_rhs_var_name(&rhs_expr) else {
+        let mut kept = Vec::with_capacity(equations.len());
+        for equation in std::mem::take(equations) {
+            let rhs_target = reroutable_alias_rhs_target(&equation).or_else(|| {
+                has_binding_anchor
+                    .then(|| defined_target_reroute_alias_rhs_target(&equation))
+                    .flatten()
+            });
+            let Some(rhs_target) = rhs_target else {
+                kept.push(equation);
                 continue;
             };
             if keep_collision_equation_without_flip(dae, lhs, &rhs_target) {
+                kept.push(equation);
                 continue;
             }
             let mut flipped = equation.clone();
@@ -581,6 +584,7 @@ fn reroute_connection_aliases_for_defined_targets(
             });
             rerouted.entry(rhs_target).or_default().push(flipped);
         }
+        *equations = kept;
     }
     for (lhs, aliases) in rerouted {
         grouped.entry(lhs).or_default().extend(aliases);
@@ -611,9 +615,9 @@ fn canonicalize_assignment_group(
 
     if equations
         .iter()
-        .any(|equation| !is_connection_equation_origin(&equation.origin))
+        .any(|equation| reroutable_alias_rhs_target(equation).is_none())
     {
-        equations.retain(|equation| !is_connection_equation_origin(&equation.origin));
+        equations.retain(|equation| reroutable_alias_rhs_target(equation).is_none());
     }
 
     let mut rewritten_equations = Vec::with_capacity(equations.len());

--- a/crates/rumoca-phase-dae/src/algorithm_lowering/alias_canonicalization.rs
+++ b/crates/rumoca-phase-dae/src/algorithm_lowering/alias_canonicalization.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+pub(super) fn is_connection_equation_origin(origin: &str) -> bool {
+    origin.contains("connection equation:")
+}
+
+fn is_reroutable_alias_equation_origin(origin: &str) -> bool {
+    is_connection_equation_origin(origin)
+}
+
+fn is_stategraph_port_alias_target(name: &VarName) -> bool {
+    name.as_str().contains(".outerStatePort.")
+        || name.as_str().contains(".subgraphStatePort.")
+        || name.as_str().contains(".stateGraphRoot.")
+}
+
+pub(super) fn is_binding_equation_origin(origin: &str) -> bool {
+    origin.starts_with("binding equation for ")
+}
+
+pub(super) fn reroutable_alias_rhs_target(equation: &rumoca_ir_dae::Equation) -> Option<VarName> {
+    let rhs_expr = dae_to_flat_expression(&equation.rhs);
+    let rhs_target = discrete_assignment_rhs_var_name(&rhs_expr)?;
+    if is_reroutable_alias_equation_origin(&equation.origin) {
+        return Some(rhs_target);
+    }
+    if equation.origin.starts_with("explicit equation from ")
+        && equation
+            .lhs
+            .as_ref()
+            .map(|lhs| dae_to_flat_var_name(lhs.var_name()))
+            .is_some_and(|lhs| {
+                is_stategraph_port_alias_target(&lhs)
+                    || is_stategraph_port_alias_target(&rhs_target)
+            })
+    {
+        return Some(rhs_target);
+    }
+    None
+}
+
+pub(super) fn defined_target_reroute_alias_rhs_target(
+    equation: &rumoca_ir_dae::Equation,
+) -> Option<VarName> {
+    if !is_connection_equation_origin(&equation.origin)
+        && !equation.origin.starts_with("explicit equation from ")
+    {
+        return None;
+    }
+    let rhs_expr = dae_to_flat_expression(&equation.rhs);
+    discrete_assignment_rhs_var_name(&rhs_expr)
+}

--- a/crates/rumoca-phase-dae/src/binding_conversion.rs
+++ b/crates/rumoca-phase-dae/src/binding_conversion.rs
@@ -558,7 +558,7 @@ fn binding_defines_underdefined_unknown(
     })
 }
 
-/// Collect all unknowns (state/algebraic/output variables).
+/// Collect all unknowns whose bindings can constrain the DAE.
 fn collect_unknowns(flat: &Model, state_vars: &IndexSet<VarName>) -> HashSet<VarName> {
     flat.variables
         .iter()
@@ -566,7 +566,10 @@ fn collect_unknowns(flat: &Model, state_vars: &IndexSet<VarName>) -> HashSet<Var
             let kind = classification::classify_variable(var, state_vars);
             matches!(
                 kind,
-                VariableKind::State | VariableKind::Algebraic | VariableKind::Output
+                VariableKind::State
+                    | VariableKind::Algebraic
+                    | VariableKind::Output
+                    | VariableKind::Discrete
             )
         })
         .map(|(name, _)| name.clone())

--- a/crates/rumoca-phase-dae/src/dae_lowering.rs
+++ b/crates/rumoca-phase-dae/src/dae_lowering.rs
@@ -1386,6 +1386,7 @@ fn scalarize_function_call_at(
     span: rumoca_core::Span,
     ctx: &ScalarizeExprContext<'_>,
 ) -> Result<rumoca_core::Expression, ToDaeError> {
+    let function = ctx.functions.get(&rumoca_core::VarName::new(name.as_str()));
     let first_output_size =
         first_function_output_size(name.as_str(), ctx.functions).ok_or_else(|| {
             ToDaeError::runtime_contract_violation_at(
@@ -1416,13 +1417,100 @@ fn scalarize_function_call_at(
     }
     Ok(rumoca_core::Expression::FunctionCall {
         name: name.clone(),
-        args: args
-            .iter()
-            .map(|a| scalarize_expr_with_context(a, ctx))
-            .collect::<Result<Vec<_>, _>>()?,
+        args: scalarize_function_call_args(args, function, ctx)?,
         is_constructor,
         span,
     })
+}
+
+fn scalarize_function_call_args(
+    args: &[rumoca_core::Expression],
+    function: Option<&rumoca_core::Function>,
+    ctx: &ScalarizeExprContext<'_>,
+) -> Result<Vec<rumoca_core::Expression>, ToDaeError> {
+    args.iter()
+        .enumerate()
+        .map(|(index, arg)| {
+            if function_input_expects_array(function, arg, index) {
+                return Ok(vectorize_phantom_expr(arg, ctx.phantom_map));
+            }
+            scalarize_expr_with_context(arg, ctx)
+        })
+        .collect()
+}
+
+fn function_input_expects_array(
+    function: Option<&rumoca_core::Function>,
+    arg: &rumoca_core::Expression,
+    index: usize,
+) -> bool {
+    let Some(function) = function else {
+        return false;
+    };
+    let input_name = named_argument_input_name(arg);
+    let param = input_name
+        .and_then(|name| function.inputs.iter().find(|param| param.name == name))
+        .or_else(|| function.inputs.get(index));
+    param.is_some_and(|param| !param.dims.is_empty() || !param.shape_expr.is_empty())
+}
+
+fn named_argument_input_name(arg: &rumoca_core::Expression) -> Option<&str> {
+    let rumoca_core::Expression::FunctionCall {
+        name,
+        is_constructor: true,
+        ..
+    } = arg
+    else {
+        return None;
+    };
+    name.as_str().strip_prefix("__rumoca_named_arg__.")
+}
+
+fn vectorize_phantom_array_formal_args(
+    expr: &rumoca_core::Expression,
+    phantom_map: &HashMap<String, Vec<rumoca_core::Reference>>,
+    functions: &IndexMap<rumoca_core::VarName, rumoca_core::Function>,
+) -> rumoca_core::Expression {
+    PhantomArrayFormalArgVectorizer {
+        phantom_map,
+        functions,
+    }
+    .rewrite_expression(expr)
+}
+
+struct PhantomArrayFormalArgVectorizer<'a> {
+    phantom_map: &'a HashMap<String, Vec<rumoca_core::Reference>>,
+    functions: &'a IndexMap<rumoca_core::VarName, rumoca_core::Function>,
+}
+
+impl ExpressionRewriter for PhantomArrayFormalArgVectorizer<'_> {
+    fn walk_function_call_expression(
+        &mut self,
+        name: &rumoca_core::Reference,
+        args: &[rumoca_core::Expression],
+        is_constructor: bool,
+        span: rumoca_core::Span,
+    ) -> rumoca_core::Expression {
+        let function = self
+            .functions
+            .get(&rumoca_core::VarName::new(name.as_str()));
+        rumoca_core::Expression::FunctionCall {
+            name: name.clone(),
+            args: args
+                .iter()
+                .enumerate()
+                .map(|(index, arg)| {
+                    if function_input_expects_array(function, arg, index) {
+                        vectorize_phantom_expr(arg, self.phantom_map)
+                    } else {
+                        self.rewrite_expression(arg)
+                    }
+                })
+                .collect(),
+            is_constructor,
+            span,
+        }
+    }
 }
 
 fn one_based_scalar_index(
@@ -1730,6 +1818,9 @@ fn scalarize_equation_list(
                 rhs: scalar_rhs,
                 ..eq
             });
+        } else if phantom_width.is_some() {
+            let rhs = vectorize_phantom_array_formal_args(&eq.rhs, phantom_map, functions);
+            new_equations.push(dae::Equation { rhs, ..eq });
         } else {
             new_equations.push(eq);
         }

--- a/crates/rumoca-phase-dae/src/dae_lowering/tests.rs
+++ b/crates/rumoca-phase-dae/src/dae_lowering/tests.rs
@@ -115,6 +115,36 @@ fn parameter(name: &str, start: Option<rumoca_core::Expression>) -> dae::Variabl
     }
 }
 
+fn add_any_true_function(dae: &mut Dae) {
+    let mut function =
+        rumoca_core::Function::new("Modelica.Math.BooleanVectors.anyTrue", test_span());
+    function.inputs.push(rumoca_core::FunctionParam {
+        def_id: None,
+        name: "b".to_string(),
+        span: test_span(),
+        type_name: "Boolean".to_string(),
+        type_class: None,
+        dims: vec![0],
+        shape_expr: Vec::new(),
+        default: None,
+        description: None,
+    });
+    function.outputs.push(rumoca_core::FunctionParam {
+        def_id: None,
+        name: "result".to_string(),
+        span: test_span(),
+        type_name: "Boolean".to_string(),
+        type_class: None,
+        dims: Vec::new(),
+        shape_expr: Vec::new(),
+        default: None,
+        description: None,
+    });
+    dae.symbols
+        .functions
+        .insert(function.name.clone(), function);
+}
+
 /// Collect all VarRef names from an expression (for assertions).
 fn all_var_names(expr: &rumoca_core::Expression) -> Vec<String> {
     let mut names = Vec::new();
@@ -180,6 +210,23 @@ fn collect_var_names_rec(expr: &rumoca_core::Expression, names: &mut Vec<String>
             collect_var_names_rec(base, names);
         }
         _ => {}
+    }
+}
+
+fn assert_any_true_array_arg(expr: &rumoca_core::Expression, expected_names: &[&str]) {
+    let rumoca_core::Expression::FunctionCall { args, .. } = expr else {
+        panic!("expected anyTrue function call");
+    };
+    let rumoca_core::Expression::Array { elements, .. } = &args[0] else {
+        panic!("array-formal phantom argument should become an array literal");
+    };
+    assert_eq!(elements.len(), expected_names.len());
+    let names = all_var_names(&args[0]);
+    for expected_name in expected_names {
+        assert!(
+            names.contains(&expected_name.to_string()),
+            "missing {expected_name} from anyTrue argument: {names:?}"
+        );
     }
 }
 
@@ -520,6 +567,102 @@ fn test_scalarize_singleton_phantom_connector_reference() {
     assert!(names.contains(&"boundary.ports[1].C_outflow".to_string()));
     assert!(names.contains(&"boundary.C".to_string()));
     assert!(!names.contains(&"boundary.ports.C_outflow".to_string()));
+}
+
+#[test]
+fn test_scalarize_singleton_phantom_array_formal_function_argument() {
+    let mut dae = Dae::new();
+    dae.variables.discrete_valued.insert(
+        rumoca_core::VarName::new("step.inPort[1].set"),
+        dae::Variable::new(rumoca_core::VarName::new("step.inPort[1].set"), test_span()),
+    );
+    dae.variables.discrete_valued.insert(
+        rumoca_core::VarName::new("step.newActive"),
+        dae::Variable::new(rumoca_core::VarName::new("step.newActive"), test_span()),
+    );
+    add_any_true_function(&mut dae);
+    dae.discrete.valued_updates.push(dae::Equation::explicit(
+        rumoca_core::Reference::new("step.newActive"),
+        function_call(
+            "Modelica.Math.BooleanVectors.anyTrue",
+            vec![var_ref("step.inPort.set")],
+        ),
+        test_span(),
+        "StateGraph step activation",
+    ));
+
+    scalarize_phantom_vector_equations(&mut dae).unwrap();
+
+    let rumoca_core::Expression::FunctionCall { args, .. } = &dae.discrete.valued_updates[0].rhs
+    else {
+        panic!("expected scalar-output function call to remain a function call");
+    };
+    let rumoca_core::Expression::Array { elements, .. } = &args[0] else {
+        panic!("array-formal phantom argument should become an array literal");
+    };
+    assert_eq!(elements.len(), 1);
+    let names = all_var_names(&args[0]);
+    assert!(names.contains(&"step.inPort[1].set".to_string()));
+    assert!(!names.contains(&"step.inPort.set".to_string()));
+}
+
+#[test]
+fn test_vectorizes_multi_element_phantom_array_formal_in_scalar_equation() {
+    let mut dae = Dae::new();
+    for name in [
+        "step.inPort[1].set",
+        "step.inPort[2].set",
+        "step.outPort[1].reset",
+        "step.newActive",
+    ] {
+        dae.variables.discrete_valued.insert(
+            rumoca_core::VarName::new(name),
+            dae::Variable::new(rumoca_core::VarName::new(name), test_span()),
+        );
+    }
+    add_any_true_function(&mut dae);
+
+    let in_port_active = function_call(
+        "Modelica.Math.BooleanVectors.anyTrue",
+        vec![var_ref("step.inPort.set")],
+    );
+    let out_port_reset = function_call(
+        "Modelica.Math.BooleanVectors.anyTrue",
+        vec![var_ref("step.outPort.reset")],
+    );
+    let rhs = rumoca_core::Expression::Binary {
+        op: rumoca_core::OpBinary::Or,
+        lhs: Box::new(in_port_active),
+        rhs: Box::new(rumoca_core::Expression::Unary {
+            op: rumoca_core::OpUnary::Not,
+            rhs: Box::new(out_port_reset),
+            span: test_span(),
+        }),
+        span: test_span(),
+    };
+    dae.discrete.valued_updates.push(dae::Equation::explicit(
+        rumoca_core::Reference::new("step.newActive"),
+        rhs,
+        test_span(),
+        "StateGraph composite step activation",
+    ));
+
+    scalarize_phantom_vector_equations(&mut dae).unwrap();
+
+    assert_eq!(dae.discrete.valued_updates.len(), 1);
+    assert_eq!(dae.discrete.valued_updates[0].scalar_count, 1);
+    let rumoca_core::Expression::Binary { lhs, rhs, .. } = &dae.discrete.valued_updates[0].rhs
+    else {
+        panic!("expected composite boolean expression");
+    };
+    assert_any_true_array_arg(lhs, &["step.inPort[1].set", "step.inPort[2].set"]);
+    let rumoca_core::Expression::Unary { rhs, .. } = rhs.as_ref() else {
+        panic!("expected negated outPort reset check");
+    };
+    assert_any_true_array_arg(rhs, &["step.outPort[1].reset"]);
+    let names = all_var_names(&dae.discrete.valued_updates[0].rhs);
+    assert!(!names.contains(&"step.inPort.set".to_string()));
+    assert!(!names.contains(&"step.outPort.reset".to_string()));
 }
 
 #[test]

--- a/crates/rumoca-phase-dae/src/tests/root/tests_regressions.rs
+++ b/crates/rumoca-phase-dae/src/tests/root/tests_regressions.rs
@@ -952,6 +952,68 @@ fn test_todae_keeps_time_guarded_discrete_output_binding_and_alias_consumer() {
 }
 
 #[test]
+fn test_todae_preserves_discrete_output_binding_as_relation_anchor() {
+    let mut flat = Model::new();
+    flat.add_variable(
+        VarName::new("root.suspend"),
+        crate::test_support::with_component_ref(flat::Variable {
+            name: VarName::new("root.suspend"),
+            causality: rumoca_core::Causality::Output(rumoca_core::Token::default()),
+            is_discrete_type: true,
+            binding: Some(Expression::Literal {
+                value: Literal::Boolean(false),
+                span: crate::test_support::test_span(),
+            }),
+            ..rumoca_ir_flat::Variable::empty_with_span(crate::test_support::test_span())
+        }),
+    );
+    flat.add_variable(
+        VarName::new("root.subgraph.suspend"),
+        crate::test_support::with_component_ref(flat::Variable {
+            name: VarName::new("root.subgraph.suspend"),
+            causality: rumoca_core::Causality::Output(rumoca_core::Token::default()),
+            is_discrete_type: true,
+            ..rumoca_ir_flat::Variable::empty_with_span(crate::test_support::test_span())
+        }),
+    );
+    flat.add_equation(rumoca_ir_flat::Equation {
+        residual: sub_expr(
+            make_var_ref("root.suspend"),
+            make_var_ref("root.subgraph.suspend"),
+        ),
+        span: crate::test_support::test_span(),
+        origin: rumoca_ir_flat::EquationOrigin::ComponentEquation {
+            component: "root".to_string(),
+        },
+        scalar_count: 1,
+    });
+
+    let dae = to_dae_with_options(
+        &flat,
+        ToDaeOptions {
+            error_on_unbalanced: false,
+        },
+    )
+    .expect("todae should preserve discrete output binding relation anchors");
+
+    assert!(
+        dae.discrete.valued_updates.iter().any(|eq| {
+            eq.origin.contains("binding equation for root.suspend")
+                && eq
+                    .lhs
+                    .as_ref()
+                    .is_some_and(|lhs| lhs.as_str() == "root.suspend")
+        }),
+        "constant discrete output binding must remain as the value anchor"
+    );
+    assert_eq!(
+        crate::balance::balance(&dae).expect("fixture balance should be computable"),
+        0,
+        "binding anchor plus relation equation should balance both discrete variables"
+    );
+}
+
+#[test]
 fn test_todae_converts_non_primitive_leaf_discrete_binding_to_f_m() {
     let mut flat = Model::new();
     flat.add_variable(

--- a/crates/rumoca-phase-flatten/src/connections/equation_generation.rs
+++ b/crates/rumoca-phase-flatten/src/connections/equation_generation.rs
@@ -743,10 +743,46 @@ fn redirect_qualified_name(
     }
 }
 
+fn bridge_scope_matches_connection_scope(inner_outer_prefix: &str, connection_scope: &str) -> bool {
+    let bridge_scope = ast::QualifiedName::from_dotted(inner_outer_prefix)
+        .parent()
+        .unwrap_or_default();
+    bridge_scope == ast::QualifiedName::from_dotted(connection_scope)
+}
+
+fn redirect_inner_outer_bridge_for_scope(
+    qn: &mut ast::QualifiedName,
+    inner_outer_to_parent_inner: &ast::AstIndexMap<String, String>,
+    connection_scope: &str,
+) {
+    if inner_outer_to_parent_inner.is_empty() {
+        return;
+    }
+    let flat = qn.to_flat_string();
+    for (inner_outer_prefix, parent_inner_prefix) in inner_outer_to_parent_inner {
+        if !bridge_scope_matches_connection_scope(inner_outer_prefix, connection_scope) {
+            continue;
+        }
+        if flat == *inner_outer_prefix || flat.starts_with(&format!("{inner_outer_prefix}.")) {
+            let new_flat = if flat == *inner_outer_prefix {
+                parent_inner_prefix.clone()
+            } else {
+                format!(
+                    "{}{}",
+                    parent_inner_prefix,
+                    &flat[inner_outer_prefix.len()..]
+                )
+            };
+            *qn = ast::QualifiedName::from_dotted(&new_flat);
+            return;
+        }
+    }
+}
+
 /// MLS §5.4: Apply outer→inner and inner-outer bridge redirects to a connection.
 ///
 /// First pass: redirect pure `outer` component references to their matching `inner`.
-/// Second pass: if no redirect happened (same-level connection), redirect `inner outer`
+/// Second pass: if no redirect happened, redirect same-level `inner outer`
 /// component references to the parent's inner for correct flow equation scoping.
 /// In both cases, reset the scope to root so flow sums merge properly.
 fn redirect_connection_for_inner_outer(
@@ -770,8 +806,16 @@ fn redirect_connection_for_inner_outer(
 
     // Second pass: inner outer bridge redirect (only when first pass had no effect)
     if !overlay.inner_outer_to_parent_inner.is_empty() {
-        redirect_qualified_name(&mut redirected.a, &overlay.inner_outer_to_parent_inner);
-        redirect_qualified_name(&mut redirected.b, &overlay.inner_outer_to_parent_inner);
+        redirect_inner_outer_bridge_for_scope(
+            &mut redirected.a,
+            &overlay.inner_outer_to_parent_inner,
+            &conn.scope,
+        );
+        redirect_inner_outer_bridge_for_scope(
+            &mut redirected.b,
+            &overlay.inner_outer_to_parent_inner,
+            &conn.scope,
+        );
         let a_bridged = a_after != redirected.a.to_flat_string();
         let b_bridged = b_after != redirected.b.to_flat_string();
         if a_bridged || b_bridged {
@@ -788,6 +832,26 @@ fn redirect_connection_for_inner_outer(
 #[cfg(test)]
 mod equation_generation_tests {
     use super::is_single_identifier_relative_path;
+    use super::*;
+
+    fn conn(a: &str, b: &str, scope: &str) -> ast::InstanceConnection {
+        ast::InstanceConnection {
+            a: ast::QualifiedName::from_dotted(a),
+            b: ast::QualifiedName::from_dotted(b),
+            connector_type: None,
+            span: rumoca_core::Span::DUMMY,
+            scope: scope.to_string(),
+        }
+    }
+
+    fn overlay_with_inner_outer_bridge() -> ast::InstanceOverlay {
+        let mut overlay = ast::InstanceOverlay::default();
+        overlay.inner_outer_to_parent_inner.insert(
+            "tankController.makeProduct.stateGraphRoot".to_string(),
+            "stateGraphRoot".to_string(),
+        );
+        overlay
+    }
 
     #[test]
     fn single_identifier_relative_path_ignores_dot_inside_subscript_expression() {
@@ -799,5 +863,49 @@ mod equation_generation_tests {
     fn single_identifier_relative_path_rejects_top_level_member_access() {
         assert!(!is_single_identifier_relative_path("plug.p"));
         assert!(!is_single_identifier_relative_path("plug[data.medium].p"));
+    }
+
+    #[test]
+    fn inner_outer_bridge_redirects_same_scope_connection_to_parent_inner() {
+        let overlay = overlay_with_inner_outer_bridge();
+        let input = conn(
+            "tankController.makeProduct.outerState.subgraphStatePort",
+            "tankController.makeProduct.stateGraphRoot.subgraphStatePort",
+            "tankController.makeProduct",
+        );
+
+        let redirected = redirect_connection_for_inner_outer(&input, &overlay);
+
+        assert_eq!(
+            redirected.a.to_flat_string(),
+            "tankController.makeProduct.outerState.subgraphStatePort"
+        );
+        assert_eq!(
+            redirected.b.to_flat_string(),
+            "stateGraphRoot.subgraphStatePort"
+        );
+        assert_eq!(redirected.scope, "");
+    }
+
+    #[test]
+    fn inner_outer_bridge_keeps_child_scope_connection_on_local_inner() {
+        let overlay = overlay_with_inner_outer_bridge();
+        let input = conn(
+            "tankController.makeProduct.fillTank1.outerStatePort.subgraphStatePort",
+            "tankController.makeProduct.stateGraphRoot.subgraphStatePort",
+            "tankController.makeProduct.fillTank1",
+        );
+
+        let redirected = redirect_connection_for_inner_outer(&input, &overlay);
+
+        assert_eq!(
+            redirected.a.to_flat_string(),
+            "tankController.makeProduct.fillTank1.outerStatePort.subgraphStatePort"
+        );
+        assert_eq!(
+            redirected.b.to_flat_string(),
+            "tankController.makeProduct.stateGraphRoot.subgraphStatePort"
+        );
+        assert_eq!(redirected.scope, "tankController.makeProduct.fillTank1");
     }
 }

--- a/crates/rumoca-phase-instantiate/src/array_expansion.rs
+++ b/crates/rumoca-phase-instantiate/src/array_expansion.rs
@@ -6,6 +6,7 @@ use super::{InstantiateContext, InstantiateResult, find_class_in_tree, get_effec
 use rumoca_eval_ast::eval_instantiate::{InstantiateEvalCtx, try_eval_integer_expr};
 use rumoca_ir_ast as ast;
 use rumoca_ir_ast::AstIndexMap as IndexMap;
+use rumoca_ir_ast::ExpressionTransformer;
 use std::sync::Arc;
 
 /// Expand an array component into individual indexed instances.
@@ -689,128 +690,7 @@ fn eval_range_bounds(
 
 /// Substitute a component reference to `var_name` with an integer literal.
 fn substitute_var(expr: &ast::Expression, var_name: &str, value: i64) -> ast::Expression {
-    if let Some(replacement) = replace_component_reference_with_integer(expr, var_name, value) {
-        return replacement;
-    }
-
-    match expr {
-        ast::Expression::Array {
-            elements,
-            is_matrix,
-            span,
-        } => ast::Expression::Array {
-            elements: elements
-                .iter()
-                .map(|elem| substitute_var(elem, var_name, value))
-                .collect(),
-            is_matrix: *is_matrix,
-            span: *span,
-        },
-        ast::Expression::Binary { op, lhs, rhs, span } => ast::Expression::Binary {
-            op: op.clone(),
-            lhs: Arc::new(substitute_var(lhs, var_name, value)),
-            rhs: Arc::new(substitute_var(rhs, var_name, value)),
-            span: *span,
-        },
-        ast::Expression::Unary { op, rhs, span } => ast::Expression::Unary {
-            op: op.clone(),
-            rhs: Arc::new(substitute_var(rhs, var_name, value)),
-            span: *span,
-        },
-        ast::Expression::FunctionCall { comp, args, span } => ast::Expression::FunctionCall {
-            comp: comp.clone(),
-            args: args
-                .iter()
-                .map(|arg| substitute_var(arg, var_name, value))
-                .collect(),
-            span: *span,
-        },
-        ast::Expression::If {
-            branches,
-            else_branch,
-            span,
-        } => ast::Expression::If {
-            branches: branches
-                .iter()
-                .map(|(cond, branch_expr)| {
-                    (
-                        substitute_var(cond, var_name, value),
-                        substitute_var(branch_expr, var_name, value),
-                    )
-                })
-                .collect(),
-            else_branch: Arc::new(substitute_var(else_branch, var_name, value)),
-            span: *span,
-        },
-        ast::Expression::FieldAccess { base, field, span } => ast::Expression::FieldAccess {
-            base: Arc::new(substitute_var(base, var_name, value)),
-            field: field.clone(),
-            span: *span,
-        },
-        ast::Expression::ComponentReference(cref) => {
-            ast::Expression::ComponentReference(substitute_component_ref_var(cref, var_name, value))
-        }
-        ast::Expression::ArrayIndex {
-            base,
-            subscripts,
-            span,
-        } => ast::Expression::ArrayIndex {
-            base: Arc::new(substitute_var(base, var_name, value)),
-            subscripts: subscripts
-                .iter()
-                .map(|sub| substitute_subscript_var(sub, var_name, value))
-                .collect(),
-            span: *span,
-        },
-        ast::Expression::Range {
-            start,
-            step,
-            end,
-            span,
-        } => ast::Expression::Range {
-            start: Arc::new(substitute_var(start, var_name, value)),
-            step: step
-                .as_ref()
-                .map(|inner| Arc::new(substitute_var(inner, var_name, value))),
-            end: Arc::new(substitute_var(end, var_name, value)),
-            span: *span,
-        },
-        ast::Expression::ArrayComprehension {
-            expr: inner_expr,
-            indices,
-            filter,
-            ..
-        } => substitute_array_comprehension_var(expr, inner_expr, indices, filter, var_name, value),
-        ast::Expression::Parenthesized { inner, span } => ast::Expression::Parenthesized {
-            inner: Arc::new(substitute_var(inner, var_name, value)),
-            span: *span,
-        },
-        _ => expr.clone(),
-    }
-}
-
-fn substitute_component_ref_var(
-    cref: &ast::ComponentReference,
-    var_name: &str,
-    value: i64,
-) -> ast::ComponentReference {
-    ast::ComponentReference {
-        local: cref.local,
-        parts: cref
-            .parts
-            .iter()
-            .map(|part| ast::ComponentRefPart {
-                ident: part.ident.clone(),
-                subs: part.subs.as_ref().map(|subs| {
-                    subs.iter()
-                        .map(|sub| substitute_subscript_var(sub, var_name, value))
-                        .collect()
-                }),
-            })
-            .collect(),
-        def_id: cref.def_id,
-        span: cref.span,
-    }
+    LoopIndexSubstituter { var_name, value }.transform_expression(expr.clone())
 }
 
 fn replace_component_reference_with_integer(
@@ -835,47 +715,57 @@ fn replace_component_reference_with_integer(
     })
 }
 
-fn substitute_subscript_var(
-    sub: &rumoca_ir_ast::Subscript,
-    var_name: &str,
+struct LoopIndexSubstituter<'a> {
+    var_name: &'a str,
     value: i64,
-) -> rumoca_ir_ast::Subscript {
-    match sub {
-        rumoca_ir_ast::Subscript::Expression(sub_expr) => {
-            rumoca_ir_ast::Subscript::Expression(substitute_var(sub_expr, var_name, value))
+}
+
+impl ast::ExpressionTransformer for LoopIndexSubstituter<'_> {
+    fn transform_expression(&mut self, expr: ast::Expression) -> ast::Expression {
+        match expr {
+            ast::Expression::ArrayComprehension {
+                expr: inner_expr,
+                indices,
+                filter,
+                span,
+            } => self.transform_array_comprehension(inner_expr, indices, filter, span),
+            _ => replace_component_reference_with_integer(&expr, self.var_name, self.value)
+                .unwrap_or_else(|| self.walk_expression(expr)),
         }
-        _ => sub.clone(),
     }
 }
 
-fn substitute_array_comprehension_var(
-    original_expr: &ast::Expression,
-    inner_expr: &ast::Expression,
-    indices: &[rumoca_ir_ast::ForIndex],
-    filter: &Option<Arc<ast::Expression>>,
-    var_name: &str,
-    value: i64,
-) -> ast::Expression {
-    if indices
-        .iter()
-        .any(|for_index| for_index.ident.text.as_ref() == var_name)
-    {
-        return original_expr.clone();
-    }
-
-    ast::Expression::ArrayComprehension {
-        expr: Arc::new(substitute_var(inner_expr, var_name, value)),
-        indices: indices
+impl LoopIndexSubstituter<'_> {
+    fn transform_array_comprehension(
+        &mut self,
+        inner_expr: Arc<ast::Expression>,
+        indices: Vec<rumoca_ir_ast::ForIndex>,
+        filter: Option<Arc<ast::Expression>>,
+        span: rumoca_core::Span,
+    ) -> ast::Expression {
+        if indices
             .iter()
-            .map(|for_index| rumoca_ir_ast::ForIndex {
-                ident: for_index.ident.clone(),
-                range: substitute_var(&for_index.range, var_name, value),
-            })
-            .collect(),
-        filter: filter
-            .as_ref()
-            .map(|filter_expr| Arc::new(substitute_var(filter_expr, var_name, value))),
-        span: original_expr.span(),
+            .any(|for_index| for_index.ident.text.as_ref() == self.var_name)
+        {
+            return ast::Expression::ArrayComprehension {
+                expr: inner_expr,
+                indices,
+                filter,
+                span,
+            };
+        }
+
+        ast::Expression::ArrayComprehension {
+            expr: Arc::new(self.transform_expression(inner_expr.as_ref().clone())),
+            indices: indices
+                .into_iter()
+                .map(|for_index| self.transform_for_index(for_index))
+                .collect(),
+            filter: filter.map(|filter_expr| {
+                Arc::new(self.transform_expression(filter_expr.as_ref().clone()))
+            }),
+            span,
+        }
     }
 }
 
@@ -1190,8 +1080,8 @@ mod tests {
         }
     }
 
-    fn make_comp_ref_expr(names: &[&str]) -> ast::Expression {
-        ast::Expression::ComponentReference(ast::ComponentReference {
+    fn make_component_ref(names: &[&str]) -> ast::ComponentReference {
+        ast::ComponentReference {
             local: false,
             parts: names
                 .iter()
@@ -1202,7 +1092,11 @@ mod tests {
                 .collect(),
             def_id: None,
             span: rumoca_core::Span::DUMMY,
-        })
+        }
+    }
+
+    fn make_comp_ref_expr(names: &[&str]) -> ast::Expression {
+        ast::Expression::ComponentReference(make_component_ref(names))
     }
 
     fn make_indexed_comp_ref_expr(name: &str, index_name: &str) -> ast::Expression {
@@ -1533,6 +1427,107 @@ mod tests {
         };
         let Some(subscripts) = cref.parts[0].subs.as_ref() else {
             panic!("expected subscript");
+        };
+        let ast::Subscript::Expression(ast::Expression::Terminal { token, .. }) = &subscripts[0]
+        else {
+            panic!("expected literal subscript");
+        };
+        assert_eq!(token.text.as_ref(), "2");
+    }
+
+    #[test]
+    fn test_index_binding_for_element_substitutes_comprehension_index_in_class_modification() {
+        let binding = ast::Expression::ArrayComprehension {
+            expr: Arc::new(ast::Expression::ClassModification {
+                target: make_component_ref(&["SalientPermeance"]),
+                modifications: vec![ast::Expression::Modification {
+                    target: make_component_ref(&["d"]),
+                    value: Arc::new(make_indexed_comp_ref_expr("effectiveTurns", "k")),
+                    span: rumoca_core::Span::DUMMY,
+                }],
+                each_flags: vec![false],
+                final_flags: vec![false],
+                redeclare_flags: vec![false],
+                span: rumoca_core::Span::DUMMY,
+            }),
+            indices: vec![ast::ForIndex {
+                ident: make_token("k"),
+                range: make_range_expr(1, 3),
+            }],
+            filter: None,
+            span: rumoca_core::Span::DUMMY,
+        };
+
+        let indexed = index_binding_for_element(
+            &ast::ClassTree::default(),
+            &IndexMap::default(),
+            &binding,
+            &[2],
+        )
+        .expect("class modification comprehension projection should succeed");
+
+        let ast::Expression::ClassModification { modifications, .. } = indexed else {
+            panic!("array comprehension should project to class modification body");
+        };
+        let ast::Expression::Modification { value, .. } = &modifications[0] else {
+            panic!("expected field modification");
+        };
+        let ast::Expression::ComponentReference(cref) = value.as_ref() else {
+            panic!("expected indexed component reference");
+        };
+        let Some(subscripts) = cref.parts[0].subs.as_ref() else {
+            panic!("expected substituted subscript");
+        };
+        let ast::Subscript::Expression(ast::Expression::Terminal { token, .. }) = &subscripts[0]
+        else {
+            panic!("expected literal subscript");
+        };
+        assert_eq!(token.text.as_ref(), "2");
+    }
+
+    #[test]
+    fn test_resolve_mod_to_array_substitutes_comprehension_index_in_class_modification() {
+        let modifier = ast::Expression::ArrayComprehension {
+            expr: Arc::new(ast::Expression::ClassModification {
+                target: make_component_ref(&["SalientPermeance"]),
+                modifications: vec![ast::Expression::Modification {
+                    target: make_component_ref(&["d"]),
+                    value: Arc::new(make_indexed_comp_ref_expr("effectiveTurns", "k")),
+                    span: rumoca_core::Span::DUMMY,
+                }],
+                each_flags: vec![false],
+                final_flags: vec![false],
+                redeclare_flags: vec![false],
+                span: rumoca_core::Span::DUMMY,
+            }),
+            indices: vec![ast::ForIndex {
+                ident: make_token("k"),
+                range: make_range_expr(1, 3),
+            }],
+            filter: None,
+            span: rumoca_core::Span::DUMMY,
+        };
+
+        let resolved = resolve_mod_to_array(
+            &modifier,
+            &rumoca_ir_ast::ModificationEnvironment::default(),
+            &IndexMap::default(),
+            &ast::ClassTree::default(),
+        );
+        let ast::Expression::Array { elements, .. } = resolved else {
+            panic!("class modification comprehension should resolve to an array");
+        };
+        let ast::Expression::ClassModification { modifications, .. } = &elements[1] else {
+            panic!("second element should remain a class modification");
+        };
+        let ast::Expression::Modification { value, .. } = &modifications[0] else {
+            panic!("expected field modification");
+        };
+        let ast::Expression::ComponentReference(cref) = value.as_ref() else {
+            panic!("expected indexed component reference");
+        };
+        let Some(subscripts) = cref.parts[0].subs.as_ref() else {
+            panic!("expected substituted subscript");
         };
         let ast::Subscript::Expression(ast::Expression::Terminal { token, .. }) = &subscripts[0]
         else {

--- a/crates/rumoca-phase-instantiate/src/attributes.rs
+++ b/crates/rumoca-phase-instantiate/src/attributes.rs
@@ -1,6 +1,7 @@
 use super::*;
 use rumoca_eval_ast::eval_instantiate::{
-    InstantiateEvalCtx, eval_state_select_expr, expr_to_bool, expr_to_string, parse_state_select,
+    InstantiateEvalCtx, eval_state_select_expr_with_source_scope, expr_to_bool, expr_to_string,
+    parse_state_select,
 };
 
 pub(super) struct ComponentAttrsAndBinding {
@@ -344,9 +345,15 @@ pub(super) fn extract_attributes(
         Some(value.value.clone())
     };
 
-    let outer_state_select = mod_env.get_attr(comp_name, "stateSelect");
+    let state_select_path = ast::QualifiedName::from_ident(comp_name).child("stateSelect");
+    let outer_state_select = mod_env.get(&state_select_path);
     let outer_state_select = match outer_state_select {
-        Some(value) => Some(parse_required_state_select(value, eval_ctx, imports)?),
+        Some(value) => Some(parse_required_state_select(
+            &value.value,
+            eval_ctx,
+            imports,
+            value.source_scope.as_ref(),
+        )?),
         None => None,
     };
     let has_outer_state_select = outer_state_select.is_some();
@@ -384,7 +391,7 @@ pub(super) fn extract_attributes(
                 attrs.display_unit = expr_to_string(value)
             }
             "stateSelect" if !has_outer_state_select => {
-                attrs.state_select = parse_required_state_select(value, eval_ctx, imports)?
+                attrs.state_select = parse_required_state_select(value, eval_ctx, imports, None)?
             }
             _ => {}
         }
@@ -402,15 +409,16 @@ fn parse_required_state_select(
     value: &ast::Expression,
     eval_ctx: &InstantiateEvalCtx<'_>,
     imports: &[(String, String)],
+    source_scope: Option<&ast::QualifiedName>,
 ) -> InstantiateResult<rumoca_core::StateSelect> {
     parse_state_select(value)
-        .or_else(|| eval_state_select_expr(eval_ctx, value))
+        .or_else(|| eval_state_select_expr_with_source_scope(eval_ctx, value, source_scope))
         .or_else(|| {
             // Enclosing-scope constants (MLS §5.3.2) appear unqualified in
             // declaration-side attributes; qualify them through the package
             // constant aliases and retry before failing.
             let qualified = crate::dims::qualify_shape_expr_imports(value, imports);
-            eval_state_select_expr(eval_ctx, &qualified)
+            eval_state_select_expr_with_source_scope(eval_ctx, &qualified, source_scope)
         })
         .ok_or_else(|| {
             Box::new(InstantiateError::InvalidTypeAttribute {

--- a/crates/rumoca-phase-instantiate/src/lib.rs
+++ b/crates/rumoca-phase-instantiate/src/lib.rs
@@ -1293,12 +1293,28 @@ fn can_resolve_missing_inner(
     missing: &MissingInnerInfo,
 ) -> bool {
     missing.name == name
+        && inner_visible_to_outer(inner_decl, missing)
         && is_type_compatible_with_def_id(
             tree,
             &missing.type_name,
             missing.type_def_id,
             &inner_decl.type_name,
             inner_decl.type_def_id,
+        )
+}
+
+fn inner_visible_to_outer(inner_decl: &InnerDeclaration, missing: &MissingInnerInfo) -> bool {
+    let inner_scope = inner_decl.qualified_name.parent().unwrap_or_default();
+    let outer_scope = missing.outer_path.parent().unwrap_or_default();
+    path_is_ancestor_or_same(&inner_scope, &outer_scope)
+}
+
+fn path_is_ancestor_or_same(ancestor: &ast::QualifiedName, path: &ast::QualifiedName) -> bool {
+    ancestor.parts.len() <= path.parts.len()
+        && ancestor.parts.iter().zip(path.parts.iter()).all(
+            |((ancestor_name, ancestor_subs), (path_name, path_subs))| {
+                ancestor_name == path_name && ancestor_subs == path_subs
+            },
         )
 }
 

--- a/crates/rumoca-phase-instantiate/src/mod_env.rs
+++ b/crates/rumoca-phase-instantiate/src/mod_env.rs
@@ -803,7 +803,10 @@ fn process_nested_modifications_recursive(
 }
 
 fn preserves_source_scoped_attribute(attr_name: &str) -> bool {
-    matches!(attr_name, "start" | "min" | "max" | "nominal")
+    matches!(
+        attr_name,
+        "start" | "min" | "max" | "nominal" | "stateSelect"
+    )
 }
 
 #[cfg(test)]

--- a/crates/rumoca-phase-instantiate/src/tests.rs
+++ b/crates/rumoca-phase-instantiate/src/tests.rs
@@ -60,6 +60,18 @@ fn make_bool_expr(value: bool) -> ast::Expression {
     }
 }
 
+fn make_if_expr(
+    condition: ast::Expression,
+    then_expr: ast::Expression,
+    else_expr: ast::Expression,
+) -> ast::Expression {
+    ast::Expression::If {
+        branches: vec![(condition, then_expr)],
+        else_branch: std::sync::Arc::new(else_expr),
+        span: rumoca_core::Span::DUMMY,
+    }
+}
+
 fn test_span() -> rumoca_core::Span {
     rumoca_core::Span::from_offsets(
         rumoca_core::SourceId::from_source_name("phase_instantiate_tests_source_7.mo"),
@@ -255,6 +267,43 @@ fn test_extract_attributes_outer_state_select_overrides_local() {
         .expect("valid attributes should extract");
 
     assert_eq!(attrs.state_select, rumoca_core::StateSelect::Never);
+}
+
+#[test]
+fn test_extract_attributes_evaluates_outer_state_select_in_modifier_source_scope() {
+    let comp = make_component("x", "Real", None);
+    let state_select_expr = make_if_expr(
+        make_comp_ref_expr(&["pT_explicit"]),
+        make_comp_ref_expr(&["StateSelect", "prefer"]),
+        make_comp_ref_expr(&["StateSelect", "default"]),
+    );
+
+    let mut mod_env = ast::ModificationEnvironment::new();
+    mod_env.add(
+        ast::QualifiedName::from_dotted("x.stateSelect"),
+        ast::ModificationValue::with_source_scope(
+            state_select_expr,
+            None,
+            Some(ast::QualifiedName::from_dotted("Medium")),
+        ),
+    );
+
+    let mut p_t_explicit = make_component("Medium.pT_explicit", "Boolean", None);
+    p_t_explicit.variability = rumoca_core::Variability::Parameter(make_token("parameter"));
+    p_t_explicit.binding = Some(make_if_expr(
+        make_bool_expr(true),
+        make_bool_expr(true),
+        make_bool_expr(false),
+    ));
+    let mut effective_components = IndexMap::default();
+    effective_components.insert("Medium.pT_explicit".to_string(), p_t_explicit);
+
+    let tree = ast::ClassTree::default();
+    let eval_ctx = make_eval_ctx(&tree, &mod_env, &effective_components);
+    let attrs = extract_attributes(&comp, &mod_env, "x", &eval_ctx, &[])
+        .expect("source-scoped stateSelect should evaluate");
+
+    assert_eq!(attrs.state_select, rumoca_core::StateSelect::Prefer);
 }
 
 #[test]
@@ -723,6 +772,59 @@ fn test_inner_shadowing() {
     // Now should find the outer "g"
     let inner = ctx.find_inner("g").unwrap();
     assert_eq!(inner.qualified_name.to_flat_string(), "root.g");
+}
+
+fn inner_decl(path: &str) -> InnerDeclaration {
+    InnerDeclaration {
+        qualified_name: ast::QualifiedName::from_dotted(path),
+        type_name: "StateGraphRoot".to_string(),
+        type_def_id: None,
+    }
+}
+
+fn missing_inner_at(path: &str) -> MissingInnerInfo {
+    MissingInnerInfo {
+        name: "stateGraphRoot".to_string(),
+        type_name: "StateGraphRoot".to_string(),
+        type_def_id: None,
+        span: Span::DUMMY,
+        source_location: make_location("inner_visibility.mo", 0, 1),
+        outer_path: ast::QualifiedName::from_dotted(path),
+        is_inner_outer: false,
+    }
+}
+
+#[test]
+fn test_pending_outer_resolution_requires_inner_ancestor_scope() {
+    let inner = inner_decl("tankController.makeProduct.stateGraphRoot");
+    let sibling_outer = missing_inner_at("tankController.s1.stateGraphRoot");
+
+    assert!(
+        !inner_visible_to_outer(&inner, &sibling_outer),
+        "inner declarations in one component must not resolve pending outers in a sibling"
+    );
+}
+
+#[test]
+fn test_pending_outer_resolution_allows_inner_ancestor_scope() {
+    let inner = inner_decl("tankController.makeProduct.stateGraphRoot");
+    let nested_outer = missing_inner_at("tankController.makeProduct.fillTank1.stateGraphRoot");
+
+    assert!(
+        inner_visible_to_outer(&inner, &nested_outer),
+        "inner declarations are visible to nested component scopes"
+    );
+}
+
+#[test]
+fn test_pending_outer_resolution_allows_root_inner_for_nested_outer() {
+    let inner = inner_decl("stateGraphRoot");
+    let nested_outer = missing_inner_at("tankController.s1.stateGraphRoot");
+
+    assert!(
+        inner_visible_to_outer(&inner, &nested_outer),
+        "root inner declarations remain visible to nested outer references"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR improves Modelica Standard Library coverage by fixing several independent issues found while running the full MSL parity suite.

Changes include:

- Preserve modifier source scope when evaluating `stateSelect`, including Boolean `if` expressions.
- Treat explicit but non-evaluable modifiers defensively instead of silently falling back to declaration defaults.
- Enforce lexical visibility for deferred `inner`/`outer` resolution.
- Fix inner/outer connection bridge redirection for StateGraph-style scopes.
- Use the expression visitor infrastructure for array-comprehension loop-index substitution in class modifications.
- Preserve phantom array formal function arguments during DAE scalarization.
- Tighten DAE discrete alias canonicalization so binding anchors are not dropped.

## Root Causes

The full MSL run exposed several coverage blockers:

- Source-scoped modifiers were being evaluated in the wrong scope, which left Fluid `stateSelect` modifiers unresolved.
- Explicit modifier expressions could fail evaluation and then incorrectly fall back to declaration defaults, masking unknown values.
- Deferred `outer` resolution did not fully enforce ancestor visibility, which allowed incorrect StateGraph connection sets.
- Array-comprehension loop indices inside class modifications were not substituted into cloned array elements, leaving unresolved references such as `electroMagneticConverter.k`.
- DAE scalarization treated array formal arguments as scalar in some function-call paths.
- Discrete alias canonicalization could remove the binding equation that anchored a discrete relation.

## Impact

Latest full MSL parity run:

- Parse/resolve/instantiate/typecheck: `566/566`
- Flatten: `565/566`
- To DAE / compiled: `545/566`
- Balanced: `532/566`
- Initial balance OK: `532/566`
- Simulation OK: `173/566`

The DAE stage improves from the baseline `539/566` to `545/566`. The previous Fluid `stateSelect` instantiate failures are gone, and the focused magnetic `electroMagneticConverter.k` failure set now compiles, balances, and passes initial balance checks.

## Validation

Ran targeted regression tests for:

- expression transformer traversal
- array-comprehension index substitution
- deferred `inner`/`outer` resolution
- StateGraph inner/outer bridge behavior
- scoped modifier condition evaluation
- source-scoped `stateSelect`
- phantom array formal DAE scalarization
- discrete alias canonicalization and binding anchors

Also ran the full local MSL parity gate:

```bash
cargo xtask verify msl-parity --results-dir target/msl/full-after-source-scope-array-transformer --monitor-interval-secs 60
```

The full gate passed.