### PR TITLE
Improve MSL initial event trace parity

### DIFF
--- a/crates/rumoca-eval-solve/src/lib.rs
+++ b/crates/rumoca-eval-solve/src/lib.rs
@@ -54,7 +54,8 @@ use random_runtime::{
     initial_state_values, projected_random_value, random_result_and_state, read_reg_range,
 };
 pub use runtime::{
-    AlgebraicLinearization, AlgebraicSettle, EventUpdateRowFilter, ProjectedEventUpdateInput,
+    AlgebraicLinearization, AlgebraicSettle, EventUpdateRowFilter, InitialEventObservation,
+    ProjectedEventUpdateInput, ProjectedInitialEventInput, ProjectedInitialEventOutcome,
     SolveRuntime, apply_discrete_slot_value,
 };
 pub use runtime_events::{

--- a/crates/rumoca-eval-solve/src/runtime.rs
+++ b/crates/rumoca-eval-solve/src/runtime.rs
@@ -26,8 +26,12 @@ use crate::{
     RowEvalContext, to_scalar_program_block,
 };
 
+mod initial_event;
 mod sensitivity;
 mod support;
+pub use initial_event::{
+    InitialEventObservation, ProjectedInitialEventInput, ProjectedInitialEventOutcome,
+};
 use support::{
     NewtonProbe, apply_newton_steps, copy_runtime_values, copy_runtime_values_into,
     reserve_runtime_index_map_capacity, reserve_runtime_vec_capacity, resize_runtime_values,
@@ -1182,36 +1186,6 @@ impl SolveRuntime {
         Err(RuntimeSolveError::solve_ir(format!(
             "initial discrete equations did not converge at t={t}"
         )))
-    }
-
-    pub fn apply_projected_post_initial_event_update<P>(
-        &self,
-        y: &mut [f64],
-        p: &mut [f64],
-        t: f64,
-        tol: f64,
-        max_iters: usize,
-        project_algebraics: P,
-    ) -> Result<EventActionOutcome, RuntimeSolveError>
-    where
-        P: FnMut(&mut [f64], &mut [f64]) -> Result<bool, RuntimeSolveError>,
-    {
-        let event_pre_y = copy_runtime_values(y, "post-initial event pre y snapshot")?;
-        let event_pre_p = copy_runtime_values(p, "post-initial event pre p snapshot")?;
-        self.apply_projected_event_update(
-            ProjectedEventUpdateInput {
-                y,
-                p,
-                t,
-                tol,
-                event_pre_y: &event_pre_y,
-                event_pre_p: &event_pre_p,
-                max_iters,
-                row_filter: EventUpdateRowFilter::FollowCurrentOnly,
-                root_relation_overrides: &[],
-            },
-            project_algebraics,
-        )
     }
 
     pub fn apply_projected_event_update<P>(

--- a/crates/rumoca-eval-solve/src/runtime/initial_event.rs
+++ b/crates/rumoca-eval-solve/src/runtime/initial_event.rs
@@ -1,0 +1,283 @@
+use rumoca_solver::{
+    EventActionOutcome, EventPreMode, RuntimeEventBoundary, RuntimeEventStop, RuntimeSolveError,
+    initial_runtime_event_stop, runtime_event_right_limit, timeline::sample_time_match_with_tol,
+};
+
+use super::{
+    EventUpdateRowFilter, ProjectedEventUpdateInput, SolveRuntime, support::copy_runtime_values,
+};
+
+pub struct ProjectedInitialEventInput<'a> {
+    pub y: &'a mut [f64],
+    pub p: &'a mut [f64],
+    pub t_start: f64,
+    pub t_end: f64,
+    pub tol: f64,
+    pub event_pre_y: &'a [f64],
+    pub event_pre_p: &'a [f64],
+    pub max_iters: usize,
+    pub dynamic_event: Option<RuntimeEventStop>,
+    pub apply_without_initial_event: bool,
+}
+
+pub struct ProjectedInitialEventOutcome {
+    pub final_t: f64,
+    pub observations: Vec<InitialEventObservation>,
+    pub action: EventActionOutcome,
+}
+
+pub struct InitialEventObservation {
+    pub t: f64,
+    pub y: Vec<f64>,
+    pub p: Vec<f64>,
+}
+
+impl InitialEventObservation {
+    fn snapshot(t: f64, y: &[f64], p: &[f64]) -> Self {
+        Self {
+            t,
+            y: y.to_vec(),
+            p: p.to_vec(),
+        }
+    }
+}
+
+struct InitialEventUpdate<'a> {
+    y: &'a mut [f64],
+    p: &'a mut [f64],
+    t: f64,
+    tol: f64,
+    event_pre_y: &'a [f64],
+    event_pre_p: &'a [f64],
+    max_iters: usize,
+    initial_event: Option<RuntimeEventStop>,
+}
+
+fn initial_event_right_limit(event: RuntimeEventStop, event_t: f64, horizon_t: f64) -> Option<f64> {
+    if !event.observe_right_limit || event.pre_mode != EventPreMode::FollowCurrent {
+        return None;
+    }
+    let right_t = runtime_event_right_limit(RuntimeEventBoundary {
+        event_t,
+        horizon_t,
+        event,
+    });
+    (right_t > event_t && !sample_time_match_with_tol(right_t, event_t)).then_some(right_t)
+}
+
+fn trace_values_match(left: &[f64], right: &[f64], tol: f64) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(left, right)| trace_value_matches(*left, *right, tol))
+}
+
+fn trace_value_matches(left: f64, right: f64, tol: f64) -> bool {
+    if left == right {
+        return true;
+    }
+    if !left.is_finite() || !right.is_finite() {
+        return false;
+    }
+    let scale = 1.0_f64.max(left.abs()).max(right.abs());
+    (left - right).abs() <= tol.max(1.0e-12) * scale
+}
+
+impl SolveRuntime {
+    pub fn set_initial_event_flag(&self, p: &mut [f64], value: bool) {
+        let Some(index) = self
+            .model
+            .problem
+            .solve_layout
+            .initial_event_parameter_index
+        else {
+            return;
+        };
+        if let Some(slot) = p.get_mut(index) {
+            *slot = f64::from(value);
+        }
+    }
+
+    pub fn apply_projected_post_initial_event_update<P>(
+        &self,
+        y: &mut [f64],
+        p: &mut [f64],
+        t: f64,
+        tol: f64,
+        max_iters: usize,
+        project_algebraics: P,
+    ) -> Result<EventActionOutcome, RuntimeSolveError>
+    where
+        P: FnMut(&mut [f64], &mut [f64]) -> Result<bool, RuntimeSolveError>,
+    {
+        let event_pre_y = copy_runtime_values(y, "post-initial event pre y snapshot")?;
+        let event_pre_p = copy_runtime_values(p, "post-initial event pre p snapshot")?;
+        self.apply_projected_event_update(
+            ProjectedEventUpdateInput {
+                y,
+                p,
+                t,
+                tol,
+                event_pre_y: &event_pre_y,
+                event_pre_p: &event_pre_p,
+                max_iters,
+                row_filter: EventUpdateRowFilter::FollowCurrentOnly,
+                root_relation_overrides: &[],
+            },
+            project_algebraics,
+        )
+    }
+
+    pub fn apply_projected_initial_event_boundary<P>(
+        &self,
+        input: ProjectedInitialEventInput<'_>,
+        mut project_algebraics: P,
+    ) -> Result<ProjectedInitialEventOutcome, RuntimeSolveError>
+    where
+        P: FnMut(&mut [f64], &mut [f64], f64) -> Result<bool, RuntimeSolveError>,
+    {
+        let ProjectedInitialEventInput {
+            y,
+            p,
+            t_start,
+            t_end,
+            tol,
+            event_pre_y,
+            event_pre_p,
+            max_iters,
+            dynamic_event,
+            apply_without_initial_event,
+        } = input;
+        let initial_event = initial_runtime_event_stop(&self.model.problem, t_start, dynamic_event);
+        let action = if initial_event.is_some() || apply_without_initial_event {
+            self.apply_initial_event_update(
+                InitialEventUpdate {
+                    y,
+                    p,
+                    t: t_start,
+                    tol,
+                    event_pre_y,
+                    event_pre_p,
+                    max_iters,
+                    initial_event,
+                },
+                &mut project_algebraics,
+            )?
+        } else {
+            EventActionOutcome::Continue
+        };
+        if action != EventActionOutcome::Continue {
+            return Ok(ProjectedInitialEventOutcome {
+                final_t: t_start,
+                observations: Vec::new(),
+                action,
+            });
+        }
+        if initial_event.is_none() {
+            self.set_initial_event_flag(p, false);
+            return Ok(ProjectedInitialEventOutcome {
+                final_t: t_start,
+                observations: Vec::new(),
+                action,
+            });
+        }
+        let mut observations = vec![InitialEventObservation::snapshot(t_start, y, p)];
+        self.set_initial_event_flag(p, false);
+        let Some(event) = initial_event else {
+            return Ok(ProjectedInitialEventOutcome {
+                final_t: t_start,
+                observations,
+                action,
+            });
+        };
+        let right_t = initial_event_right_limit(event, t_start, t_end);
+        let post_t = right_t.unwrap_or(t_start);
+        let post_action = self.apply_projected_post_initial_event_update(
+            y,
+            p,
+            post_t,
+            tol,
+            max_iters,
+            |y, p| project_algebraics(y, p, post_t),
+        )?;
+        if let Some(right_t) = right_t {
+            let post_observation = InitialEventObservation::snapshot(right_t, y, p);
+            if !self.initial_event_observations_match_trace(
+                &observations[0],
+                &post_observation,
+                tol,
+            )? {
+                observations.push(post_observation);
+            }
+        }
+        Ok(ProjectedInitialEventOutcome {
+            final_t: post_t,
+            observations,
+            action: post_action,
+        })
+    }
+
+    fn initial_event_observations_match_trace(
+        &self,
+        left: &InitialEventObservation,
+        right: &InitialEventObservation,
+        tol: f64,
+    ) -> Result<bool, RuntimeSolveError> {
+        let left_values = self.visible_values(&left.y, &left.p, left.t)?;
+        let right_values = self.visible_values(&right.y, &right.p, right.t)?;
+        Ok(trace_values_match(&left_values, &right_values, tol))
+    }
+
+    fn apply_initial_event_update<P>(
+        &self,
+        input: InitialEventUpdate<'_>,
+        project_algebraics: &mut P,
+    ) -> Result<EventActionOutcome, RuntimeSolveError>
+    where
+        P: FnMut(&mut [f64], &mut [f64], f64) -> Result<bool, RuntimeSolveError>,
+    {
+        let InitialEventUpdate {
+            y,
+            p,
+            t,
+            tol,
+            event_pre_y,
+            event_pre_p,
+            max_iters,
+            initial_event,
+        } = input;
+        if initial_event.is_some() {
+            return self.apply_projected_event_update(
+                ProjectedEventUpdateInput {
+                    y,
+                    p,
+                    t,
+                    tol,
+                    event_pre_y,
+                    event_pre_p,
+                    max_iters,
+                    row_filter: EventUpdateRowFilter::All,
+                    root_relation_overrides: &[],
+                },
+                |y, p| project_algebraics(y, p, t),
+            );
+        }
+        let event_pre_y = copy_runtime_values(y, "initial event pre y snapshot")?;
+        let event_pre_p = copy_runtime_values(p, "initial event pre p snapshot")?;
+        self.apply_projected_event_update(
+            ProjectedEventUpdateInput {
+                y,
+                p,
+                t,
+                tol,
+                event_pre_y: &event_pre_y,
+                event_pre_p: &event_pre_p,
+                max_iters,
+                row_filter: EventUpdateRowFilter::All,
+                root_relation_overrides: &[],
+            },
+            |y, p| project_algebraics(y, p, t),
+        )
+    }
+}

--- a/crates/rumoca-phase-dae/src/runtime_precompute/mod.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/mod.rs
@@ -92,13 +92,15 @@ pub(crate) fn populate_runtime_precompute(dae_model: &mut dae::Dae) -> Result<()
     log_runtime_precompute_profile("scheduled_time_events", time_event_start);
 
     let clock_metadata_start = maybe_start_timer_if(profile);
+    let clock_compile_time_scalars =
+        collect_clock_compile_time_scalars(dae_model, &compile_time_scalars);
     let (
         clock_constructor_exprs,
         clock_schedules,
         clock_intervals,
         clock_timings,
         triggered_clock_conditions,
-    ) = clock::compute_clock_runtime_metadata(dae_model, &compile_time_scalars)?;
+    ) = clock::compute_clock_runtime_metadata(dae_model, &clock_compile_time_scalars)?;
     log_runtime_precompute_profile("clock_metadata", clock_metadata_start);
 
     let prune_start = maybe_start_timer_if(profile);
@@ -630,6 +632,98 @@ fn collect_compile_time_scalars(dae_model: &dae::Dae) -> HashMap<String, f64> {
 
     values
 }
+
+fn collect_clock_compile_time_scalars(
+    dae_model: &dae::Dae,
+    compile_time_scalars: &HashMap<String, f64>,
+) -> HashMap<String, f64> {
+    let mut values = compile_time_scalars.clone();
+    for name in initial_time_parameter_names(dae_model) {
+        values.insert(name, 0.0);
+    }
+    values
+}
+
+fn initial_time_parameter_names(dae_model: &dae::Dae) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut seen = HashSet::new();
+    for equation in &dae_model.initialization.equations {
+        if let Some(name) = initial_time_parameter_name_from_equation(dae_model, equation)
+            && seen.insert(name.clone())
+        {
+            names.push(name);
+        }
+    }
+    names
+}
+
+fn initial_time_parameter_name_from_equation(
+    dae_model: &dae::Dae,
+    equation: &dae::Equation,
+) -> Option<String> {
+    if let Some(lhs) = &equation.lhs
+        && expr_is_time_ref(&equation.rhs)
+        && dae_model
+            .variables
+            .parameters
+            .contains_key(&rumoca_core::VarName::new(lhs.as_str()))
+    {
+        return Some(lhs.as_str().to_string());
+    }
+
+    let rumoca_core::Expression::Binary {
+        op: rumoca_core::OpBinary::Sub,
+        lhs,
+        rhs,
+        ..
+    } = &equation.rhs
+    else {
+        return None;
+    };
+
+    match (
+        initial_time_parameter_var_ref(dae_model, lhs),
+        expr_is_time_ref(rhs),
+        expr_is_time_ref(lhs),
+        initial_time_parameter_var_ref(dae_model, rhs),
+    ) {
+        (Some(name), true, _, _) | (_, _, true, Some(name)) => Some(name),
+        _ => None,
+    }
+}
+
+fn initial_time_parameter_var_ref(
+    dae_model: &dae::Dae,
+    expr: &rumoca_core::Expression,
+) -> Option<String> {
+    let rumoca_core::Expression::VarRef {
+        name, subscripts, ..
+    } = expr
+    else {
+        return None;
+    };
+    if !subscripts.is_empty()
+        || !dae_model
+            .variables
+            .parameters
+            .contains_key(&rumoca_core::VarName::new(name.as_str()))
+    {
+        return None;
+    }
+    Some(name.as_str().to_string())
+}
+
+fn expr_is_time_ref(expr: &rumoca_core::Expression) -> bool {
+    matches!(
+        expr,
+        rumoca_core::Expression::VarRef {
+            name,
+            subscripts,
+            ..
+        } if name.as_str() == "time" && subscripts.is_empty()
+    )
+}
+
 fn eval_scalar_const_expr(
     expr: &rumoca_core::Expression,
     constants: &HashMap<String, f64>,

--- a/crates/rumoca-phase-dae/src/runtime_precompute/tests/mod.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/tests/mod.rs
@@ -1085,6 +1085,80 @@ fn test_runtime_precompute_collects_sample_start_interval_schedule() {
 }
 
 #[test]
+fn test_runtime_precompute_collects_sample_schedule_from_initial_time_parameter() {
+    let mut dae_model = dae::Dae::default();
+    let mut frequency = dae::Variable::new(
+        rumoca_core::VarName::new("mean.f"),
+        rumoca_core::Span::from_offsets(rumoca_core::SourceId::from_source_name(file!()), 1, 2),
+    );
+    frequency.start = Some(lit(150.0));
+    dae_model
+        .variables
+        .parameters
+        .insert(rumoca_core::VarName::new("mean.f"), frequency);
+    dae_model.variables.parameters.insert(
+        rumoca_core::VarName::new("mean.t0"),
+        dae::Variable::new(
+            rumoca_core::VarName::new("mean.t0"),
+            rumoca_core::Span::from_offsets(rumoca_core::SourceId::from_source_name(file!()), 1, 2),
+        ),
+    );
+    dae_model.variables.discrete_reals.insert(
+        rumoca_core::VarName::new("s"),
+        dae::Variable::new(
+            rumoca_core::VarName::new("s"),
+            rumoca_core::Span::from_offsets(rumoca_core::SourceId::from_source_name(file!()), 1, 2),
+        ),
+    );
+    dae_model
+        .initialization
+        .equations
+        .push(dae::Equation::residual(
+            sub(var("mean.t0"), var("time")),
+            test_span(1, 2),
+            "initial t0 = time",
+        ));
+
+    let interval = rumoca_core::Expression::Binary {
+        op: rumoca_core::OpBinary::Div,
+        lhs: Box::new(lit(1.0)),
+        rhs: Box::new(var("mean.f")),
+        span: test_span(140, 148),
+    };
+    dae_model
+        .discrete
+        .real_updates
+        .push(dae::Equation::residual(
+            sub(
+                var("s"),
+                rumoca_core::Expression::FunctionCall {
+                    name: rumoca_core::VarName::new(rumoca_core::INTERNAL_SAMPLE_FUNCTION_NAME)
+                        .into(),
+                    args: vec![
+                        rumoca_core::Expression::Binary {
+                            op: rumoca_core::OpBinary::Add,
+                            lhs: Box::new(var("mean.t0")),
+                            rhs: Box::new(interval.clone()),
+                            span: test_span(130, 148),
+                        },
+                        interval,
+                    ],
+                    is_constructor: false,
+                    span: test_span(120, 149),
+                },
+            ),
+            test_span(1, 2),
+            "periodic sample with initial-time origin",
+        ));
+
+    populate_runtime_precompute(&mut dae_model).expect("runtime precompute should succeed");
+
+    assert_eq!(dae_model.clocks.schedules.len(), 1);
+    assert!((dae_model.clocks.schedules[0].period_seconds - 1.0 / 150.0).abs() <= 1e-12);
+    assert!((dae_model.clocks.schedules[0].phase_seconds - 1.0 / 150.0).abs() <= 1e-12);
+}
+
+#[test]
 fn test_runtime_precompute_assigns_implicit_sample_interval_from_unique_schedule() {
     let mut dae_model = dae::Dae::default();
     dae_model.variables.discrete_reals.insert(

--- a/crates/rumoca-phase-flatten/src/connections/equation_generation.rs
+++ b/crates/rumoca-phase-flatten/src/connections/equation_generation.rs
@@ -3,6 +3,8 @@ use indexmap::IndexSet;
 use rumoca_ir_ast as ast;
 
 type FlowVarSet = IndexSet<rumoca_core::VarName>;
+type InterfaceConnectorRootSet = IndexSet<rumoca_core::ComponentPath>;
+pub(super) type InterfaceConnectorRootsByScope = IndexMap<String, InterfaceConnectorRootSet>;
 
 /// Compute scalar count from variable dimensions.
 ///
@@ -221,9 +223,18 @@ fn is_outside_flow_var_for_scope(
     scope: &str,
     interface_flow_vars_by_scope: &IndexMap<String, FlowVarSet>,
 ) -> bool {
-    interface_flow_vars_by_scope
-        .get(scope)
-        .is_some_and(|scope_vars| scope_vars.contains(var_name))
+    let Some(scope_vars) = interface_flow_vars_by_scope.get(scope) else {
+        return false;
+    };
+    if scope_vars.contains(var_name) {
+        return true;
+    }
+
+    // Connector-array expansion can generate scalar flow variables such as
+    // `plug.pin[1].i` while interface discovery records the connector member as
+    // `plug.pin.i`. They have the same inside/outside role for MLS §9.2 signs.
+    strip_embedded_array_indices(var_name.as_str())
+        .is_some_and(|base_name| scope_vars.contains(&rumoca_core::VarName::new(base_name)))
 }
 
 // =============================================================================
@@ -335,8 +346,14 @@ pub(crate) fn process_connections(
     let flow_vars_at_scope =
         collect_flow_vars_by_scope(&all_connections, flat, &prefix_children, &var_index);
 
-    let interface_flow_vars_by_scope =
-        collect_interface_flow_vars_by_scope(&all_connections, flat, &prefix_children, &var_index);
+    let interface_connector_roots_by_scope = collect_interface_connector_roots_by_scope(overlay);
+    let interface_flow_vars_by_scope = collect_interface_flow_vars_by_scope(
+        &all_connections,
+        flat,
+        &prefix_children,
+        &var_index,
+        &interface_connector_roots_by_scope,
+    );
 
     // Build connection sets (variables connected together)
     let (connection_sets, raw_stream_groups) =
@@ -378,6 +395,7 @@ pub(crate) fn process_connections(
         &all_connections,
         &prefix_children,
         &var_index,
+        &interface_connector_roots_by_scope,
     )?;
 
     Ok(())
@@ -483,16 +501,39 @@ fn collect_flow_vars_from_conn_path(
     }
 }
 
+fn collect_interface_connector_roots_by_scope(
+    overlay: &ast::InstanceOverlay,
+) -> InterfaceConnectorRootsByScope {
+    let mut result: InterfaceConnectorRootsByScope = IndexMap::default();
+
+    for instance in overlay.components.values() {
+        if !instance.is_connector_type || instance.is_protected {
+            continue;
+        }
+        let path = instance.qualified_name.to_component_path();
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+        result
+            .entry(parent.to_flat_string())
+            .or_default()
+            .insert(path);
+    }
+
+    result
+}
+
 /// Collect flow variables on interface connectors at each scope level (MLS §9.2).
 ///
-/// An interface connector is referenced as a single identifier (no dots) relative
-/// to its connection scope. These are the model boundary connectors that may need
-/// `flow = 0` at the parent scope if not connected there.
+/// An interface connector is a public connector-typed component declared directly
+/// in the connection scope. Connection paths can name the connector itself or a
+/// nested connector member below that root, e.g. `plug.pin`.
 fn collect_interface_flow_vars_by_scope(
     connections: &[&ast::InstanceConnection],
     flat: &flat::Model,
     prefix_children: &FxHashMap<String, Vec<rumoca_core::VarName>>,
     var_index: &ConnectionVarIndex,
+    interface_connector_roots_by_scope: &InterfaceConnectorRootsByScope,
 ) -> IndexMap<String, FlowVarSet> {
     let mut result: IndexMap<String, FlowVarSet> = IndexMap::default();
 
@@ -501,14 +542,11 @@ fn collect_interface_flow_vars_by_scope(
 
         for path_qn in [&conn.a, &conn.b] {
             let path = path_qn.to_flat_string();
-
-            let Some(relative) = relative_component_path(&path, scope) else {
-                continue;
-            };
-
-            // Interface connector: single identifier (no top-level dots in relative path).
-            // Dots inside bracketed subscripts are part of subscript expressions.
-            if is_single_identifier_path(&relative) {
+            if is_interface_connection_path_for_scope(
+                &path,
+                scope,
+                interface_connector_roots_by_scope,
+            ) {
                 let scope_set = result.entry(scope.clone()).or_default();
                 collect_flow_vars_from_conn_path(
                     flat,
@@ -522,6 +560,24 @@ fn collect_interface_flow_vars_by_scope(
     }
 
     result
+}
+
+pub(super) fn is_interface_connection_path_for_scope(
+    path: &str,
+    scope: &str,
+    interface_connector_roots_by_scope: &InterfaceConnectorRootsByScope,
+) -> bool {
+    let path = rumoca_core::ComponentPath::from_flat_path(path);
+    if let Some(scope_roots) = interface_connector_roots_by_scope.get(scope)
+        && scope_roots
+            .iter()
+            .any(|root| path == *root || path.starts_with(root))
+    {
+        return true;
+    }
+
+    relative_component_path_from_path(&path, scope)
+        .is_some_and(|relative| is_single_identifier_path(&relative))
 }
 
 /// MLS §15.2 inStream() rewrite for two-connector stream connection sets.
@@ -590,13 +646,15 @@ fn is_single_identifier_path(path: &rumoca_core::ComponentPath) -> bool {
     path.len() == 1
 }
 
-fn relative_component_path(path: &str, scope: &str) -> Option<rumoca_core::ComponentPath> {
-    let path = rumoca_core::ComponentPath::from_flat_path(path);
+fn relative_component_path_from_path(
+    path: &rumoca_core::ComponentPath,
+    scope: &str,
+) -> Option<rumoca_core::ComponentPath> {
     let scope = rumoca_core::ComponentPath::from_flat_path(scope);
     if scope.is_root() {
-        return Some(path);
+        return Some(path.clone());
     }
-    component_path_has_scope_prefix(&path, &scope)
+    component_path_has_scope_prefix(path, &scope)
         .then(|| path.suffix_from(scope.len()))
         .flatten()
 }
@@ -659,9 +717,15 @@ fn generate_external_unconnected_flow_equations(
     connections: &[&ast::InstanceConnection],
     prefix_children: &FxHashMap<String, Vec<rumoca_core::VarName>>,
     var_index: &ConnectionVarIndex,
+    interface_connector_roots_by_scope: &InterfaceConnectorRootsByScope,
 ) -> Result<(), FlattenError> {
-    let interface_flow_vars_by_scope =
-        collect_interface_flow_vars_by_scope(connections, flat, prefix_children, var_index);
+    let interface_flow_vars_by_scope = collect_interface_flow_vars_by_scope(
+        connections,
+        flat,
+        prefix_children,
+        var_index,
+        interface_connector_roots_by_scope,
+    );
     let need_flow_zero =
         find_unconnected_interface_flows(&interface_flow_vars_by_scope, flow_vars_at_scope, flat);
 

--- a/crates/rumoca-phase-flatten/src/connections/tests.rs
+++ b/crates/rumoca-phase-flatten/src/connections/tests.rs
@@ -733,6 +733,125 @@ fn test_generate_flow_equation_sign_for_nested_outside_connector_member() {
 }
 
 #[test]
+fn test_generate_flow_equation_sign_for_scalarized_outside_connector_array_member() {
+    let mut flat = flat::Model::new();
+
+    let outside_scalarized = flat::Variable {
+        flow: true,
+        ..flat::Variable::empty_with_span(test_span())
+    };
+    flat.add_variable(
+        rumoca_core::VarName::new("cell.plug.pin[1].i"),
+        outside_scalarized,
+    );
+
+    let inside = flat::Variable {
+        flow: true,
+        ..flat::Variable::empty_with_span(test_span())
+    };
+    flat.add_variable(rumoca_core::VarName::new("cell.diode.p.i"), inside);
+
+    let vars = vec![
+        rumoca_core::VarName::new("cell.plug.pin[1].i"),
+        rumoca_core::VarName::new("cell.diode.p.i"),
+    ];
+    let mut interface_flow_vars_by_scope = IndexMap::default();
+    interface_flow_vars_by_scope.insert(
+        "cell".to_string(),
+        indexmap::IndexSet::from([rumoca_core::VarName::new("cell.plug.pin.i")]),
+    );
+    generate_flow_equation(
+        &mut flat,
+        &vars,
+        "cell",
+        &interface_flow_vars_by_scope,
+        test_span(),
+    )
+    .unwrap();
+
+    let origin = &flat.equations[0].origin;
+    let origin_str = origin.to_string();
+    assert!(
+        origin_str.contains("-cell.plug.pin[1].i") && origin_str.contains("cell.diode.p.i"),
+        "Expected scalarized outside connector array member to be negated, got: {}",
+        origin_str
+    );
+}
+
+#[test]
+fn test_process_connections_negates_nested_connector_under_outside_root() {
+    let mut flat = flat::Model::new();
+    for name in ["cell.plug.pin[1].i", "cell.diode.p.i"] {
+        flat.add_variable(
+            rumoca_core::VarName::new(name),
+            flat::Variable {
+                name: rumoca_core::VarName::new(name),
+                flow: true,
+                is_primitive: true,
+                source_span: test_span(),
+                ..flat::Variable::empty_with_span(test_span())
+            },
+        );
+    }
+
+    let mut overlay = ast::InstanceOverlay::new();
+    overlay.add_component(ast::InstanceData {
+        instance_id: ast::InstanceId(1),
+        qualified_name: ast::QualifiedName::from_dotted("cell.plug"),
+        is_connector_type: true,
+        is_protected: false,
+        ..Default::default()
+    });
+    overlay.add_class(ast::ClassInstanceData {
+        instance_id: ast::InstanceId(0),
+        qualified_name: ast::QualifiedName::from_dotted("cell"),
+        connections: vec![ast::InstanceConnection {
+            a: ast::QualifiedName::from_dotted("cell.plug.pin"),
+            b: ast::QualifiedName::from_dotted("cell.diode.p"),
+            connector_type: None,
+            span: test_span(),
+            scope: "cell".to_string(),
+        }],
+        ..Default::default()
+    });
+
+    process_connections(&mut flat, &overlay, false).expect("nested connector connection");
+
+    let flow_origins: Vec<String> = flat
+        .equations
+        .iter()
+        .map(|eq| eq.origin.to_string())
+        .collect();
+    assert!(
+        flow_origins.iter().any(|origin| {
+            origin.contains("-cell.plug.pin[1].i") && origin.contains("cell.diode.p.i")
+        }),
+        "Expected nested connector member under outside root to be negated, got: {:?}",
+        flow_origins
+    );
+}
+
+#[test]
+fn test_interface_path_uses_single_identifier_fallback_when_roots_do_not_match() {
+    let mut roots = InterfaceConnectorRootsByScope::default();
+    roots
+        .entry("cell".to_string())
+        .or_default()
+        .insert(rumoca_core::ComponentPath::from_flat_path("cell.unrelated"));
+
+    assert!(is_interface_connection_path_for_scope(
+        "cell.plug",
+        "cell",
+        &roots
+    ));
+    assert!(!is_interface_connection_path_for_scope(
+        "cell.inner.plug",
+        "cell",
+        &roots
+    ));
+}
+
+#[test]
 fn test_generate_flow_equation_uses_scope_specific_interface_flows() {
     let mut flat = flat::Model::new();
     flat.add_variable(

--- a/crates/rumoca-solver-diffsol/src/init_projection.rs
+++ b/crates/rumoca-solver-diffsol/src/init_projection.rs
@@ -5,6 +5,7 @@
 //! parameter vector before time integration starts.
 
 use super::*;
+use rumoca_solver::EventActionOutcome;
 
 pub(crate) fn initialize_state_runtime_values(
     model: &solve::SolveModel,
@@ -13,53 +14,53 @@ pub(crate) fn initialize_state_runtime_values(
     equilibrium_model: &OdeModel,
     current_y: &mut [f64],
     params: &mut [f64],
-    current_t: f64,
-) -> Result<(), SimError> {
+    current_t: &mut f64,
+) -> Result<Vec<solve_eval::InitialEventObservation>, SimError> {
     let tol = opts.atol.max(1.0e-10);
-    set_initial_event_flag(model, params, true);
+    runtime.set_initial_event_flag(params, true);
     let event_pre = InitialEventPreValues::snapshot(current_y, params);
+    let t_start = *current_t;
     let initial_projection_params = state_initial_projection_params(
         model,
         runtime,
         equilibrium_model,
         current_y,
         params,
-        current_t,
+        t_start,
         tol,
     )?;
     params.copy_from_slice(&initial_projection_params);
-    let initial_event = initial_runtime_event_stop(
-        &model.problem,
-        current_t,
-        current_dynamic_time_event_stop(
-            model,
-            &equilibrium_model.runtime_state,
-            current_y,
-            params,
-            current_t,
-        )?,
-    );
+    let dynamic_event = current_dynamic_time_event_stop(
+        model,
+        &equilibrium_model.runtime_state,
+        current_y,
+        params,
+        t_start,
+    )?;
     settle_algebraics_and_relation_memory(
         runtime,
         equilibrium_model,
         current_y,
         params,
-        current_t,
+        t_start,
         model.state_scalar_count(),
         tol,
     )?;
-    apply_state_initial_event_updates(StateInitialEventUpdates {
+    let outcome = apply_state_initial_event_updates(StateInitialEventUpdates {
         model,
+        opts,
         runtime,
         equilibrium_model,
         current_y,
         params,
-        current_t,
+        current_t: t_start,
         tol,
-        initial_event,
+        dynamic_event,
         event_pre: &event_pre,
     })?;
-    Ok(())
+    initial_event_action_to_result(outcome.action, outcome.final_t)?;
+    *current_t = outcome.final_t;
+    Ok(outcome.observations)
 }
 
 struct InitialEventPreValues {
@@ -131,62 +132,75 @@ fn state_initial_projection_params(
 
 struct StateInitialEventUpdates<'a> {
     model: &'a solve::SolveModel,
+    opts: &'a SimOptions,
     runtime: &'a SolveRuntime,
     equilibrium_model: &'a OdeModel,
     current_y: &'a mut [f64],
     params: &'a mut [f64],
     current_t: f64,
     tol: f64,
-    initial_event: Option<RuntimeEventStop>,
+    dynamic_event: Option<RuntimeEventStop>,
     event_pre: &'a InitialEventPreValues,
 }
 
-fn apply_state_initial_event_updates(ctx: StateInitialEventUpdates<'_>) -> Result<(), SimError> {
+fn apply_state_initial_event_updates(
+    ctx: StateInitialEventUpdates<'_>,
+) -> Result<solve_eval::ProjectedInitialEventOutcome, SimError> {
     let StateInitialEventUpdates {
         model,
+        opts,
         runtime,
         equilibrium_model,
         current_y,
         params,
         current_t,
         tol,
-        initial_event,
+        dynamic_event,
         event_pre,
     } = ctx;
-    if initial_event.is_some() {
-        apply_event_updates_with_event_pre(EventUpdateInput {
-            runtime,
-            ode_model: equilibrium_model,
+    let outcome = runtime.apply_projected_initial_event_boundary(
+        solve_eval::ProjectedInitialEventInput {
             y: current_y,
             p: params,
-            t: current_t,
+            t_start: current_t,
+            t_end: opts.t_end,
             tol,
             event_pre_y: &event_pre.y,
             event_pre_p: &event_pre.p,
-        })?;
-    } else {
-        apply_event_updates(
-            runtime,
-            equilibrium_model,
-            current_y,
-            params,
-            current_t,
-            tol,
-        )?;
-    }
-    set_initial_event_flag(model, params, false);
-    if initial_event.is_some() {
-        apply_post_initial_event_updates(
-            runtime,
-            equilibrium_model,
-            current_y,
-            params,
-            current_t,
-            tol,
-        )?;
-    }
+            max_iters: EVENT_UPDATE_MAX_ITERS,
+            dynamic_event,
+            apply_without_initial_event: true,
+        },
+        |y, p, t| {
+            project_algebraics_and_detect_changes(
+                equilibrium_model,
+                y,
+                p,
+                t,
+                equilibrium_model.state_count_for_projection(),
+                tol,
+            )
+        },
+    )?;
     commit_pre_params_after_event(model, current_y, params, tol);
-    Ok(())
+    Ok(outcome)
+}
+
+fn initial_event_action_to_result(
+    outcome: EventActionOutcome,
+    event_t: f64,
+) -> Result<(), SimError> {
+    match outcome {
+        EventActionOutcome::Continue => Ok(()),
+        EventActionOutcome::AssertionFailed { time, message } => Err(SimError::AssertionFailed {
+            time: if time.is_finite() { time } else { event_t },
+            message,
+        }),
+        EventActionOutcome::Terminated { time, message } => Err(SimError::Terminated {
+            time: if time.is_finite() { time } else { event_t },
+            message,
+        }),
+    }
 }
 
 fn project_initial_algebraics_and_updates(
@@ -286,14 +300,19 @@ impl RuntimeEventBoundaryHandler for EventObservation<'_> {
             event_t,
             self.tol,
         )?;
+        let mut samples = SampleRecorder {
+            runtime: Some(self.runtime),
+            model: self.model,
+            recorded_times: &mut *self.recorded_times,
+            data: &mut *self.data,
+        };
         record_sample_if_new(
-            Some(self.runtime),
-            self.model,
-            self.y,
-            self.params,
-            self.recorded_times,
-            self.data,
-            event_t,
+            &mut samples,
+            SamplePoint {
+                y: self.y,
+                params: self.params,
+                t: event_t,
+            },
         )?;
         Ok(())
     }
@@ -321,24 +340,20 @@ impl RuntimeEventBoundaryHandler for EventObservation<'_> {
             right_t,
             self.tol,
         )?;
+        let mut samples = SampleRecorder {
+            runtime: Some(self.runtime),
+            model: self.model,
+            recorded_times: &mut *self.recorded_times,
+            data: &mut *self.data,
+        };
         record_sample_if_new(
-            Some(self.runtime),
-            self.model,
-            self.y,
-            self.params,
-            self.recorded_times,
-            self.data,
-            right_t,
+            &mut samples,
+            SamplePoint {
+                y: self.y,
+                params: self.params,
+                t: right_t,
+            },
         )?;
         Ok(())
-    }
-}
-
-pub(crate) fn set_initial_event_flag(model: &solve::SolveModel, params: &mut [f64], value: bool) {
-    let Some(index) = model.problem.solve_layout.initial_event_parameter_index else {
-        return;
-    };
-    if let Some(slot) = params.get_mut(index) {
-        *slot = f64::from(value);
     }
 }

--- a/crates/rumoca-solver-diffsol/src/lib.rs
+++ b/crates/rumoca-solver-diffsol/src/lib.rs
@@ -25,10 +25,10 @@ pub(crate) use bdf::{
 };
 use diffsol::{
     BacktrackingLineSearch, BdfState, FaerSparseLU, FaerSparseMat, MatrixCommon,
-    NewtonNonlinearSolver, OdeEquations, OdeSolverMethod, OdeSolverState, OdeSolverStopReason,
-    VectorHost,
+    NewtonNonlinearSolver, OdeEquations, OdeEquationsImplicit, OdeSolverMethod, OdeSolverProblem,
+    OdeSolverState, OdeSolverStopReason, VectorHost,
 };
-use init_projection::{EventObservation, initialize_state_runtime_values, set_initial_event_flag};
+use init_projection::{EventObservation, initialize_state_runtime_values};
 use rumoca_eval_solve::sim_driver::{
     SimDriverError, SolverStepper, StateTrajectory, StepOutcome, simulate_state_targets,
 };
@@ -41,14 +41,13 @@ use rumoca_solver::{
     DiffsolMethod, EventPreMode, RuntimeEventBoundary, RuntimeEventBoundaryHandler,
     RuntimeEventStop, SimOptions, SimResult, SimTermination, SolveStopSchedule,
     build_sim_result_from_solve_model, commit_pre_params_after_event, discrete_row_pre_mode,
-    initial_runtime_event_stop, process_runtime_event_boundary, push_visible_values,
-    replace_last_visible_values, runtime_event_horizon, runtime_root_event_application_time,
+    process_runtime_event_boundary, push_visible_values, replace_last_visible_values,
+    runtime_event_horizon, runtime_root_event_application_time,
     timeline::sample_time_match_with_tol, write_pre_params_from_sources,
 };
 pub(crate) use runtime::{
     EventUpdateInput, apply_discrete_value, apply_event_updates,
-    apply_event_updates_with_event_pre, apply_initialization_updates,
-    apply_post_initial_event_updates, seed_initial_discrete_values,
+    apply_event_updates_with_event_pre, apply_initialization_updates, seed_initial_discrete_values,
     settle_algebraics_and_relation_memory,
 };
 use runtime::{check_no_state_initialization, simulate_no_state_solve_ir};
@@ -133,6 +132,7 @@ pub fn check_initialization(model: &solve::SolveModel, opts: &SimOptions) -> Res
     let equilibrium_model = Arc::new(OdeModel::new(model)?);
     let mut current_y = model.initial_y.clone();
     let mut params = model.parameters.clone();
+    let mut current_t = opts.t_start;
     initialize_state_runtime_values(
         model,
         opts,
@@ -140,14 +140,14 @@ pub fn check_initialization(model: &solve::SolveModel, opts: &SimOptions) -> Res
         &equilibrium_model,
         &mut current_y,
         &mut params,
-        opts.t_start,
+        &mut current_t,
     )?;
     let runtime_params: RuntimeParameters = Rc::new(RefCell::new(params.clone()));
     let problem = build_ode_problem_with_runtime_params_and_initial(
         model,
         opts,
         runtime_params,
-        opts.t_start,
+        current_t,
         current_y.clone(),
         equilibrium_model.clone(),
     )?;
@@ -198,23 +198,29 @@ fn simulate_with_states(
     let mut recorded_times = Vec::with_capacity(times.len());
     let mut current_t = opts.t_start;
     let mut current_y = model.initial_y.clone();
-    initialize_state_runtime_values(
+    let initial_observations = initialize_state_runtime_values(
         model,
         opts,
         runtime,
         equilibrium_model,
         &mut current_y,
         &mut params,
-        current_t,
+        &mut current_t,
     )?;
-    record_sample_if_new(
-        Some(runtime),
+    let mut samples = SampleRecorder {
+        runtime: Some(runtime.as_ref()),
         model,
-        &current_y,
-        &params,
-        &mut recorded_times,
-        &mut data,
-        current_t,
+        recorded_times: &mut recorded_times,
+        data: &mut data,
+    };
+    record_initial_samples(
+        &mut samples,
+        SamplePoint {
+            y: &current_y,
+            params: &params,
+            t: current_t,
+        },
+        &initial_observations,
     )?;
 
     // Shared runtime params captured by ODE closures and updated by event handlers.
@@ -229,47 +235,16 @@ fn simulate_with_states(
         current_y.clone(),
         equilibrium_model.clone(),
     )?;
-    // The solver borrows `problem` for the full simulation. `Bdf` and `Sdirk` are
-    // distinct concrete types, so we build whichever one was requested and box it
-    // behind `BdfStepper` to run the single (backend-neutral) driver once. ESDIRK34
-    // / TR-BDF2 reuse the same projection-aware consistent IC via `initial_rk_state`.
-    let mut stepper: Box<dyn SolverStepper + '_> = match opts.diffsol_method {
-        DiffsolMethod::Bdf => {
-            let state = initial_bdf_state(model, equilibrium_model, &problem, &current_y, &params)?;
-            let nl_solver = NewtonNonlinearSolver::new(
-                LinearSolver::default(),
-                BacktrackingLineSearch::default(),
-            );
-            let solver = solver_call("BDF new", || {
-                diffsol::Bdf::<_, _, _, diffsol::NoAug<_>>::new(&problem, state, nl_solver)
-            })?;
-            Box::new(DiffsolStepper::new(DiffsolStepperInputs {
-                solver,
-                model,
-                equilibrium_model,
-                runtime,
-                runtime_params: runtime_params.clone(),
-                opts,
-                mode: DiffsolMode::General,
-            }))
-        }
-        method @ (DiffsolMethod::Esdirk34 | DiffsolMethod::TrBdf2) => {
-            let state = initial_rk_state(model, equilibrium_model, &problem, &current_y, &params)?;
-            let solver = solver_call("SDIRK new", || match method {
-                DiffsolMethod::Esdirk34 => problem.esdirk34_solver::<LinearSolver>(state),
-                _ => problem.tr_bdf2_solver::<LinearSolver>(state),
-            })?;
-            Box::new(DiffsolStepper::new(DiffsolStepperInputs {
-                solver,
-                model,
-                equilibrium_model,
-                runtime,
-                runtime_params: runtime_params.clone(),
-                opts,
-                mode: DiffsolMode::General,
-            }))
-        }
-    };
+    let mut stepper = build_general_stepper(GeneralStepperInput {
+        model,
+        opts,
+        equilibrium_model,
+        runtime,
+        runtime_params: runtime_params.clone(),
+        problem: &problem,
+        current_y: &current_y,
+        params: &params,
+    })?;
     let result = simulate_state_targets(
         model,
         opts,
@@ -302,6 +277,89 @@ fn simulate_with_states(
             current_y,
         },
     )
+}
+
+struct GeneralStepperInput<'a, 'b, Eqn>
+where
+    Eqn: OdeEquations,
+{
+    model: &'a solve::SolveModel,
+    opts: &'a SimOptions,
+    equilibrium_model: &'a Arc<OdeModel>,
+    runtime: &'a Arc<SolveRuntime>,
+    runtime_params: RuntimeParameters,
+    problem: &'a OdeSolverProblem<Eqn>,
+    current_y: &'b [f64],
+    params: &'b [f64],
+}
+
+fn build_general_stepper<'a, Eqn>(
+    input: GeneralStepperInput<'a, '_, Eqn>,
+) -> Result<Box<dyn SolverStepper + 'a>, SimError>
+where
+    Eqn:
+        OdeEquationsImplicit<M = Matrix, V = Vector, T = f64, C = <Matrix as MatrixCommon>::C> + 'a,
+    Eqn::V: VectorHost<T = f64>,
+{
+    let GeneralStepperInput {
+        model,
+        opts,
+        equilibrium_model,
+        runtime,
+        runtime_params,
+        problem,
+        current_y,
+        params,
+    } = input;
+    match opts.diffsol_method {
+        DiffsolMethod::Bdf => {
+            let state = initial_bdf_state(
+                model,
+                equilibrium_model.as_ref(),
+                problem,
+                current_y,
+                params,
+            )?;
+            let nl_solver = NewtonNonlinearSolver::new(
+                LinearSolver::default(),
+                BacktrackingLineSearch::default(),
+            );
+            let solver = solver_call("BDF new", || {
+                diffsol::Bdf::<_, _, _, diffsol::NoAug<_>>::new(problem, state, nl_solver)
+            })?;
+            Ok(Box::new(DiffsolStepper::new(DiffsolStepperInputs {
+                solver,
+                model,
+                equilibrium_model: equilibrium_model.as_ref(),
+                runtime: runtime.as_ref(),
+                runtime_params,
+                opts,
+                mode: DiffsolMode::General,
+            })))
+        }
+        method @ (DiffsolMethod::Esdirk34 | DiffsolMethod::TrBdf2) => {
+            let state = initial_rk_state(
+                model,
+                equilibrium_model.as_ref(),
+                problem,
+                current_y,
+                params,
+            )?;
+            let solver = solver_call("SDIRK new", || match method {
+                DiffsolMethod::Esdirk34 => problem.esdirk34_solver::<LinearSolver>(state),
+                _ => problem.tr_bdf2_solver::<LinearSolver>(state),
+            })?;
+            Ok(Box::new(DiffsolStepper::new(DiffsolStepperInputs {
+                solver,
+                model,
+                equilibrium_model: equilibrium_model.as_ref(),
+                runtime: runtime.as_ref(),
+                runtime_params,
+                opts,
+                mode: DiffsolMode::General,
+            })))
+        }
+    }
 }
 
 /// Owned trajectory buffers + context needed to turn a `simulate_state_targets`
@@ -340,14 +398,19 @@ fn finalize_state_simulation(
                 fin.opts.atol.max(1.0e-10),
             )?;
             fin.runtime_params.borrow_mut().copy_from_slice(&fin.params);
+            let mut samples = SampleRecorder {
+                runtime: Some(fin.runtime.as_ref()),
+                model: fin.model,
+                recorded_times: &mut fin.recorded_times,
+                data: &mut fin.data,
+            };
             record_sample_if_new(
-                Some(fin.runtime),
-                fin.model,
-                &fin.current_y,
-                &fin.params,
-                &mut fin.recorded_times,
-                &mut fin.data,
-                time,
+                &mut samples,
+                SamplePoint {
+                    y: &fin.current_y,
+                    params: &fin.params,
+                    t: time,
+                },
             )?;
             Ok(build_sim_result_from_solve_model(
                 fin.model,
@@ -372,24 +435,30 @@ fn simulate_state_only_bdf(
     let mut recorded_times = Vec::with_capacity(times.len());
     let mut current_t = opts.t_start;
     let mut current_y = model.initial_y.clone();
-    initialize_state_runtime_values(
+    let initial_observations = initialize_state_runtime_values(
         model,
         opts,
         runtime,
         equilibrium_model,
         &mut current_y,
         &mut params,
-        current_t,
+        &mut current_t,
     )?;
     let current_state = current_y[..model.state_scalar_count()].to_vec();
-    record_sample_if_new(
-        Some(runtime),
+    let mut samples = SampleRecorder {
+        runtime: Some(runtime.as_ref()),
         model,
-        &current_y,
-        &params,
-        &mut recorded_times,
-        &mut data,
-        current_t,
+        recorded_times: &mut recorded_times,
+        data: &mut data,
+    };
+    record_initial_samples(
+        &mut samples,
+        SamplePoint {
+            y: &current_y,
+            params: &params,
+            t: current_t,
+        },
+        &initial_observations,
     )?;
 
     let runtime_params: RuntimeParameters = Rc::new(RefCell::new(params.clone()));
@@ -706,16 +775,13 @@ where
         p: &[f64],
         t: f64,
     ) -> Result<(), SimDriverError> {
-        record_sample_if_new(
-            Some(self.runtime),
-            self.model,
-            y,
-            p,
+        let mut samples = SampleRecorder {
+            runtime: Some(self.runtime),
+            model: self.model,
             recorded_times,
             data,
-            t,
-        )
-        .map_err(sim_to_driver)
+        };
+        record_sample_if_new(&mut samples, SamplePoint { y, params: p, t }).map_err(sim_to_driver)
     }
 
     fn refresh_observation(
@@ -759,34 +825,64 @@ where
     }
 }
 
-fn record_sample_if_new(
-    runtime: Option<&SolveRuntime>,
-    model: &solve::SolveModel,
-    y: &[f64],
-    params: &[f64],
-    recorded_times: &mut Vec<f64>,
-    data: &mut [Vec<f64>],
-    t: f64,
+pub(crate) struct SampleRecorder<'a> {
+    pub(crate) runtime: Option<&'a SolveRuntime>,
+    pub(crate) model: &'a solve::SolveModel,
+    pub(crate) recorded_times: &'a mut Vec<f64>,
+    pub(crate) data: &'a mut [Vec<f64>],
+}
+
+pub(crate) struct SamplePoint<'a> {
+    pub(crate) y: &'a [f64],
+    pub(crate) params: &'a [f64],
+    pub(crate) t: f64,
+}
+
+pub(crate) fn record_sample_if_new(
+    recorder: &mut SampleRecorder<'_>,
+    sample: SamplePoint<'_>,
 ) -> Result<(), SimError> {
-    let values = if let Some(runtime) = runtime {
+    let values = if let Some(runtime) = recorder.runtime {
         runtime
-            .visible_values(y, params, t)
+            .visible_values(sample.y, sample.params, sample.t)
             .map_err(|err| SimError::SolveIr(err.to_string()))?
     } else {
-        visible_values(model, y, params, t)?
+        visible_values(recorder.model, sample.y, sample.params, sample.t)?
     };
-    if recorded_times
+    if recorder
+        .recorded_times
         .last()
-        .is_some_and(|last| sample_time_match_with_tol(*last, t))
+        .is_some_and(|last| sample_time_match_with_tol(*last, sample.t))
     {
-        if let Some(last) = recorded_times.last_mut() {
-            *last = t;
+        if let Some(last) = recorder.recorded_times.last_mut() {
+            *last = sample.t;
         }
-        replace_last_visible_values(data, &values)?;
+        replace_last_visible_values(recorder.data, &values)?;
         return Ok(());
     }
-    recorded_times.push(t);
-    push_visible_values(data, &values)?;
+    recorder.recorded_times.push(sample.t);
+    push_visible_values(recorder.data, &values)?;
+    Ok(())
+}
+
+fn record_initial_samples(
+    recorder: &mut SampleRecorder<'_>,
+    current: SamplePoint<'_>,
+    observations: &[solve_eval::InitialEventObservation],
+) -> Result<(), SimError> {
+    if observations.is_empty() {
+        return record_sample_if_new(recorder, current);
+    }
+    for observation in observations {
+        record_sample_if_new(
+            recorder,
+            SamplePoint {
+                y: &observation.y,
+                params: &observation.p,
+                t: observation.t,
+            },
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/rumoca-solver-diffsol/src/runtime.rs
+++ b/crates/rumoca-solver-diffsol/src/runtime.rs
@@ -68,25 +68,6 @@ pub(crate) fn apply_event_updates_with_event_pre(
     apply_event_updates_with_filter(input, EventUpdateRowFilter::All)
 }
 
-pub(crate) fn apply_post_initial_event_updates(
-    runtime: &SolveRuntime,
-    ode_model: &OdeModel,
-    y: &mut [f64],
-    p: &mut [f64],
-    t: f64,
-    tol: f64,
-) -> Result<(), SimError> {
-    let outcome = runtime.apply_projected_post_initial_event_update(
-        y,
-        p,
-        t,
-        tol,
-        EVENT_UPDATE_MAX_ITERS,
-        project_algebraics_callback(ode_model, t, tol),
-    )?;
-    event_action_outcome_to_result(outcome, t)
-}
-
 fn apply_event_updates_with_filter(
     input: EventUpdateInput<'_>,
     row_filter: EventUpdateRowFilter,
@@ -343,14 +324,19 @@ fn record_no_state_event_step(
             runtime.current_t,
             step.tol,
         )?;
-        record_sample_if_new(
-            None,
+        let mut samples = SampleRecorder {
+            runtime: None,
             model,
-            &runtime.current_y,
-            &runtime.params,
-            &mut runtime.recorded_times,
-            &mut runtime.data,
-            runtime.current_t,
+            recorded_times: &mut runtime.recorded_times,
+            data: &mut runtime.data,
+        };
+        record_sample_if_new(
+            &mut samples,
+            SamplePoint {
+                y: &runtime.current_y,
+                params: &runtime.params,
+                t: runtime.current_t,
+            },
         )?;
         runtime.current_t = runtime_root_event_application_time(runtime.current_t, step.target);
         return Ok(());
@@ -412,14 +398,19 @@ fn settle_and_record_no_state_output(
         runtime.current_t,
         opts.atol.max(1.0e-10),
     )?;
-    record_sample_if_new(
-        None,
+    let mut samples = SampleRecorder {
+        runtime: None,
         model,
-        &runtime.current_y,
-        &runtime.params,
-        &mut runtime.recorded_times,
-        &mut runtime.data,
-        runtime.current_t,
+        recorded_times: &mut runtime.recorded_times,
+        data: &mut runtime.data,
+    };
+    record_sample_if_new(
+        &mut samples,
+        SamplePoint {
+            y: &runtime.current_y,
+            params: &runtime.params,
+            t: runtime.current_t,
+        },
     )
 }
 
@@ -430,11 +421,11 @@ fn initialize_no_state_runtime(
 ) -> Result<NoStateRuntime, SimError> {
     let mut params = model.parameters.clone();
     let mut current_y = model.initial_y.clone();
-    let current_t = opts.t_start;
+    let mut current_t = opts.t_start;
     let tol = opts.atol.max(1.0e-10);
     let runtime = SolveRuntime::new(model)?;
     let equilibrium_model = OdeModel::new(model)?;
-    set_initial_event_flag(model, &mut params, true);
+    runtime.set_initial_event_flag(&mut params, true);
     settle_algebraics_and_relation_memory(
         &runtime,
         &equilibrium_model,
@@ -444,34 +435,52 @@ fn initialize_no_state_runtime(
         0,
         tol,
     )?;
-    let initial_event = initial_runtime_event_stop(&model.problem, current_t, None);
-    apply_event_updates(
-        &runtime,
-        &equilibrium_model,
-        &mut current_y,
-        &mut params,
-        current_t,
-        tol,
-    )?;
-    set_initial_event_flag(model, &mut params, false);
-    if initial_event.is_some() {
-        apply_post_initial_event_updates(
-            &runtime,
-            &equilibrium_model,
-            &mut current_y,
-            &mut params,
-            current_t,
+    let dynamic_event = runtime.current_dynamic_time_event_stop(&current_y, &params, current_t)?;
+    let event_pre_y = current_y.clone();
+    let event_pre_p = params.clone();
+    let outcome = runtime.apply_projected_initial_event_boundary(
+        solve_eval::ProjectedInitialEventInput {
+            y: &mut current_y,
+            p: &mut params,
+            t_start: current_t,
+            t_end: opts.t_end,
             tol,
+            event_pre_y: &event_pre_y,
+            event_pre_p: &event_pre_p,
+            max_iters: EVENT_UPDATE_MAX_ITERS,
+            dynamic_event,
+            apply_without_initial_event: true,
+        },
+        |y, p, t| project_algebraics_and_detect_changes(&equilibrium_model, y, p, t, 0, tol),
+    )?;
+    event_action_outcome_to_result(outcome.action, outcome.final_t)?;
+    current_t = outcome.final_t;
+    commit_pre_params_after_event(model, &current_y, &mut params, tol);
+    let mut data = vec![Vec::with_capacity(output_count); model.visible_names.len()];
+    let mut recorded_times = Vec::with_capacity(output_count);
+    for observation in &outcome.observations {
+        let mut samples = SampleRecorder {
+            runtime: None,
+            model,
+            recorded_times: &mut recorded_times,
+            data: &mut data,
+        };
+        record_sample_if_new(
+            &mut samples,
+            SamplePoint {
+                y: &observation.y,
+                params: &observation.p,
+                t: observation.t,
+            },
         )?;
     }
-    commit_pre_params_after_event(model, &current_y, &mut params, tol);
     Ok(NoStateRuntime {
         runtime,
         params,
         current_y,
         current_t,
-        data: vec![Vec::with_capacity(output_count); model.visible_names.len()],
-        recorded_times: Vec::with_capacity(output_count),
+        data,
+        recorded_times,
         equilibrium_model,
         stop_schedule: SolveStopSchedule::new(&model.problem, opts.t_start, opts.t_end),
     })

--- a/crates/rumoca-solver-diffsol/src/tests/runtime_value_tests.rs
+++ b/crates/rumoca-solver-diffsol/src/tests/runtime_value_tests.rs
@@ -11,18 +11,30 @@ fn event_sample_replaces_near_duplicate_output_sample() {
     let mut times = Vec::new();
     let mut data = vec![Vec::new()];
 
+    let mut samples = SampleRecorder {
+        runtime: None,
+        model: &model,
+        recorded_times: &mut times,
+        data: &mut data,
+    };
     record_sample_if_new(
-        None,
-        &model,
-        &[],
-        &[5.0],
-        &mut times,
-        &mut data,
-        4.999999999999981,
+        &mut samples,
+        SamplePoint {
+            y: &[],
+            params: &[5.0],
+            t: 4.999999999999981,
+        },
     )
     .expect("pre-event output sample should be recorded");
-    record_sample_if_new(None, &model, &[], &[7.0], &mut times, &mut data, 5.0)
-        .expect("near-duplicate event sample should replace the stale output value");
+    record_sample_if_new(
+        &mut samples,
+        SamplePoint {
+            y: &[],
+            params: &[7.0],
+            t: 5.0,
+        },
+    )
+    .expect("near-duplicate event sample should replace the stale output value");
 
     assert_eq!(times, vec![5.0]);
     assert_eq!(data, vec![vec![7.0]]);
@@ -551,6 +563,7 @@ fn initialization_projects_demoted_state_layout_slots() {
     let runtime = SolveRuntime::new(&model).expect("valid runtime should prepare");
     let mut y = model.initial_y.clone();
     let mut params = model.parameters.clone();
+    let mut current_t = 0.0;
     initialize_state_runtime_values(
         &model,
         &SimOptions::default(),
@@ -558,7 +571,7 @@ fn initialization_projects_demoted_state_layout_slots() {
         &ode_model,
         &mut y,
         &mut params,
-        0.0,
+        &mut current_t,
     )
     .expect("demoted state-layout slots should be projected by initialization");
 

--- a/crates/rumoca-solver-rk45/src/lib.rs
+++ b/crates/rumoca-solver-rk45/src/lib.rs
@@ -5,15 +5,18 @@
 use std::{cell::RefCell, time::Instant};
 
 use indexmap::IndexMap;
-use rumoca_eval_solve::{EventUpdateRowFilter, ProjectedEventUpdateInput, SolveRuntime};
+use rumoca_eval_solve::{
+    EventUpdateRowFilter, InitialEventObservation, ProjectedEventUpdateInput,
+    ProjectedInitialEventInput, SolveRuntime,
+};
 use rumoca_ir_solve as solve;
 use rumoca_solver::{
     BackendState, EventActionOutcome, EventPreMode, RootCrossing, RuntimeEventBoundary,
     RuntimeEventBoundaryHandler, RuntimeEventStop, RuntimeSolveError, SimOptions, SimResult,
     SimSolverMode, SimTermination, SimulationBackend, SolveStopSchedule, StepUntilOutcome,
     TimeoutBudget, TimeoutExceeded, commit_pre_params_after_event, convert_variable_meta,
-    initial_runtime_event_stop, process_runtime_event_boundary,
-    root_crossings_with_relation_memory, root_value_crossed, runtime_event_horizon, timeline,
+    process_runtime_event_boundary, root_crossings_with_relation_memory, root_value_crossed,
+    runtime_event_horizon, timeline,
 };
 
 mod reset;
@@ -224,6 +227,26 @@ impl SimStepper {
     }
 }
 
+fn record_rk_initial_samples(
+    model: &SolveRuntime,
+    backend: &Rk45Backend<'_>,
+    data: &mut [Vec<f64>],
+    times: &mut Vec<f64>,
+    t_start: f64,
+) -> Result<(), SimError> {
+    if backend.initial_observations.is_empty() {
+        let solver_y = backend.current_solver_y()?;
+        model.record_visible_sample(data, &solver_y, &backend.params, t_start)?;
+        times.push(t_start);
+        return Ok(());
+    }
+    for observation in &backend.initial_observations {
+        model.record_visible_sample(data, &observation.y, &observation.p, observation.t)?;
+        times.push(observation.t);
+    }
+    Ok(())
+}
+
 fn collect_visible_values(
     names: &[String],
     values: Vec<f64>,
@@ -282,6 +305,7 @@ struct Rk45Backend<'a> {
     solver_y_guess: RefCell<Vec<f64>>,
     derivative_cache: RefCell<Option<CachedDerivative>>,
     root_cache: RefCell<Option<CachedRootConditions>>,
+    initial_observations: Vec<InitialEventObservation>,
 }
 
 struct TrialStep {
@@ -342,9 +366,7 @@ pub fn simulate(model: &solve::SolveModel, opts: &SimOptions) -> Result<SimResul
             "RK45 output samples",
         )?);
     }
-    let solver_y = backend.current_solver_y()?;
-    model.record_visible_sample(&mut data, &solver_y, &backend.params, opts.t_start)?;
-    times.push(opts.t_start);
+    record_rk_initial_samples(&model, &backend, &mut data, &mut times, opts.t_start)?;
 
     for &target_t in sample_times.iter().skip(1) {
         advance_backend_to(&mut backend, target_t)?;
@@ -470,6 +492,7 @@ impl<'a> Rk45Backend<'a> {
             solver_y_guess: RefCell::new(Vec::new()),
             derivative_cache: RefCell::new(None),
             root_cache: RefCell::new(None),
+            initial_observations: Vec::new(),
         })
     }
 
@@ -1056,6 +1079,7 @@ impl<'a> Rk45Backend<'a> {
 
 impl SimulationBackend for Rk45Backend<'_> {
     fn init(&mut self) -> Result<(), Self::Error> {
+        self.model.set_initial_event_flag(&mut self.params, true);
         let startup_event_pre_y = self.current_solver_y()?;
         let startup_event_pre_p = self.params.clone();
         let mut solver_y = self.current_solver_y()?;
@@ -1074,25 +1098,31 @@ impl SimulationBackend for Rk45Backend<'_> {
             self.atol,
             UPDATE_MAX_ITERS,
         )?;
-        let initial_event = initial_runtime_event_stop(
-            &self.model.model.problem,
-            self.time,
+        let dynamic_event =
             self.model
-                .current_dynamic_time_event_stop(&solver_y, &self.params, self.time)?,
-        );
-        if let Some(event) = initial_event {
-            self.pending_event_pre_y = Some(startup_event_pre_y);
-            self.pending_event_pre_p = Some(startup_event_pre_p);
-            let outcome = process_runtime_event_boundary(
-                RuntimeEventBoundary {
-                    event_t: self.time,
-                    horizon_t: self.time,
-                    event,
-                },
-                self,
-            )?;
-            self.apply_event_actions(outcome.final_t)?;
-        }
+                .current_dynamic_time_event_stop(&solver_y, &self.params, self.time)?;
+        let runtime = self.model;
+        let state_count = runtime.state_count;
+        let tol = self.atol;
+        let outcome = runtime.apply_projected_initial_event_boundary(
+            ProjectedInitialEventInput {
+                y: &mut solver_y,
+                p: &mut self.params,
+                t_start: self.time,
+                t_end: self.t_end,
+                tol,
+                event_pre_y: &startup_event_pre_y,
+                event_pre_p: &startup_event_pre_p,
+                max_iters: UPDATE_MAX_ITERS,
+                dynamic_event,
+                apply_without_initial_event: false,
+            },
+            move |y, p, t| project_rk_algebraics(runtime, y, p, t, state_count, tol),
+        )?;
+        self.copy_state_from_solver_y(&solver_y);
+        self.time = outcome.final_t;
+        self.initial_observations = outcome.observations;
+        self.apply_event_action_outcome(outcome.action, outcome.final_t)?;
         let post_initial_y = self.current_solver_y()?;
         commit_pre_params_after_event(
             &self.model.model,

--- a/crates/rumoca-solver/src/runtime/no_state.rs
+++ b/crates/rumoca-solver/src/runtime/no_state.rs
@@ -1,4 +1,5 @@
 use super::{schedule::RuntimeEventStop, solve_ops::EventPreMode};
+use crate::timeline::sample_time_match_with_tol;
 
 #[derive(Debug, Clone, Copy)]
 pub struct NoStateScheduledStop {
@@ -57,16 +58,20 @@ where
     I: IntoIterator<Item = f64>,
 {
     for target in output_times {
-        advance_no_state_to_target(backend, target, tol)?;
-        backend.settle_and_record_output()?;
+        if advance_no_state_to_target(backend, target, tol)? {
+            backend.settle_and_record_output()?;
+        }
     }
     Ok(())
 }
 
-fn advance_no_state_to_target<B>(backend: &mut B, target: f64, tol: f64) -> Result<(), B::Error>
+fn advance_no_state_to_target<B>(backend: &mut B, target: f64, tol: f64) -> Result<bool, B::Error>
 where
     B: NoStateOrchestrationBackend,
 {
+    if no_state_output_target_is_stale(backend.current_time(), target) {
+        return Ok(false);
+    }
     while target > backend.current_time() + tol {
         let scheduled = backend.next_scheduled_stop(target)?;
         let root_event_time = backend.next_root_event_time(target, tol)?;
@@ -90,5 +95,71 @@ where
     if backend.current_time() < target {
         backend.set_current_time(target);
     }
-    Ok(())
+    Ok(true)
+}
+
+fn no_state_output_target_is_stale(current: f64, target: f64) -> bool {
+    current > target && !sample_time_match_with_tol(current, target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingBackend {
+        current_time: f64,
+        recorded_times: Vec<f64>,
+    }
+
+    impl NoStateOrchestrationBackend for RecordingBackend {
+        type Error = ();
+
+        fn current_time(&self) -> f64 {
+            self.current_time
+        }
+
+        fn set_current_time(&mut self, time: f64) {
+            self.current_time = time;
+        }
+
+        fn next_scheduled_stop(
+            &mut self,
+            target: f64,
+        ) -> Result<NoStateScheduledStop, Self::Error> {
+            Ok(NoStateScheduledStop {
+                stop_time: target,
+                event_stop: None,
+            })
+        }
+
+        fn next_root_event_time(
+            &mut self,
+            _target: f64,
+            _tol: f64,
+        ) -> Result<Option<f64>, Self::Error> {
+            Ok(None)
+        }
+
+        fn handle_event_step(&mut self, _step: NoStateEventStep) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn settle_and_record_output(&mut self) -> Result<(), Self::Error> {
+            self.recorded_times.push(self.current_time);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn output_schedule_skips_targets_before_current_right_limit_time() {
+        let mut backend = RecordingBackend {
+            current_time: 1.0e-6,
+            recorded_times: Vec::new(),
+        };
+
+        run_no_state_output_schedule(&mut backend, [0.0, 0.1], 1.0e-6).unwrap();
+
+        assert_eq!(backend.recorded_times, vec![0.1]);
+    }
 }


### PR DESCRIPTION
## Summary

This PR improves MSL trace agreement with OpenModelica for the PowerConverters-focused cluster by fixing initial-event and connector-boundary behavior in shared runtime/compiler code rather than in a solver-specific path.

## What changed

- Centralized projected initial-event boundary handling in `rumoca-eval-solve`, with both Diffsol and RK45 consuming the same observation sequence.
- Skipped stale no-state output targets after right-limit advancement so no-state simulations do not emit duplicate samples when initial-event right-limit time has already advanced.
- Inferred sample schedules from parameters initialized from `time`, covering the MSL `Blocks.Math.Mean` pattern.
- Preserved nested connector interface-root flow signs for scalarized outside connector array members.

## Root cause

Rumoca was recording initial-event/right-limit observations and no-state output samples inconsistently across solver paths, while a subset of connector interface roots and initial-time sample schedules were not represented with enough semantic context. That produced avoidable high/near trace agreement loss against OpenModelica for evented electrical converter models.

## Validation

- `cargo xtask verify full`
- MSL trace gate passed: `high=73.53%`, `near=15.88%`, `deviation=10.59%`, `bad_channels=655` versus baseline `926`.
