### PR TITLE
Refresh Diffsol root event algebraics

### DIFF
--- a/crates/rumoca-solver-diffsol/src/lib.rs
+++ b/crates/rumoca-solver-diffsol/src/lib.rs
@@ -130,13 +130,14 @@ pub fn check_initialization(model: &solve::SolveModel, opts: &SimOptions) -> Res
     }
 
     let equilibrium_model = Arc::new(OdeModel::new(model)?);
+    let runtime = Arc::new(SolveRuntime::new(model)?);
     let mut current_y = model.initial_y.clone();
     let mut params = model.parameters.clone();
     let mut current_t = opts.t_start;
     initialize_state_runtime_values(
         model,
         opts,
-        &SolveRuntime::new(model)?,
+        runtime.as_ref(),
         &equilibrium_model,
         &mut current_y,
         &mut params,
@@ -150,6 +151,7 @@ pub fn check_initialization(model: &solve::SolveModel, opts: &SimOptions) -> Res
         current_t,
         current_y.clone(),
         equilibrium_model.clone(),
+        runtime,
     )?;
     initial_bdf_state(model, &equilibrium_model, &problem, &current_y, &params).map(|_| ())
 }
@@ -234,6 +236,7 @@ fn simulate_with_states(
         current_t,
         current_y.clone(),
         equilibrium_model.clone(),
+        runtime.clone(),
     )?;
     let mut stepper = build_general_stepper(GeneralStepperInput {
         model,

--- a/crates/rumoca-solver-diffsol/src/ode.rs
+++ b/crates/rumoca-solver-diffsol/src/ode.rs
@@ -12,7 +12,7 @@ use rumoca_eval_solve::{
 use rumoca_ir_solve as solve;
 use rumoca_solver::{AlgebraicProjectionModel, PreparedMassMatrix, RuntimeSolveError, SimOptions};
 
-use crate::{Matrix, RuntimeParameters, Scalar, SimError, Vector};
+use crate::{EVENT_UPDATE_MAX_ITERS, Matrix, RuntimeParameters, Scalar, SimError, Vector};
 
 #[derive(Debug, Default)]
 pub(crate) struct BdfEvalCounters {
@@ -349,6 +349,7 @@ pub(crate) fn build_ode_problem_with_runtime_params_and_initial(
     t_start: f64,
     initial_y: Vec<f64>,
     ode_model: Arc<OdeModel>,
+    root_runtime: Arc<SolveRuntime>,
 ) -> Result<
     OdeSolverProblem<
         impl OdeEquationsImplicit<M = Matrix, V = Vector, T = Scalar, C = <Matrix as MatrixCommon>::C>
@@ -363,6 +364,7 @@ pub(crate) fn build_ode_problem_with_runtime_params_and_initial(
         initial_y,
         Some(runtime_params),
         ode_model,
+        root_runtime,
     )
 }
 
@@ -438,7 +440,14 @@ pub(crate) fn build_state_ode_problem_with_runtime_params_and_initial(
         let start = root_counters.as_ref().map(|_| Instant::now());
         with_runtime_params(&root_params, p.as_slice(), |params| {
             if root_runtime
-                .eval_root_conditions_into(t, y.as_slice(), params, tol, 256, out.as_mut_slice())
+                .eval_root_conditions_into(
+                    t,
+                    y.as_slice(),
+                    params,
+                    tol,
+                    EVENT_UPDATE_MAX_ITERS,
+                    out.as_mut_slice(),
+                )
                 .is_err()
             {
                 fill_eval_error(out.as_mut_slice());
@@ -474,6 +483,7 @@ fn build_ode_problem_with_initial(
     initial_y: Vec<f64>,
     runtime_params: Option<RuntimeParameters>,
     ode_model: Arc<OdeModel>,
+    root_runtime: Arc<SolveRuntime>,
 ) -> Result<
     OdeSolverProblem<
         impl OdeEquationsImplicit<M = Matrix, V = Vector, T = Scalar, C = <Matrix as MatrixCommon>::C>
@@ -496,7 +506,7 @@ fn build_ode_problem_with_initial(
     let jac_runtime_params = runtime_params.clone();
     let root_runtime_params = runtime_params.clone();
     let jac_model = ode_model.clone();
-    let root_model = ode_model.clone();
+    let tol = opts.atol.max(1.0e-10);
     let jac_fn = move |y: &Vector, p: &Vector, t: Scalar, v: &Vector, out: &mut Vector| {
         with_runtime_params(&jac_runtime_params, p.as_slice(), |params| {
             if jac_model
@@ -509,8 +519,15 @@ fn build_ode_problem_with_initial(
     };
     let root_fn = move |y: &Vector, p: &Vector, t: Scalar, out: &mut Vector| {
         with_runtime_params(&root_runtime_params, p.as_slice(), |params| {
-            if root_model
-                .eval_roots(y.as_slice(), params, t, out.as_mut_slice())
+            if root_runtime
+                .eval_root_conditions_into(
+                    t,
+                    y.as_slice(),
+                    params,
+                    tol,
+                    EVENT_UPDATE_MAX_ITERS,
+                    out.as_mut_slice(),
+                )
                 .is_err()
             {
                 fill_eval_error(out.as_mut_slice());

--- a/crates/rumoca-solver-diffsol/src/runtime.rs
+++ b/crates/rumoca-solver-diffsol/src/runtime.rs
@@ -238,6 +238,7 @@ impl NoStateOrchestrationBackend for DiffsolNoStateOrchestration<'_> {
 
     fn next_root_event_time(&mut self, target: f64, tol: f64) -> Result<Option<f64>, Self::Error> {
         next_no_state_root_event_time(
+            &self.runtime.runtime,
             &self.runtime.equilibrium_model,
             &self.runtime.current_y,
             &self.runtime.params,
@@ -487,6 +488,7 @@ fn initialize_no_state_runtime(
 }
 
 fn next_no_state_root_event_time(
+    runtime: &SolveRuntime,
     model: &OdeModel,
     y: &[f64],
     p: &[f64],
@@ -494,7 +496,8 @@ fn next_no_state_root_event_time(
     target: f64,
     tol: f64,
 ) -> Result<Option<f64>, SimError> {
-    let Some(root_time) = first_root_crossing_time(model, y, p, current_t, target, tol)? else {
+    let Some(root_time) = first_root_crossing_time(runtime, model, y, p, current_t, target, tol)?
+    else {
         return Ok(None);
     };
     if root_time > current_t + tol
@@ -552,6 +555,7 @@ fn event_left_limit_time(t: f64) -> f64 {
 const ROOT_BISECTION_ITERS: usize = 64;
 
 fn first_root_crossing_time(
+    runtime: &SolveRuntime,
     model: &OdeModel,
     y: &[f64],
     p: &[f64],
@@ -559,19 +563,35 @@ fn first_root_crossing_time(
     t_end: f64,
     tol: f64,
 ) -> Result<Option<f64>, SimError> {
+    if model.root_conditions.is_empty() {
+        return Ok(None);
+    }
     let mut start = vec![0.0; model.root_conditions.len()];
     let mut end = vec![0.0; model.root_conditions.len()];
-    model.eval_roots(y, p, t_start, &mut start)?;
-    model.eval_roots(y, p, t_end, &mut end)?;
+    eval_refreshed_roots(runtime, y, p, t_start, tol, &mut start)?;
+    eval_refreshed_roots(runtime, y, p, t_end, tol, &mut end)?;
 
     let mut crossing = None;
     for (a, b) in start.iter().zip(end.iter()) {
         if root_surface_crossed_or_near(*a, *b, tol) {
-            let root = bisect_first_root(model, y, p, t_start, t_end, tol)?;
+            let root = bisect_first_root(runtime, model, y, p, t_start, t_end, tol)?;
             crossing = Some(crossing.map_or(root, |current| f64::min(current, root)));
         }
     }
     Ok(crossing)
+}
+
+fn eval_refreshed_roots(
+    runtime: &SolveRuntime,
+    y: &[f64],
+    p: &[f64],
+    t: f64,
+    tol: f64,
+    out: &mut [f64],
+) -> Result<(), SimError> {
+    runtime
+        .eval_root_conditions_into(t, y, p, tol, EVENT_UPDATE_MAX_ITERS, out)
+        .map_err(Into::into)
 }
 
 fn root_surface_crossed_or_near(a: f64, b: f64, tol: f64) -> bool {
@@ -583,6 +603,7 @@ fn root_surface_near_zero(value: f64, tol: f64) -> bool {
 }
 
 fn bisect_first_root(
+    runtime: &SolveRuntime,
     model: &OdeModel,
     y: &[f64],
     p: &[f64],
@@ -591,11 +612,11 @@ fn bisect_first_root(
     tol: f64,
 ) -> Result<f64, SimError> {
     let mut lo_roots = vec![0.0; model.root_conditions.len()];
-    model.eval_roots(y, p, lo, &mut lo_roots)?;
+    eval_refreshed_roots(runtime, y, p, lo, tol, &mut lo_roots)?;
     for _ in 0..ROOT_BISECTION_ITERS {
         let mid = lo + 0.5 * (hi - lo);
         let mut mid_roots = vec![0.0; model.root_conditions.len()];
-        model.eval_roots(y, p, mid, &mut mid_roots)?;
+        eval_refreshed_roots(runtime, y, p, mid, tol, &mut mid_roots)?;
         if lo_roots
             .iter()
             .zip(mid_roots.iter())

--- a/crates/rumoca-solver-diffsol/src/stepper.rs
+++ b/crates/rumoca-solver-diffsol/src/stepper.rs
@@ -56,6 +56,7 @@ impl SimStepper {
         let runtime_context = solve_eval::SimulationContext::new();
         runtime_context.hydrate_solve_model(model);
         let runtime = SolveRuntime::new(model)?;
+        let root_runtime = Arc::new(runtime.clone());
         let ode_model = OdeModel::new(model)?;
         let runtime_params = Rc::new(RefCell::new(model.parameters.clone()));
         let initial_y = settled_initial_y(model, &runtime, &ode_model, &opts, &runtime_params)?;
@@ -67,6 +68,7 @@ impl SimStepper {
             opts.t_start,
             initial_y.clone(),
             ode_model.clone(),
+            root_runtime,
         )?;
         let problem_ref = Box::leak(Box::new(problem));
         let newton = || {
@@ -112,6 +114,7 @@ impl SimStepper {
             };
             let ode_model = Arc::new(OdeModel::new(&event_reset_model)?);
             let reset_runtime = SolveRuntime::new(&event_reset_model)?;
+            let root_runtime = Arc::new(reset_runtime.clone());
             let initial_y = settled_problem_y(
                 &event_reset_model,
                 &reset_runtime,
@@ -128,6 +131,7 @@ impl SimStepper {
                 t_start,
                 initial_y.clone(),
                 ode_model.clone(),
+                root_runtime,
             )?;
             let problem_ref = Box::leak(Box::new(problem));
             let state = {

--- a/crates/rumoca-solver-diffsol/src/tests/runtime_value_tests.rs
+++ b/crates/rumoca-solver-diffsol/src/tests/runtime_value_tests.rs
@@ -111,6 +111,110 @@ fn simulate_no_state_solve_ir_stops_for_root_event_updates() {
 }
 
 #[test]
+fn no_state_root_search_refreshes_algebraic_root_dependencies() {
+    let mut model = solve::SolveModel::default();
+    model.problem.solve_layout.parameter_count = 0;
+    model.problem.solve_layout.compiled_parameter_len = 1;
+    model.problem.solve_layout.algebraic_scalar_count = 1;
+    model.problem.solve_layout.discrete_valued_scalar_names = vec!["m".to_string()];
+    model.problem.solve_layout.solver_maps.names = vec!["u".to_string()];
+    model.problem.solve_layout.solver_maps.name_to_idx =
+        indexmap::IndexMap::from([("u".to_string(), 0)]);
+    model.problem.solve_layout.solver_maps.base_to_indices =
+        indexmap::IndexMap::from([("u".to_string(), vec![0])]);
+    model.problem.continuous.implicit_rhs = solve::ComputeBlock::from_scalar_program_block(
+        solve::ScalarProgramBlock::with_source_span(
+            vec![vec![
+                solve::LinearOp::LoadY { dst: 0, index: 0 },
+                solve::LinearOp::LoadTime { dst: 1 },
+                solve::LinearOp::Binary {
+                    dst: 2,
+                    op: solve::BinaryOp::Sub,
+                    lhs: 0,
+                    rhs: 1,
+                },
+                solve::LinearOp::StoreOutput { src: 2 },
+            ]],
+            fixture_span!(),
+        ),
+    );
+    model.problem.continuous.implicit_row_targets = vec![Some(solve::scalar_slot_y(0))];
+    model.artifacts.continuous.implicit_jacobian_v = solve::ComputeBlock::from_scalar_program_block(
+        solve::ScalarProgramBlock::with_source_span(
+            vec![vec![
+                solve::LinearOp::LoadSeed { dst: 0, index: 0 },
+                solve::LinearOp::StoreOutput { src: 0 },
+            ]],
+            fixture_span!(),
+        ),
+    );
+    install_dense_algebraic_projection_plan(&mut model);
+    model.problem.events.root_conditions = solve::ScalarProgramBlock::with_source_span(
+        vec![vec![
+            solve::LinearOp::LoadY { dst: 0, index: 0 },
+            solve::LinearOp::Const {
+                dst: 1,
+                value: 0.05,
+            },
+            solve::LinearOp::Binary {
+                dst: 2,
+                op: solve::BinaryOp::Sub,
+                lhs: 0,
+                rhs: 1,
+            },
+            solve::LinearOp::StoreOutput { src: 2 },
+        ]],
+        fixture_span!(),
+    );
+    model.problem.discrete.update_targets = vec![solve::scalar_slot_p(0)];
+    model.problem.discrete.rhs = solve::ScalarProgramBlock::with_source_span(
+        vec![vec![
+            solve::LinearOp::LoadY { dst: 0, index: 0 },
+            solve::LinearOp::Const {
+                dst: 1,
+                value: 0.05,
+            },
+            solve::LinearOp::Compare {
+                dst: 2,
+                op: solve::CompareOp::Ge,
+                lhs: 0,
+                rhs: 1,
+            },
+            solve::LinearOp::Const { dst: 3, value: 2.0 },
+            solve::LinearOp::LoadP { dst: 4, index: 0 },
+            solve::LinearOp::Select {
+                dst: 5,
+                cond: 2,
+                if_true: 3,
+                if_false: 4,
+            },
+            solve::LinearOp::StoreOutput { src: 5 },
+        ]],
+        fixture_span!(),
+    );
+    model.initial_y = vec![0.0];
+    model.parameters = vec![0.0];
+    model.visible_names = vec!["m".to_string()];
+
+    let result = simulate(
+        &model,
+        &SimOptions {
+            t_start: 0.0,
+            t_end: 0.1,
+            dt: Some(0.1),
+            ..Default::default()
+        },
+    )
+    .expect("no-state root search should refresh algebraics before evaluating roots");
+
+    assert_eq!(result.times.len(), 3);
+    assert_eq!(result.times[0], 0.0);
+    assert!((result.times[1] - 0.05).abs() <= 2.0e-6);
+    assert_eq!(result.times[2], 0.1);
+    assert_eq!(result.data, vec![vec![0.0, 2.0, 2.0]]);
+}
+
+#[test]
 fn no_state_root_inside_start_tolerance_is_not_retriggered() {
     let model = root_event_update_model(1.0e-11);
 


### PR DESCRIPTION
## Summary

Refresh Diffsol root event evaluation through `SolveRuntime` so algebraic dependencies of root residuals are current during event callbacks and no-state root bisection.

## Root Cause

Diffsol root callbacks and no-state root searches were evaluating root residuals directly from the ODE model vectors. For models whose root condition depends on an algebraic projection, that could leave the root residual using stale algebraic values during event detection and bisection.

## Impact

This is a solver-neutral semantics fix at the runtime refresh boundary: root conditions now go through the same runtime algebraic refresh path used elsewhere before event decisions are made. The change improves MSL trace agreement, especially the StateGraph-style event cluster, without adding model-specific behavior.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p rumoca-solver-diffsol`
- `cargo test -p rumoca-solver-rk45 root`
- Focused MSL rerun for the affected StateGraph/Clocked models
- `cargo xtask verify full`

Full verify MSL gate passed:

- trace: 26.68% (`151/566`, baseline `142/566`)
- high: 74.85%
- near: 15.57%
- bad channels: 633, down from baseline 926
- severe channels: 109, down from baseline 165
