### PR TITLE
Publish MSL ratchet baseline as release asset

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@ Alignment". Update both files together if you change either one.
 - For compiler/simulator changes: did you run the MSL gate
   (`cargo test --release --package rumoca-test-msl --features msl-full-test --test msl_tests
   balance_pipeline::balance_pipeline_core::test_msl_all -- --nocapture`) and
-  confirm no regression vs `msl_quality_baseline.json`?
+  confirm no regression vs the resolved `msl_quality_baseline.json`?
 
 ## Code Size Budget (required)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,7 +595,7 @@ jobs:
 
       - name: Run full MSL quality gate
         # Keep the full parity run conservative on standard GitHub-hosted
-        # runners. The committed quality baseline is promoted from this CI
+        # runners. The promoted quality baseline is ratcheted from this CI
         # worker context rather than from a larger local workstation.
         run: >
           cargo xtask verify msl-parity
@@ -655,7 +655,15 @@ jobs:
       - name: Generate MSL PR summary comment
         if: always()
         shell: bash
-        run: cargo xtask repo msl pr-comment --results-dir target/msl/results
+        run: |
+          set -euo pipefail
+          baseline="crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json"
+          if [[ -f target/msl/baselines/msl_quality_baseline.json ]]; then
+            baseline="target/msl/baselines/msl_quality_baseline.json"
+          fi
+          cargo xtask repo msl pr-comment \
+            --results-dir target/msl/results \
+            --baseline "$baseline"
 
       - name: Upload MSL compatibility artifacts
         if: always()

--- a/.github/workflows/msl-baseline-ratchet.yml
+++ b/.github/workflows/msl-baseline-ratchet.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   actions: read
   contents: write
-  pull-requests: write
 
 concurrency:
   group: msl-baseline-ratchet-main
@@ -25,25 +24,14 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-24.04
     env:
-      MSL_BASELINE_RATCHET_BRANCH: automation/msl-quality-baseline
-      # Prefer a bot/App token so the promotion branch push can trigger PR CI.
-      # GITHUB_TOKEN is a safe fallback, but GitHub may suppress CI for events
-      # created by it, leaving branch-protected auto-merge waiting for checks.
-      MSL_BASELINE_RATCHET_TOKEN: ${{ secrets.MSL_BASELINE_RATCHET_TOKEN || github.token }}
-      MSL_BASELINE_RATCHET_TOKEN_SOURCE: ${{ secrets.MSL_BASELINE_RATCHET_TOKEN && 'MSL_BASELINE_RATCHET_TOKEN' || 'GITHUB_TOKEN' }}
+      MSL_BASELINE_RELEASE_TAG: msl-quality-baseline
+      MSL_BASELINE_RELEASE_ASSET: msl_quality_baseline.json
     steps:
       - uses: actions/checkout@v5
         with:
-          token: ${{ env.MSL_BASELINE_RATCHET_TOKEN }}
-          persist-credentials: true
+          persist-credentials: false
           fetch-depth: 0
           ref: main
-
-      - name: Warn when ratchet uses GITHUB_TOKEN fallback
-        if: env.MSL_BASELINE_RATCHET_TOKEN_SOURCE == 'GITHUB_TOKEN'
-        run: |
-          echo "::warning::MSL_BASELINE_RATCHET_TOKEN is not configured."
-          echo "::warning::The ratchet can open/update a baseline PR with GITHUB_TOKEN, but GitHub may suppress CI for bot-created branch updates, so branch-protected auto-merge may not complete."
 
       - name: Install Node
         uses: actions/setup-node@v5
@@ -141,117 +129,145 @@ jobs:
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "path=$snapshot" >> "$GITHUB_OUTPUT"
 
+      - name: Load current promoted baseline
+        id: release-baseline
+        if: steps.snapshot.outputs.found == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { owner, repo } = context.repo;
+            const tag = process.env.MSL_BASELINE_RELEASE_TAG;
+            const assetName = process.env.MSL_BASELINE_RELEASE_ASSET;
+            const outputPath = 'target/msl-baseline-ratchet/current-baseline.json';
+            fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+
+            try {
+              const release = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag,
+              });
+              const asset = release.data.assets.find(item => item.name === assetName);
+              if (!asset) {
+                core.info(`Release ${tag} has no ${assetName}; using checked-in fallback.`);
+                fs.copyFileSync(
+                  'crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json',
+                  outputPath
+                );
+              } else {
+                const download = await github.rest.repos.getReleaseAsset({
+                  owner,
+                  repo,
+                  asset_id: asset.id,
+                  headers: { accept: 'application/octet-stream' },
+                });
+                fs.writeFileSync(outputPath, Buffer.from(download.data));
+                core.info(`Loaded current promoted baseline from release ${tag}/${assetName}.`);
+              }
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              core.info(`Release ${tag} does not exist; using checked-in fallback.`);
+              fs.copyFileSync(
+                'crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json',
+                outputPath
+              );
+            }
+            core.setOutput('path', outputPath);
+
       - name: Promote baseline if the artifact improves it
+        id: promote
         if: steps.snapshot.outputs.found == 'true'
         shell: bash
         run: |
           set -euo pipefail
+          previous="${{ steps.release-baseline.outputs.path }}"
+          promoted="target/msl-baseline-ratchet/$MSL_BASELINE_RELEASE_ASSET"
+          cp "$previous" "$promoted"
           node .github/scripts/msl-baseline-ratchet.mjs \
             --source "${{ steps.snapshot.outputs.path }}" \
-            --baseline crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json
+            --baseline "$promoted"
 
-      - name: Commit promoted baseline to ratchet branch
-        id: commit
-        if: steps.snapshot.outputs.found == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          baseline="crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json"
-          if git diff --quiet -- "$baseline"; then
-            echo "MSL quality baseline did not change."
+          if cmp -s "$previous" "$promoted"; then
+            echo "MSL quality baseline did not improve the promoted release baseline."
             echo "promoted=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          promotion_branch="$MSL_BASELINE_RATCHET_BRANCH"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git switch -c "$promotion_branch"
-          git add "$baseline"
-          git commit \
-            -s \
-            -m "Ratchet MSL quality baseline" \
-            -m "Promoted from successful CI workflow run ${{ github.event.workflow_run.id }} for ${{ github.event.workflow_run.head_sha }}."
-          git push --force-with-lease origin "HEAD:$promotion_branch"
+          echo "MSL quality baseline improved the promoted release baseline."
           echo "promoted=true" >> "$GITHUB_OUTPUT"
-          echo "branch=$promotion_branch" >> "$GITHUB_OUTPUT"
+          echo "path=$promoted" >> "$GITHUB_OUTPUT"
 
-      - name: Open or update baseline promotion PR
-        if: steps.commit.outputs.promoted == 'true'
+      - name: Publish promoted baseline release asset
+        if: steps.promote.outputs.promoted == 'true'
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.MSL_BASELINE_RATCHET_TOKEN }}
           script: |
+            const fs = require('fs');
             const { owner, repo } = context.repo;
-            const branch = '${{ steps.commit.outputs.branch }}';
+            const tag = process.env.MSL_BASELINE_RELEASE_TAG;
+            const assetName = process.env.MSL_BASELINE_RELEASE_ASSET;
+            const assetPath = '${{ steps.promote.outputs.path }}';
             const runId = context.payload.workflow_run.id;
             const runSha = context.payload.workflow_run.head_sha;
-            const title = 'Ratchet MSL quality baseline';
-            const marker = '<!-- rumoca-msl-baseline-ratchet -->';
             const body = [
-              marker,
-              '',
-              'Promotes `crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json` from a successful main CI artifact.',
+              'Mutable release that stores the latest promoted MSL quality baseline.',
               '',
               `Source CI run: ${context.serverUrl}/${owner}/${repo}/actions/runs/${runId}`,
               `Source commit: \`${runSha}\``,
               '',
-              'This PR is generated by the MSL Baseline Ratchet workflow. The baseline helper already verified that the artifact is a full MSL quality snapshot and that every ratcheted metric is non-regressing.',
-              '',
-              'Auto-merge is requested when the repository allows it; branch protection may still require code-owner approval or required checks before GitHub can merge this PR.',
+              '`cargo xtask verify msl-parity` downloads this asset when available and falls back to the checked-in baseline when offline.',
               '',
             ].join('\n');
 
-            const existing = await github.paginate(github.rest.pulls.list, {
+            let release;
+            try {
+              release = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: release.data.id,
+                name: 'MSL Quality Baseline',
+                body,
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              release = await github.rest.repos.createRelease({
+                owner,
+                repo,
+                tag_name: tag,
+                target_commitish: 'main',
+                name: 'MSL Quality Baseline',
+                body,
+                draft: false,
+                prerelease: false,
+              });
+            }
+
+            const existingAsset = release.data.assets.find(asset => asset.name === assetName);
+            if (existingAsset) {
+              await github.rest.repos.deleteReleaseAsset({
+                owner,
+                repo,
+                asset_id: existingAsset.id,
+              });
+            }
+
+            const data = fs.readFileSync(assetPath);
+            await github.rest.repos.uploadReleaseAsset({
               owner,
               repo,
-              state: 'open',
-              head: `${owner}:${branch}`,
-              base: 'main',
-              per_page: 100,
+              release_id: release.data.id,
+              name: assetName,
+              data,
+              headers: {
+                'content-type': 'application/json',
+                'content-length': data.length,
+              },
             });
-
-            let pull;
-            if (existing.length > 0) {
-              const response = await github.rest.pulls.update({
-                owner,
-                repo,
-                pull_number: existing[0].number,
-                title,
-                body,
-                maintainer_can_modify: true,
-              });
-              pull = response.data;
-              core.info(`Updated baseline promotion PR #${pull.number}.`);
-            } else {
-              const response = await github.rest.pulls.create({
-                owner,
-                repo,
-                title,
-                head: branch,
-                base: 'main',
-                body,
-                maintainer_can_modify: true,
-              });
-              pull = response.data;
-              core.info(`Opened baseline promotion PR #${pull.number}.`);
-            }
-
-            try {
-              await github.graphql(
-                `mutation($pullRequestId: ID!) {
-                  enablePullRequestAutoMerge(input: {
-                    pullRequestId: $pullRequestId,
-                    mergeMethod: SQUASH
-                  }) {
-                    pullRequest {
-                      number
-                    }
-                  }
-                }`,
-                { pullRequestId: pull.node_id },
-              );
-              core.info(`Enabled auto-merge for baseline promotion PR #${pull.number}.`);
-            } catch (error) {
-              core.warning(`Could not enable auto-merge for baseline promotion PR #${pull.number}: ${error.message}`);
-            }
+            core.info(`Published ${assetName} to release ${tag}.`);

--- a/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_config.rs
+++ b/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_config.rs
@@ -55,6 +55,9 @@ pub(crate) struct MslParityConfig {
     pub sim_worker_memory_mb: Option<usize>,
     /// Total simulation memory budget in MB; caps the sim worker count.
     pub sim_total_memory_mb: Option<usize>,
+    /// Resolved quality baseline JSON file. Relative paths are resolved from
+    /// the workspace root.
+    pub quality_baseline_file: Option<PathBuf>,
     /// Opt into the generated simulation-targets file when no explicit file or
     /// committed file applies.
     pub generated_sim_targets_file: Option<bool>,
@@ -95,4 +98,15 @@ pub(crate) fn msl_results_dir() -> PathBuf {
         return path.clone();
     }
     workspace_root_from_manifest_dir(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+pub(crate) fn quality_baseline_file_override() -> Option<PathBuf> {
+    let path = parity_config().quality_baseline_file.as_ref()?;
+    if path.as_os_str().is_empty() {
+        return None;
+    }
+    if path.is_absolute() {
+        return Some(path.clone());
+    }
+    Some(workspace_root_from_manifest_dir(env!("CARGO_MANIFEST_DIR")).join(path))
 }

--- a/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_quality_gate.rs
+++ b/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_quality_gate.rs
@@ -340,6 +340,9 @@ pub(super) fn balance_success_rate(
 }
 
 pub(super) fn msl_quality_baseline_path() -> PathBuf {
+    if let Some(path) = quality_baseline_file_override() {
+        return path;
+    }
     Path::new(env!("CARGO_MANIFEST_DIR")).join(MSL_QUALITY_BASELINE_FILE_REL)
 }
 
@@ -1169,7 +1172,7 @@ pub(super) fn write_current_msl_quality_snapshot(summary: &MslSummary) -> io::Re
         .map_err(|error| io::Error::other(format!("failed to serialize baseline JSON: {error}")))?;
     fs::write(&baseline_path, baseline_json)?;
     println!(
-        "MSL current quality snapshot written to {}. Promote with `rum repo msl promote-quality-baseline` after approved full baseline runs; committed baseline path is {}.",
+        "MSL current quality snapshot written to {}. Promote with `rum repo msl promote-quality-baseline` after approved full baseline runs; fallback baseline path is {}.",
         baseline_path.display(),
         msl_quality_baseline_path().display()
     );

--- a/crates/rumoca-test-msl/tests/msl_tests/README.md
+++ b/crates/rumoca-test-msl/tests/msl_tests/README.md
@@ -83,10 +83,12 @@ This directory contains helper includes for `tests/msl_tests.rs`.
   counts for the fixed root-example denominator: parse/IR-AST, flatten/IR-flat,
   DAE/IR-DAE, solve/IR-Solve, initial-condition solve, and simulation. The CI
   gate treats any increase in an early-stage cumulative count as an improvement
-  and fails only when a cumulative stage count drops below the committed
-  baseline for the same fixed target set. Promote reviewed full-run data, and
-  keep the committed stage counts conservative enough to absorb compile-timeout
-  jitter; focused subsets and one-off explicit target files are not baselines.
+  and fails only when a cumulative stage count drops below the resolved
+  promoted baseline for the same fixed target set. `cargo xtask verify
+  msl-parity` downloads the latest promoted baseline from the
+  `msl-quality-baseline` GitHub release asset and falls back to the checked-in
+  JSON when offline. Focused subsets and one-off explicit target files are not
+  baselines.
 - Baseline JSON also captures OMC parity distributions for this set (runtime
   speedup ratio + trace-accuracy min/median/mean/max), populated from
   `omc_simulation_reference.json`.
@@ -96,7 +98,7 @@ This directory contains helper includes for `tests/msl_tests.rs`.
     OMC-vs-Rumoca trace deviation metrics unless deterministic parity support is added.
 - Successful baseline `test_msl_all` runs write current quality snapshot:
   - `target/msl/results/msl_quality_current.json`
-- Committed baseline updates are explicit/manual:
+- Checked-in fallback baseline updates are explicit/manual:
   - `cargo xtask repo msl promote-quality-baseline`
 - Alternate simulation sets:
   - unset or `RUMOCA_MSL_SIM_SET=full` to keep all models from the selected list

--- a/crates/xtask/src/bin/rumoca-msl-tools.rs
+++ b/crates/xtask/src/bin/rumoca-msl-tools.rs
@@ -32,7 +32,7 @@ enum Commands {
     Rerun(rerun::Args),
     /// Regenerate OMC+Rumoca traces and plot them for one model
     PlotCompare(plot_compare::Args),
-    /// Promote target quality snapshot to committed baseline JSON
+    /// Promote target quality snapshot to the checked-in fallback baseline JSON
     PromoteQualityBaseline(promote_quality_baseline::Args),
 }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -465,7 +465,7 @@ enum RepoMslCommand {
     // -- Catalog & baseline maintenance --
     /// Catalog MSL-shipped ModelicaTest cases by semantic feature area
     ModelicaTestCatalog(msl_tools::modelica_test_catalog::Args),
-    /// Promote a quality snapshot to the committed baseline JSON
+    /// Promote a quality snapshot to the checked-in fallback baseline JSON
     PromoteQualityBaseline(msl_tools::promote_quality_baseline::Args),
 }
 

--- a/crates/xtask/src/main_tests.rs
+++ b/crates/xtask/src/main_tests.rs
@@ -212,6 +212,25 @@ fn cli_parses_verify_msl_parity_job() {
 }
 
 #[test]
+fn cli_parses_verify_msl_parity_quality_baseline_flags() {
+    let cli = Cli::try_parse_from([
+        "xtask",
+        "verify",
+        "msl-parity",
+        "--quality-baseline",
+        "baseline.json",
+        "--no-remote-quality-baseline",
+    ])
+    .expect("parse verify msl-parity baseline flags");
+    match cli.command {
+        Commands::Verify(args) => {
+            assert!(matches!(args.command, VerifyCommand::MslParity(_)))
+        }
+        other => panic!("expected verify command, got {other:?}"),
+    }
+}
+
+#[test]
 fn cli_parses_verify_msl_hotspots_job() {
     let cli = Cli::try_parse_from(["xtask", "verify", "msl-hotspots"])
         .expect("parse verify msl-hotspots");

--- a/crates/xtask/src/msl_tools/pr_comment.rs
+++ b/crates/xtask/src/msl_tools/pr_comment.rs
@@ -27,7 +27,7 @@ pub struct Args {
     /// Markdown file to write for CI PR publication
     #[arg(long)]
     pub out: Option<PathBuf>,
-    /// Committed quality baseline used to render summary deltas
+    /// Quality baseline used to render summary deltas
     #[arg(long, default_value = DEFAULT_BASELINE_FILE)]
     pub baseline: PathBuf,
 }
@@ -120,7 +120,7 @@ fn render_quality_snapshot_summary(
     let mut delta_note = String::new();
     if let Some(baseline) = baseline.as_ref() {
         delta_note.push_str(
-            "\n_Deltas compare numerator/denominator against the committed MSL quality baseline._\n",
+            "\n_Deltas compare numerator/denominator against the resolved MSL quality baseline._\n",
         );
         delta_note.push_str(&baseline_identity_note(baseline));
         if let Some(trace_note) = trace_baseline_delta_note(&json, baseline) {

--- a/crates/xtask/src/verify_cmd.rs
+++ b/crates/xtask/src/verify_cmd.rs
@@ -20,11 +20,13 @@ use crate::{
 };
 
 mod msl_cargo_setup_timing;
+mod msl_quality_baseline;
 
 use msl_cargo_setup_timing::{
     MslCargoSetupStepMetadata, MslCargoSetupTimingStep, run_msl_cargo_setup_step,
     write_msl_cargo_setup_timing_report,
 };
+use msl_quality_baseline::resolve_msl_quality_baseline;
 
 const MSL_VERSION: &str = "4.1.0";
 const MSL_RELEASE_ZIP_URL: &str = "https://github.com/modelica/ModelicaStandardLibrary/releases/download/v4.1.0/ModelicaStandardLibrary_v4.1.0.zip";
@@ -105,6 +107,12 @@ pub(crate) struct VerifyMslParityArgs {
     /// Total simulation memory budget in MB (caps the sim worker count)
     #[arg(long)]
     sim_total_memory_mb: Option<usize>,
+    /// Explicit MSL quality baseline JSON for baseline-relative gates
+    #[arg(long)]
+    quality_baseline: Option<PathBuf>,
+    /// Use the checked-in MSL quality baseline instead of downloading the latest promoted asset
+    #[arg(long)]
+    no_remote_quality_baseline: bool,
 }
 
 impl VerifyMslParityArgs {
@@ -161,6 +169,12 @@ impl VerifyMslParityArgs {
         if let Some(value) = self.sim_total_memory_mb {
             config.insert("sim_total_memory_mb".into(), value.into());
         }
+        if let Some(value) = &self.quality_baseline {
+            config.insert(
+                "quality_baseline_file".into(),
+                value.to_string_lossy().into_owned().into(),
+            );
+        }
         serde_json::Value::Object(config)
     }
 
@@ -169,6 +183,16 @@ impl VerifyMslParityArgs {
             || self.sim_targets_file.is_some()
             || !self.sim_match.is_empty()
             || self.sim_limit.is_some()
+    }
+
+    fn uses_baseline_relative_quality_gate(&self) -> bool {
+        if self.requires_selected_targets_success() {
+            return false;
+        }
+        if !matches!(self.target_scope.as_deref(), None | Some("root-examples")) {
+            return false;
+        }
+        matches!(self.sim_set.as_deref(), None | Some("full"))
     }
 }
 
@@ -187,7 +211,11 @@ fn write_parity_config(root: &Path, args: &VerifyMslParityArgs) -> Result<()> {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
-    let json = serde_json::to_string_pretty(&args.to_parity_config_json())?;
+    let mut config = args.clone();
+    if args.quality_baseline.is_some() || args.uses_baseline_relative_quality_gate() {
+        config.quality_baseline = Some(resolve_msl_quality_baseline(root, args)?);
+    }
+    let json = serde_json::to_string_pretty(&config.to_parity_config_json())?;
     fs::write(&path, json).with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
 }
@@ -1720,6 +1748,7 @@ mod tests {
                 .and_then(serde_json::Value::as_bool),
             Some(true)
         );
+        assert!(!args.uses_baseline_relative_quality_gate());
     }
 
     #[test]

--- a/crates/xtask/src/verify_cmd/msl_quality_baseline.rs
+++ b/crates/xtask/src/verify_cmd/msl_quality_baseline.rs
@@ -1,0 +1,152 @@
+use anyhow::{Context, Result, ensure};
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use super::VerifyMslParityArgs;
+
+const MSL_QUALITY_BASELINE_ASSET_URL: &str = "https://github.com/CogniPilot/rumoca/releases/download/msl-quality-baseline/msl_quality_baseline.json";
+const MSL_QUALITY_BASELINE_FALLBACK_REL: &str =
+    "crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json";
+
+pub(super) fn resolve_msl_quality_baseline(
+    root: &Path,
+    args: &VerifyMslParityArgs,
+) -> Result<PathBuf> {
+    if let Some(path) = args.quality_baseline.as_ref() {
+        let resolved = resolve_workspace_path(root, path);
+        ensure!(
+            resolved.is_file(),
+            "explicit MSL quality baseline not found: {}",
+            resolved.display()
+        );
+        println!(
+            "MSL quality baseline: using explicit {}",
+            resolved.display()
+        );
+        return Ok(resolved);
+    }
+
+    if !args.no_remote_quality_baseline
+        && let Some(path) = download_msl_quality_baseline_asset(root)?
+    {
+        return Ok(path);
+    }
+
+    let fallback = checked_in_msl_quality_baseline_path(root);
+    ensure!(
+        fallback.is_file(),
+        "checked-in MSL quality baseline not found: {}",
+        fallback.display()
+    );
+    if args.no_remote_quality_baseline {
+        println!(
+            "MSL quality baseline: using checked-in fallback because --no-remote-quality-baseline was set ({})",
+            fallback.display()
+        );
+    } else {
+        println!(
+            "MSL quality baseline: using checked-in fallback {}",
+            fallback.display()
+        );
+    }
+    Ok(fallback)
+}
+
+fn downloaded_msl_quality_baseline_path(root: &Path) -> PathBuf {
+    root.join("target/msl/baselines/msl_quality_baseline.json")
+}
+
+fn checked_in_msl_quality_baseline_path(root: &Path) -> PathBuf {
+    root.join(MSL_QUALITY_BASELINE_FALLBACK_REL)
+}
+
+fn resolve_workspace_path(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+fn download_msl_quality_baseline_asset(root: &Path) -> Result<Option<PathBuf>> {
+    let output_path = downloaded_msl_quality_baseline_path(root);
+    println!(
+        "MSL quality baseline: downloading latest promoted asset from {}",
+        MSL_QUALITY_BASELINE_ASSET_URL
+    );
+    let response = match ureq::get(MSL_QUALITY_BASELINE_ASSET_URL).call() {
+        Ok(response) => response,
+        Err(error) => {
+            eprintln!(
+                "MSL quality baseline: failed to download latest promoted asset ({error}); falling back to checked-in baseline."
+            );
+            return Ok(None);
+        }
+    };
+
+    let content_len = response
+        .header("content-length")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    let mut data = Vec::with_capacity(content_len);
+    if let Err(error) = response.into_reader().read_to_end(&mut data) {
+        eprintln!(
+            "MSL quality baseline: failed to read latest promoted asset ({error}); falling back to checked-in baseline."
+        );
+        return Ok(None);
+    }
+
+    if let Err(error) = serde_json::from_slice::<serde_json::Value>(&data) {
+        eprintln!(
+            "MSL quality baseline: downloaded promoted asset is not valid JSON ({error}); falling back to checked-in baseline."
+        );
+        return Ok(None);
+    }
+
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(&output_path, data)
+        .with_context(|| format!("failed to write {}", output_path.display()))?;
+    println!(
+        "MSL quality baseline: using downloaded promoted asset {}",
+        output_path.display()
+    );
+    Ok(Some(output_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::VerifyMslParityArgs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn msl_parity_config_forwards_resolved_quality_baseline_path() {
+        let args = VerifyMslParityArgs {
+            quality_baseline: Some(PathBuf::from(
+                "target/msl/baselines/msl_quality_baseline.json",
+            )),
+            ..VerifyMslParityArgs::default()
+        };
+        let config = args.to_parity_config_json();
+
+        assert_eq!(
+            config
+                .get("quality_baseline_file")
+                .and_then(serde_json::Value::as_str),
+            Some("target/msl/baselines/msl_quality_baseline.json")
+        );
+    }
+
+    #[test]
+    fn default_msl_parity_uses_baseline_relative_quality_gate() {
+        assert!(VerifyMslParityArgs::default().uses_baseline_relative_quality_gate());
+        let short_run = VerifyMslParityArgs {
+            sim_set: Some("short".to_string()),
+            ..VerifyMslParityArgs::default()
+        };
+        assert!(!short_run.uses_baseline_relative_quality_gate());
+    }
+}

--- a/docs/dev-guide/src/tooling/msl-quality-gate.md
+++ b/docs/dev-guide/src/tooling/msl-quality-gate.md
@@ -31,8 +31,12 @@ Local full runs also generate OMC compile/flatten reference data in
 cold GitHub runners repeatedly reload MSL for the compile reference; the CI
 gate still checks Rumoca stage counts and OMC simulation trace parity.
 
-CI compares the current run against
-`crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json`.
+CI compares the current run against the resolved MSL quality baseline.
+`cargo xtask verify msl-parity` downloads the latest promoted
+`msl_quality_baseline.json` from the stable `msl-quality-baseline` GitHub
+release asset when available, caches it under `target/msl/baselines/`, and
+falls back to `crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json`
+for offline runs.
 The stage checks are cumulative over the fixed root-example denominator:
 parse/IR-AST, flatten/IR-flat, DAE/IR-DAE, solve/IR-Solve,
 initial-condition solve, and simulation. Increasing an early-stage pass count
@@ -56,14 +60,14 @@ On pull requests, CI also generates
 publishes it as a sticky PR comment. The comment embeds the package pass-rate,
 MLS contract coverage, and OMC trace-accuracy markdown tables so reviewers can
 inspect the MSL gate without downloading artifacts first. Its top summary also
-shows deltas against the committed MSL quality baseline. Forked pull requests
+shows deltas against the resolved MSL quality baseline. Forked pull requests
 receive the uploaded artifacts from the read-only CI run, then a separate
 `workflow_run` publisher comments from the artifact using repository write
 permissions.
 
-When a full run is promoted, use reviewed full-run data and keep the committed
-stage counts conservative enough to absorb compile-timeout jitter. Do not
-promote focused subsets or one-off explicit target files as the baseline.
+When a full main CI run improves every ratcheted metric without regressions, the
+MSL Baseline Ratchet workflow publishes the new baseline to that release asset.
+Do not promote focused subsets or one-off explicit target files as the baseline.
 Promotion requires a full-run snapshot with non-empty `omc_version` metadata.
 
 Focused debugging runs can use `RUMOCA_MSL_SIM_MATCH`,

--- a/spec/SPEC_0025_PR_REVIEW_PROCESS.md
+++ b/spec/SPEC_0025_PR_REVIEW_PROCESS.md
@@ -127,13 +127,13 @@ Rust developer workflow MUST remain Cargo-native.
 |---|---|
 | Run the unified MSL gate for any parser, instantiate, flatten, ToDae, or sim change | One gate produces consistent OMC reference + sim trace + quality artifacts |
 | Run the separate ModelicaTest semantic gate for language-semantics changes when the MSL source-tree `ModelicaTest` package is available | ModelicaTest is an assertion-heavy semantic suite and must not be conflated with the curated MSL example target set |
-| Compare against `crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json` | Baseline is the regression bar |
+| Compare against the resolved MSL quality baseline (`cargo xtask verify msl-parity` downloads the promoted `msl-quality-baseline/msl_quality_baseline.json` release asset and falls back to `crates/rumoca-test-msl/tests/msl_tests/msl_quality_baseline.json` offline) | Baseline is the regression bar |
 | Cumulative MSL stage counts (parse, flatten, DAE, IR-Solve, initial-condition solve, simulation) MUST NOT materially decrease on the fixed root-example baseline denominator; full-library runs may tolerate one-model runner jitter | Early-stage pass-rate increases are always improvements, later stages are compared against their own cumulative counts, and CI/OMC host variance must not block equivalent runs |
 | Balanced / OMC-agreement counts MUST NOT decrease | These are headline correctness and numerical-quality numbers |
 | Focused or limited MSL runs MUST mark quality snapshots as partial and partial snapshots MUST NOT be promoted | Prevents local-debug subsets from becoming the committed release baseline |
-| Trace-quality metrics MUST be gated against the committed baseline when OMC parity data is available | Prevents balanced-but-numerically-worse simulations from passing unnoticed |
+| Trace-quality metrics MUST be gated against the resolved promoted baseline when OMC parity data is available | Prevents balanced-but-numerically-worse simulations from passing unnoticed |
 | Runtime speedup medians (system & wall) MUST NOT regress by > 35% | Tolerates 4-core hosted-runner noise without hiding material regressions |
-| Baseline updates require explicit `cargo xtask repo msl promote-quality-baseline` | Prevents silent baseline drift |
+| Promoted baseline release-asset updates require a successful full main CI run and a non-regressing ratchet decision; checked-in fallback updates remain explicit via `cargo xtask repo msl promote-quality-baseline` | Prevents silent baseline drift |
 | Coverage trim/gate updates follow `cargo xtask coverage {run,report,gate}` workflow | Coverage promotion is explicit only |
 
 ### 5. Code Size Budget
@@ -187,7 +187,7 @@ they are enforced by §4 commands.
 | `cargo clippy --all-features -- -D warnings` | SPEC_0021 maintainability limits |
 | `cargo test --workspace` | All tests including `architecture_hardening_test` (SPEC_0029) and `spec_budget_test` (SPEC_0000 §3) |
 | `cargo doc --no-deps` | Docs build without errors |
-| MSL gate (compiler/sim changes) | `msl_quality_baseline.json` regressions |
+| MSL gate (compiler/sim changes) | resolved `msl_quality_baseline.json` regressions |
 | ModelicaTest semantic gate (semantic compiler/sim changes) | selected `ModelicaTest.*` models compile, simulate, and preserve assertion/parity diagnostics |
 
 ## References


### PR DESCRIPTION
## Summary

Fixes the MSL baseline ratchet failure where the workflow could push a branch but GitHub rejected PR creation with `GitHub Actions is not permitted to create or approve pull requests`.

Instead of opening a PR or writing to `main`, the post-CI ratchet now publishes the improved full-run baseline as a stable GitHub Release asset:

- release tag: `msl-quality-baseline`
- asset: `msl_quality_baseline.json`

`cargo xtask verify msl-parity` downloads that asset automatically for full baseline-relative runs, caches it under `target/msl/baselines/`, and falls back to the checked-in baseline when the asset is unavailable or `--no-remote-quality-baseline` is used.

The CI follow-up split the release-asset baseline resolver into `verify_cmd/msl_quality_baseline.rs`, keeping `verify_cmd.rs` under the SPEC_0021 2,000-line hard limit.

## Spec / MLS Alignment

- Checked SPEC_0018: added CLI flags and the existing fixed config-file handoff; no new environment knob.
- Checked SPEC_0021: split the oversized xtask command file by concern instead of adding an exception.
- Checked SPEC_0025 and updated it for the release-asset baseline flow.
- Checked SPEC_0032: focused/partial MSL runs still cannot promote baselines.
- MLS: not applicable; this is CI/tooling only.

## Risk and Design Notes

Main correctness risk: the ratchet must compare against the currently promoted release asset, not the stale checked-in fallback. The workflow now loads the existing release asset when present and only publishes when the new artifact improves it without regressions.

Main maintenance risk: CI comments and gates could drift if they use different baselines. CI now passes the downloaded baseline to `cargo xtask repo msl pr-comment` when present.

The checked-in JSON remains the offline fallback and can still be updated explicitly with `cargo xtask repo msl promote-quality-baseline`.

## Testing

- `node --test .github/scripts/msl-baseline-ratchet.test.mjs`
- `CARGO_TARGET_DIR=/home/jgoppert/git/rumoca/target cargo test -p xtask msl_parity -- --nocapture`
- `CARGO_TARGET_DIR=/home/jgoppert/git/rumoca/target cargo check --package rumoca-test-msl --features msl-full-test --test msl_tests`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/home/jgoppert/git/rumoca/target cargo clippy -p xtask --all-targets -- -D warnings`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/msl-baseline-ratchet.yml"); YAML.load_file(".github/workflows/ci.yml")'`
- `CARGO_TARGET_DIR=/home/jgoppert/git/rumoca/target cargo clippy --package rumoca-test-msl --features msl-full-test --test msl_tests -- -D warnings`
- `CARGO_TARGET_DIR=/home/jgoppert/git/rumoca/target cargo test -p rumoca --test architecture_hardening_test size_and_validation::span_debt::test_rs_files_stay_under_spec_0021_hard_limit -- --nocapture`
- `CARGO_TARGET_DIR=/home/jgoppert/git/rumoca/target cargo xtask verify lint`

Commands NOT run: full MSL parity, because this change does not alter compiler/simulator behavior and the focused harness compile/clippy checks cover the new config path. The live release upload path can only be exercised by GitHub Actions after merge.

## Code Size Budget

- production_lines_added: 309
- production_lines_deleted: 114
- test_lines_added: 52
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 14
- net_added_lines: 247
