### PR TITLE
fix(ci): restore neural ode branch gates

### DIFF
--- a/crates/rumoca-phase-solve/src/lower/array_values/builtins.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/builtins.rs
@@ -226,32 +226,48 @@ impl<'a> LowerBuilder<'a> {
                 let arg = required_array_builtin_arg(args, function, 1, call_span)?;
                 self.lower_array_like_values(arg, scope, call_depth)
             }
-            function if let Some(op) = unary_array_builtin_op(&function) => {
-                let arg = required_array_builtin_arg(args, function, 0, call_span)?;
-                let span = expression_or_call_span(arg, call_span);
-                let values = self.lower_array_like_values(arg, scope, call_depth)?;
-                let mut lowered = Vec::new();
-                let context = format!("{} array value count", function.name());
-                reserve_reg_capacity(&mut lowered, values.len(), &context, Some(span))?;
-                for value in values {
-                    lowered.push(self.emit_unary_at(op, value, span)?);
-                }
-                Ok(lowered)
-            }
             rumoca_core::BuiltinFunction::Sample if is_array_like_sample_value_form(args) => {
                 let arg = required_array_builtin_arg(args, function, 0, call_span)?;
                 self.lower_array_like_values_in_mode(arg, scope, call_depth, ValueMode::Pre)
             }
-            _ => Err(array_builtin_contract_error(
-                format!(
-                    "{} does not have array-like builtin lowering",
-                    function.name()
-                ),
-                args.first()
-                    .and_then(rumoca_core::Expression::span)
-                    .or_else(|| (!call_span.is_dummy()).then_some(call_span)),
-            )),
+            _ => {
+                if let Some(op) = unary_array_builtin_op(&function) {
+                    return self.lower_unary_builtin_array_like_values(
+                        function, op, args, scope, call_depth, call_span,
+                    );
+                }
+                Err(array_builtin_contract_error(
+                    format!(
+                        "{} does not have array-like builtin lowering",
+                        function.name()
+                    ),
+                    args.first()
+                        .and_then(rumoca_core::Expression::span)
+                        .or_else(|| (!call_span.is_dummy()).then_some(call_span)),
+                ))
+            }
         }
+    }
+
+    fn lower_unary_builtin_array_like_values(
+        &mut self,
+        function: rumoca_core::BuiltinFunction,
+        op: UnaryOp,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+        call_span: rumoca_core::Span,
+    ) -> Result<Vec<Reg>, LowerError> {
+        let arg = required_array_builtin_arg(args, function, 0, call_span)?;
+        let span = expression_or_call_span(arg, call_span);
+        let values = self.lower_array_like_values(arg, scope, call_depth)?;
+        let mut lowered = Vec::new();
+        let context = format!("{} array value count", function.name());
+        reserve_reg_capacity(&mut lowered, values.len(), &context, Some(span))?;
+        for value in values {
+            lowered.push(self.emit_unary_at(op, value, span)?);
+        }
+        Ok(lowered)
     }
 
     fn lower_der_array_like_values(

--- a/crates/rumoca-phase-solve/src/solve_model.rs
+++ b/crates/rumoca-phase-solve/src/solve_model.rs
@@ -319,17 +319,17 @@ fn lower_profiled_solve_problem(
     }
 }
 
-fn lower_profiled_solve_artifacts(
-    problem: &solve::SolveProblem,
+fn profiled_solver_len(
+    dae_model: &dae::Dae,
     state_count: usize,
-    model_span: rumoca_core::Span,
     profile: SolveModelLoweringProfile,
-) -> Result<solve::SolveArtifacts, SolveModelLowerError> {
-    if !profile.needs_solve_artifacts() {
-        return Ok(solve::SolveArtifacts::default());
+) -> Result<usize, SolveModelLowerError> {
+    match profile {
+        SolveModelLoweringProfile::Runtime | SolveModelLoweringProfile::RuntimeValueOnly => {
+            Ok(solver_visible_scalar_count(dae_model)?.max(dae_model.continuous.equations.len()))
+        }
+        SolveModelLoweringProfile::GpuPreparation => Ok(state_count),
     }
-    let mass_matrix = state_identity_mass_matrix(state_count, model_span)?;
-    crate::lower_solve_artifacts_with_mass_matrix(problem, mass_matrix).map_err(Into::into)
 }
 
 fn lower_runtime_visible_outputs(
@@ -397,18 +397,18 @@ fn lower_dae_to_solve_model_inner(
         )?;
         crate::timing::log_stage("model.order_state_derivative_rows", timer);
     }
-    let solver_len = match profile {
-        SolveModelLoweringProfile::Runtime | SolveModelLoweringProfile::RuntimeValueOnly => {
-            solver_visible_scalar_count(&dae_model)?.max(dae_model.continuous.equations.len())
-        }
-        SolveModelLoweringProfile::GpuPreparation => state_count,
-    };
+    let solver_len = profiled_solver_len(&dae_model, state_count, profile)?;
     let model_span = model_provenance_span(&dae_model, metadata_dae_model)?;
     let timer = crate::timing::stage_start();
     let problem = lower_profiled_solve_problem(&dae_model, solver_len, model_span, profile)?;
     crate::timing::log_stage("model.lower_solve_problem", timer);
     let timer = crate::timing::stage_start();
-    let artifacts = lower_profiled_solve_artifacts(&problem, state_count, model_span, profile)?;
+    let artifacts = if profile.needs_solve_artifacts() {
+        let mass_matrix = state_identity_mass_matrix(state_count, model_span)?;
+        crate::lower_solve_artifacts_with_mass_matrix(&problem, mass_matrix)?
+    } else {
+        solve::SolveArtifacts::default()
+    };
     crate::timing::log_stage("model.lower_solve_artifacts", timer);
     let timer = crate::timing::stage_start();
     let mut parameters = compiled_parameter_values(

--- a/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_selection.rs
+++ b/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_selection.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::collections::BTreeSet;
 
 // =============================================================================
 // Focused simulation target selection and subset controls

--- a/crates/xtask/src/vscode_cmd.rs
+++ b/crates/xtask/src/vscode_cmd.rs
@@ -1485,12 +1485,11 @@ fn cargo_target_cc_env_suffix(target: &str) -> String {
 mod tests {
     use super::{
         VscodeMslSmokeSummary, VscodeNpmDependencyMode, VscodeNpmInstallPlan, VscodePackageTarget,
-        VscodeSmokeEnvironment, VscodeSmokeLaunchMode, VscodeSmokeOptions,
-        cargo_target_cc_env_suffix, cargo_target_linker_env_suffix,
-        mirror_cached_vscode_smoke_install, prepare_install_check_workspace, replace_staged_binary,
-        resolve_install_check_document, resolve_install_check_profile_root,
-        resolve_vscode_npm_install_plan, resolve_workspace_dir, select_vscode_smoke_launch_mode,
-        should_copy_vscode_smoke_root_entry, should_install_vscode_smoke_prereqs,
+        VscodeSmokeEnvironment, VscodeSmokeLaunchMode, cargo_target_cc_env_suffix,
+        cargo_target_linker_env_suffix, mirror_cached_vscode_smoke_install,
+        prepare_install_check_workspace, replace_staged_binary, resolve_install_check_document,
+        resolve_install_check_profile_root, resolve_vscode_npm_install_plan, resolve_workspace_dir,
+        select_vscode_smoke_launch_mode, should_copy_vscode_smoke_root_entry,
         should_retry_vscode_npm_ci_after_clean, stage_vscode_smoke_workspace,
     };
     use anyhow::anyhow;


### PR DESCRIPTION
## Summary
- replace unstable if-let match guard in array builtin lowering with stable helper-based lowering
- restore Appendix B solve artifact admission call inside lower_dae_to_solve_model_inner while keeping clippy line budget
- clean unused imports exposed by current branch linting

## Verification
- cargo fmt --check
- cargo clippy -p rumoca-phase-solve --all-targets --all-features -- -D warnings
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p rumoca --test architecture_hardening_test size_and_validation::span_debt::test_rs_files_stay_under_spec_0021_hard_limit -- --exact
- cargo test -p rumoca --test architecture_hardening_test size_and_validation::architecture_boundaries::test_solve_ir_appendix_b_validation_gate_exists -- --exact
- cargo test --workspace --verbose --exclude rumoca-bind-python --exclude rumoca-bind-wasm (environment failed at Docker-backed omc_differential_semantics due local Docker temp mount I/O error after prior tests passed)

Upstream branch push was attempted first but failed with 403 for hechuan9.