### PR TITLE
fix(ci): restore neural ode branch gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,6 +3501,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumoca-opt"
+version = "0.9.9"
+dependencies = [
+ "indexmap",
+ "rumoca",
+ "rumoca-eval-solve",
+ "rumoca-ir-dae",
+ "rumoca-ir-solve",
+ "rumoca-sim",
+ "rumoca-solver",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "rumoca-phase-codegen"
 version = "0.9.9"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/rumoca-input-keyboard",
     "crates/rumoca-solver",
     "crates/rumoca-sim",
+    "crates/rumoca-opt",
     "crates/rumoca-solver-diffsol",
     "crates/rumoca-solver-rk45",
     "crates/rumoca-phase-typecheck",
@@ -96,6 +97,7 @@ rumoca-input-gamepad = { path = "crates/rumoca-input-gamepad" }
 rumoca-input-keyboard = { path = "crates/rumoca-input-keyboard" }
 rumoca-solver = { path = "crates/rumoca-solver" }
 rumoca-sim = { path = "crates/rumoca-sim", default-features = false }
+rumoca-opt = { path = "crates/rumoca-opt" }
 rumoca-solver-diffsol = { path = "crates/rumoca-solver-diffsol" }
 rumoca-solver-rk45 = { path = "crates/rumoca-solver-rk45" }
 rumoca-phase-typecheck = { path = "crates/rumoca-phase-typecheck" }

--- a/crates/rumoca-eval-solve/src/prepared.rs
+++ b/crates/rumoca-eval-solve/src/prepared.rs
@@ -12,6 +12,7 @@ use rumoca_ir_solve::{
 };
 use rumoca_solver::{MatMulKernel, select_matmul_kernel};
 
+use crate::refresh_plan::AlgebraicRefreshRow;
 use crate::{
     EvalSolveError, OutputCursor, PreparedRowEval, RowEvalContext, RowEvalScratch,
     RowInputRequirements, SimulationRuntimeState,
@@ -470,6 +471,13 @@ impl PreparedScalarProgramBlock {
             .is_some_and(|shape| shape.is_some())
     }
 
+    pub(crate) fn row_output_count(&self, row_idx: usize) -> Option<usize> {
+        self.block
+            .programs
+            .get(row_idx)
+            .map(|row| ScalarProgramBlock::program_output_count(row))
+    }
+
     pub fn can_evaluate_target_assignment(&self, row_idx: usize, target_y_index: usize) -> bool {
         let Some(row) = self.block.programs.get(row_idx) else {
             return false;
@@ -499,6 +507,78 @@ impl PreparedScalarProgramBlock {
             validate_inputs: false,
             label: "target_row_unchecked",
         })
+    }
+
+    pub(crate) fn eval_row_outputs_unchecked_with_context(
+        &self,
+        row_idx: usize,
+        y: &[f64],
+        p: &[f64],
+        t: f64,
+        context: RowEvalContext<'_>,
+        out: &mut Vec<f64>,
+    ) -> Result<(), EvalSolveError> {
+        let row = self
+            .block
+            .programs
+            .get(row_idx)
+            .ok_or(EvalSolveError::OutputTooSmall {
+                required: checked_required_row_count(row_idx)?,
+                len: self.block.row_count(),
+                span: self.block.program_span(row_idx),
+            })?;
+        let output_count = ScalarProgramBlock::program_output_count(row);
+        out.resize(output_count, 0.0);
+        out.fill(0.0);
+        let mut scratch = self.scratch.borrow_mut();
+        record_solve_block_eval(
+            "scalar_row_outputs_unchecked",
+            self.block.len(),
+            output_count,
+        );
+        let mut sink = OutputCursor::new(out.as_mut_slice());
+        eval_row_prepared_maybe_fast(
+            PreparedRowEval::new(row, self.row_registers[row_idx], y, p, t, context)
+                .with_source_span(self.block.program_span(row_idx)),
+            self.row_register_safe[row_idx],
+            &mut scratch,
+            &mut sink,
+        )
+        .map_err(|error| error.with_source_span(self.block.program_span(row_idx)))
+    }
+
+    pub(crate) fn apply_target_assignment_rows_unchecked_with_context(
+        &self,
+        rows: &[AlgebraicRefreshRow],
+        y: &mut [f64],
+        p: &[f64],
+        t: f64,
+        context: RowEvalContext<'_>,
+    ) -> Result<(), EvalSolveError> {
+        let local_runtime_state;
+        let context = match context.runtime_state {
+            Some(_) => context,
+            None => {
+                local_runtime_state = SimulationRuntimeState::new();
+                context.with_runtime_state(&local_runtime_state)
+            }
+        };
+        let mut scratch = self.scratch.borrow_mut();
+        record_solve_block_eval("target_rows_batch", self.block.len(), rows.len());
+        for row in rows {
+            let value =
+                self.eval_target_assignment_row_with_scratch(TargetAssignmentScratchRequest {
+                    row_idx: row.row_idx,
+                    target_y_index: row.target_index,
+                    y,
+                    p,
+                    t,
+                    context,
+                    scratch: &mut scratch,
+                })?;
+            y[row.target_index] = value;
+        }
+        Ok(())
     }
 
     fn eval_target_assignment_row_inner(
@@ -572,6 +652,58 @@ impl PreparedScalarProgramBlock {
         Ok(Some(value))
     }
 
+    fn eval_target_assignment_row_with_scratch(
+        &self,
+        request: TargetAssignmentScratchRequest<'_>,
+    ) -> Result<f64, EvalSolveError> {
+        let row =
+            self.block
+                .programs
+                .get(request.row_idx)
+                .ok_or(EvalSolveError::OutputTooSmall {
+                    required: checked_required_row_count(request.row_idx)?,
+                    len: self.block.row_count(),
+                    span: self.block.program_span(request.row_idx),
+                })?;
+        let Some(shape) = self.row_assignment_shapes[request.row_idx] else {
+            return Err(invalid_prepared_row_with_span(
+                "batched target assignment row has no assignment shape",
+                self.block.program_span(request.row_idx),
+            ));
+        };
+        if shape.target_y_index() != request.target_y_index {
+            return Err(invalid_prepared_row_with_span(
+                format!(
+                    "batched target assignment row targets y[{}], not y[{}]",
+                    shape.target_y_index(),
+                    request.target_y_index
+                ),
+                self.block.program_span(request.row_idx),
+            ));
+        }
+        eval_program_single(
+            PreparedRowEval::new(
+                &row[..shape.expr_eval_len()],
+                self.row_registers[request.row_idx],
+                request.y,
+                request.p,
+                request.t,
+                request.context,
+            )
+            .with_source_span(self.block.program_span(request.row_idx)),
+            self.row_register_safe[request.row_idx],
+            &mut *request.scratch,
+        )
+        .map_err(|error| error.with_source_span(self.block.program_span(request.row_idx)))?;
+        shape
+            .eval_value(
+                request.row_idx,
+                &request.scratch.regs,
+                self.block.program_span(request.row_idx),
+            )
+            .map_err(|error| error.with_source_span(self.block.program_span(request.row_idx)))
+    }
+
     fn eval_rows_unchecked(
         &self,
         y: &[f64],
@@ -631,6 +763,16 @@ struct TargetAssignmentRowRequest<'a> {
     context: RowEvalContext<'a>,
     validate_inputs: bool,
     label: &'static str,
+}
+
+struct TargetAssignmentScratchRequest<'a> {
+    row_idx: usize,
+    target_y_index: usize,
+    y: &'a [f64],
+    p: &'a [f64],
+    t: f64,
+    context: RowEvalContext<'a>,
+    scratch: &'a mut RowEvalScratch,
 }
 
 #[derive(Clone, Copy)]

--- a/crates/rumoca-eval-solve/src/refresh_plan.rs
+++ b/crates/rumoca-eval-solve/src/refresh_plan.rs
@@ -343,9 +343,7 @@ fn algebraic_refresh_rows_from_row_targets(
         let Some(position) = output_row_positions.get(&row_idx).copied() else {
             continue;
         };
-        if position.output_offset != 0
-            || !block.can_evaluate_target_assignment(position.program_index, target_index)
-        {
+        if !block.can_evaluate_target_assignment(position.program_index, target_index) {
             continue;
         }
         reserve_refresh_index_set_capacity(&mut claimed_targets, 1, "claimed row targets", span)?;

--- a/crates/rumoca-eval-solve/src/runtime.rs
+++ b/crates/rumoca-eval-solve/src/runtime.rs
@@ -24,6 +24,7 @@ use crate::{
 mod event_update;
 mod initial_event;
 mod plans;
+mod refresh_batch;
 mod sensitivity;
 mod support;
 use event_update::{DiscretePreSnapshot, DiscreteRowsSettleInput, EventEvalParamCache};
@@ -729,10 +730,37 @@ impl SolveRuntime {
         solver_y: &mut [f64],
         params: &[f64],
     ) -> Result<(), RuntimeSolveError> {
-        for refresh_row in plan {
+        if self.can_batch_assignment_refresh(plan) {
+            return self
+                .implicit_scalar_rhs
+                .apply_target_assignment_rows_unchecked_with_context(
+                    plan,
+                    solver_y,
+                    params,
+                    t,
+                    self.row_eval_context(),
+                )
+                .map_err(Into::into);
+        }
+        let mut row_outputs = Vec::new();
+        let mut row_pos = 0usize;
+        while row_pos < plan.len() {
+            if let Some(next_pos) = self.try_refresh_shapeless_output_segment(
+                plan,
+                row_pos,
+                t,
+                solver_y,
+                params,
+                &mut row_outputs,
+            )? {
+                row_pos = next_pos;
+                continue;
+            }
+            let refresh_row = &plan[row_pos];
             let index = refresh_row.target_index;
             let value = self.eval_refresh_row(refresh_row, t, solver_y, params)?;
             solver_y[index] = value;
+            row_pos += 1;
         }
         Ok(())
     }

--- a/crates/rumoca-eval-solve/src/runtime/refresh_batch.rs
+++ b/crates/rumoca-eval-solve/src/runtime/refresh_batch.rs
@@ -1,0 +1,79 @@
+use rumoca_solver::RuntimeSolveError;
+
+use crate::refresh_plan::AlgebraicRefreshRow;
+use crate::runtime::SolveRuntime;
+
+impl SolveRuntime {
+    pub(super) fn try_refresh_shapeless_output_segment(
+        &self,
+        plan: &[AlgebraicRefreshRow],
+        start: usize,
+        t: f64,
+        solver_y: &mut [f64],
+        params: &[f64],
+        row_outputs: &mut Vec<f64>,
+    ) -> Result<Option<usize>, RuntimeSolveError> {
+        let first = &plan[start];
+        let Some(output_count) = self.implicit_scalar_rhs.row_output_count(first.row_idx) else {
+            return Ok(None);
+        };
+        if output_count <= 1 || !self.can_batch_shapeless_output_refresh(first) {
+            return Ok(None);
+        }
+        let row_idx = first.row_idx;
+        let mut end = start + 1;
+        while end < plan.len()
+            && plan[end].row_idx == row_idx
+            && self.can_batch_shapeless_output_refresh(&plan[end])
+        {
+            end += 1;
+        }
+        self.implicit_scalar_rhs
+            .eval_row_outputs_unchecked_with_context(
+                row_idx,
+                solver_y,
+                params,
+                t,
+                self.row_eval_context(),
+                row_outputs,
+            )?;
+        for refresh_row in &plan[start..end] {
+            let Some(value) = row_outputs.get(refresh_row.output_offset).copied() else {
+                return Err(RuntimeSolveError::solve_ir(format!(
+                    "refresh row {} requested output offset {} from {} outputs",
+                    refresh_row.row_idx,
+                    refresh_row.output_offset,
+                    row_outputs.len()
+                )));
+            };
+            if !value.is_finite() {
+                return Err(self.non_finite_value_error(refresh_row.target_index, value));
+            }
+            solver_y[refresh_row.target_index] = value;
+        }
+        Ok(Some(end))
+    }
+
+    pub(super) fn can_batch_assignment_refresh(&self, plan: &[AlgebraicRefreshRow]) -> bool {
+        plan.iter().all(|row| {
+            row.assignment_target == Some(row.target_index)
+                && row.output_offset == 0
+                && self
+                    .implicit_scalar_rhs
+                    .row_has_assignment_shape(row.row_idx)
+                && self
+                    .implicit_scalar_rhs
+                    .can_evaluate_target_assignment(row.row_idx, row.target_index)
+        })
+    }
+
+    fn can_batch_shapeless_output_refresh(&self, row: &AlgebraicRefreshRow) -> bool {
+        row.assignment_target == Some(row.target_index)
+            && !self
+                .implicit_scalar_rhs
+                .row_has_assignment_shape(row.row_idx)
+            && !self
+                .implicit_scalar_rhs
+                .row_reads_y(row.row_idx, row.target_index)
+    }
+}

--- a/crates/rumoca-eval-solve/src/runtime/sensitivity.rs
+++ b/crates/rumoca-eval-solve/src/runtime/sensitivity.rs
@@ -578,6 +578,11 @@ impl SolveRuntime {
                     ..self.row_eval_context()
                 },
             )
-            .map_err(Into::into)
+            .map_err(|err| {
+                RuntimeSolveError::solve_ir(format!(
+                    "implicit Jacobian seed row {} output {} failed: {err}",
+                    row.row_idx, row.output_offset
+                ))
+            })
     }
 }

--- a/crates/rumoca-eval-solve/src/runtime/tests.rs
+++ b/crates/rumoca-eval-solve/src/runtime/tests.rs
@@ -165,6 +165,81 @@ fn refresh_plan_accepts_scaled_affine_residual_target() {
 }
 
 #[test]
+fn refresh_once_batches_shapeless_multi_output_assignment_program() {
+    let mut model = solve::SolveModel::default();
+    model.problem.solve_layout.state_scalar_count = 1;
+    model.problem.solve_layout.algebraic_scalar_count = 2;
+    model.problem.solve_layout.solver_maps.names =
+        vec!["x".to_string(), "a".to_string(), "b".to_string()];
+    model.problem.continuous.implicit_rhs =
+        solve::ComputeBlock::from_scalar_program_block(multi_output_assignment_block());
+    model.problem.continuous.implicit_row_targets = vec![
+        Some(solve::scalar_slot_y(0)),
+        Some(solve::scalar_slot_y(1)),
+        Some(solve::scalar_slot_y(2)),
+    ];
+
+    let runtime = SolveRuntime::new(&model).expect("runtime should prepare");
+
+    assert_eq!(runtime.algebraic_refresh.rows.len(), 2);
+    assert_eq!(runtime.algebraic_refresh.rows[0].row_idx, 1);
+    assert_eq!(runtime.algebraic_refresh.rows[0].output_offset, 0);
+    assert_eq!(runtime.algebraic_refresh.rows[1].row_idx, 1);
+    assert_eq!(runtime.algebraic_refresh.rows[1].output_offset, 1);
+
+    let mut solver_y = vec![5.0, 0.0, 0.0];
+    runtime
+        .refresh_algebraic_and_output_slots(0.0, &mut solver_y, &[], 1.0e-9, 4)
+        .expect("multi-output refresh should update both targets");
+
+    assert_eq!(solver_y, vec![5.0, 10.0, 20.0]);
+}
+
+#[test]
+fn batched_assignment_refresh_preserves_row_order_dependencies() {
+    let model = solve::SolveModel {
+        problem: solve::SolveProblem {
+            solve_layout: solve::SolveLayout {
+                solver_maps: solve::SolverNameIndexMaps {
+                    names: vec!["x".to_string(), "a".to_string(), "b".to_string()],
+                    ..Default::default()
+                },
+                state_scalar_count: 1,
+                algebraic_scalar_count: 2,
+                ..Default::default()
+            },
+            continuous: solve::ContinuousSolveSystem {
+                implicit_rhs: solve::ComputeBlock::from_scalar_program_block(spanned_block(
+                    vec![
+                        derivative_placeholder_row(0),
+                        add_assignment_residual_row(1, 0, 2.0),
+                        scale_assignment_residual_row(2, 1, 3.0),
+                    ],
+                    "batched_assignment_refresh.mo",
+                )),
+                implicit_row_targets: vec![
+                    Some(solve::scalar_slot_y(0)),
+                    Some(solve::scalar_slot_y(1)),
+                    Some(solve::scalar_slot_y(2)),
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        initial_y: vec![1.0, 0.0, 0.0],
+        ..Default::default()
+    };
+    let runtime = SolveRuntime::new(&model).expect("runtime should prepare");
+    let mut solver_y = model.initial_y.clone();
+
+    runtime
+        .refresh_algebraic_and_output_slots(0.0, &mut solver_y, &[], 1.0e-12, 4)
+        .expect("batched assignment refresh should evaluate");
+
+    assert_eq!(solver_y, vec![1.0, 3.0, 9.0]);
+}
+
+#[test]
 fn refresh_plan_accepts_direct_affine_residual_target() {
     let model = solve::SolveModel {
         problem: solve::SolveProblem {
@@ -605,6 +680,66 @@ fn assignment_residual_row() -> Vec<solve::LinearOp> {
     ]
 }
 
+fn add_assignment_residual_row(target: usize, source: usize, offset: f64) -> Vec<solve::LinearOp> {
+    vec![
+        solve::LinearOp::LoadY {
+            dst: 0,
+            index: target,
+        },
+        solve::LinearOp::LoadY {
+            dst: 1,
+            index: source,
+        },
+        solve::LinearOp::Const {
+            dst: 2,
+            value: offset,
+        },
+        solve::LinearOp::Binary {
+            dst: 3,
+            op: solve::BinaryOp::Add,
+            lhs: 1,
+            rhs: 2,
+        },
+        solve::LinearOp::Binary {
+            dst: 4,
+            op: solve::BinaryOp::Sub,
+            lhs: 0,
+            rhs: 3,
+        },
+        solve::LinearOp::StoreOutput { src: 4 },
+    ]
+}
+
+fn scale_assignment_residual_row(target: usize, source: usize, scale: f64) -> Vec<solve::LinearOp> {
+    vec![
+        solve::LinearOp::LoadY {
+            dst: 0,
+            index: target,
+        },
+        solve::LinearOp::LoadY {
+            dst: 1,
+            index: source,
+        },
+        solve::LinearOp::Const {
+            dst: 2,
+            value: scale,
+        },
+        solve::LinearOp::Binary {
+            dst: 3,
+            op: solve::BinaryOp::Mul,
+            lhs: 1,
+            rhs: 2,
+        },
+        solve::LinearOp::Binary {
+            dst: 4,
+            op: solve::BinaryOp::Sub,
+            lhs: 0,
+            rhs: 3,
+        },
+        solve::LinearOp::StoreOutput { src: 4 },
+    ]
+}
+
 fn scaled_assignment_residual_row() -> Vec<solve::LinearOp> {
     vec![
         solve::LinearOp::LoadP { dst: 0, index: 0 },
@@ -629,6 +764,35 @@ fn scaled_assignment_residual_row() -> Vec<solve::LinearOp> {
         },
         solve::LinearOp::StoreOutput { src: 5 },
     ]
+}
+
+fn multi_output_assignment_block() -> solve::ScalarProgramBlock {
+    solve::ScalarProgramBlock::with_output_indices(
+        vec![
+            vec![
+                solve::LinearOp::LoadY { dst: 0, index: 0 },
+                solve::LinearOp::StoreOutput { src: 0 },
+            ],
+            vec![
+                solve::LinearOp::Const {
+                    dst: 0,
+                    value: 10.0,
+                },
+                solve::LinearOp::StoreOutput { src: 0 },
+                solve::LinearOp::Const {
+                    dst: 1,
+                    value: 20.0,
+                },
+                solve::LinearOp::StoreOutput { src: 1 },
+            ],
+        ],
+        vec![
+            test_span("multi_output_assignment.mo"),
+            test_span("multi_output_assignment.mo"),
+        ],
+        vec![0, 1, 2],
+    )
+    .expect("multi-output assignment fixture should be valid")
 }
 
 fn const_visible_value_row(value: f64) -> Vec<solve::LinearOp> {

--- a/crates/rumoca-opt/Cargo.toml
+++ b/crates/rumoca-opt/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rumoca-opt"
+description = "Optimization and training APIs over Rumoca differentiable Solve IR"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+indexmap = { workspace = true }
+rumoca-eval-solve = { workspace = true }
+rumoca-ir-dae = { workspace = true }
+rumoca-ir-solve = { workspace = true }
+rumoca-sim = { workspace = true, features = ["native-solvers"] }
+rumoca-solver = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+rumoca = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rumoca-opt/src/error.rs
+++ b/crates/rumoca-opt/src/error.rs
@@ -1,0 +1,42 @@
+use thiserror::Error;
+
+/// Error returned by optimization and backpropagation APIs.
+#[derive(Debug, Error)]
+pub enum OptError {
+    #[error("failed to lower model for optimization: {0}")]
+    Lowering(String),
+    #[error("failed to build differentiable runtime: {0}")]
+    Runtime(String),
+    #[error("unknown trainable parameter `{name}`; available trainables: {available}")]
+    UnknownTrainable { name: String, available: String },
+    #[error("no trainable parameters selected")]
+    EmptyTrainableSet,
+    #[error("{what} length mismatch: got {got}, expected {expected}")]
+    LengthMismatch {
+        what: &'static str,
+        got: usize,
+        expected: usize,
+    },
+    #[error("gradient mode `{mode}` is unsupported for this model: {reason}")]
+    UnsupportedGradientMode { mode: &'static str, reason: String },
+    #[error("non-finite optimization value in `{what}`: {value}")]
+    NonFinite { what: &'static str, value: f64 },
+}
+
+impl From<rumoca_sim::SimulationDiagnosticError> for OptError {
+    fn from(value: rumoca_sim::SimulationDiagnosticError) -> Self {
+        Self::Lowering(value.to_string())
+    }
+}
+
+impl From<rumoca_eval_solve::EvalSolveError> for OptError {
+    fn from(value: rumoca_eval_solve::EvalSolveError) -> Self {
+        Self::Runtime(value.to_string())
+    }
+}
+
+impl From<rumoca_solver::RuntimeSolveError> for OptError {
+    fn from(value: rumoca_solver::RuntimeSolveError) -> Self {
+        Self::Runtime(value.to_string())
+    }
+}

--- a/crates/rumoca-opt/src/lib.rs
+++ b/crates/rumoca-opt/src/lib.rs
@@ -1,0 +1,20 @@
+//! Optimization and training APIs over Rumoca's differentiable Solve runtime.
+//!
+//! This crate does not extend Modelica semantics. Modelica still describes the
+//! model; optimization code describes trainables, objectives, and update rules
+//! over a compiled differentiable model.
+
+mod error;
+mod model;
+mod objective;
+mod optimizer;
+
+pub use error::OptError;
+pub use model::{DifferentiableModel, OptOptions, TrainableParameter, TrainableSet};
+pub use objective::{
+    GradientMode, GradientReport, GradientStrategy, RhsMseObjective, rhs_mse_value_and_gradient,
+};
+pub use optimizer::{GradientDescent, OptimizationReport, OptimizationStep};
+
+#[cfg(test)]
+mod tests;

--- a/crates/rumoca-opt/src/model.rs
+++ b/crates/rumoca-opt/src/model.rs
@@ -1,0 +1,251 @@
+use crate::OptError;
+use indexmap::IndexMap;
+use rumoca_ir_dae as dae;
+use rumoca_ir_solve as solve;
+use rumoca_solver::SimOptions;
+
+/// Runtime and numerical options used by optimization APIs.
+#[derive(Debug, Clone, Copy)]
+pub struct OptOptions {
+    /// Algebraic projection tolerance used while evaluating gradients.
+    pub settle_tol: f64,
+    /// Maximum algebraic projection iterations used while evaluating gradients.
+    pub settle_max_iters: usize,
+}
+
+impl Default for OptOptions {
+    fn default() -> Self {
+        Self {
+            settle_tol: 1.0e-10,
+            settle_max_iters: 64,
+        }
+    }
+}
+
+impl OptOptions {
+    pub(crate) fn settle(self) -> rumoca_eval_solve::AlgebraicSettle {
+        rumoca_eval_solve::AlgebraicSettle {
+            tol: self.settle_tol,
+            max_iters: self.settle_max_iters,
+        }
+    }
+}
+
+/// One scalar trainable parameter in the lowered Solve parameter vector.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrainableParameter {
+    /// Human-readable parameter name.
+    pub name: String,
+    /// Slot in the runtime `p[]` vector.
+    pub slot: usize,
+}
+
+/// Selected trainable parameters for an optimization pass.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrainableSet {
+    entries: Vec<TrainableParameter>,
+}
+
+impl TrainableSet {
+    /// Select every model parameter exposed by the differentiable model.
+    pub fn all(model: &DifferentiableModel) -> Result<Self, OptError> {
+        Self::from_entries(model.parameter_slots().to_vec())
+    }
+
+    /// Select trainables by exact lowered parameter names.
+    pub fn by_names(model: &DifferentiableModel, names: &[&str]) -> Result<Self, OptError> {
+        let entries = names
+            .iter()
+            .map(|name| model.parameter_by_name(name))
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::from_entries(entries)
+    }
+
+    /// Selected scalar parameters in deterministic slot order.
+    pub fn entries(&self) -> &[TrainableParameter] {
+        &self.entries
+    }
+
+    /// Number of selected scalar parameters.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// True when no trainables are selected.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn from_entries(mut entries: Vec<TrainableParameter>) -> Result<Self, OptError> {
+        entries.sort_by_key(|entry| entry.slot);
+        entries.dedup_by_key(|entry| entry.slot);
+        if entries.is_empty() {
+            return Err(OptError::EmptyTrainableSet);
+        }
+        Ok(Self { entries })
+    }
+}
+
+/// A compiled, lowered, differentiable model with mutable parameter values.
+pub struct DifferentiableModel {
+    runtime: rumoca_eval_solve::SolveRuntime,
+    state: Vec<f64>,
+    params: Vec<f64>,
+    parameters: Vec<TrainableParameter>,
+    options: OptOptions,
+}
+
+impl DifferentiableModel {
+    /// Lower a DAE model once and prepare the differentiable runtime.
+    pub fn from_dae(
+        dae_model: &dae::Dae,
+        sim_options: &SimOptions,
+        opt_options: OptOptions,
+    ) -> Result<Self, OptError> {
+        let solve_model = rumoca_sim::lower_for_simulation_with_overrides(dae_model, sim_options)?;
+        let state = solve_model.initial_y[..solve_model.state_scalar_count()].to_vec();
+        let params = solve_model.parameters.clone();
+        let parameters = collect_model_parameter_slots(&solve_model);
+        let runtime = rumoca_eval_solve::SolveRuntime::new(&solve_model)?;
+        Ok(Self {
+            runtime,
+            state,
+            params,
+            parameters,
+            options: opt_options,
+        })
+    }
+
+    /// Lower a DAE model with default optimization options.
+    pub fn from_dae_default(
+        dae_model: &dae::Dae,
+        sim_options: &SimOptions,
+    ) -> Result<Self, OptError> {
+        Self::from_dae(dae_model, sim_options, OptOptions::default())
+    }
+
+    /// State names in solver state order.
+    pub fn state_names(&self) -> &[String] {
+        &self.runtime.model.problem.solve_layout.solver_maps.names[..self.runtime.state_count]
+    }
+
+    /// Current state vector used for objective evaluation.
+    pub fn state(&self) -> &[f64] {
+        &self.state
+    }
+
+    /// Replace the current state vector.
+    pub fn set_state(&mut self, state: &[f64]) -> Result<(), OptError> {
+        if state.len() != self.state.len() {
+            return Err(OptError::LengthMismatch {
+                what: "state",
+                got: state.len(),
+                expected: self.state.len(),
+            });
+        }
+        self.state.copy_from_slice(state);
+        Ok(())
+    }
+
+    /// Exposed model-parameter slots.
+    pub fn parameter_slots(&self) -> &[TrainableParameter] {
+        &self.parameters
+    }
+
+    /// Current runtime parameter vector.
+    pub fn parameters(&self) -> &[f64] {
+        &self.params
+    }
+
+    /// Set one model parameter by exact lowered name.
+    pub fn set_parameter_value(&mut self, name: &str, value: f64) -> Result<(), OptError> {
+        let parameter = self.parameter_by_name(name)?;
+        self.params[parameter.slot] = value;
+        Ok(())
+    }
+
+    /// Current value of one model parameter by exact lowered name.
+    pub fn parameter_value(&self, name: &str) -> Result<f64, OptError> {
+        let parameter = self.parameter_by_name(name)?;
+        Ok(self.params[parameter.slot])
+    }
+
+    /// Evaluate `der(state)` at the model's current state and parameters.
+    pub fn eval_rhs(&self, t: f64) -> Result<Vec<f64>, OptError> {
+        self.runtime
+            .eval_state_derivatives(
+                t,
+                &self.state,
+                &self.params,
+                self.options.settle_tol,
+                self.options.settle_max_iters,
+            )
+            .map_err(Into::into)
+    }
+
+    /// True when reverse-mode derivative VJP is exact for this model.
+    pub fn supports_rhs_reverse_vjp(&self) -> bool {
+        self.runtime.solver_count == self.runtime.state_count
+    }
+
+    pub(crate) fn runtime(&self) -> &rumoca_eval_solve::SolveRuntime {
+        &self.runtime
+    }
+
+    pub(crate) fn params_mut(&mut self) -> &mut [f64] {
+        &mut self.params
+    }
+
+    pub(crate) fn linearization(&self, t: f64) -> rumoca_eval_solve::AlgebraicLinearization<'_> {
+        rumoca_eval_solve::AlgebraicLinearization {
+            t,
+            params: &self.params,
+            settle: self.options.settle(),
+        }
+    }
+
+    pub(crate) fn parameter_by_name(&self, name: &str) -> Result<TrainableParameter, OptError> {
+        self.parameters
+            .iter()
+            .find(|parameter| parameter.name == name)
+            .cloned()
+            .ok_or_else(|| OptError::UnknownTrainable {
+                name: name.to_string(),
+                available: available_trainables(&self.parameters),
+            })
+    }
+}
+
+fn available_trainables(parameters: &[TrainableParameter]) -> String {
+    parameters
+        .iter()
+        .map(|parameter| parameter.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn collect_model_parameter_slots(model: &solve::SolveModel) -> Vec<TrainableParameter> {
+    let n = model.problem.layout.p_scalars();
+    let mut by_slot: Vec<Option<String>> = vec![None; n];
+    write_binding_parameter_slots(model.problem.layout.bindings(), &mut by_slot);
+    by_slot
+        .into_iter()
+        .enumerate()
+        .filter_map(|(slot, name)| name.map(|name| TrainableParameter { name, slot }))
+        .collect()
+}
+
+fn write_binding_parameter_slots(
+    bindings: &IndexMap<String, solve::ScalarSlot>,
+    by_slot: &mut [Option<String>],
+) {
+    for (name, slot) in bindings {
+        if let solve::ScalarSlot::P { index, .. } = slot
+            && *index < by_slot.len()
+            && !name.starts_with("__")
+            && by_slot[*index].is_none()
+        {
+            by_slot[*index] = Some(name.clone());
+        }
+    }
+}

--- a/crates/rumoca-opt/src/objective.rs
+++ b/crates/rumoca-opt/src/objective.rs
@@ -1,0 +1,238 @@
+use crate::{DifferentiableModel, OptError, TrainableSet};
+use std::collections::HashMap;
+
+/// Gradient calculation strategy for an objective.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GradientMode {
+    /// Prefer reverse-mode VJP when exact for the model, otherwise use forward AD.
+    Auto,
+    /// Use reverse-mode VJP of the derivative RHS.
+    Reverse,
+    /// Use forward-mode parameter Jacobian columns.
+    Forward,
+}
+
+/// Concrete strategy used for a gradient report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GradientStrategy {
+    /// Reverse-mode VJP over the derivative RHS.
+    ReverseVjp,
+    /// Forward-mode parameter Jacobian.
+    ForwardJacobian,
+}
+
+/// Mean-squared-error target for a model RHS value.
+#[derive(Debug, Clone)]
+pub struct RhsMseObjective {
+    /// Evaluation time.
+    pub t: f64,
+    /// Target derivative values, aligned with model state order.
+    pub target_derivatives: Vec<f64>,
+}
+
+impl RhsMseObjective {
+    /// Create an RHS MSE objective evaluated at time `t`.
+    pub fn new(t: f64, target_derivatives: Vec<f64>) -> Self {
+        Self {
+            t,
+            target_derivatives,
+        }
+    }
+}
+
+/// Objective value and gradient for a selected trainable set.
+#[derive(Debug, Clone)]
+pub struct GradientReport {
+    /// Scalar objective value.
+    pub loss: f64,
+    /// Strategy used to assemble the gradient.
+    pub strategy: GradientStrategy,
+    /// Trainable names aligned with `gradients`.
+    pub trainable_names: Vec<String>,
+    /// Parameter slots aligned with `gradients`.
+    pub trainable_slots: Vec<usize>,
+    /// `d(loss)/d(trainable_i)`.
+    pub gradients: Vec<f64>,
+    /// Primal RHS value used to evaluate the loss.
+    pub rhs: Vec<f64>,
+}
+
+/// Evaluate RHS MSE and `d(loss)/d(trainables)` for the current model point.
+pub fn rhs_mse_value_and_gradient(
+    model: &DifferentiableModel,
+    objective: &RhsMseObjective,
+    trainables: &TrainableSet,
+    mode: GradientMode,
+) -> Result<GradientReport, OptError> {
+    let rhs = model.eval_rhs(objective.t)?;
+    validate_target_len(&rhs, objective)?;
+    let residual = residual(&rhs, &objective.target_derivatives);
+    let loss = mse_loss(&residual)?;
+    let cotangents = loss_cotangents(&residual);
+    let strategy = select_strategy(model, mode)?;
+    let gradients = match strategy {
+        GradientStrategy::ReverseVjp => {
+            reverse_gradients(model, objective.t, trainables, &cotangents)?
+        }
+        GradientStrategy::ForwardJacobian => {
+            forward_gradients(model, objective.t, trainables, &cotangents)?
+        }
+    };
+    Ok(report(loss, strategy, trainables, gradients, rhs))
+}
+
+fn validate_target_len(rhs: &[f64], objective: &RhsMseObjective) -> Result<(), OptError> {
+    if rhs.len() != objective.target_derivatives.len() {
+        return Err(OptError::LengthMismatch {
+            what: "target derivative",
+            got: objective.target_derivatives.len(),
+            expected: rhs.len(),
+        });
+    }
+    Ok(())
+}
+
+fn residual(rhs: &[f64], target: &[f64]) -> Vec<f64> {
+    rhs.iter()
+        .zip(target)
+        .map(|(value, target)| value - target)
+        .collect()
+}
+
+fn mse_loss(residual: &[f64]) -> Result<f64, OptError> {
+    let n = residual.len().max(1) as f64;
+    let loss = residual.iter().map(|value| value * value).sum::<f64>() / (2.0 * n);
+    finite("loss", loss)?;
+    Ok(loss)
+}
+
+fn loss_cotangents(residual: &[f64]) -> Vec<f64> {
+    let n = residual.len().max(1) as f64;
+    residual.iter().map(|value| value / n).collect()
+}
+
+fn select_strategy(
+    model: &DifferentiableModel,
+    mode: GradientMode,
+) -> Result<GradientStrategy, OptError> {
+    match mode {
+        GradientMode::Auto if model.supports_rhs_reverse_vjp() => Ok(GradientStrategy::ReverseVjp),
+        GradientMode::Auto => Ok(GradientStrategy::ForwardJacobian),
+        GradientMode::Reverse if model.supports_rhs_reverse_vjp() => {
+            Ok(GradientStrategy::ReverseVjp)
+        }
+        GradientMode::Reverse => Err(OptError::UnsupportedGradientMode {
+            mode: "reverse",
+            reason: "derivative RHS reverse VJP is exact only for pure ODE models today"
+                .to_string(),
+        }),
+        GradientMode::Forward => Ok(GradientStrategy::ForwardJacobian),
+    }
+}
+
+fn reverse_gradients(
+    model: &DifferentiableModel,
+    t: f64,
+    trainables: &TrainableSet,
+    cotangents: &[f64],
+) -> Result<Vec<f64>, OptError> {
+    let p_scalars = model.runtime().model.problem.layout.p_scalars();
+    let mut vjp = vec![0.0; model.runtime().solver_count + p_scalars];
+    model.runtime().reverse_state_derivative_vjp(
+        model.linearization(t),
+        model.state(),
+        cotangents,
+        &mut vjp,
+    )?;
+    Ok(trainables
+        .entries()
+        .iter()
+        .map(|trainable| vjp[model.runtime().solver_count + trainable.slot])
+        .collect())
+}
+
+fn forward_gradients(
+    model: &DifferentiableModel,
+    t: f64,
+    trainables: &TrainableSet,
+    cotangents: &[f64],
+) -> Result<Vec<f64>, OptError> {
+    let report = model.runtime().eval_parameter_jacobian(
+        t,
+        model.state(),
+        model.parameters(),
+        model.linearization(t).settle,
+    );
+    if let Some(error) = report.error {
+        return Err(OptError::Runtime(error));
+    }
+    let columns = parameter_columns_by_slot(&report);
+    trainables
+        .entries()
+        .iter()
+        .map(|trainable| gradient_for_slot(&report.matrix, cotangents, &columns, trainable.slot))
+        .collect()
+}
+
+fn parameter_columns_by_slot(
+    report: &rumoca_eval_solve::ParameterJacobianReport,
+) -> HashMap<usize, usize> {
+    report
+        .param_slots
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(column, slot)| (slot, column))
+        .collect()
+}
+
+fn gradient_for_slot(
+    matrix: &[Vec<f64>],
+    cotangents: &[f64],
+    columns: &HashMap<usize, usize>,
+    slot: usize,
+) -> Result<f64, OptError> {
+    let Some(&column) = columns.get(&slot) else {
+        return Ok(0.0);
+    };
+    let value = cotangents
+        .iter()
+        .zip(matrix)
+        .map(|(cotangent, row)| cotangent * row[column])
+        .sum::<f64>();
+    finite("gradient", value)?;
+    Ok(value)
+}
+
+fn report(
+    loss: f64,
+    strategy: GradientStrategy,
+    trainables: &TrainableSet,
+    gradients: Vec<f64>,
+    rhs: Vec<f64>,
+) -> GradientReport {
+    GradientReport {
+        loss,
+        strategy,
+        trainable_names: trainables
+            .entries()
+            .iter()
+            .map(|trainable| trainable.name.clone())
+            .collect(),
+        trainable_slots: trainables
+            .entries()
+            .iter()
+            .map(|trainable| trainable.slot)
+            .collect(),
+        gradients,
+        rhs,
+    }
+}
+
+fn finite(what: &'static str, value: f64) -> Result<(), OptError> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(OptError::NonFinite { what, value })
+    }
+}

--- a/crates/rumoca-opt/src/optimizer.rs
+++ b/crates/rumoca-opt/src/optimizer.rs
@@ -1,0 +1,136 @@
+use crate::{
+    DifferentiableModel, GradientMode, GradientReport, OptError, RhsMseObjective, TrainableSet,
+    rhs_mse_value_and_gradient,
+};
+
+/// Basic gradient-descent optimizer for model fitting and training smoke tests.
+#[derive(Debug, Clone, Copy)]
+pub struct GradientDescent {
+    /// Positive parameter update scale.
+    pub learning_rate: f64,
+    /// Number of optimization steps to run.
+    pub steps: usize,
+    /// Gradient implementation to use.
+    pub gradient_mode: GradientMode,
+}
+
+impl GradientDescent {
+    /// Create gradient descent with an explicit step count.
+    pub fn new(learning_rate: f64, steps: usize) -> Self {
+        Self {
+            learning_rate,
+            steps,
+            gradient_mode: GradientMode::Auto,
+        }
+    }
+
+    /// Set the gradient implementation.
+    pub fn with_gradient_mode(mut self, mode: GradientMode) -> Self {
+        self.gradient_mode = mode;
+        self
+    }
+
+    /// Fit trainable parameters against an RHS MSE objective.
+    pub fn optimize_rhs_mse(
+        self,
+        model: &mut DifferentiableModel,
+        objective: &RhsMseObjective,
+        trainables: &TrainableSet,
+    ) -> Result<OptimizationReport, OptError> {
+        validate_learning_rate(self.learning_rate)?;
+        let mut steps = Vec::with_capacity(self.steps.saturating_add(1));
+        steps.push(step_report(
+            0,
+            model,
+            objective,
+            trainables,
+            self.gradient_mode,
+        )?);
+        for index in 1..=self.steps {
+            let previous = steps
+                .last()
+                .expect("initial step report was pushed before optimization");
+            apply_gradient_step(model, trainables, &previous.gradient, self.learning_rate)?;
+            steps.push(step_report(
+                index,
+                model,
+                objective,
+                trainables,
+                self.gradient_mode,
+            )?);
+        }
+        Ok(OptimizationReport { steps })
+    }
+}
+
+/// Per-iteration optimizer state.
+#[derive(Debug, Clone)]
+pub struct OptimizationStep {
+    /// Zero-based iteration index. Step 0 is the initial point.
+    pub index: usize,
+    /// Objective and gradient report at this step.
+    pub gradient: GradientReport,
+}
+
+/// Complete optimizer history.
+#[derive(Debug, Clone)]
+pub struct OptimizationReport {
+    /// Initial step plus every post-update step.
+    pub steps: Vec<OptimizationStep>,
+}
+
+impl OptimizationReport {
+    /// Initial objective value.
+    pub fn initial_loss(&self) -> Option<f64> {
+        self.steps.first().map(|step| step.gradient.loss)
+    }
+
+    /// Final objective value.
+    pub fn final_loss(&self) -> Option<f64> {
+        self.steps.last().map(|step| step.gradient.loss)
+    }
+}
+
+fn validate_learning_rate(learning_rate: f64) -> Result<(), OptError> {
+    if learning_rate.is_finite() && learning_rate > 0.0 {
+        Ok(())
+    } else {
+        Err(OptError::NonFinite {
+            what: "learning_rate",
+            value: learning_rate,
+        })
+    }
+}
+
+fn step_report(
+    index: usize,
+    model: &DifferentiableModel,
+    objective: &RhsMseObjective,
+    trainables: &TrainableSet,
+    gradient_mode: GradientMode,
+) -> Result<OptimizationStep, OptError> {
+    Ok(OptimizationStep {
+        index,
+        gradient: rhs_mse_value_and_gradient(model, objective, trainables, gradient_mode)?,
+    })
+}
+
+fn apply_gradient_step(
+    model: &mut DifferentiableModel,
+    trainables: &TrainableSet,
+    report: &GradientReport,
+    learning_rate: f64,
+) -> Result<(), OptError> {
+    if report.gradients.len() != trainables.len() {
+        return Err(OptError::LengthMismatch {
+            what: "gradient",
+            got: report.gradients.len(),
+            expected: trainables.len(),
+        });
+    }
+    for (trainable, gradient) in trainables.entries().iter().zip(&report.gradients) {
+        let slot = trainable.slot;
+        model.params_mut()[slot] -= learning_rate * gradient;
+    }
+    Ok(())
+}

--- a/crates/rumoca-opt/src/tests.rs
+++ b/crates/rumoca-opt/src/tests.rs
@@ -1,0 +1,86 @@
+use crate::{
+    DifferentiableModel, GradientDescent, GradientMode, GradientStrategy, RhsMseObjective,
+    TrainableSet, rhs_mse_value_and_gradient,
+};
+use rumoca::Compiler;
+use rumoca_solver::SimOptions;
+
+const LINEAR_FIT: &str = r#"
+model LinearFit
+  parameter Real a = 0.0;
+  parameter Real b = 0.0;
+  Real x(start = 2.0, fixed = true);
+equation
+  der(x) = a * x + b;
+end LinearFit;
+"#;
+
+fn linear_model() -> DifferentiableModel {
+    let result = Compiler::new()
+        .model("LinearFit")
+        .compile_str(LINEAR_FIT, "LinearFit.mo")
+        .expect("LinearFit should compile");
+    DifferentiableModel::from_dae_default(&result.dae, &SimOptions::default())
+        .expect("LinearFit should prepare for optimization")
+}
+
+#[test]
+fn reverse_rhs_mse_gradient_matches_analytic_linear_model() {
+    let model = linear_model();
+    let trainables = TrainableSet::by_names(&model, &["a", "b"]).expect("known trainables");
+    let objective = RhsMseObjective::new(0.0, vec![5.0]);
+
+    let report = rhs_mse_value_and_gradient(&model, &objective, &trainables, GradientMode::Reverse)
+        .expect("reverse gradient should evaluate");
+
+    assert_eq!(report.strategy, GradientStrategy::ReverseVjp);
+    assert!((report.loss - 12.5).abs() < 1.0e-12);
+    assert_eq!(report.trainable_names, ["a", "b"]);
+    assert!((report.gradients[0] + 10.0).abs() < 1.0e-12);
+    assert!((report.gradients[1] + 5.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn forward_and_reverse_rhs_mse_gradients_agree() {
+    let model = linear_model();
+    let trainables = TrainableSet::by_names(&model, &["a", "b"]).expect("known trainables");
+    let objective = RhsMseObjective::new(0.0, vec![5.0]);
+
+    let reverse =
+        rhs_mse_value_and_gradient(&model, &objective, &trainables, GradientMode::Reverse)
+            .expect("reverse gradient should evaluate");
+    let forward =
+        rhs_mse_value_and_gradient(&model, &objective, &trainables, GradientMode::Forward)
+            .expect("forward gradient should evaluate");
+
+    assert_eq!(forward.strategy, GradientStrategy::ForwardJacobian);
+    assert_eq!(reverse.gradients.len(), forward.gradients.len());
+    for (reverse, forward) in reverse.gradients.iter().zip(&forward.gradients) {
+        assert!((reverse - forward).abs() < 1.0e-12);
+    }
+}
+
+#[test]
+fn gradient_descent_reduces_rhs_mse_loss() {
+    let mut model = linear_model();
+    let trainables = TrainableSet::by_names(&model, &["a", "b"]).expect("known trainables");
+    let objective = RhsMseObjective::new(0.0, vec![5.0]);
+
+    let report = GradientDescent::new(0.05, 20)
+        .with_gradient_mode(GradientMode::Reverse)
+        .optimize_rhs_mse(&mut model, &objective, &trainables)
+        .expect("gradient descent should run");
+
+    let initial = report.initial_loss().expect("initial loss");
+    let final_loss = report.final_loss().expect("final loss");
+    assert!(
+        final_loss < initial * 0.05,
+        "initial={initial}, final={final_loss}"
+    );
+    assert!(
+        (model.parameter_value("a").expect("a") * 2.0 + model.parameter_value("b").expect("b")
+            - 5.0)
+            .abs()
+            < 0.8
+    );
+}

--- a/crates/rumoca-phase-dae/src/promote_parameter_variable.rs
+++ b/crates/rumoca-phase-dae/src/promote_parameter_variable.rs
@@ -709,6 +709,9 @@ fn reference_is_parameter_variable(
     algebraics: &HashSet<String>,
     parameter_variable: &HashSet<String>,
 ) -> bool {
+    if r == "time" {
+        return false;
+    }
     if disqualifying.contains(r) {
         return false;
     }
@@ -774,5 +777,25 @@ impl ExpressionVisitor for ReferencedBases {
         for subscript in subscripts {
             self.visit_subscript(subscript);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn time_is_not_parameter_variable_reference() {
+        let disqualifying = HashSet::new();
+        let algebraics = HashSet::new();
+        let parameter_variable = HashSet::from(["time".to_string()]);
+
+        assert!(!reference_is_parameter_variable(
+            "time",
+            "sampleX",
+            &disqualifying,
+            &algebraics,
+            &parameter_variable,
+        ));
     }
 }

--- a/crates/rumoca-phase-flatten/src/param_variability.rs
+++ b/crates/rumoca-phase-flatten/src/param_variability.rs
@@ -29,7 +29,7 @@ use std::ops::ControlFlow;
 
 use rumoca_ir_ast::{
     self as ast, ComponentReference, ComponentReferenceContext, Visitor, contains_function_call,
-    walk_component_reference_default,
+    walk_component_reference_default, walk_expression_default,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -108,7 +108,7 @@ fn classify_family(
         return false;
     }
     let provable = family.external_refs.iter().all(|name| {
-        parameter_constant_bases.contains(name.as_str()) || param_variability.contains(name)
+        reference_is_parameter_variability(name, parameter_constant_bases, param_variability)
     });
     if !provable {
         return false;
@@ -118,6 +118,14 @@ fn classify_family(
         changed |= param_variability.insert(lhs.clone());
     }
     changed
+}
+
+fn reference_is_parameter_variability(
+    name: &str,
+    parameter_constant_bases: &FxHashSet<&str>,
+    param_variability: &FxHashSet<String>,
+) -> bool {
+    name != "time" && (parameter_constant_bases.contains(name) || param_variability.contains(name))
 }
 
 /// Variable-dependence over the model equations: which arrays each `der(...)` equation
@@ -342,6 +350,15 @@ struct RefBaseCollector<'a> {
 }
 
 impl Visitor for RefBaseCollector<'_> {
+    fn visit_expression(&mut self, expr: &ast::Expression) -> ControlFlow<()> {
+        if let ast::Expression::Terminal { token, .. } = expr
+            && token.text.as_ref() == "time"
+        {
+            self.bases.insert("time".to_string());
+        }
+        walk_expression_default(self, expr)
+    }
+
     fn visit_component_reference_ctx(
         &mut self,
         cr: &ComponentReference,
@@ -363,4 +380,41 @@ impl Visitor for RefBaseCollector<'_> {
 /// Strip a trailing array subscript so `sig[1,2]` and `sig` compare equal.
 fn base(name: &str) -> &str {
     name.split('[').next().unwrap_or(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn time_blocks_parameter_variability_family() {
+        let family = FamilyRefs {
+            lhs_bases: FxHashSet::from_iter(["sampleX".to_string()]),
+            external_refs: FxHashSet::from_iter(["time".to_string()]),
+        };
+        let parameter_constant_bases = FxHashSet::from_iter(["time"]);
+        let mut param_variability = FxHashSet::default();
+
+        let changed = classify_family(&family, &parameter_constant_bases, &mut param_variability);
+
+        assert!(!changed);
+        assert!(!param_variability.contains("sampleX"));
+    }
+
+    #[test]
+    fn terminal_time_is_collected_as_runtime_reference() {
+        let expr = ast::Expression::Terminal {
+            terminal_type: ast::TerminalType::End,
+            token: rumoca_core::Token {
+                text: "time".into(),
+                ..Default::default()
+            },
+            span: rumoca_core::Span::DUMMY,
+        };
+        let mut refs = FxHashSet::default();
+
+        collect_reference_bases(&expr, &mut refs);
+
+        assert!(refs.contains("time"));
+    }
 }

--- a/crates/rumoca-phase-solve/src/implicit_rhs.rs
+++ b/crates/rumoca-phase-solve/src/implicit_rhs.rs
@@ -113,9 +113,12 @@ pub(crate) fn build_implicit_rhs_compute_block(
         residual_to_implicit_rows,
         state_scalar_count,
         span,
-    )? && let Some(residual_nodes) =
-        remap_residual_compute_nodes(residual_block, residual_to_implicit_rows, span)?
-    {
+    )? && let Some(residual_nodes) = remap_residual_compute_nodes(
+        residual_block,
+        residual_to_implicit_rows,
+        state_scalar_count,
+        span,
+    )? {
         reserve_implicit_rhs_capacity(
             &mut nodes,
             residual_nodes.len(),
@@ -385,6 +388,7 @@ fn uncovered_implicit_tail_rows(
 fn remap_residual_compute_nodes(
     residual_block: &solve::ComputeBlock,
     residual_to_implicit_rows: &[Option<usize>],
+    implicit_output_cursor: usize,
     context_span: rumoca_core::Span,
 ) -> Result<Option<Vec<solve::ComputeNode>>, LowerError> {
     if residual_block.nodes.is_empty() {
@@ -396,11 +400,25 @@ fn remap_residual_compute_nodes(
         "residual compute node remap count",
         span,
     )?;
-    for node in &residual_block.nodes {
-        let Some(remapped) = remap_residual_compute_node(node, residual_to_implicit_rows, span)?
+    let mut residual_output_cursor = 0usize;
+    let mut implicit_output_cursor = implicit_output_cursor;
+    for (node_index, node) in residual_block.nodes.iter().enumerate() {
+        let residual_indices =
+            residual_compute_node_output_indices(node, node_index, residual_output_cursor, span)?;
+        let Some(implicit_indices) =
+            remap_residual_output_indices(&residual_indices, residual_to_implicit_rows, span)?
         else {
             return Ok(None);
         };
+        let Some(remapped) =
+            remap_residual_compute_node(node, &implicit_indices, implicit_output_cursor, span)?
+        else {
+            return Ok(None);
+        };
+        residual_output_cursor =
+            next_output_cursor_from_indices(&residual_indices, residual_output_cursor, span)?;
+        implicit_output_cursor =
+            remapped_compute_node_next_output_cursor(&remapped, implicit_output_cursor, span)?;
         nodes.push(remapped);
     }
     Ok(Some(nodes))
@@ -408,8 +426,9 @@ fn remap_residual_compute_nodes(
 
 fn remap_residual_compute_node(
     node: &solve::ComputeNode,
-    residual_to_implicit_rows: &[Option<usize>],
-    context_span: rumoca_core::Span,
+    implicit_indices: &[usize],
+    implicit_output_cursor: usize,
+    _context_span: rumoca_core::Span,
 ) -> Result<Option<solve::ComputeNode>, LowerError> {
     match node {
         solve::ComputeNode::ScalarPrograms(block) => {
@@ -422,37 +441,24 @@ fn remap_residual_compute_node(
                     )?,
                 )));
             }
-            let span = first_non_dummy_span(&block.program_spans).unwrap_or(context_span);
-            let mut output_indices = implicit_rhs_vec_with_capacity(
-                block.output_indices.len(),
-                "scalar residual output remap count",
-                span,
-            )?;
-            for index in &block.output_indices {
-                let Some(output_index) = residual_to_implicit_rows.get(*index).copied().flatten()
-                else {
-                    return Ok(None);
-                };
-                output_indices.push(output_index);
-            }
             Ok(Some(solve::ComputeNode::ScalarPrograms(
                 solve::ScalarProgramBlock::with_output_indices(
                     block.programs.clone(),
                     block.program_spans.clone(),
-                    output_indices,
+                    implicit_indices.to_vec(),
                 )?,
             )))
         }
         solve::ComputeNode::Map {
             domain,
-            output_map,
             base_ops,
             load_strides,
             const_strides,
             metadata,
             span,
+            ..
         } => Ok(
-            remap_tensor_output_map(domain, output_map, residual_to_implicit_rows, *span)?.map(
+            stencil::tensor_output_map_from_values(domain, implicit_indices, *span)?.map(
                 |output_map| solve::ComputeNode::Map {
                     domain: domain.clone(),
                     output_map,
@@ -466,14 +472,14 @@ fn remap_residual_compute_node(
         ),
         solve::ComputeNode::AffineStencil {
             domain,
-            output_map,
             base_ops,
             load_strides,
             const_strides,
             metadata,
             span,
+            ..
         } => Ok(
-            remap_tensor_output_map(domain, output_map, residual_to_implicit_rows, *span)?.map(
+            stencil::tensor_output_map_from_values(domain, implicit_indices, *span)?.map(
                 |output_map| solve::ComputeNode::AffineStencil {
                     domain: domain.clone(),
                     output_map,
@@ -485,32 +491,112 @@ fn remap_residual_compute_node(
                 },
             ),
         ),
-        solve::ComputeNode::MatMul { .. } | solve::ComputeNode::LinSolve { .. } => Ok(None),
+        solve::ComputeNode::MatMul { .. } | solve::ComputeNode::LinSolve { .. } => Ok(
+            contiguous_at_cursor(implicit_indices, implicit_output_cursor).then(|| node.clone()),
+        ),
     }
 }
 
-fn remap_tensor_output_map(
-    domain: &rumoca_core::StructuredIndexDomain,
-    output_map: &solve::TensorOutputMap,
+fn remap_residual_output_indices(
+    residual_indices: &[usize],
     residual_to_implicit_rows: &[Option<usize>],
     span: rumoca_core::Span,
-) -> Result<Option<solve::TensorOutputMap>, LowerError> {
-    let output_indices = match output_map.output_indices(domain) {
-        Ok(output_indices) => output_indices,
-        Err(_) => return Ok(None),
-    };
+) -> Result<Option<Vec<usize>>, LowerError> {
     let mut implicit_indices = implicit_rhs_vec_with_capacity(
-        output_indices.len(),
+        residual_indices.len(),
         "tensor residual output remap count",
         span,
     )?;
-    for index in output_indices {
-        let Some(implicit_index) = residual_to_implicit_rows.get(index).copied().flatten() else {
+    for index in residual_indices {
+        let Some(implicit_index) = residual_to_implicit_rows.get(*index).copied().flatten() else {
             return Ok(None);
         };
         implicit_indices.push(implicit_index);
     }
-    stencil::tensor_output_map_from_values(domain, &implicit_indices, span)
+    Ok(Some(implicit_indices))
+}
+
+fn residual_compute_node_output_indices(
+    node: &solve::ComputeNode,
+    node_index: usize,
+    output_cursor: usize,
+    span: rumoca_core::Span,
+) -> Result<Vec<usize>, LowerError> {
+    match node {
+        solve::ComputeNode::ScalarPrograms(block) => block
+            .compute_block_output_indices("implicit RHS residual remap", node_index, output_cursor)
+            .map_err(shape_contract_lower_error),
+        solve::ComputeNode::Map {
+            domain, output_map, ..
+        }
+        | solve::ComputeNode::AffineStencil {
+            domain, output_map, ..
+        } => output_map.output_indices(domain).map_err(|err| {
+            implicit_rhs_contract_violation(
+                format!("implicit RHS residual tensor output map is invalid: {err:?}"),
+                span,
+            )
+        }),
+        solve::ComputeNode::MatMul { m, n, .. } => {
+            contiguous_output_indices(output_cursor, checked_output_product(*m, *n, span)?, span)
+        }
+        solve::ComputeNode::LinSolve { n, .. } => {
+            contiguous_output_indices(output_cursor, *n, span)
+        }
+    }
+}
+
+fn remapped_compute_node_next_output_cursor(
+    node: &solve::ComputeNode,
+    output_cursor: usize,
+    span: rumoca_core::Span,
+) -> Result<usize, LowerError> {
+    let indices = residual_compute_node_output_indices(node, 0, output_cursor, span)?;
+    next_output_cursor_from_indices(&indices, output_cursor, span)
+}
+
+fn next_output_cursor_from_indices(
+    indices: &[usize],
+    fallback: usize,
+    span: rumoca_core::Span,
+) -> Result<usize, LowerError> {
+    indices.iter().copied().max().map_or(Ok(fallback), |index| {
+        index.checked_add(1).ok_or_else(|| {
+            implicit_rhs_contract_violation("implicit RHS output cursor overflows", span)
+        })
+    })
+}
+
+fn contiguous_output_indices(
+    start: usize,
+    count: usize,
+    span: rumoca_core::Span,
+) -> Result<Vec<usize>, LowerError> {
+    let end = start.checked_add(count).ok_or_else(|| {
+        implicit_rhs_contract_violation("implicit RHS contiguous output range overflows", span)
+    })?;
+    let mut indices =
+        implicit_rhs_vec_with_capacity(count, "implicit RHS contiguous output count", span)?;
+    indices.extend(start..end);
+    Ok(indices)
+}
+
+fn checked_output_product(
+    lhs: usize,
+    rhs: usize,
+    span: rumoca_core::Span,
+) -> Result<usize, LowerError> {
+    lhs.checked_mul(rhs).ok_or_else(|| {
+        implicit_rhs_contract_violation("implicit RHS tensor output count overflows", span)
+    })
+}
+
+fn contiguous_at_cursor(indices: &[usize], cursor: usize) -> bool {
+    indices
+        .iter()
+        .copied()
+        .enumerate()
+        .all(|(offset, index)| cursor.checked_add(offset) == Some(index))
 }
 
 // SPEC_0021: Exception - residual placement mutates row storage, target maps,
@@ -719,5 +805,95 @@ mod tests {
         );
         assert_eq!(residual_to_implicit_rows, vec![Some(2)]);
         Ok(())
+    }
+
+    #[test]
+    fn remapped_implicit_rhs_preserves_contiguous_matmul_residual() -> Result<(), LowerError> {
+        let span = test_span();
+        let derivative_rhs = derivative_compute_block(span);
+        let residual_block = solve::ComputeBlock {
+            nodes: vec![two_output_matmul_node(span)],
+        };
+        let scalar_programs = vec![zero_rhs_row(), zero_rhs_row(), zero_rhs_row()];
+        let residual_to_implicit_rows = vec![Some(1), Some(2)];
+
+        let block = build_implicit_rhs_compute_block(
+            &derivative_rhs,
+            &residual_block,
+            &residual_to_implicit_rows,
+            scalar_programs,
+            1,
+            span,
+        )?;
+
+        assert_eq!(block.compute_node_counts().matmul, 1);
+        assert_eq!(block.len().map_err(shape_contract_lower_error)?, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn remapped_implicit_rhs_scalarizes_sparse_matmul_residual() -> Result<(), LowerError> {
+        let span = test_span();
+        let derivative_rhs = derivative_compute_block(span);
+        let residual_block = solve::ComputeBlock {
+            nodes: vec![two_output_matmul_node(span)],
+        };
+        let scalar_programs = vec![
+            zero_rhs_row(),
+            zero_rhs_row(),
+            zero_rhs_row(),
+            zero_rhs_row(),
+        ];
+        let residual_to_implicit_rows = vec![Some(1), Some(3)];
+
+        let block = build_implicit_rhs_compute_block(
+            &derivative_rhs,
+            &residual_block,
+            &residual_to_implicit_rows,
+            scalar_programs,
+            1,
+            span,
+        )?;
+
+        assert_eq!(block.compute_node_counts().matmul, 0);
+        assert_eq!(block.len().map_err(shape_contract_lower_error)?, 4);
+        Ok(())
+    }
+
+    fn derivative_compute_block(span: rumoca_core::Span) -> solve::ComputeBlock {
+        solve::ComputeBlock::from_scalar_program_block(solve::ScalarProgramBlock::with_source_span(
+            vec![zero_rhs_row()],
+            span,
+        ))
+    }
+
+    fn two_output_matmul_node(span: rumoca_core::Span) -> solve::ComputeNode {
+        solve::ComputeNode::MatMul {
+            lhs_ops: vec![
+                solve::LinearOp::Const { dst: 0, value: 2.0 },
+                solve::LinearOp::Const { dst: 1, value: 3.0 },
+            ],
+            lhs_start: 0,
+            rhs_ops: vec![
+                solve::LinearOp::Const { dst: 2, value: 5.0 },
+                solve::LinearOp::Const { dst: 3, value: 7.0 },
+                solve::LinearOp::Const {
+                    dst: 4,
+                    value: 11.0,
+                },
+                solve::LinearOp::Const {
+                    dst: 5,
+                    value: 13.0,
+                },
+            ],
+            rhs_start: 2,
+            m: 1,
+            k: 2,
+            n: 2,
+            lhs_sparsity: solve::SparsityPattern::Dense,
+            rhs_sparsity: solve::SparsityPattern::Dense,
+            metadata: solve::TensorNodeMetadata::default(),
+            span,
+        }
     }
 }

--- a/crates/rumoca-phase-solve/src/lib.rs
+++ b/crates/rumoca-phase-solve/src/lib.rs
@@ -50,6 +50,7 @@ mod subscript_indices;
 mod test_support;
 #[cfg(test)]
 mod tests;
+mod timing;
 
 pub use ad::{
     lower_compute_block_jvp, lower_initial_residual_ad, lower_initial_residual_full_ad,
@@ -94,6 +95,8 @@ pub use solve_model::{
     lower_dae_to_solve_model_owned,
     lower_dae_to_solve_model_owned_for_gpu_preparation_with_metadata,
     lower_dae_to_solve_model_owned_for_gpu_preparation_with_metadata_and_overrides,
+    lower_dae_to_solve_model_owned_value_only_with_visible_expressions_and_metadata,
+    lower_dae_to_solve_model_owned_value_only_with_visible_expressions_and_metadata_and_overrides,
     lower_dae_to_solve_model_owned_with_visible_expressions,
     lower_dae_to_solve_model_owned_with_visible_expressions_and_metadata,
     lower_dae_to_solve_model_owned_with_visible_expressions_and_metadata_and_overrides,
@@ -211,24 +214,29 @@ pub fn lower_solve_problem(dae_model: &dae::Dae) -> Result<solve::SolveProblem, 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SolveProblemLoweringProfile {
     Runtime,
+    RuntimeValueOnly,
     GpuPreparation,
 }
 
 impl SolveProblemLoweringProfile {
     fn load_projection_algebraics_in_derivative_rhs(self) -> bool {
-        self == Self::Runtime
+        matches!(self, Self::Runtime | Self::RuntimeValueOnly)
     }
 
     fn lower_residual_equations(self) -> bool {
-        self == Self::Runtime
+        matches!(self, Self::Runtime | Self::RuntimeValueOnly)
     }
 
     fn lower_initialization_system(self) -> bool {
         self == Self::Runtime
     }
 
+    fn lower_initialization_updates(self) -> bool {
+        matches!(self, Self::Runtime | Self::RuntimeValueOnly)
+    }
+
     fn lower_runtime_systems(self) -> bool {
-        self == Self::Runtime
+        matches!(self, Self::Runtime | Self::RuntimeValueOnly)
     }
 }
 
@@ -292,15 +300,22 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
     // scalarization pass here for vector-only solver renderers. The existing
     // `phase_structural::scalarize` pass intentionally remains DAE-to-DAE so
     // DAE templates can request scalarized equation form before rendering.
+    let timer = timing::stage_start();
     let layout = build_var_layout_with_solver_len(dae_model, solver_len)?;
+    timing::log_stage("problem.build_var_layout", timer);
     let solver_len = layout.y_scalars();
+    let timer = timing::stage_start();
     let solve_layout = lower_solve_layout_with_var_layout(dae_model, solver_len, &layout)?;
+    timing::log_stage("problem.lower_solve_layout", timer);
 
+    let timer = timing::stage_start();
     let runtime_tail_updates = runtime_tail_update_names(dae_model)?;
     let runtime_assignment_equations =
         runtime_assignment_equations(dae_model, &runtime_tail_updates)?;
     let discrete_update_equations = normalized_discrete_update_equations(dae_model)
         .map_err(|err| lower_problem_context(err, "collect discrete update equations"))?;
+    timing::log_stage("problem.collect_runtime_equations", timer);
+    let timer = timing::stage_start();
     let mut derivative_analysis = lower::analyze_derivative_rhs(dae_model)
         .map_err(|err| lower_problem_context(err, "analyze derivative RHS rows"))?;
     let state_derivative_rows = lower_bool_slice_copy(
@@ -308,6 +323,8 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
         "state derivative row flag count",
         model_span,
     )?;
+    timing::log_stage("problem.analyze_derivative_rhs", timer);
+    let timer = timing::stage_start();
     let residual_equations = if profile.lower_residual_equations() {
         solver_residual_equations(dae_model, &runtime_tail_updates, &state_derivative_rows)?
     } else {
@@ -326,6 +343,7 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
         },
     )
     .map_err(|err| lower_problem_context(err, "lower continuous residual rows and targets"))?;
+    timing::log_stage("problem.lower_residual_rows", timer);
     // Derivative lowering must LOAD retained algebraic unknowns from their projected
     // slot rather than inline their definitions (roadmap 4b): inlining a boundary cell
     // whose flux folds to a constant makes a structured derivative family non-uniform
@@ -348,9 +366,11 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
     if profile.load_projection_algebraics_in_derivative_rhs() {
         derivative_analysis.load_retained_algebraics(&layout, &solved_algebraic_y);
     }
+    let timer = timing::stage_start();
     let derivative_rhs =
         lower::lower_derivative_rhs_with_analysis(dae_model, &layout, &derivative_analysis)
             .map_err(|err| lower_problem_context(err, "lower derivative RHS rows"))?;
+    timing::log_stage("problem.lower_derivative_rhs", timer);
     let state_scalar_count = solve_layout.state_scalar_count();
     let solver_scalar_count = solve_layout.solver_scalar_count();
     let derivative_rhs_len = derivative_rhs
@@ -359,6 +379,7 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
     let state_only_implicit_rhs = residual.is_empty()
         && solver_scalar_count == state_scalar_count
         && derivative_rhs_len == state_scalar_count;
+    let timer = timing::stage_start();
     let implicit = if state_only_implicit_rhs {
         state_only_implicit_rows_and_targets(state_scalar_count, model_span)?
     } else {
@@ -374,7 +395,9 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
             model_span,
         )?
     };
+    timing::log_stage("problem.build_implicit_rows", timer);
     debug_assert_eq!(implicit.residual_to_implicit_rows.len(), residual.len());
+    let timer = timing::stage_start();
     let algebraic_projection_plan = lower_algebraic_projection_plan(
         &implicit.rows,
         &implicit.row_targets,
@@ -382,6 +405,8 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
         solver_scalar_count,
         model_span,
     )?;
+    timing::log_stage("problem.lower_projection_plan", timer);
+    let timer = timing::stage_start();
     let runtime_assignment_targets = if profile.lower_runtime_systems() {
         lower_runtime_assignment_targets(dae_model, &runtime_assignment_equations, &layout)?
     } else {
@@ -392,17 +417,23 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
     } else {
         Vec::new()
     };
+    timing::log_stage("problem.lower_runtime_systems", timer);
+    let timer = timing::stage_start();
     let initialization = if profile.lower_initialization_system() {
         lower_initialization_system(dae_model, &layout, &solve_layout)?
+    } else if profile.lower_initialization_updates() {
+        lower_initialization_updates_only(dae_model, &layout)?
     } else {
         solve::InitializationSolveSystem::default()
     };
+    timing::log_stage("problem.lower_initialization", timer);
     let dynamic_time_event_exprs = if profile.lower_runtime_systems() {
         dynamic_events::collect_dynamic_time_event_exprs(dae_model)
             .map_err(|err| lower_problem_context(err, "collect dynamic time event expressions"))?
     } else {
         Vec::new()
     };
+    let timer = timing::stage_start();
     let residual_block = if profile.lower_residual_equations() {
         residual_compute_block::build_residual_compute_block(
             dae_model,
@@ -414,6 +445,8 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
     } else {
         solve::ComputeBlock::default()
     };
+    timing::log_stage("problem.build_residual_block", timer);
+    let timer = timing::stage_start();
     let implicit_rhs = build_implicit_rhs_compute_block(
         &derivative_rhs,
         &residual_block,
@@ -423,6 +456,7 @@ pub(crate) fn lower_solve_problem_with_solver_len_and_model_span_and_profile(
         model_span,
     )
     .map_err(|err| lower_problem_context(err, "build implicit RHS compute block"))?;
+    timing::log_stage("problem.build_implicit_rhs_block", timer);
     let problem = solve::SolveProblem {
         schema_version: solve::SOLVE_SCHEMA_VERSION,
         continuous: solve::ContinuousSolveSystem {
@@ -708,6 +742,26 @@ fn lower_initialization_system(
     })
 }
 
+fn lower_initialization_updates_only(
+    dae_model: &dae::Dae,
+    layout: &solve::VarLayout,
+) -> Result<solve::InitializationSolveSystem, LowerError> {
+    let update_equations = lower::initial_condition_update_equations(dae_model)
+        .map_err(|err| lower_problem_context(err, "collect initial condition updates"))?;
+    Ok(solve::InitializationSolveSystem {
+        update_rhs: solve::ScalarProgramBlock::with_program_spans(
+            lower_initial_update_rhs(dae_model, layout)
+                .map_err(|err| lower_problem_context(err, "lower initial update rows"))?,
+            program_spans_for_owned_equations(&update_equations)?,
+        )?,
+        update_targets: lower_update_targets_from_equations(dae_model, layout, &update_equations)
+            .map_err(|err| {
+            lower_problem_context(err, "lower initial update targets")
+        })?,
+        ..Default::default()
+    })
+}
+
 fn initial_projection_indices_for_layout(
     dae_model: &dae::Dae,
     solve_layout: &solve::SolveLayout,
@@ -785,7 +839,7 @@ fn lower_continuous_solve_artifacts(
     let implicit_rhs_rows =
         rumoca_eval_solve::to_scalar_program_block(&problem.continuous.implicit_rhs)
             .map_err(|err| lower_problem_context(err.into(), "scalarize implicit RHS rows"))?;
-    let implicit_jacobian_v_scalar = solve::ScalarProgramBlock::with_program_spans(
+    let implicit_jacobian_v_scalar = solve::ScalarProgramBlock::with_output_indices(
         lower_scalar_program_block_full_ad_with_spans(
             &implicit_rhs_rows.programs,
             &implicit_rhs_rows.program_spans,
@@ -793,11 +847,12 @@ fn lower_continuous_solve_artifacts(
         )
         .map_err(|err| lower_problem_context(err, "lower scalar implicit Jacobian rows"))?,
         implicit_rhs_rows.program_spans,
+        implicit_rhs_rows.output_indices,
     )?;
     let derivative_rhs_rows =
         rumoca_eval_solve::to_scalar_program_block(&problem.continuous.derivative_rhs)
             .map_err(|err| lower_problem_context(err.into(), "scalarize derivative RHS rows"))?;
-    let full_jacobian_v = solve::ScalarProgramBlock::with_program_spans(
+    let full_jacobian_v = solve::ScalarProgramBlock::with_output_indices(
         lower_scalar_program_block_full_ad_with_spans(
             &derivative_rhs_rows.programs,
             &derivative_rhs_rows.program_spans,
@@ -805,6 +860,7 @@ fn lower_continuous_solve_artifacts(
         )
         .map_err(|err| lower_problem_context(err, "lower derivative Jacobian rows"))?,
         derivative_rhs_rows.program_spans,
+        derivative_rhs_rows.output_indices,
     )?;
 
     Ok(solve::ContinuousSolveArtifacts {

--- a/crates/rumoca-phase-solve/src/lower/array_values/builtins.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/builtins.rs
@@ -226,32 +226,48 @@ impl<'a> LowerBuilder<'a> {
                 let arg = required_array_builtin_arg(args, function, 1, call_span)?;
                 self.lower_array_like_values(arg, scope, call_depth)
             }
-            function if let Some(op) = unary_array_builtin_op(&function) => {
-                let arg = required_array_builtin_arg(args, function, 0, call_span)?;
-                let span = expression_or_call_span(arg, call_span);
-                let values = self.lower_array_like_values(arg, scope, call_depth)?;
-                let mut lowered = Vec::new();
-                let context = format!("{} array value count", function.name());
-                reserve_reg_capacity(&mut lowered, values.len(), &context, Some(span))?;
-                for value in values {
-                    lowered.push(self.emit_unary_at(op, value, span)?);
-                }
-                Ok(lowered)
-            }
             rumoca_core::BuiltinFunction::Sample if is_array_like_sample_value_form(args) => {
                 let arg = required_array_builtin_arg(args, function, 0, call_span)?;
                 self.lower_array_like_values_in_mode(arg, scope, call_depth, ValueMode::Pre)
             }
-            _ => Err(array_builtin_contract_error(
-                format!(
-                    "{} does not have array-like builtin lowering",
-                    function.name()
-                ),
-                args.first()
-                    .and_then(rumoca_core::Expression::span)
-                    .or_else(|| (!call_span.is_dummy()).then_some(call_span)),
-            )),
+            _ => {
+                if let Some(op) = unary_array_builtin_op(&function) {
+                    return self.lower_unary_builtin_array_like_values(
+                        function, op, args, scope, call_depth, call_span,
+                    );
+                }
+                Err(array_builtin_contract_error(
+                    format!(
+                        "{} does not have array-like builtin lowering",
+                        function.name()
+                    ),
+                    args.first()
+                        .and_then(rumoca_core::Expression::span)
+                        .or_else(|| (!call_span.is_dummy()).then_some(call_span)),
+                ))
+            }
         }
+    }
+
+    fn lower_unary_builtin_array_like_values(
+        &mut self,
+        function: rumoca_core::BuiltinFunction,
+        op: UnaryOp,
+        args: &[rumoca_core::Expression],
+        scope: &Scope,
+        call_depth: usize,
+        call_span: rumoca_core::Span,
+    ) -> Result<Vec<Reg>, LowerError> {
+        let arg = required_array_builtin_arg(args, function, 0, call_span)?;
+        let span = expression_or_call_span(arg, call_span);
+        let values = self.lower_array_like_values(arg, scope, call_depth)?;
+        let mut lowered = Vec::new();
+        let context = format!("{} array value count", function.name());
+        reserve_reg_capacity(&mut lowered, values.len(), &context, Some(span))?;
+        for value in values {
+            lowered.push(self.emit_unary_at(op, value, span)?);
+        }
+        Ok(lowered)
     }
 
     fn lower_der_array_like_values(

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs.rs
@@ -1,3 +1,4 @@
+mod direct_matmul;
 mod equation_collection;
 #[path = "derivative_rhs/function_projection.rs"]
 mod function_projection;
@@ -60,6 +61,12 @@ pub(crate) struct DerivativeRhsAnalysis {
 impl DerivativeRhsAnalysis {
     pub(crate) fn equation_flags(&self) -> &[bool] {
         &self.equation_flags
+    }
+
+    pub(crate) fn direct_dae_equation_index_for_state(&self, state_name: &str) -> Option<usize> {
+        self.direct_equations
+            .get(state_name)
+            .and_then(|equation| self.equations[*equation].dae_equation_index)
     }
 
     /// Drop direct-assignment definitions for algebraics that are retained solver
@@ -367,7 +374,7 @@ pub(crate) fn lower_derivative_rhs_with_analysis(
 
         if let Some(group_len) = direct_vector_group_len(analysis, &processed, i) {
             match lower_direct_row_group(analysis, i, group_len, &lowering_ctx) {
-                Ok(row) => {
+                Ok(DirectRowGroupLowering::Scalar(row)) => {
                     flush_pending_derivative_programs(
                         &mut block.nodes,
                         &mut pending_derivative_programs,
@@ -388,6 +395,23 @@ pub(crate) fn lower_derivative_rhs_with_analysis(
                         span,
                     )?;
                     block.nodes.push(ComputeNode::ScalarPrograms(scalar_block));
+                    processed[i..i + group_len].fill(true);
+                    i += group_len;
+                    continue;
+                }
+                Ok(DirectRowGroupLowering::Tensor(node)) => {
+                    flush_pending_derivative_programs(
+                        &mut block.nodes,
+                        &mut pending_derivative_programs,
+                        dae_model,
+                    )?;
+                    reserve_derivative_capacity(
+                        &mut block.nodes,
+                        1,
+                        "derivative direct vector tensor node count",
+                        derivative_state_or_context_span(dae_model, state)?,
+                    )?;
+                    block.nodes.push(node);
                     processed[i..i + group_len].fill(true);
                     i += group_len;
                     continue;
@@ -1287,10 +1311,32 @@ fn direct_vector_group_len(
     Some(base_size)
 }
 
+enum DirectRowGroupLowering {
+    Scalar(Vec<LinearOp>),
+    Tensor(ComputeNode),
+}
+
 /// Lower a group of consecutive vector-state components that share one direct
-/// RHS into a single multi-output program: compute the RHS vector once, then
-/// emit `value[component] / coeff` + StoreOutput for each component in order.
+/// RHS. Direct tensor products stay as tensor nodes when the group can use the
+/// product output stream directly; everything else falls back to one
+/// multi-output scalar program.
 fn lower_direct_row_group(
+    analysis: &DerivativeRhsAnalysis,
+    start: usize,
+    group_len: usize,
+    ctx: &DerivativeRhsLoweringContext<'_>,
+) -> Result<DirectRowGroupLowering, LowerError> {
+    if let Some(node) =
+        direct_matmul::lower_direct_row_group_matmul(analysis, start, group_len, ctx)?
+    {
+        return Ok(DirectRowGroupLowering::Tensor(node));
+    }
+
+    lower_direct_row_group_scalar(analysis, start, group_len, ctx)
+        .map(DirectRowGroupLowering::Scalar)
+}
+
+fn lower_direct_row_group_scalar(
     analysis: &DerivativeRhsAnalysis,
     start: usize,
     group_len: usize,

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs/direct_matmul.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs/direct_matmul.rs
@@ -1,0 +1,126 @@
+use super::{
+    DerivativeRhsAnalysis, DerivativeRhsLoweringContext, LowerError, Scope,
+    active_assignment_stack, derivative_rhs_expr_or_owner_span, inline_direct_assignment_expr,
+    row_builder, shared_vector_rhs_base,
+};
+use rumoca_core::{Literal, OpBinary};
+use rumoca_ir_solve::ComputeNode;
+
+pub(super) fn lower_direct_row_group_matmul(
+    analysis: &DerivativeRhsAnalysis,
+    start: usize,
+    group_len: usize,
+    ctx: &DerivativeRhsLoweringContext<'_>,
+) -> Result<Option<ComputeNode>, LowerError> {
+    if !direct_row_group_has_unit_coefficients(analysis, start, group_len) {
+        return Ok(None);
+    }
+    let Some(base) = direct_row_group_inlined_base(analysis, start, ctx)? else {
+        return Ok(None);
+    };
+    let rumoca_core::Expression::Binary {
+        op: OpBinary::Mul,
+        lhs,
+        rhs,
+        span,
+    } = &base
+    else {
+        return Ok(None);
+    };
+
+    let mut builder = row_builder(
+        ctx.dae_model,
+        ctx.layout,
+        ctx.direct_assignments,
+        ctx.structural_bindings,
+        ctx.indexed_bindings,
+    );
+    let scope = Scope::new();
+    let lhs_dims = match builder.infer_expr_dims(lhs, &scope) {
+        Ok(dims) => dims,
+        Err(err) if direct_group_tensor_probe_can_fallback(&err) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let rhs_dims = match builder.infer_expr_dims(rhs, &scope) {
+        Ok(dims) => dims,
+        Err(err) if direct_group_tensor_probe_can_fallback(&err) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let Some(shape) =
+        super::super::array_values::matmul_shape_from_dims(&lhs_dims, &rhs_dims, group_len)
+    else {
+        return Ok(None);
+    };
+
+    let head = &analysis.states[start];
+    let head_eq = &analysis.equations[analysis.direct_equations[&head.name]];
+    let matmul_span = if span.is_dummy() { head_eq.span } else { *span };
+    if matmul_span.is_dummy() {
+        return Err(LowerError::UnspannedContractViolation {
+            reason: "direct derivative MatMul lowering requires a source span".to_string(),
+        });
+    }
+    builder
+        .with_optional_source_context(Some(matmul_span), |builder| {
+            builder.build_matmul_node(lhs, rhs, matmul_span, &scope, 0, shape)
+        })
+        .map(Some)
+}
+
+fn direct_row_group_has_unit_coefficients(
+    analysis: &DerivativeRhsAnalysis,
+    start: usize,
+    group_len: usize,
+) -> bool {
+    (start..start + group_len).all(|idx| {
+        let state = &analysis.states[idx];
+        let equation = &analysis.equations[analysis.direct_equations[&state.name]];
+        equation
+            .coefficients
+            .get(&state.name)
+            .is_some_and(is_one_literal)
+    })
+}
+
+fn is_one_literal(expr: &rumoca_core::Expression) -> bool {
+    matches!(
+        expr,
+        rumoca_core::Expression::Literal {
+            value: Literal::Real(value),
+            ..
+        } if *value == 1.0
+    ) || matches!(
+        expr,
+        rumoca_core::Expression::Literal {
+            value: Literal::Integer(value),
+            ..
+        } if *value == 1
+    )
+}
+
+fn direct_row_group_inlined_base(
+    analysis: &DerivativeRhsAnalysis,
+    start: usize,
+    ctx: &DerivativeRhsLoweringContext<'_>,
+) -> Result<Option<rumoca_core::Expression>, LowerError> {
+    let head = &analysis.states[start];
+    let head_eq = &analysis.equations[analysis.direct_equations[&head.name]];
+    let head_base = shared_vector_rhs_base(&head_eq.rhs);
+    let span = derivative_rhs_expr_or_owner_span(head_base, head_eq.span)?;
+    let mut active_assignments = active_assignment_stack(span)?;
+    match inline_direct_assignment_expr(head_base, ctx, &mut active_assignments) {
+        Ok(expr) => Ok(Some(expr)),
+        Err(err) if direct_group_tensor_probe_can_fallback(&err) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn direct_group_tensor_probe_can_fallback(err: &LowerError) -> bool {
+    matches!(
+        err,
+        LowerError::Unsupported { .. }
+            | LowerError::UnsupportedAt { .. }
+            | LowerError::MissingBinding { .. }
+            | LowerError::DynamicSubscript
+    )
+}

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs/projection.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs/projection.rs
@@ -327,6 +327,23 @@ pub(in crate::lower) fn scalarized_rhs_expressions_with_owner(
     {
         return Ok(elements);
     }
+    if preserve_indexed_tensor_product_rhs(
+        expr,
+        target,
+        expected,
+        dae_model,
+        structural_bindings,
+        span,
+    )? {
+        return indexed_rhs_expressions(
+            expr,
+            target,
+            expected,
+            dae_model,
+            structural_bindings,
+            span,
+        );
+    }
     if expected == 1 {
         return single_expression_vec(expr.clone(), "scalarized RHS expression count", span);
     }
@@ -339,6 +356,32 @@ pub(in crate::lower) fn scalarized_rhs_expressions_with_owner(
         return Ok(values);
     }
     indexed_rhs_expressions(expr, target, expected, dae_model, structural_bindings, span)
+}
+
+fn preserve_indexed_tensor_product_rhs(
+    expr: &rumoca_core::Expression,
+    target: &rumoca_core::Expression,
+    expected: usize,
+    dae_model: &dae::Dae,
+    structural_bindings: &IndexMap<String, f64>,
+    owner_span: rumoca_core::Span,
+) -> Result<bool, LowerError> {
+    let rumoca_core::Expression::Binary { op, .. } = expr else {
+        return Ok(false);
+    };
+    if !is_mul(op) || expected <= 1 {
+        return Ok(false);
+    }
+    let expr_dims = expression_result_dims(expr, dae_model, structural_bindings, owner_span)?;
+    if expr_dims.is_empty()
+        || checked_usize_scalar_count(&expr_dims, "tensor product RHS shape", owner_span)?
+            != expected
+    {
+        return Ok(false);
+    }
+    let target_dims =
+        derivative_target_result_dims(target, dae_model, structural_bindings, owner_span)?;
+    Ok(target_dims == expr_dims)
 }
 
 pub(in crate::lower) fn scalarized_coefficient_expressions(

--- a/crates/rumoca-phase-solve/src/lower/tests/array_operator_tests/derivative_projection_tests.rs
+++ b/crates/rumoca-phase-solve/src/lower/tests/array_operator_tests/derivative_projection_tests.rs
@@ -8,6 +8,75 @@ use record_projection_tests::{projection_assignment, projection_call};
 mod vector_projection_tests;
 
 #[test]
+fn lower_derivative_rhs_preserves_direct_matrix_vector_matmul() {
+    let mut dae_model = dae::Dae::default();
+    dae_model.variables.states.insert(
+        rumoca_core::VarName::new("x"),
+        dae::Variable {
+            dims: vec![2],
+            ..scalar_var("x")
+        },
+    );
+    dae_model.variables.parameters.insert(
+        rumoca_core::VarName::new("W"),
+        dae::Variable {
+            dims: vec![2, 3],
+            ..scalar_var("W")
+        },
+    );
+    dae_model.variables.algebraics.insert(
+        rumoca_core::VarName::new("v"),
+        dae::Variable {
+            dims: vec![3],
+            ..scalar_var("v")
+        },
+    );
+
+    dae_model.continuous.equations.push(dae::Equation {
+        lhs: None,
+        rhs: sub(der(var("x")), mul(var("W"), var("v"))),
+        span: lower_test_span(),
+        origin: "direct derivative matrix-vector multiply".to_string(),
+        scalar_count: 2,
+    });
+
+    let layout = build_var_layout(&dae_model).expect("test DAE layout should build");
+    let block = lower_derivative_rhs(&dae_model, &layout)
+        .expect("direct matrix-vector derivative should lower");
+
+    assert!(
+        matches!(
+            block.nodes.as_slice(),
+            [ComputeNode::MatMul {
+                m: 2,
+                k: 3,
+                n: 1,
+                ..
+            }]
+        ),
+        "expected derivative MatMul node, got {:?}",
+        block.nodes
+    );
+
+    let rows = scalar_program_block_fixture(&block);
+    let mut y = vec![0.0; layout.y_scalars()];
+    let mut p = vec![0.0; layout.p_scalars()];
+    set_y_value(&layout, &mut y, "v[1]", 2.0);
+    set_y_value(&layout, &mut y, "v[2]", 3.0);
+    set_y_value(&layout, &mut y, "v[3]", 5.0);
+    set_p_value(&layout, &mut p, "W[1,1]", 7.0);
+    set_p_value(&layout, &mut p, "W[1,2]", 11.0);
+    set_p_value(&layout, &mut p, "W[1,3]", 13.0);
+    set_p_value(&layout, &mut p, "W[2,1]", 17.0);
+    set_p_value(&layout, &mut p, "W[2,2]", 19.0);
+    set_p_value(&layout, &mut p, "W[2,3]", 23.0);
+
+    let actual = eval_block_all_outputs(&rows, &y, &p, 0.0);
+
+    assert_eq!(actual, vec![112.0, 206.0]);
+}
+
+#[test]
 fn lower_derivative_rhs_inlines_direct_matrix_vector_assignment() {
     let mut dae_model = dae::Dae::default();
     dae_model.variables.states.insert(

--- a/crates/rumoca-phase-solve/src/observation_refresh.rs
+++ b/crates/rumoca-phase-solve/src/observation_refresh.rs
@@ -28,10 +28,8 @@ pub(super) fn lower_discrete_observation_refresh(
         for (idx, row) in rows.iter().enumerate() {
             if !refresh[idx]
                 && row.safe
-                && row
-                    .reads
-                    .iter()
-                    .any(|slot| active_targets.iter().any(|target| target == slot))
+                && (row_reads_active_target(row, &active_targets)
+                    || active_row_reads_target(&rows, &refresh, row.target))
             {
                 refresh[idx] = true;
             }
@@ -51,6 +49,25 @@ fn row_reads_runtime_assignment_target(
             .iter()
             .any(|target| target == slot)
     })
+}
+
+fn row_reads_active_target(
+    row: &DiscreteObservationRefreshRow,
+    active_targets: &[solve::ScalarSlot],
+) -> bool {
+    row.reads
+        .iter()
+        .any(|slot| active_targets.iter().any(|target| target == slot))
+}
+
+fn active_row_reads_target(
+    rows: &[DiscreteObservationRefreshRow],
+    refresh: &[bool],
+    target: solve::ScalarSlot,
+) -> bool {
+    rows.iter()
+        .zip(refresh.iter().copied())
+        .any(|(row, active)| active && row.reads.iter().any(|slot| slot == &target))
 }
 
 #[derive(Debug)]
@@ -314,6 +331,7 @@ impl ExpressionVisitor for ClockedValueOperatorChecker<'_> {
     ) {
         if *function == rumoca_core::BuiltinFunction::Sample
             && !sample_args_are_event_indicator(self.dae_model, args)
+            && !sample_args_are_time_value(args)
         {
             self.found = true;
             return;
@@ -359,6 +377,17 @@ fn sample_args_are_event_indicator(dae_model: &dae::Dae, args: &[rumoca_core::Ex
         }
         _ => false,
     }
+}
+
+fn sample_args_are_time_value(args: &[rumoca_core::Expression]) -> bool {
+    matches!(
+        args,
+        [rumoca_core::Expression::VarRef {
+            name,
+            subscripts,
+            ..
+        }] if subscripts.is_empty() && name.as_str() == "time"
+    )
 }
 
 fn expression_is_parameter_like_event_arg(

--- a/crates/rumoca-phase-solve/src/solve_model.rs
+++ b/crates/rumoca-phase-solve/src/solve_model.rs
@@ -3,10 +3,6 @@
 //! This is the last DAE-aware step before runtime backends. Backends should
 //! receive only `rumoca-ir-solve` data.
 //!
-//! SPEC_0021 file-size exception: solve-model lowering still coordinates model
-//! inventory, RHS assembly, visibility rows, and tensor preservation.
-//! split plan: move visibility assembly and model inventory helpers into submodules.
-
 use indexmap::{IndexMap, IndexSet};
 use rumoca_core::{ExpressionVisitor, Literal, OpBinary, OpUnary};
 use rumoca_ir_dae as dae;
@@ -31,6 +27,7 @@ use std::collections::{HashMap, HashSet};
 
 mod state_derivative_ordering;
 mod variable_meta;
+mod visible;
 use state_derivative_ordering::order_state_derivative_rows;
 #[cfg(test)]
 use state_derivative_ordering::{
@@ -40,21 +37,24 @@ use variable_meta::{
     continuous_real_role_is_event_discontinuous, event_discontinuous_scalar_names,
     variable_meta_classification,
 };
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct VisibleExpression {
-    pub name: String,
-    pub expr: rumoca_core::Expression,
-}
+use visible::lower_visible_observations;
+#[cfg(test)]
+use visible::visible_subscripts_from_usize;
+pub use visible::{VisibleExpression, visible_expressions_for_dae};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SolveModelLoweringProfile {
     Runtime,
+    RuntimeValueOnly,
     GpuPreparation,
 }
 
 impl SolveModelLoweringProfile {
     fn needs_runtime_support(self) -> bool {
+        matches!(self, Self::Runtime | Self::RuntimeValueOnly)
+    }
+
+    fn needs_solve_artifacts(self) -> bool {
         self == Self::Runtime
     }
 }
@@ -221,6 +221,35 @@ pub fn lower_dae_to_solve_model_owned_with_visible_expressions_and_metadata_and_
     )
 }
 
+pub fn lower_dae_to_solve_model_owned_value_only_with_visible_expressions_and_metadata(
+    dae_model: dae::Dae,
+    visible_expressions: Vec<VisibleExpression>,
+    metadata_dae_model: &dae::Dae,
+) -> Result<solve::SolveModel, SolveModelLowerError> {
+    lower_dae_to_solve_model_owned_value_only_with_visible_expressions_and_metadata_and_overrides(
+        dae_model,
+        visible_expressions,
+        metadata_dae_model,
+        &HashMap::new(),
+    )
+}
+
+pub fn lower_dae_to_solve_model_owned_value_only_with_visible_expressions_and_metadata_and_overrides(
+    dae_model: dae::Dae,
+    visible_expressions: Vec<VisibleExpression>,
+    metadata_dae_model: &dae::Dae,
+    param_overrides: &HashMap<String, f64>,
+) -> Result<solve::SolveModel, SolveModelLowerError> {
+    crate::clear_solve_lowering_runtime_state();
+    lower_dae_to_solve_model_inner(
+        dae_model,
+        Some(visible_expressions),
+        Some(metadata_dae_model),
+        SolveModelLoweringProfile::RuntimeValueOnly,
+        param_overrides,
+    )
+}
+
 pub fn lower_dae_to_solve_model_owned_for_gpu_preparation_with_metadata(
     dae_model: dae::Dae,
     metadata_dae_model: &dae::Dae,
@@ -271,6 +300,14 @@ fn lower_profiled_solve_problem(
                 Some(model_span),
             )
         }
+        SolveModelLoweringProfile::RuntimeValueOnly => {
+            crate::lower_solve_problem_with_solver_len_and_model_span_and_profile(
+                dae_model,
+                solver_len,
+                Some(model_span),
+                crate::SolveProblemLoweringProfile::RuntimeValueOnly,
+            )
+        }
         SolveModelLoweringProfile::GpuPreparation => {
             crate::lower_solve_problem_with_solver_len_and_model_span_and_profile(
                 dae_model,
@@ -282,6 +319,47 @@ fn lower_profiled_solve_problem(
     }
 }
 
+fn lower_profiled_solve_artifacts(
+    problem: &solve::SolveProblem,
+    state_count: usize,
+    model_span: rumoca_core::Span,
+    profile: SolveModelLoweringProfile,
+) -> Result<solve::SolveArtifacts, SolveModelLowerError> {
+    if !profile.needs_solve_artifacts() {
+        return Ok(solve::SolveArtifacts::default());
+    }
+    let mass_matrix = state_identity_mass_matrix(state_count, model_span)?;
+    crate::lower_solve_artifacts_with_mass_matrix(problem, mass_matrix).map_err(Into::into)
+}
+
+fn lower_runtime_visible_outputs(
+    dae_model: &dae::Dae,
+    layout: &solve::VarLayout,
+    visible_expressions: &[VisibleExpression],
+    metadata_dae_model: Option<&dae::Dae>,
+    profile: SolveModelLoweringProfile,
+) -> Result<
+    (
+        Vec<String>,
+        solve::ScalarProgramBlock,
+        Vec<solve::SolveVariableMeta>,
+    ),
+    SolveModelLowerError,
+> {
+    if !profile.needs_runtime_support() {
+        return Ok((Vec::new(), solve::ScalarProgramBlock::default(), Vec::new()));
+    }
+    let timer = crate::timing::stage_start();
+    let (visible_names, visible_value_rows) =
+        lower_visible_observations(dae_model, layout, visible_expressions)?;
+    crate::timing::log_stage("model.lower_visible_observations", timer);
+    let timer = crate::timing::stage_start();
+    let variable_meta =
+        build_variable_meta(metadata_dae_model.unwrap_or(dae_model), &visible_names)?;
+    crate::timing::log_stage("model.build_variable_meta", timer);
+    Ok((visible_names, visible_value_rows, variable_meta))
+}
+
 fn lower_dae_to_solve_model_inner(
     mut dae_model: dae::Dae,
     visible_expressions: Option<Vec<VisibleExpression>>,
@@ -289,6 +367,7 @@ fn lower_dae_to_solve_model_inner(
     profile: SolveModelLoweringProfile,
     param_overrides: &HashMap<String, f64>,
 ) -> Result<solve::SolveModel, SolveModelLowerError> {
+    let timer = crate::timing::stage_start();
     let visible_expressions = if profile.needs_runtime_support() {
         match visible_expressions {
             Some(visible_expressions) => visible_expressions,
@@ -297,36 +376,41 @@ fn lower_dae_to_solve_model_inner(
     } else {
         Vec::new()
     };
+    crate::timing::log_stage("model.visible_expressions", timer);
     let state_count = scalar_count(dae_model.variables.states.values())?;
     let eval_runtime = Arc::new(EvalRuntimeState::default());
+    let timer = crate::timing::stage_start();
     let base_parameters = default_parameter_values(
         &dae_model,
         metadata_dae_model,
         eval_runtime.clone(),
         param_overrides,
     )?;
+    crate::timing::log_stage("model.default_parameter_values", timer);
     if profile.needs_runtime_support() {
+        let timer = crate::timing::stage_start();
         order_state_derivative_rows(
             &mut dae_model,
             state_count,
             &base_parameters,
             eval_runtime.clone(),
         )?;
+        crate::timing::log_stage("model.order_state_derivative_rows", timer);
     }
     let solver_len = match profile {
-        SolveModelLoweringProfile::Runtime => {
+        SolveModelLoweringProfile::Runtime | SolveModelLoweringProfile::RuntimeValueOnly => {
             solver_visible_scalar_count(&dae_model)?.max(dae_model.continuous.equations.len())
         }
         SolveModelLoweringProfile::GpuPreparation => state_count,
     };
     let model_span = model_provenance_span(&dae_model, metadata_dae_model)?;
+    let timer = crate::timing::stage_start();
     let problem = lower_profiled_solve_problem(&dae_model, solver_len, model_span, profile)?;
-    let artifacts = if profile.needs_runtime_support() {
-        let mass_matrix = state_identity_mass_matrix(state_count, model_span)?;
-        crate::lower_solve_artifacts_with_mass_matrix(&problem, mass_matrix)?
-    } else {
-        solve::SolveArtifacts::default()
-    };
+    crate::timing::log_stage("model.lower_solve_problem", timer);
+    let timer = crate::timing::stage_start();
+    let artifacts = lower_profiled_solve_artifacts(&problem, state_count, model_span, profile)?;
+    crate::timing::log_stage("model.lower_solve_artifacts", timer);
+    let timer = crate::timing::stage_start();
     let mut parameters = compiled_parameter_values(
         &dae_model,
         metadata_dae_model,
@@ -334,6 +418,8 @@ fn lower_dae_to_solve_model_inner(
         base_parameters,
         eval_runtime.clone(),
     )?;
+    crate::timing::log_stage("model.compiled_parameter_values", timer);
+    let timer = crate::timing::stage_start();
     let mut initial_y = initial_solver_values(
         &dae_model,
         metadata_dae_model,
@@ -341,6 +427,8 @@ fn lower_dae_to_solve_model_inner(
         problem.solve_layout.solver_scalar_count(),
         eval_runtime.clone(),
     )?;
+    crate::timing::log_stage("model.initial_solver_values", timer);
+    let timer = crate::timing::stage_start();
     apply_initial_equations_to_start_values(
         &dae_model,
         &problem.layout,
@@ -348,6 +436,8 @@ fn lower_dae_to_solve_model_inner(
         &mut initial_y,
         eval_runtime.clone(),
     )?;
+    crate::timing::log_stage("model.apply_initial_equations", timer);
+    let timer = crate::timing::stage_start();
     let table_env = build_runtime_parameter_tail_env_with_declared_slots_and_runtime(
         &dae_model,
         &parameters,
@@ -356,16 +446,14 @@ fn lower_dae_to_solve_model_inner(
     )
     .map_err(|source| runtime_tail_error(&dae_model, source))?;
     let external_tables = external_table_data_for_parameter_values_in(&table_env, &parameters);
-    let (visible_names, visible_value_rows) = if profile.needs_runtime_support() {
-        lower_visible_observations(&dae_model, &problem.layout, &visible_expressions)?
-    } else {
-        (Vec::new(), solve::ScalarProgramBlock::default())
-    };
-    let variable_meta = if profile.needs_runtime_support() {
-        build_variable_meta(metadata_dae_model.unwrap_or(&dae_model), &visible_names)?
-    } else {
-        Vec::new()
-    };
+    crate::timing::log_stage("model.external_tables", timer);
+    let (visible_names, visible_value_rows, variable_meta) = lower_runtime_visible_outputs(
+        &dae_model,
+        &problem.layout,
+        &visible_expressions,
+        metadata_dae_model,
+        profile,
+    )?;
 
     Ok(solve::SolveModel {
         problem,
@@ -376,161 +464,6 @@ fn lower_dae_to_solve_model_inner(
         visible_names,
         visible_value_rows,
         variable_meta,
-    })
-}
-
-fn lower_visible_observations(
-    dae_model: &dae::Dae,
-    layout: &solve::VarLayout,
-    visible_expressions: &[VisibleExpression],
-) -> Result<(Vec<String>, solve::ScalarProgramBlock), SolveModelLowerError> {
-    let mut names = Vec::new();
-    let mut rows = Vec::new();
-    let mut program_spans = Vec::new();
-    let structural_bindings = crate::lower::structural_bindings_for_dae(dae_model)?;
-    let indexed_bindings = crate::lower::indexed_bindings_for_layout(layout);
-    for visible in visible_expressions {
-        if is_unbound_identity_observation(layout, visible) {
-            continue;
-        }
-        match crate::lower::lower_observation_rhs_with_structural_bindings(
-            dae_model,
-            layout,
-            std::slice::from_ref(&visible.expr),
-            &structural_bindings,
-            &indexed_bindings,
-        ) {
-            Ok(mut lowered) => {
-                let span = visible_expression_span(visible)?;
-                append_visible_names(&mut names, &visible.name, lowered.len());
-                program_spans.extend(std::iter::repeat_n(span, lowered.len()));
-                rows.append(&mut lowered);
-            }
-            Err(err) if should_skip_unbound_observation(layout, visible, &err) => {}
-            Err(err) if should_skip_unsupported_observation(&err) => {}
-            Err(err) => {
-                return Err(
-                    crate::lower_problem_context(err, "lower visible observation rows").into(),
-                );
-            }
-        }
-    }
-    Ok((
-        names,
-        solve::ScalarProgramBlock::with_program_spans(rows, program_spans)
-            .map_err(LowerError::from)?,
-    ))
-}
-
-fn visible_expression_span(
-    visible: &VisibleExpression,
-) -> Result<rumoca_core::Span, SolveModelLowerError> {
-    visible.expr.span().ok_or_else(|| {
-        SolveModelLowerError::Lower(LowerError::UnspannedContractViolation {
-            reason: format!(
-                "visible observation `{}` reached solve-model lowering without expression provenance",
-                visible.name
-            ),
-        })
-    })
-}
-
-fn append_visible_names(names: &mut Vec<String>, base_name: &str, row_count: usize) {
-    if row_count == 1 {
-        names.push(base_name.to_string());
-        return;
-    }
-    names.extend((1..=row_count).map(|index| format!("{base_name}[{index}]")));
-}
-
-fn should_skip_unbound_observation(
-    layout: &solve::VarLayout,
-    _visible: &VisibleExpression,
-    err: &LowerError,
-) -> bool {
-    let Some(name) = observation_missing_binding_name(err) else {
-        return false;
-    };
-    layout.binding(name).is_none()
-}
-
-fn observation_missing_binding_name(err: &LowerError) -> Option<&str> {
-    match err {
-        LowerError::MissingBinding { name } => Some(name.as_str()),
-        LowerError::Spanned { source, .. } | LowerError::WithContext { source, .. } => {
-            observation_missing_binding_name(source)
-        }
-        _ => None,
-    }
-}
-
-/// Observation (visible-expression) declines: constructs the solve lowering
-/// cannot express yet. Classification is variant-based; an error that is not
-/// one of these typed declines fails the compile.
-fn should_skip_unsupported_observation(err: &LowerError) -> bool {
-    match err {
-        LowerError::DynamicSubscript
-        | LowerError::ForRangeUnknownDimension { .. }
-        | LowerError::MissingActualArgument { .. }
-        | LowerError::DynamicBindingBase { .. }
-        | LowerError::MissingFunction { .. } => true,
-        LowerError::Spanned { source, .. } | LowerError::WithContext { source, .. } => {
-            should_skip_unsupported_observation(source)
-        }
-        _ => false,
-    }
-}
-
-fn is_unbound_identity_observation(layout: &solve::VarLayout, visible: &VisibleExpression) -> bool {
-    layout.binding(&visible.name).is_none()
-        && matches!(
-            &visible.expr,
-            rumoca_core::Expression::VarRef {
-                name,
-                subscripts,
-                ..
-            } if subscripts.is_empty() && name.as_str() == visible.name
-        )
-}
-
-pub fn visible_expressions_for_dae(
-    dae_model: &dae::Dae,
-) -> Result<Vec<VisibleExpression>, LowerError> {
-    let solver_len =
-        solver_visible_scalar_count(dae_model)?.max(dae_model.continuous.equations.len());
-    let mut expressions = collect_visible_solver_expressions(dae_model, solver_len)?;
-    let runtime_expressions = collect_visible_runtime_expressions(dae_model)?;
-    reserve_lower_capacity(
-        &mut expressions,
-        runtime_expressions.len(),
-        "visible expression count",
-        dae_model_span(dae_model, "visible expression inventory")?,
-    )?;
-    expressions.extend(runtime_expressions);
-    Ok(expressions)
-}
-
-fn lower_vec_with_capacity<T>(
-    capacity: usize,
-    context: &'static str,
-    span: rumoca_core::Span,
-) -> Result<Vec<T>, LowerError> {
-    let mut values = Vec::new();
-    reserve_lower_capacity(&mut values, capacity, context, span)?;
-    Ok(values)
-}
-
-fn reserve_lower_capacity<T>(
-    values: &mut Vec<T>,
-    additional: usize,
-    context: &'static str,
-    span: rumoca_core::Span,
-) -> Result<(), LowerError> {
-    values.try_reserve_exact(additional).map_err(|_| {
-        lower_contract_violation(
-            format!("{context} capacity exceeds host memory limits"),
-            span,
-        )
     })
 }
 
@@ -572,183 +505,6 @@ fn dae_model_span(
         .ok_or_else(|| LowerError::UnspannedContractViolation {
             reason: format!("DAE model has no source provenance for {context}"),
         })
-}
-
-fn collect_visible_solver_expressions(
-    dae_model: &dae::Dae,
-    solver_len: usize,
-) -> Result<Vec<VisibleExpression>, LowerError> {
-    let span = dae_model_span(dae_model, "visible solver expression count")?;
-    let mut expressions =
-        lower_vec_with_capacity(solver_len, "visible solver expression count", span)?;
-    for (name, var) in dae_model
-        .variables
-        .states
-        .iter()
-        .chain(dae_model.variables.algebraics.iter())
-        .chain(dae_model.variables.outputs.iter())
-        .filter(|(name, _)| !crate::layout::is_runtime_parameter_tail_variable(dae_model, name))
-    {
-        let variable_expressions = visible_expressions_for_variable(name, var)?;
-        reserve_lower_capacity(
-            &mut expressions,
-            variable_expressions.len(),
-            "visible solver expression count",
-            var.source_span,
-        )?;
-        expressions.extend(variable_expressions);
-    }
-    expressions.truncate(solver_len);
-    Ok(expressions)
-}
-
-fn collect_visible_runtime_expressions(
-    dae_model: &dae::Dae,
-) -> Result<Vec<VisibleExpression>, LowerError> {
-    let span = dae_model_span(dae_model, "visible runtime expression count")?;
-    let capacity = checked_lower_count_add(
-        dae_model.variables.inputs.len(),
-        dae_model.variables.discrete_reals.len(),
-        "visible runtime expression count",
-        span,
-    )?;
-    let capacity = checked_lower_count_add(
-        capacity,
-        dae_model.variables.discrete_valued.len(),
-        "visible runtime expression count",
-        span,
-    )?;
-    let mut expressions =
-        lower_vec_with_capacity(capacity, "visible runtime expression count", span)?;
-    for (name, var) in dae_model
-        .variables
-        .inputs
-        .iter()
-        .chain(dae_model.variables.discrete_reals.iter())
-        .chain(dae_model.variables.discrete_valued.iter())
-    {
-        let variable_expressions = visible_expressions_for_variable(name, var)?;
-        reserve_lower_capacity(
-            &mut expressions,
-            variable_expressions.len(),
-            "visible runtime expression count",
-            var.source_span,
-        )?;
-        expressions.extend(variable_expressions);
-    }
-    Ok(expressions)
-}
-
-fn checked_lower_count_add(
-    lhs: usize,
-    rhs: usize,
-    context: &'static str,
-    span: rumoca_core::Span,
-) -> Result<usize, LowerError> {
-    lhs.checked_add(rhs).ok_or_else(|| {
-        lower_contract_violation(format!("{context} exceeds host index range"), span)
-    })
-}
-
-fn visible_expressions_for_variable(
-    name: &rumoca_core::VarName,
-    var: &dae::Variable,
-) -> Result<Vec<VisibleExpression>, LowerError> {
-    let size = variable_size(var)?;
-    if size <= 1 && var.dims.is_empty() {
-        let mut expressions =
-            lower_vec_with_capacity(1, "visible variable expression count", var.source_span)?;
-        expressions.push(visible_expression_for_variable_scalar(
-            name,
-            var,
-            name.as_str().to_string(),
-            Vec::new(),
-        )?);
-        return Ok(expressions);
-    }
-    let mut expressions =
-        lower_vec_with_capacity(size, "visible variable expression count", var.source_span)?;
-    for idx in 0..size {
-        let subscripts = dae::flat_index_to_subscripts(&var.dims, idx).ok_or_else(|| {
-            lower_contract_violation(
-                format!(
-                    "visible expression scalar index {idx} is outside variable `{}` shape",
-                    name.as_str()
-                ),
-                var.source_span,
-            )
-        })?;
-        expressions.push(visible_expression_for_variable_scalar(
-            name,
-            var,
-            dae::scalar_name_text_for_flat_index(name.as_str(), &var.dims, idx),
-            subscripts,
-        )?);
-    }
-    Ok(expressions)
-}
-
-fn visible_expression_for_variable_scalar(
-    name: &rumoca_core::VarName,
-    var: &dae::Variable,
-    scalar_name: String,
-    subscripts: Vec<usize>,
-) -> Result<VisibleExpression, LowerError> {
-    let reference = match var.origin {
-        dae::VariableOrigin::Generated => rumoca_core::Reference::generated(name.as_str()),
-        dae::VariableOrigin::Source => {
-            #[cfg(test)]
-            if var.source_span.is_dummy() {
-                return Ok(VisibleExpression {
-                    name: scalar_name,
-                    expr: rumoca_core::Expression::VarRef {
-                        name: rumoca_core::Reference::generated(name.as_str()),
-                        subscripts: visible_subscripts_from_usize(subscripts, var.source_span)?,
-                        span: var.source_span,
-                    },
-                });
-            }
-            let component_ref =
-                var.component_ref
-                    .clone()
-                    .ok_or_else(|| {
-                        lower_contract_violation(
-                            format!(
-                                "source DAE variable `{}` lost structured component-reference metadata before visible observation lowering",
-                                name.as_str()
-                            ),
-                            var.source_span,
-                        )
-                    })?;
-            rumoca_core::Reference::from_component_reference(component_ref)
-        }
-    };
-    Ok(VisibleExpression {
-        name: scalar_name,
-        expr: rumoca_core::Expression::VarRef {
-            name: reference,
-            subscripts: visible_subscripts_from_usize(subscripts, var.source_span)?,
-            span: var.source_span,
-        },
-    })
-}
-
-fn visible_subscripts_from_usize(
-    subscripts: Vec<usize>,
-    span: rumoca_core::Span,
-) -> Result<Vec<rumoca_core::Subscript>, LowerError> {
-    let mut lowered =
-        lower_vec_with_capacity(subscripts.len(), "visible variable subscript count", span)?;
-    for index in subscripts {
-        let value = i64::try_from(index).map_err(|_| {
-            lower_contract_violation(
-                "visible variable subscript exceeds Modelica integer range".to_string(),
-                span,
-            )
-        })?;
-        lowered.push(rumoca_core::Subscript::index(value, span));
-    }
-    Ok(lowered)
 }
 
 fn variable_size(var: &dae::Variable) -> Result<usize, LowerError> {

--- a/crates/rumoca-phase-solve/src/solve_model.rs
+++ b/crates/rumoca-phase-solve/src/solve_model.rs
@@ -319,17 +319,17 @@ fn lower_profiled_solve_problem(
     }
 }
 
-fn lower_profiled_solve_artifacts(
-    problem: &solve::SolveProblem,
+fn profiled_solver_len(
+    dae_model: &dae::Dae,
     state_count: usize,
-    model_span: rumoca_core::Span,
     profile: SolveModelLoweringProfile,
-) -> Result<solve::SolveArtifacts, SolveModelLowerError> {
-    if !profile.needs_solve_artifacts() {
-        return Ok(solve::SolveArtifacts::default());
+) -> Result<usize, SolveModelLowerError> {
+    match profile {
+        SolveModelLoweringProfile::Runtime | SolveModelLoweringProfile::RuntimeValueOnly => {
+            Ok(solver_visible_scalar_count(dae_model)?.max(dae_model.continuous.equations.len()))
+        }
+        SolveModelLoweringProfile::GpuPreparation => Ok(state_count),
     }
-    let mass_matrix = state_identity_mass_matrix(state_count, model_span)?;
-    crate::lower_solve_artifacts_with_mass_matrix(problem, mass_matrix).map_err(Into::into)
 }
 
 fn lower_runtime_visible_outputs(
@@ -397,18 +397,18 @@ fn lower_dae_to_solve_model_inner(
         )?;
         crate::timing::log_stage("model.order_state_derivative_rows", timer);
     }
-    let solver_len = match profile {
-        SolveModelLoweringProfile::Runtime | SolveModelLoweringProfile::RuntimeValueOnly => {
-            solver_visible_scalar_count(&dae_model)?.max(dae_model.continuous.equations.len())
-        }
-        SolveModelLoweringProfile::GpuPreparation => state_count,
-    };
+    let solver_len = profiled_solver_len(&dae_model, state_count, profile)?;
     let model_span = model_provenance_span(&dae_model, metadata_dae_model)?;
     let timer = crate::timing::stage_start();
     let problem = lower_profiled_solve_problem(&dae_model, solver_len, model_span, profile)?;
     crate::timing::log_stage("model.lower_solve_problem", timer);
     let timer = crate::timing::stage_start();
-    let artifacts = lower_profiled_solve_artifacts(&problem, state_count, model_span, profile)?;
+    let artifacts = if profile.needs_solve_artifacts() {
+        let mass_matrix = state_identity_mass_matrix(state_count, model_span)?;
+        crate::lower_solve_artifacts_with_mass_matrix(&problem, mass_matrix)?
+    } else {
+        solve::SolveArtifacts::default()
+    };
     crate::timing::log_stage("model.lower_solve_artifacts", timer);
     let timer = crate::timing::stage_start();
     let mut parameters = compiled_parameter_values(

--- a/crates/rumoca-phase-solve/src/solve_model/state_derivative_ordering.rs
+++ b/crates/rumoca-phase-solve/src/solve_model/state_derivative_ordering.rs
@@ -37,6 +37,12 @@ pub(super) fn order_state_derivative_rows(
         )?;
         state_names.extend(names);
     }
+    if let Some(ordered_indices) =
+        direct_derivative_row_order(dae_model, &state_names, state_count, span)?
+    {
+        apply_row_order(dae_model, ordered_indices, span)?;
+        return Ok(());
+    }
     let env = build_runtime_parameter_tail_env_with_declared_slots_and_runtime(
         dae_model, params, 0.0, runtime,
     )
@@ -46,6 +52,8 @@ pub(super) fn order_state_derivative_rows(
     let mut used = reserve_state_derivative_order_flags(equation_count, span)?;
     let mut ordered = Vec::new();
     reserve_state_derivative_order_capacity(&mut ordered, equation_count, span)?;
+    let mut ordered_indices = Vec::new();
+    reserve_state_derivative_order_capacity(&mut ordered_indices, equation_count, span)?;
 
     for state_name in state_names.iter().take(state_count) {
         let Some((row_idx, _)) = dae_model
@@ -64,22 +72,129 @@ pub(super) fn order_state_derivative_rows(
             continue;
         };
         used[row_idx] = true;
+        ordered_indices.push(row_idx);
         ordered.push(dae_model.continuous.equations[row_idx].clone());
     }
 
     if ordered.len() != state_count {
         return Ok(());
     }
-    ordered.extend(
-        dae_model
-            .continuous
-            .equations
-            .iter()
-            .enumerate()
-            .filter(|(idx, _)| !used[*idx])
-            .map(|(_, equation)| equation.clone()),
-    );
+    for (idx, equation) in dae_model
+        .continuous
+        .equations
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| !used[*idx])
+    {
+        ordered_indices.push(idx);
+        ordered.push(equation.clone());
+    }
+    remap_structured_families_after_row_order(
+        &mut dae_model.continuous.structured_equations,
+        &ordered_indices,
+        span,
+    )?;
     dae_model.continuous.equations = ordered;
+    Ok(())
+}
+
+fn direct_derivative_row_order(
+    dae_model: &dae::Dae,
+    state_names: &[String],
+    state_count: usize,
+    span: rumoca_core::Span,
+) -> Result<Option<Vec<usize>>, SolveModelLowerError> {
+    let analysis =
+        crate::lower::analyze_derivative_rhs(dae_model).map_err(SolveModelLowerError::Lower)?;
+    let equation_count = dae_model.continuous.equations.len();
+    let mut used = reserve_state_derivative_order_flags(equation_count, span)?;
+    let mut ordered_indices = Vec::new();
+    reserve_state_derivative_order_capacity(&mut ordered_indices, equation_count, span)?;
+    for state_name in state_names.iter().take(state_count) {
+        let Some(row_idx) = analysis.direct_dae_equation_index_for_state(state_name) else {
+            return Ok(None);
+        };
+        if row_idx >= equation_count || used[row_idx] {
+            return Ok(None);
+        }
+        used[row_idx] = true;
+        ordered_indices.push(row_idx);
+    }
+    for (idx, used) in used.iter().copied().enumerate().take(equation_count) {
+        if !used {
+            ordered_indices.push(idx);
+        }
+    }
+    Ok(Some(ordered_indices))
+}
+
+fn apply_row_order(
+    dae_model: &mut dae::Dae,
+    ordered_indices: Vec<usize>,
+    span: rumoca_core::Span,
+) -> Result<(), SolveModelLowerError> {
+    let mut ordered = Vec::new();
+    reserve_state_derivative_order_capacity(
+        &mut ordered,
+        dae_model.continuous.equations.len(),
+        span,
+    )?;
+    for idx in &ordered_indices {
+        let Some(equation) = dae_model.continuous.equations.get(*idx) else {
+            return Ok(());
+        };
+        ordered.push(equation.clone());
+    }
+    remap_structured_families_after_row_order(
+        &mut dae_model.continuous.structured_equations,
+        &ordered_indices,
+        span,
+    )?;
+    dae_model.continuous.equations = ordered;
+    Ok(())
+}
+
+fn remap_structured_families_after_row_order(
+    families: &mut Vec<dae::StructuredEquationFamily>,
+    old_indices_in_new_order: &[usize],
+    span: rumoca_core::Span,
+) -> Result<(), SolveModelLowerError> {
+    if families.is_empty() {
+        return Ok(());
+    }
+    let mut old_to_new = Vec::new();
+    reserve_state_derivative_order_capacity(&mut old_to_new, old_indices_in_new_order.len(), span)?;
+    old_to_new.resize(old_indices_in_new_order.len(), usize::MAX);
+    for (new_index, old_index) in old_indices_in_new_order.iter().copied().enumerate() {
+        if let Some(slot) = old_to_new.get_mut(old_index) {
+            *slot = new_index;
+        }
+    }
+    families.retain_mut(|family| {
+        let total: usize = family.equation_counts.iter().sum();
+        if total == 0 {
+            return false;
+        }
+        let Some(first_new) = old_to_new.get(family.first_equation_index).copied() else {
+            return false;
+        };
+        if first_new == usize::MAX {
+            return false;
+        }
+        for offset in 1..total {
+            let Some(new_index) = old_to_new
+                .get(family.first_equation_index + offset)
+                .copied()
+            else {
+                return false;
+            };
+            if new_index != first_new + offset {
+                return false;
+            }
+        }
+        family.first_equation_index = first_new;
+        true
+    });
     Ok(())
 }
 
@@ -104,4 +219,65 @@ pub(super) fn reserve_state_derivative_order_capacity<T>(
             span,
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_span() -> rumoca_core::Span {
+        rumoca_core::Span::from_offsets(
+            rumoca_core::SourceId::from_source_name("state_derivative_ordering_tests.mo"),
+            1,
+            2,
+        )
+    }
+
+    fn family(first_equation_index: usize, count: usize) -> dae::StructuredEquationFamily {
+        dae::StructuredEquationFamily {
+            domain: rumoca_core::StructuredIndexDomain {
+                binders: vec![rumoca_core::StructuredIndexBinder {
+                    id: 0,
+                    display_name: "i".to_string(),
+                    lower: 1,
+                    upper: i64::try_from(count).expect("test count should fit i64"),
+                    step: 1,
+                }],
+            },
+            first_equation_index,
+            equation_counts: vec![1; count],
+            span: test_span(),
+            origin: "test".to_string(),
+            regular: None,
+            template: None,
+            interiors_materialized: true,
+        }
+    }
+
+    #[test]
+    fn row_ordering_remaps_intact_structured_family_block() {
+        let mut families = vec![family(2, 2), family(6, 2)];
+
+        remap_structured_families_after_row_order(
+            &mut families,
+            &[4, 5, 0, 1, 2, 3, 6, 7],
+            test_span(),
+        )
+        .expect("structured families should remap");
+
+        assert_eq!(families.len(), 2);
+        assert_eq!(families[0].first_equation_index, 4);
+        assert_eq!(families[1].first_equation_index, 6);
+    }
+
+    #[test]
+    fn row_ordering_drops_structured_family_split_by_permutation() {
+        let mut families = vec![family(1, 2), family(3, 1)];
+
+        remap_structured_families_after_row_order(&mut families, &[2, 0, 1, 3], test_span())
+            .expect("structured families should remap");
+
+        assert_eq!(families.len(), 1);
+        assert_eq!(families[0].first_equation_index, 3);
+    }
 }

--- a/crates/rumoca-phase-solve/src/solve_model/tests.rs
+++ b/crates/rumoca-phase-solve/src/solve_model/tests.rs
@@ -207,6 +207,78 @@ fn lower_expands_visible_observation_for_scalarized_record_field_slice() {
 }
 
 #[test]
+fn value_only_lowering_skips_eager_sensitivity_artifacts() {
+    let dae_model = single_state_zero_derivative_model();
+    let value_only =
+        lower_dae_to_solve_model_owned_value_only_with_visible_expressions_and_metadata(
+            dae_model.clone(),
+            Vec::new(),
+            &dae_model,
+        )
+        .expect("value-only lowering should produce a simulation problem");
+
+    assert!(
+        !value_only
+            .problem
+            .continuous
+            .derivative_rhs
+            .nodes
+            .is_empty()
+    );
+    assert!(
+        value_only
+            .artifacts
+            .continuous
+            .implicit_jacobian_v
+            .nodes
+            .is_empty()
+    );
+    assert!(
+        value_only
+            .artifacts
+            .continuous
+            .implicit_jacobian_v_scalar
+            .programs
+            .is_empty()
+    );
+    assert!(
+        value_only
+            .artifacts
+            .continuous
+            .full_jacobian_v
+            .programs
+            .is_empty()
+    );
+    assert!(value_only.artifacts.continuous.mass_matrix.is_empty());
+
+    let full = lower_dae_to_solve_model(&dae_model)
+        .expect("full runtime lowering should still produce sensitivity artifacts");
+    assert_eq!(full.artifacts.continuous.mass_matrix, vec![vec![1.0]]);
+    assert!(
+        !full
+            .artifacts
+            .continuous
+            .full_jacobian_v
+            .programs
+            .is_empty()
+    );
+}
+
+fn single_state_zero_derivative_model() -> dae::Dae {
+    let mut dae_model = dae::Dae::default();
+    dae_model
+        .variables
+        .states
+        .insert(rumoca_core::VarName::new("x"), scalar_var("x"));
+    dae_model.continuous.equations.push(dae::Equation::residual(
+        sub(der(var("x")), real_expr(0.0)),
+        solve_model_test_span(),
+        "der(x) = 0",
+    ));
+    dae_model
+}
+
+#[test]
 fn seed_var_values_rejects_empty_scalar_seed() {
     let var = scalar_var("p");
     let mut env = rumoca_eval_dae::VarEnv::<f64>::new();

--- a/crates/rumoca-phase-solve/src/solve_model/variable_meta.rs
+++ b/crates/rumoca-phase-solve/src/solve_model/variable_meta.rs
@@ -13,6 +13,9 @@ pub(super) fn event_discontinuous_scalar_names(
     dae_model: &dae::Dae,
 ) -> Result<IndexSet<String>, SolveModelLowerError> {
     let event_discrete_names = event_discrete_scalar_names(dae_model)?;
+    if event_discrete_names.is_empty() && !continuous_equations_have_event_seed(dae_model) {
+        return Ok(IndexSet::new());
+    }
     let event_discrete_bases = base_name_index(&event_discrete_names);
     let mut definitions = continuous_definition_expressions(dae_model)?;
     let mut event_discontinuous = IndexSet::new();
@@ -53,6 +56,66 @@ pub(super) fn event_discontinuous_scalar_names(
             return Ok(event_discontinuous);
         }
         definitions.retain(|name, _| !event_discontinuous.contains(name));
+    }
+}
+
+fn continuous_equations_have_event_seed(dae_model: &dae::Dae) -> bool {
+    dae_model.continuous.equations.iter().any(|eq| {
+        let mut checker = IntrinsicEventSeedChecker {
+            found: false,
+            no_event_depth: 0,
+        };
+        checker.visit_expression(&eq.rhs);
+        checker.found
+    })
+}
+
+struct IntrinsicEventSeedChecker {
+    found: bool,
+    no_event_depth: usize,
+}
+
+impl ExpressionVisitor for IntrinsicEventSeedChecker {
+    fn visit_expression(&mut self, expr: &rumoca_core::Expression) {
+        if !self.found {
+            self.walk_expression(expr);
+        }
+    }
+
+    fn visit_builtin_call(
+        &mut self,
+        function: &rumoca_core::BuiltinFunction,
+        args: &[rumoca_core::Expression],
+    ) {
+        if *function == rumoca_core::BuiltinFunction::NoEvent {
+            self.no_event_depth += 1;
+            for arg in args {
+                self.visit_expression(arg);
+            }
+            self.no_event_depth -= 1;
+            return;
+        }
+        if self.no_event_depth == 0 && builtin_creates_event_seed(function) {
+            self.found = true;
+            return;
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+
+    fn visit_binary(
+        &mut self,
+        op: &rumoca_core::OpBinary,
+        lhs: &rumoca_core::Expression,
+        rhs: &rumoca_core::Expression,
+    ) {
+        if self.no_event_depth == 0 && binary_creates_event_seed(op) {
+            self.found = true;
+            return;
+        }
+        self.visit_expression(lhs);
+        self.visit_expression(rhs);
     }
 }
 
@@ -313,18 +376,7 @@ impl ExpressionVisitor for EventDiscontinuityChecker<'_> {
             self.no_event_depth -= 1;
             return;
         }
-        if self.no_event_depth == 0
-            && matches!(
-                function,
-                rumoca_core::BuiltinFunction::Div
-                    | rumoca_core::BuiltinFunction::Mod
-                    | rumoca_core::BuiltinFunction::Rem
-                    | rumoca_core::BuiltinFunction::Ceil
-                    | rumoca_core::BuiltinFunction::Floor
-                    | rumoca_core::BuiltinFunction::Integer
-                    | rumoca_core::BuiltinFunction::Delay
-            )
-        {
+        if self.no_event_depth == 0 && builtin_creates_event_seed(function) {
             self.found = true;
             return;
         }
@@ -339,21 +391,36 @@ impl ExpressionVisitor for EventDiscontinuityChecker<'_> {
         lhs: &rumoca_core::Expression,
         rhs: &rumoca_core::Expression,
     ) {
-        if self.no_event_depth == 0
-            && matches!(
-                op,
-                rumoca_core::OpBinary::Ge
-                    | rumoca_core::OpBinary::Gt
-                    | rumoca_core::OpBinary::Le
-                    | rumoca_core::OpBinary::Lt
-            )
-        {
+        if self.no_event_depth == 0 && binary_creates_event_seed(op) {
             self.found = true;
             return;
         }
         self.visit_expression(lhs);
         self.visit_expression(rhs);
     }
+}
+
+fn builtin_creates_event_seed(function: &rumoca_core::BuiltinFunction) -> bool {
+    matches!(
+        function,
+        rumoca_core::BuiltinFunction::Div
+            | rumoca_core::BuiltinFunction::Mod
+            | rumoca_core::BuiltinFunction::Rem
+            | rumoca_core::BuiltinFunction::Ceil
+            | rumoca_core::BuiltinFunction::Floor
+            | rumoca_core::BuiltinFunction::Integer
+            | rumoca_core::BuiltinFunction::Delay
+    )
+}
+
+fn binary_creates_event_seed(op: &rumoca_core::OpBinary) -> bool {
+    matches!(
+        op,
+        rumoca_core::OpBinary::Ge
+            | rumoca_core::OpBinary::Gt
+            | rumoca_core::OpBinary::Le
+            | rumoca_core::OpBinary::Lt
+    )
 }
 
 fn event_dependency_ref_names(

--- a/crates/rumoca-phase-solve/src/solve_model/visible.rs
+++ b/crates/rumoca-phase-solve/src/solve_model/visible.rs
@@ -1,0 +1,340 @@
+use rumoca_ir_dae as dae;
+use rumoca_ir_solve as solve;
+
+use crate::LowerError;
+
+use super::{
+    SolveModelLowerError, dae_model_span, lower_contract_violation, solver_visible_scalar_count,
+    variable_size,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct VisibleExpression {
+    pub name: String,
+    pub expr: rumoca_core::Expression,
+}
+
+pub(super) fn lower_visible_observations(
+    dae_model: &dae::Dae,
+    layout: &solve::VarLayout,
+    visible_expressions: &[VisibleExpression],
+) -> Result<(Vec<String>, solve::ScalarProgramBlock), SolveModelLowerError> {
+    let mut names = Vec::new();
+    let mut rows = Vec::new();
+    let mut program_spans = Vec::new();
+    let structural_bindings = crate::lower::structural_bindings_for_dae(dae_model)?;
+    let indexed_bindings = crate::lower::indexed_bindings_for_layout(layout);
+    for visible in visible_expressions {
+        if is_unbound_identity_observation(layout, visible) {
+            continue;
+        }
+        match crate::lower::lower_observation_rhs_with_structural_bindings(
+            dae_model,
+            layout,
+            std::slice::from_ref(&visible.expr),
+            &structural_bindings,
+            &indexed_bindings,
+        ) {
+            Ok(mut lowered) => {
+                let span = visible_expression_span(visible)?;
+                append_visible_names(&mut names, &visible.name, lowered.len());
+                program_spans.extend(std::iter::repeat_n(span, lowered.len()));
+                rows.append(&mut lowered);
+            }
+            Err(err) if should_skip_unbound_observation(layout, &err) => {}
+            Err(err) if should_skip_unsupported_observation(&err) => {}
+            Err(err) => {
+                return Err(
+                    crate::lower_problem_context(err, "lower visible observation rows").into(),
+                );
+            }
+        }
+    }
+    Ok((
+        names,
+        solve::ScalarProgramBlock::with_program_spans(rows, program_spans)
+            .map_err(LowerError::from)?,
+    ))
+}
+
+fn visible_expression_span(
+    visible: &VisibleExpression,
+) -> Result<rumoca_core::Span, SolveModelLowerError> {
+    visible.expr.span().ok_or_else(|| {
+        SolveModelLowerError::Lower(LowerError::UnspannedContractViolation {
+            reason: format!(
+                "visible observation `{}` reached solve-model lowering without expression provenance",
+                visible.name
+            ),
+        })
+    })
+}
+
+fn append_visible_names(names: &mut Vec<String>, base_name: &str, row_count: usize) {
+    if row_count == 1 {
+        names.push(base_name.to_string());
+        return;
+    }
+    names.extend((1..=row_count).map(|index| format!("{base_name}[{index}]")));
+}
+
+fn should_skip_unbound_observation(layout: &solve::VarLayout, err: &LowerError) -> bool {
+    let Some(name) = observation_missing_binding_name(err) else {
+        return false;
+    };
+    layout.binding(name).is_none()
+}
+
+fn observation_missing_binding_name(err: &LowerError) -> Option<&str> {
+    match err {
+        LowerError::MissingBinding { name } => Some(name.as_str()),
+        LowerError::Spanned { source, .. } | LowerError::WithContext { source, .. } => {
+            observation_missing_binding_name(source)
+        }
+        _ => None,
+    }
+}
+
+/// Observation (visible-expression) declines: constructs the solve lowering
+/// cannot express yet. Classification is variant-based; an error that is not
+/// one of these typed declines fails the compile.
+fn should_skip_unsupported_observation(err: &LowerError) -> bool {
+    match err {
+        LowerError::DynamicSubscript
+        | LowerError::ForRangeUnknownDimension { .. }
+        | LowerError::MissingActualArgument { .. }
+        | LowerError::DynamicBindingBase { .. }
+        | LowerError::MissingFunction { .. } => true,
+        LowerError::Spanned { source, .. } | LowerError::WithContext { source, .. } => {
+            should_skip_unsupported_observation(source)
+        }
+        _ => false,
+    }
+}
+
+fn is_unbound_identity_observation(layout: &solve::VarLayout, visible: &VisibleExpression) -> bool {
+    layout.binding(&visible.name).is_none()
+        && matches!(
+            &visible.expr,
+            rumoca_core::Expression::VarRef {
+                name,
+                subscripts,
+                ..
+            } if subscripts.is_empty() && name.as_str() == visible.name
+        )
+}
+
+pub fn visible_expressions_for_dae(
+    dae_model: &dae::Dae,
+) -> Result<Vec<VisibleExpression>, LowerError> {
+    let solver_len =
+        solver_visible_scalar_count(dae_model)?.max(dae_model.continuous.equations.len());
+    let mut expressions = collect_visible_solver_expressions(dae_model, solver_len)?;
+    let runtime_expressions = collect_visible_runtime_expressions(dae_model)?;
+    reserve_lower_capacity(
+        &mut expressions,
+        runtime_expressions.len(),
+        "visible expression count",
+        dae_model_span(dae_model, "visible expression inventory")?,
+    )?;
+    expressions.extend(runtime_expressions);
+    Ok(expressions)
+}
+
+fn lower_vec_with_capacity<T>(
+    capacity: usize,
+    context: &'static str,
+    span: rumoca_core::Span,
+) -> Result<Vec<T>, LowerError> {
+    let mut values = Vec::new();
+    reserve_lower_capacity(&mut values, capacity, context, span)?;
+    Ok(values)
+}
+
+fn reserve_lower_capacity<T>(
+    values: &mut Vec<T>,
+    additional: usize,
+    context: &'static str,
+    span: rumoca_core::Span,
+) -> Result<(), LowerError> {
+    values.try_reserve_exact(additional).map_err(|_| {
+        lower_contract_violation(
+            format!("{context} capacity exceeds host memory limits"),
+            span,
+        )
+    })
+}
+
+fn collect_visible_solver_expressions(
+    dae_model: &dae::Dae,
+    solver_len: usize,
+) -> Result<Vec<VisibleExpression>, LowerError> {
+    let span = dae_model_span(dae_model, "visible solver expression count")?;
+    let mut expressions =
+        lower_vec_with_capacity(solver_len, "visible solver expression count", span)?;
+    for (name, var) in dae_model
+        .variables
+        .states
+        .iter()
+        .chain(dae_model.variables.algebraics.iter())
+        .chain(dae_model.variables.outputs.iter())
+        .filter(|(name, _)| !crate::layout::is_runtime_parameter_tail_variable(dae_model, name))
+    {
+        let variable_expressions = visible_expressions_for_variable(name, var)?;
+        reserve_lower_capacity(
+            &mut expressions,
+            variable_expressions.len(),
+            "visible solver expression count",
+            var.source_span,
+        )?;
+        expressions.extend(variable_expressions);
+    }
+    expressions.truncate(solver_len);
+    Ok(expressions)
+}
+
+fn collect_visible_runtime_expressions(
+    dae_model: &dae::Dae,
+) -> Result<Vec<VisibleExpression>, LowerError> {
+    let span = dae_model_span(dae_model, "visible runtime expression count")?;
+    let capacity = checked_lower_count_add(
+        dae_model.variables.inputs.len(),
+        dae_model.variables.discrete_reals.len(),
+        "visible runtime expression count",
+        span,
+    )?;
+    let capacity = checked_lower_count_add(
+        capacity,
+        dae_model.variables.discrete_valued.len(),
+        "visible runtime expression count",
+        span,
+    )?;
+    let mut expressions =
+        lower_vec_with_capacity(capacity, "visible runtime expression count", span)?;
+    for (name, var) in dae_model
+        .variables
+        .inputs
+        .iter()
+        .chain(dae_model.variables.discrete_reals.iter())
+        .chain(dae_model.variables.discrete_valued.iter())
+    {
+        let variable_expressions = visible_expressions_for_variable(name, var)?;
+        reserve_lower_capacity(
+            &mut expressions,
+            variable_expressions.len(),
+            "visible runtime expression count",
+            var.source_span,
+        )?;
+        expressions.extend(variable_expressions);
+    }
+    Ok(expressions)
+}
+
+fn checked_lower_count_add(
+    lhs: usize,
+    rhs: usize,
+    context: &'static str,
+    span: rumoca_core::Span,
+) -> Result<usize, LowerError> {
+    lhs.checked_add(rhs).ok_or_else(|| {
+        lower_contract_violation(format!("{context} exceeds host index range"), span)
+    })
+}
+
+fn visible_expressions_for_variable(
+    name: &rumoca_core::VarName,
+    var: &dae::Variable,
+) -> Result<Vec<VisibleExpression>, LowerError> {
+    let size = variable_size(var)?;
+    if size <= 1 && var.dims.is_empty() {
+        let mut expressions =
+            lower_vec_with_capacity(1, "visible variable expression count", var.source_span)?;
+        expressions.push(visible_expression_for_variable_scalar(
+            name,
+            var,
+            name.as_str().to_string(),
+            Vec::new(),
+        )?);
+        return Ok(expressions);
+    }
+    let mut expressions =
+        lower_vec_with_capacity(size, "visible variable expression count", var.source_span)?;
+    for idx in 0..size {
+        let subscripts = dae::flat_index_to_subscripts(&var.dims, idx).ok_or_else(|| {
+            lower_contract_violation(
+                format!(
+                    "visible expression scalar index {idx} is outside variable `{}` shape",
+                    name.as_str()
+                ),
+                var.source_span,
+            )
+        })?;
+        expressions.push(visible_expression_for_variable_scalar(
+            name,
+            var,
+            dae::scalar_name_text_for_flat_index(name.as_str(), &var.dims, idx),
+            subscripts,
+        )?);
+    }
+    Ok(expressions)
+}
+
+fn visible_expression_for_variable_scalar(
+    name: &rumoca_core::VarName,
+    var: &dae::Variable,
+    scalar_name: String,
+    subscripts: Vec<usize>,
+) -> Result<VisibleExpression, LowerError> {
+    let reference = match var.origin {
+        dae::VariableOrigin::Generated => rumoca_core::Reference::generated(name.as_str()),
+        dae::VariableOrigin::Source => {
+            #[cfg(test)]
+            if var.source_span.is_dummy() {
+                return Ok(VisibleExpression {
+                    name: scalar_name,
+                    expr: rumoca_core::Expression::VarRef {
+                        name: rumoca_core::Reference::generated(name.as_str()),
+                        subscripts: visible_subscripts_from_usize(subscripts, var.source_span)?,
+                        span: var.source_span,
+                    },
+                });
+            }
+            let component_ref = var.component_ref.clone().ok_or_else(|| {
+                lower_contract_violation(
+                    format!(
+                        "source DAE variable `{}` lost structured component-reference metadata before visible observation lowering",
+                        name.as_str()
+                    ),
+                    var.source_span,
+                )
+            })?;
+            rumoca_core::Reference::from_component_reference(component_ref)
+        }
+    };
+    Ok(VisibleExpression {
+        name: scalar_name,
+        expr: rumoca_core::Expression::VarRef {
+            name: reference,
+            subscripts: visible_subscripts_from_usize(subscripts, var.source_span)?,
+            span: var.source_span,
+        },
+    })
+}
+
+pub(super) fn visible_subscripts_from_usize(
+    subscripts: Vec<usize>,
+    span: rumoca_core::Span,
+) -> Result<Vec<rumoca_core::Subscript>, LowerError> {
+    let mut lowered =
+        lower_vec_with_capacity(subscripts.len(), "visible variable subscript count", span)?;
+    for index in subscripts {
+        let value = i64::try_from(index).map_err(|_| {
+            lower_contract_violation(
+                "visible variable subscript exceeds Modelica integer range".to_string(),
+                span,
+            )
+        })?;
+        lowered.push(rumoca_core::Subscript::index(value, span));
+    }
+    Ok(lowered)
+}

--- a/crates/rumoca-phase-solve/src/timing.rs
+++ b/crates/rumoca-phase-solve/src/timing.rs
@@ -1,0 +1,35 @@
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) type StageTimer = Instant;
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) type StageTimer = ();
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn stage_start() -> StageTimer {
+    Instant::now()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn stage_start() -> StageTimer {}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn stage_elapsed_seconds(start: StageTimer) -> f64 {
+    start.elapsed().as_secs_f64()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn stage_elapsed_seconds(_start: StageTimer) -> f64 {
+    0.0
+}
+
+pub(crate) fn log_stage(label: &'static str, start: StageTimer) {
+    tracing::debug!(
+        target: "rumoca_phase_solve::timing",
+        phase = label,
+        elapsed_seconds = stage_elapsed_seconds(start),
+        "solve model lowering stage"
+    );
+}

--- a/crates/rumoca-phase-structural/src/dae_prepare/dae_prepare_demotion_tests.rs
+++ b/crates/rumoca-phase-structural/src/dae_prepare/dae_prepare_demotion_tests.rs
@@ -196,6 +196,64 @@ fn spanned_eq(rhs: Expression, origin: &str, span: Span) -> Equation {
 }
 
 #[test]
+fn compound_derivative_expansion_skips_plain_state_derivatives() {
+    let mut dae = Dae::new();
+    let mut x = test_variable("x");
+    x.dims = vec![2];
+    dae.variables.states.insert(VarName::new("x"), x);
+    dae.continuous
+        .equations
+        .push(eq(sub(der_idx("x", 1), int(1))));
+    dae.continuous
+        .equations
+        .push(eq(sub(der_idx("x", 2), int(2))));
+
+    assert!(!needs_compound_derivative_expansion(&dae));
+
+    let before: Vec<Expression> = dae
+        .continuous
+        .equations
+        .iter()
+        .map(|eq| eq.rhs.clone())
+        .collect();
+    expand_compound_derivatives(&mut dae);
+    let after: Vec<Expression> = dae
+        .continuous
+        .equations
+        .iter()
+        .map(|eq| eq.rhs.clone())
+        .collect();
+
+    assert_eq!(after, before);
+}
+
+#[test]
+fn compound_derivative_expansion_keeps_algebraic_derivative_path() {
+    let mut dae = Dae::new();
+    dae.variables
+        .states
+        .insert(VarName::new("x"), test_variable("x"));
+    dae.variables
+        .algebraics
+        .insert(VarName::new("y"), test_variable("y"));
+    dae.continuous.equations.push(eq(sub(var("y"), var("x"))));
+    dae.continuous.equations.push(eq(sub(der("x"), int(1))));
+    dae.continuous.equations.push(eq(sub(der("y"), int(0))));
+
+    assert!(needs_compound_derivative_expansion(&dae));
+
+    expand_compound_derivatives(&mut dae);
+
+    assert!(
+        dae.continuous
+            .equations
+            .iter()
+            .all(|eq| !expr_contains_der_of(&eq.rhs, &VarName::new("y"))),
+        "der(y) should still expand through y = x"
+    );
+}
+
+#[test]
 fn test_split_linear_target_zero_remainder_uses_context_span() {
     let span = Span::from_offsets(
         rumoca_core::SourceId::from_source_name(

--- a/crates/rumoca-phase-structural/src/dae_prepare/mod.rs
+++ b/crates/rumoca-phase-structural/src/dae_prepare/mod.rs
@@ -11,7 +11,7 @@ use rumoca_core::{ExpressionRewriter, ExpressionVisitor};
 use rumoca_ir_dae as dae;
 use rumoca_ir_dae::{
     DerivativeNameMatcher, expr_contains_der_of, expr_contains_der_of_any, expr_contains_var,
-    expr_refers_to_var,
+    expr_refers_to_var, var_ref_matches_unknown,
 };
 
 use crate::StructuralError;
@@ -23,6 +23,7 @@ type Expression = rumoca_core::Expression;
 type Literal = rumoca_core::Literal;
 type OpBinary = rumoca_core::OpBinary;
 type OpUnary = rumoca_core::OpUnary;
+type Reference = rumoca_core::Reference;
 type Span = rumoca_core::Span;
 type Subscript = rumoca_core::Subscript;
 type VarName = rumoca_core::VarName;
@@ -467,6 +468,10 @@ pub fn compute_full_derivative_map(dae: &Dae) -> HashMap<String, Expression> {
 /// All `der(algebraic)` and `der(compound)` calls are replaced with algebraic
 /// expressions. This prevents spurious state promotion.
 pub fn expand_compound_derivatives(dae: &mut Dae) {
+    if !needs_compound_derivative_expansion(dae) {
+        return;
+    }
+
     let der_map = compute_full_derivative_map(dae);
     if der_map.is_empty() {
         return;
@@ -488,6 +493,50 @@ pub fn expand_compound_derivatives(dae: &mut Dae) {
         .collect();
     for (eq, new_rhs) in dae.continuous.equations.iter_mut().zip(expanded) {
         eq.rhs = new_rhs;
+    }
+}
+
+fn needs_compound_derivative_expansion(dae: &Dae) -> bool {
+    let state_names: Vec<VarName> = dae.variables.states.keys().cloned().collect();
+    let matcher = DerivativeNameMatcher::from_var_names(&state_names);
+    dae.continuous
+        .equations
+        .iter()
+        .any(|eq| expr_contains_expandable_derivative(&eq.rhs, &matcher))
+}
+
+fn expr_contains_expandable_derivative(expr: &Expression, matcher: &DerivativeNameMatcher) -> bool {
+    let mut checker = ExpandableDerivativeChecker {
+        matcher,
+        found: false,
+    };
+    checker.visit_expression(expr);
+    checker.found
+}
+
+struct ExpandableDerivativeChecker<'a> {
+    matcher: &'a DerivativeNameMatcher,
+    found: bool,
+}
+
+impl ExpressionVisitor for ExpandableDerivativeChecker<'_> {
+    fn visit_expression(&mut self, expr: &Expression) {
+        if !self.found {
+            self.walk_expression(expr);
+        }
+    }
+
+    fn visit_builtin_call(&mut self, function: &BuiltinFunction, args: &[Expression]) {
+        if *function == BuiltinFunction::Der {
+            self.found = match args.first() {
+                Some(arg) => !self.matcher.expression_refers_to_match(arg),
+                None => true,
+            };
+            return;
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
     }
 }
 
@@ -949,7 +998,7 @@ impl ExpressionVisitor for UnslicedVectorRefChecker<'_> {
         }
     }
 
-    fn visit_var_ref(&mut self, name: &rumoca_core::Reference, subscripts: &[Subscript]) {
+    fn visit_var_ref(&mut self, name: &Reference, subscripts: &[Subscript]) {
         if subscripts.is_empty()
             && dae_variable_size(self.dae, name.var_name())
                 .is_ok_and(|size| size.is_some_and(|size| size > 1))
@@ -1454,14 +1503,11 @@ fn extract_state_direct_assignment_equation(
     // Residual form: 0 = expr. If expr is affine in exactly one state with
     // coefficient ±1, solve for that state.
     let mut solved: Option<(VarName, Expression)> = None;
-    for state_name in state_names {
-        if !expr_contains_var(&eq.rhs, state_name) {
+    for state_name in state_value_refs_outside_der(&eq.rhs, state_names) {
+        if expr_contains_der_of(&eq.rhs, &state_name) {
             continue;
         }
-        if expr_contains_der_of(&eq.rhs, state_name) {
-            continue;
-        }
-        let Some((coef, remainder)) = split_linear_target(&eq.rhs, state_name, eq.span) else {
+        let Some((coef, remainder)) = split_linear_target(&eq.rhs, &state_name, eq.span) else {
             continue;
         };
         let defining_expr = match coef {
@@ -1475,6 +1521,44 @@ fn extract_state_direct_assignment_equation(
         solved = Some((state_name.clone(), defining_expr));
     }
     solved
+}
+
+fn state_value_refs_outside_der(expr: &Expression, state_names: &[VarName]) -> Vec<VarName> {
+    let mut collector = StateValueRefCollector {
+        state_names,
+        refs: IndexSet::new(),
+    };
+    collector.visit_expression(expr);
+    collector.refs.into_iter().collect()
+}
+
+struct StateValueRefCollector<'a> {
+    state_names: &'a [VarName],
+    refs: IndexSet<VarName>,
+}
+
+impl ExpressionVisitor for StateValueRefCollector<'_> {
+    fn visit_builtin_call(&mut self, function: &BuiltinFunction, args: &[Expression]) {
+        if *function == BuiltinFunction::Der {
+            return;
+        }
+        for arg in args {
+            self.visit_expression(arg);
+        }
+    }
+
+    fn visit_var_ref(&mut self, name: &rumoca_core::Reference, subscripts: &[Subscript]) {
+        if let Some(state_name) = self
+            .state_names
+            .iter()
+            .find(|state_name| var_ref_matches_unknown(name, subscripts, state_name))
+        {
+            self.refs.insert(state_name.clone());
+        }
+        for subscript in subscripts {
+            self.visit_subscript(subscript);
+        }
+    }
 }
 
 fn der_call_targets_state(expr: &Expression, state_name: &VarName) -> bool {

--- a/crates/rumoca-phase-structural/src/eliminate/boundary_scan.rs
+++ b/crates/rumoca-phase-structural/src/eliminate/boundary_scan.rs
@@ -1,0 +1,124 @@
+use super::*;
+
+pub(super) struct BoundaryScanCtx<'a> {
+    pub(super) dae: &'a Dae,
+    pub(super) state_names: &'a [VarName],
+    pub(super) unknown_index: &'a BoundaryUnknownIndex<'a>,
+    pub(super) state_derivative_matcher: &'a DerivativeNameMatcher,
+    pub(super) runtime_protected_unknowns: &'a IndexSet<String>,
+    pub(super) runtime_defined_discrete_targets: &'a HashSet<String>,
+    pub(super) direct_definitions: &'a DirectDefinitionIndex,
+}
+
+pub(super) struct BoundaryScanState {
+    pub(super) resolved: HashSet<VarName>,
+    pub(super) substitutions: Vec<Substitution>,
+    pub(super) eliminated_eq_indices: Vec<usize>,
+    pub(super) eliminated_eq_flags: Vec<bool>,
+}
+
+impl BoundaryScanState {
+    pub(super) fn new(equation_count: usize) -> Self {
+        Self {
+            resolved: HashSet::new(),
+            substitutions: Vec::new(),
+            eliminated_eq_indices: Vec::new(),
+            eliminated_eq_flags: vec![false; equation_count],
+        }
+    }
+
+    fn push_solution(
+        &mut self,
+        dae: &Dae,
+        eq_idx: usize,
+        var_name: VarName,
+        solution: Expression,
+    ) -> Result<(), StructuralError> {
+        self.substitutions
+            .push(substitution_for_var(dae, var_name.clone(), solution)?);
+        self.eliminated_eq_indices.push(eq_idx);
+        self.eliminated_eq_flags[eq_idx] = true;
+        self.resolved.insert(var_name);
+        Ok(())
+    }
+}
+
+pub(super) fn scan_boundary_equations(
+    eq_order: Vec<(usize, usize)>,
+    ctx: &BoundaryScanCtx<'_>,
+    state: &mut BoundaryScanState,
+) -> Result<(), StructuralError> {
+    for (eq_idx, _) in eq_order {
+        scan_boundary_equation(eq_idx, ctx, state)?;
+    }
+    Ok(())
+}
+
+fn scan_boundary_equation(
+    eq_idx: usize,
+    ctx: &BoundaryScanCtx<'_>,
+    state: &mut BoundaryScanState,
+) -> Result<(), StructuralError> {
+    if state.eliminated_eq_flags[eq_idx] {
+        return Ok(());
+    }
+    let equation = &ctx.dae.continuous.equations[eq_idx];
+    let expr = equation_analysis_expr(equation);
+    let eq_rhs = apply_substitutions_in_order(&expr, &state.substitutions)?;
+    let is_connection_eq = equation.origin.starts_with("connection equation:");
+    let live = find_live_scalar_unknowns(&eq_rhs, ctx.unknown_index, &state.resolved)?;
+    if should_skip_connection_equation(
+        ctx.dae,
+        &eq_rhs,
+        is_connection_eq,
+        &live,
+        ctx.runtime_defined_discrete_targets,
+    ) {
+        return Ok(());
+    }
+    let has_state_derivative = expr_contains_der_of_any(&eq_rhs, ctx.state_derivative_matcher);
+    if let Some((var_name, solution)) = aggregate_alias_for_elimination(
+        ctx.dae,
+        &eq_rhs,
+        ctx.runtime_protected_unknowns,
+        ctx.runtime_defined_discrete_targets,
+    )? {
+        return state.push_solution(ctx.dae, eq_idx, var_name, solution);
+    }
+    if live.is_empty() {
+        let mut zero_unknown_ctx = ZeroUnknownEliminationCtx {
+            dae: ctx.dae,
+            state_names: ctx.state_names,
+            unknown_index: ctx.unknown_index,
+            resolved: &state.resolved,
+            runtime_protected_unknowns: ctx.runtime_protected_unknowns,
+            runtime_defined_discrete_targets: ctx.runtime_defined_discrete_targets,
+            substitutions: &mut state.substitutions,
+            eliminated_eq_indices: &mut state.eliminated_eq_indices,
+            eliminated_eq_flags: &mut state.eliminated_eq_flags,
+        };
+        return try_eliminate_zero_unknown_equation(
+            eq_idx,
+            &eq_rhs,
+            has_state_derivative,
+            &mut zero_unknown_ctx,
+        );
+    }
+    if is_flow_equation_origin(&equation.origin)
+        && expr_contains_indexed_multiscalar_ref(&eq_rhs, ctx.dae)?
+    {
+        return Ok(());
+    }
+    if let Some((var_name, solution)) = choose_solvable_unknown_for_elimination(
+        ctx.dae,
+        eq_idx,
+        &eq_rhs,
+        &live,
+        has_state_derivative,
+        ctx.runtime_protected_unknowns,
+        ctx.direct_definitions,
+    )? {
+        state.push_solution(ctx.dae, eq_idx, var_name, solution)?;
+    }
+    Ok(())
+}

--- a/crates/rumoca-phase-structural/src/eliminate/direct_definition_index.rs
+++ b/crates/rumoca-phase-structural/src/eliminate/direct_definition_index.rs
@@ -1,0 +1,89 @@
+use indexmap::{IndexMap, IndexSet};
+
+use rumoca_core::{Expression, OpBinary, OpUnary, VarName};
+use rumoca_ir_dae as dae;
+
+use super::runtime_protection::assignment_var_ref_name;
+
+pub(super) struct DirectDefinitionIndex {
+    per_equation: Vec<Vec<VarName>>,
+    counts: IndexMap<VarName, usize>,
+}
+
+impl DirectDefinitionIndex {
+    pub(super) fn build(dae: &dae::Dae) -> Self {
+        let mut per_equation = Vec::with_capacity(dae.continuous.equations.len());
+        let mut counts = IndexMap::<VarName, usize>::new();
+        for equation in &dae.continuous.equations {
+            let targets = direct_assignment_targets(&equation.rhs);
+            for target in &targets {
+                *counts.entry(target.clone()).or_default() += 1;
+            }
+            per_equation.push(targets.into_iter().collect());
+        }
+        Self {
+            per_equation,
+            counts,
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.counts.len()
+    }
+
+    pub(super) fn has_other_direct_definition(
+        &self,
+        current_eq_idx: usize,
+        candidate: &VarName,
+    ) -> bool {
+        let count = self.counts.get(candidate).copied().unwrap_or_default();
+        if count == 0 {
+            return false;
+        }
+        let current_has_definition = self
+            .per_equation
+            .get(current_eq_idx)
+            .is_some_and(|targets| targets.iter().any(|target| target == candidate));
+        count > usize::from(current_has_definition)
+    }
+}
+
+fn direct_assignment_targets(expr: &Expression) -> IndexSet<VarName> {
+    let mut targets = IndexSet::new();
+    collect_direct_assignment_targets(expr, &mut targets);
+    targets
+}
+
+fn collect_direct_assignment_targets(expr: &Expression, targets: &mut IndexSet<VarName>) {
+    match expr {
+        Expression::Binary {
+            op: OpBinary::Sub,
+            lhs,
+            rhs,
+            ..
+        } => {
+            if let Some(target) = direct_assignment_side_target(lhs) {
+                targets.insert(target);
+            }
+            if let Some(target) = direct_assignment_side_target(rhs) {
+                targets.insert(target);
+            }
+        }
+        Expression::Unary {
+            op: OpUnary::Minus,
+            rhs,
+            ..
+        } => collect_direct_assignment_targets(rhs, targets),
+        _ => {}
+    }
+}
+
+fn direct_assignment_side_target(expr: &Expression) -> Option<VarName> {
+    let Expression::VarRef {
+        name, subscripts, ..
+    } = expr
+    else {
+        return None;
+    };
+    assignment_var_ref_name(name.var_name(), subscripts)
+}

--- a/crates/rumoca-phase-structural/src/eliminate/mod.rs
+++ b/crates/rumoca-phase-structural/src/eliminate/mod.rs
@@ -21,15 +21,19 @@ use rumoca_core::{
 use rumoca_ir_dae as dae;
 
 mod aggregate_alias;
+mod boundary_scan;
 mod connection_policy;
 mod diagnostics;
+mod direct_definition_index;
 mod flow_policy;
 mod orphan_unknowns;
+mod profiling;
 mod runtime_known;
 mod runtime_protection;
 mod scalar_shape;
 mod solve_for_unknown;
 mod substitution_application;
+mod substitution_target;
 mod tearing_elimination;
 mod unknown_index;
 
@@ -37,10 +41,13 @@ use aggregate_alias::{
     aggregate_alias_for_elimination, aggregate_variable_fully_resolved,
     is_scalarized_element_of_aggregate,
 };
+use boundary_scan::{BoundaryScanCtx, BoundaryScanState, scan_boundary_equations};
 use connection_policy::should_skip_connection_equation;
 use diagnostics::trace_singular_reduced_rows;
+use direct_definition_index::DirectDefinitionIndex;
 use flow_policy::{expr_contains_indexed_multiscalar_ref, is_flow_equation_origin};
 use orphan_unknowns::{drop_unreferenced_continuous_unknowns, output_partition_contains_unknown};
+use profiling::{eliminate_profile_enabled, log_eliminate_profile};
 use runtime_known::singular_rows_are_runtime_known_assignments;
 use runtime_protection::{
     assignment_target_name, expr_references_any_discrete_name,
@@ -53,6 +60,9 @@ pub use solve_for_unknown::try_solve_for_unknown;
 use substitution_application::{
     apply_substitutions_in_order, apply_substitutions_to_dae_partitions,
     apply_substitutions_to_remaining_once, equation_analysis_expr,
+};
+use substitution_target::{
+    expr_contains_derivative_substitution_target, expr_contains_substitution_target,
 };
 use tearing_elimination::tear_and_eliminate_loop_block;
 use unknown_index::{
@@ -134,11 +144,20 @@ struct ZeroUnknownEliminationCtx<'a> {
 /// base variable names (not expanded scalar names).
 pub fn eliminate_trivial(dae: &mut Dae) -> Result<EliminationResult, StructuralError> {
     let trace = eliminate_trace_enabled();
+    let profile = eliminate_profile_enabled();
     let t_total = maybe_start_timer_if(trace);
+    let p_total = maybe_start_timer_if(profile);
 
     // Phase A: resolve boundary equations to make the system non-singular.
     let t_boundary = maybe_start_timer_if(trace);
+    let p_boundary = maybe_start_timer_if(profile);
     let (mut result, direct_demoted) = resolve_boundary_and_direct_demotions_to_fixpoint(dae)?;
+    log_eliminate_profile(
+        profile,
+        "boundary_fixpoint",
+        p_boundary,
+        result.n_eliminated,
+    );
     if trace {
         crate::structural_trace!(
             "[sim-trace] eliminate_trivial boundary elapsed={:.3}s eliminated_eqs={} demoted_states={}",
@@ -151,8 +170,23 @@ pub fn eliminate_trivial(dae: &mut Dae) -> Result<EliminationResult, StructuralE
     // Phase B: BLT scalar-block elimination on the (now hopefully non-singular) system.
     // Extract blocks before mutating dae (SortedDae borrows dae immutably).
     let mut blt_error = None;
+    let p_clone = maybe_start_timer_if(profile);
     let mut sort_input = dae.clone();
+    log_eliminate_profile(
+        profile,
+        "clone_sort_input",
+        p_clone,
+        sort_input.continuous.equations.len(),
+    );
+    let p_drop = maybe_start_timer_if(profile);
     drop_unreferenced_continuous_unknowns(&mut sort_input);
+    log_eliminate_profile(
+        profile,
+        "drop_unreferenced_unknowns",
+        p_drop,
+        sort_input.continuous.equations.len(),
+    );
+    let p_sort = maybe_start_timer_if(profile);
     let blocks = match sort_dae(&sort_input) {
         Ok(sorted) => Some(sorted.blocks.clone()),
         Err(StructuralError::EmptySystem) => None,
@@ -163,10 +197,18 @@ pub fn eliminate_trivial(dae: &mut Dae) -> Result<EliminationResult, StructuralE
             None
         }
     };
+    log_eliminate_profile(
+        profile,
+        "sort_dae",
+        p_sort,
+        blocks.as_ref().map_or(0, Vec::len),
+    );
     if let Some(blocks) = blocks {
         let state_names: Vec<VarName> = dae.variables.states.keys().cloned().collect();
         let t_blt = maybe_start_timer_if(trace);
+        let p_blt = maybe_start_timer_if(profile);
         let blt_result = eliminate_via_blt(dae, &blocks, &state_names)?;
+        log_eliminate_profile(profile, "eliminate_via_blt", p_blt, blt_result.n_eliminated);
         if trace {
             crate::structural_trace!(
                 "[sim-trace] eliminate_trivial blt elapsed={:.3}s eliminated_eqs={}",
@@ -178,7 +220,15 @@ pub fn eliminate_trivial(dae: &mut Dae) -> Result<EliminationResult, StructuralE
         result.n_eliminated += blt_result.n_eliminated;
     }
     result.blt_error = blt_error;
+    let p_apply = maybe_start_timer_if(profile);
     apply_substitutions_to_dae_partitions(dae, &result.substitutions)?;
+    log_eliminate_profile(
+        profile,
+        "apply_substitutions_to_partitions",
+        p_apply,
+        result.substitutions.len(),
+    );
+    log_eliminate_profile(profile, "total", p_total, result.n_eliminated);
     if trace {
         crate::structural_trace!(
             "[sim-trace] eliminate_trivial total elapsed={:.3}s eliminated_eqs={}",
@@ -209,14 +259,24 @@ fn resolve_boundary_and_direct_demotions_to_fixpoint(
 ) -> Result<(EliminationResult, usize), StructuralError> {
     let mut result = EliminationResult::default();
     let mut total_demoted = 0usize;
+    let profile = eliminate_profile_enabled();
 
     loop {
+        let p_boundary = maybe_start_timer_if(profile);
         let pass = resolve_boundary_equations_to_fixpoint(dae)?;
+        log_eliminate_profile(
+            profile,
+            "boundary_equations_to_fixpoint",
+            p_boundary,
+            pass.n_eliminated,
+        );
         let eliminated = pass.n_eliminated;
         result.n_eliminated += pass.n_eliminated;
         result.substitutions.extend(pass.substitutions);
 
+        let p_demote = maybe_start_timer_if(profile);
         let demoted = crate::dae_prepare::demote_direct_assigned_states(dae)?;
+        log_eliminate_profile(profile, "boundary_direct_demotion", p_demote, demoted);
         total_demoted += demoted;
         if eliminated == 0 && demoted == 0 {
             return Ok((result, total_demoted));
@@ -247,107 +307,79 @@ fn eliminate_trace_enabled() -> bool {
 ///
 /// ODE equations (containing `der(state)`) are always skipped.
 fn resolve_boundary_equations(dae: &mut Dae) -> Result<EliminationResult, StructuralError> {
+    let profile = eliminate_profile_enabled();
+    let p_unknowns = maybe_start_timer_if(profile);
     let all_unknowns = collect_boundary_unknowns(dae)?;
+    log_eliminate_profile(
+        profile,
+        "boundary_collect_unknowns",
+        p_unknowns,
+        all_unknowns.len(),
+    );
+    let p_index = maybe_start_timer_if(profile);
     let unknown_index = BoundaryUnknownIndex::build(dae, &all_unknowns)?;
+    log_eliminate_profile(
+        profile,
+        "boundary_build_unknown_index",
+        p_index,
+        all_unknowns.len(),
+    );
+    let p_runtime = maybe_start_timer_if(profile);
     let runtime_protected_unknowns = runtime_protected_unknown_names(dae);
     let runtime_defined_discrete_targets = runtime_defined_discrete_target_names(dae);
+    log_eliminate_profile(
+        profile,
+        "boundary_runtime_protection_sets",
+        p_runtime,
+        runtime_protected_unknowns.len() + runtime_defined_discrete_targets.len(),
+    );
 
     let state_names: Vec<VarName> = dae.variables.states.keys().cloned().collect();
     let state_derivative_matcher = DerivativeNameMatcher::from_var_names(&state_names);
-    // Track which unknowns have been resolved (removed from the live set).
-    let mut resolved: HashSet<VarName> = HashSet::new();
-    let mut substitutions: Vec<Substitution> = Vec::new();
-    let mut eliminated_eq_indices: Vec<usize> = Vec::new();
-    let mut eliminated_eq_flags = vec![false; dae.continuous.equations.len()];
+    let p_direct = maybe_start_timer_if(profile);
+    let direct_definitions = DirectDefinitionIndex::build(dae);
+    log_eliminate_profile(
+        profile,
+        "boundary_direct_definition_index",
+        p_direct,
+        direct_definitions.len(),
+    );
+    let mut scan_state = BoundaryScanState::new(dae.continuous.equations.len());
 
-    let eq_order = boundary_equation_order(dae, &unknown_index, &resolved)?;
+    let p_order = maybe_start_timer_if(profile);
+    let eq_order = boundary_equation_order(dae, &unknown_index, &scan_state.resolved)?;
+    log_eliminate_profile(profile, "boundary_equation_order", p_order, eq_order.len());
 
-    for (eq_idx, _) in eq_order {
-        if eliminated_eq_flags[eq_idx] {
-            continue;
-        }
-
-        let expr = equation_analysis_expr(&dae.continuous.equations[eq_idx]);
-        let eq_rhs = apply_substitutions_in_order(&expr, &substitutions)?;
-        let is_connection_eq = dae.continuous.equations[eq_idx]
-            .origin
-            .starts_with("connection equation:");
-
-        // Re-count live unknowns (may have decreased due to prior resolutions).
-        let live: Vec<VarName> = find_live_scalar_unknowns(&eq_rhs, &unknown_index, &resolved)?;
-
-        if should_skip_connection_equation(
+    let p_loop = maybe_start_timer_if(profile);
+    {
+        let scan_ctx = BoundaryScanCtx {
             dae,
-            &eq_rhs,
-            is_connection_eq,
-            &live,
-            &runtime_defined_discrete_targets,
-        ) {
-            continue;
-        }
-        let has_state_derivative = expr_contains_der_of_any(&eq_rhs, &state_derivative_matcher);
-        if let Some((var_name, solution)) = aggregate_alias_for_elimination(
-            dae,
-            &eq_rhs,
-            &runtime_protected_unknowns,
-            &runtime_defined_discrete_targets,
-        )? {
-            substitutions.push(substitution_for_var(dae, var_name.clone(), solution)?);
-            eliminated_eq_indices.push(eq_idx);
-            eliminated_eq_flags[eq_idx] = true;
-            resolved.insert(var_name);
-            continue;
-        }
-        if live.is_empty() {
-            let mut zero_unknown_ctx = ZeroUnknownEliminationCtx {
-                dae,
-                state_names: &state_names,
-                unknown_index: &unknown_index,
-                resolved: &resolved,
-                runtime_protected_unknowns: &runtime_protected_unknowns,
-                runtime_defined_discrete_targets: &runtime_defined_discrete_targets,
-                substitutions: &mut substitutions,
-                eliminated_eq_indices: &mut eliminated_eq_indices,
-                eliminated_eq_flags: &mut eliminated_eq_flags,
-            };
-            try_eliminate_zero_unknown_equation(
-                eq_idx,
-                &eq_rhs,
-                has_state_derivative,
-                &mut zero_unknown_ctx,
-            )?;
-            continue;
-        }
-        if is_flow_equation_origin(&dae.continuous.equations[eq_idx].origin)
-            && expr_contains_indexed_multiscalar_ref(&eq_rhs, dae)?
-        {
-            continue;
-        }
-
-        let Some((var_name, solution)) = choose_solvable_unknown_for_elimination(
-            dae,
-            eq_idx,
-            &eq_rhs,
-            &live,
-            has_state_derivative,
-            &runtime_protected_unknowns,
-        )?
-        else {
-            continue;
+            state_names: &state_names,
+            unknown_index: &unknown_index,
+            state_derivative_matcher: &state_derivative_matcher,
+            runtime_protected_unknowns: &runtime_protected_unknowns,
+            runtime_defined_discrete_targets: &runtime_defined_discrete_targets,
+            direct_definitions: &direct_definitions,
         };
-        substitutions.push(substitution_for_var(dae, var_name.clone(), solution)?);
-        eliminated_eq_indices.push(eq_idx);
-        eliminated_eq_flags[eq_idx] = true;
-        resolved.insert(var_name.clone());
+        scan_boundary_equations(eq_order, &scan_ctx, &mut scan_state)?;
     }
+    log_eliminate_profile(
+        profile,
+        "boundary_scan_equations",
+        p_loop,
+        scan_state.substitutions.len(),
+    );
 
-    finish_boundary_elimination(
+    let p_finish = maybe_start_timer_if(profile);
+    let result = finish_boundary_elimination(
         dae,
-        substitutions,
-        eliminated_eq_flags,
-        eliminated_eq_indices,
-        &resolved,
-    )
+        scan_state.substitutions,
+        scan_state.eliminated_eq_flags,
+        scan_state.eliminated_eq_indices,
+        &scan_state.resolved,
+    )?;
+    log_eliminate_profile(profile, "boundary_finish", p_finish, result.n_eliminated);
+    Ok(result)
 }
 
 fn boundary_equation_order(
@@ -420,6 +452,26 @@ fn shift_structured_families_after_equation_removal(dae: &mut Dae, removed_sorte
             .count();
         family.first_equation_index -= shift;
         true
+    });
+}
+
+/// Drop structured families whose row bodies were symbolically rewritten.
+///
+/// Substitutions can change a family row's LHS/RHS without changing row count.
+/// The old compact family metadata was proven for the pre-substitution body, so
+/// keeping it would let downstream Solve-IR rebuild a tensor node from stale row
+/// provenance. Regenerating a family proof belongs in a dedicated pass; the safe
+/// structural-elimination behavior is to scalarize rewritten families.
+fn drop_structured_families_touching_equations(dae: &mut Dae, touched_sorted: &[usize]) {
+    if touched_sorted.is_empty() {
+        return;
+    }
+    dae.continuous.structured_equations.retain(|family| {
+        let total: usize = family.equation_counts.iter().sum();
+        let block_end = family.first_equation_index + total;
+        !touched_sorted
+            .iter()
+            .any(|&idx| idx >= family.first_equation_index && idx < block_end)
     });
 }
 
@@ -604,11 +656,12 @@ fn choose_solvable_unknown_for_elimination(
     live: &[VarName],
     has_state_derivative: bool,
     runtime_protected_unknowns: &IndexSet<String>,
+    direct_definitions: &DirectDefinitionIndex,
 ) -> Result<Option<(VarName, Expression)>, StructuralError> {
     let mut candidates: Vec<&VarName> = live.iter().collect();
     candidates.sort_by(|a, b| {
-        let a_has_definition = has_other_direct_definition(dae, eq_idx, a);
-        let b_has_definition = has_other_direct_definition(dae, eq_idx, b);
+        let a_has_definition = direct_definitions.has_other_direct_definition(eq_idx, a);
+        let b_has_definition = direct_definitions.has_other_direct_definition(eq_idx, b);
         let a_is_output = output_partition_contains_unknown(dae, a);
         let b_is_output = output_partition_contains_unknown(dae, b);
         a_has_definition
@@ -676,16 +729,6 @@ fn choose_solvable_unknown_for_elimination(
         return Ok(Some((candidate.clone(), solution)));
     }
     Ok(None)
-}
-
-fn has_other_direct_definition(dae: &Dae, current_eq_idx: usize, candidate: &VarName) -> bool {
-    dae.continuous
-        .equations
-        .iter()
-        .enumerate()
-        .any(|(eq_idx, eq)| {
-            eq_idx != current_eq_idx && has_direct_assignment_form(&eq.rhs, candidate)
-        })
 }
 
 fn choose_solvable_non_unknown_alias_for_elimination(
@@ -1235,77 +1278,6 @@ pub(crate) fn apply_substitutions_to_expr_with_derivatives(
     Ok(out)
 }
 
-fn expr_contains_substitution_target(expr: &Expression, substitution: &Substitution) -> bool {
-    let mut checker = SubstitutionTargetChecker {
-        substitution,
-        found: false,
-    };
-    checker.visit_expression(expr);
-    checker.found
-}
-
-struct SubstitutionTargetChecker<'a> {
-    substitution: &'a Substitution,
-    found: bool,
-}
-
-impl ExpressionVisitor for SubstitutionTargetChecker<'_> {
-    fn visit_expression(&mut self, expr: &Expression) {
-        if !self.found {
-            self.walk_expression(expr);
-        }
-    }
-
-    fn visit_var_ref(&mut self, name: &Reference, subscripts: &[rumoca_core::Subscript]) {
-        if aggregate_subscript_ref_matches_var(name, subscripts, self.substitution)
-            || var_ref_matches_unknown_for_substitution(name, subscripts, self.substitution)
-            || embedded_alias_indices_for_substitution(name, subscripts, self.substitution)
-                .is_some()
-        {
-            self.found = true;
-            return;
-        }
-        for subscript in subscripts {
-            self.visit_subscript(subscript);
-        }
-    }
-}
-
-fn expr_contains_derivative_substitution_target(
-    expr: &Expression,
-    substitution: &Substitution,
-) -> bool {
-    let mut checker = DerivativeSubstitutionTargetChecker {
-        substitution,
-        found: false,
-    };
-    checker.visit_expression(expr);
-    checker.found
-}
-
-struct DerivativeSubstitutionTargetChecker<'a> {
-    substitution: &'a Substitution,
-    found: bool,
-}
-
-impl ExpressionVisitor for DerivativeSubstitutionTargetChecker<'_> {
-    fn visit_expression(&mut self, expr: &Expression) {
-        if self.found {
-            return;
-        }
-        match expr {
-            Expression::BuiltinCall {
-                function: BuiltinFunction::Der,
-                args,
-                ..
-            } if der_call_matches_scalar_substitution(args, self.substitution) => {
-                self.found = true;
-            }
-            _ => self.walk_expression(expr),
-        }
-    }
-}
-
 fn apply_record_field_aggregate_substitutions(
     expr: &Expression,
     substitutions: &[Substitution],
@@ -1663,7 +1635,7 @@ fn expr_contains_unsliced_multiscalar_ref(
     Ok(false)
 }
 
-fn embedded_alias_indices_for_substitution(
+pub(super) fn embedded_alias_indices_for_substitution(
     name: &Reference,
     subscripts: &[rumoca_core::Subscript],
     substitution: &Substitution,
@@ -1792,7 +1764,7 @@ fn replacement_indices_for_alias(
     indices.to_vec()
 }
 
-fn var_ref_matches_unknown_for_substitution(
+pub(super) fn var_ref_matches_unknown_for_substitution(
     name: &Reference,
     subscripts: &[rumoca_core::Subscript],
     substitution: &Substitution,
@@ -1825,7 +1797,7 @@ fn var_ref_matches_unknown_for_substitution(
     var_ref_matches_unknown(name, subscripts, &substitution.var_name)
 }
 
-fn aggregate_subscript_ref_matches_var(
+pub(super) fn aggregate_subscript_ref_matches_var(
     name: &Reference,
     subscripts: &[rumoca_core::Subscript],
     substitution: &Substitution,
@@ -1929,7 +1901,10 @@ impl SubstituteVarRewriter<'_> {
     }
 }
 
-fn der_call_matches_scalar_substitution(args: &[Expression], substitution: &Substitution) -> bool {
+pub(super) fn der_call_matches_scalar_substitution(
+    args: &[Expression],
+    substitution: &Substitution,
+) -> bool {
     if !substitution.var_dims.is_empty() {
         return false;
     }

--- a/crates/rumoca-phase-structural/src/eliminate/profiling.rs
+++ b/crates/rumoca-phase-structural/src/eliminate/profiling.rs
@@ -1,0 +1,37 @@
+#[cfg(feature = "tracing")]
+pub(super) fn eliminate_profile_enabled() -> bool {
+    tracing::enabled!(target: "rumoca_phase_structural::eliminate", tracing::Level::DEBUG)
+}
+
+#[cfg(not(feature = "tracing"))]
+pub(super) fn eliminate_profile_enabled() -> bool {
+    false
+}
+
+#[cfg(feature = "tracing")]
+pub(super) fn log_eliminate_profile(
+    enabled: bool,
+    phase: &'static str,
+    start: rumoca_core::OptionalTimer,
+    count: usize,
+) {
+    if !enabled {
+        return;
+    }
+    tracing::debug!(
+        target: "rumoca_phase_structural::eliminate",
+        phase,
+        elapsed_seconds = rumoca_core::maybe_elapsed_seconds(start),
+        count,
+        "eliminate_trivial stage"
+    );
+}
+
+#[cfg(not(feature = "tracing"))]
+pub(super) fn log_eliminate_profile(
+    _enabled: bool,
+    _phase: &'static str,
+    _start: rumoca_core::OptionalTimer,
+    _count: usize,
+) {
+}

--- a/crates/rumoca-phase-structural/src/eliminate/runtime_protection.rs
+++ b/crates/rumoca-phase-structural/src/eliminate/runtime_protection.rs
@@ -203,7 +203,7 @@ pub(super) fn assignment_target_name(expr: &Expression) -> Option<VarName> {
     None
 }
 
-fn assignment_var_ref_name(
+pub(super) fn assignment_var_ref_name(
     name: &VarName,
     subscripts: &[rumoca_core::Subscript],
 ) -> Option<VarName> {

--- a/crates/rumoca-phase-structural/src/eliminate/substitution_application.rs
+++ b/crates/rumoca-phase-structural/src/eliminate/substitution_application.rs
@@ -33,6 +33,7 @@ pub(super) fn apply_substitutions_to_remaining_once(
     }
     let derivative_source = dae.clone();
     let mut derivative_replacements = DerivativeReplacementCache::new(&derivative_source);
+    let mut touched_equations = Vec::new();
     for (i, eq) in dae.continuous.equations.iter_mut().enumerate() {
         let eliminated = eliminated_eq_flags.get(i).ok_or_else(|| {
             StructuralError::ContractViolation {
@@ -46,6 +47,8 @@ pub(super) fn apply_substitutions_to_remaining_once(
         if *eliminated {
             continue;
         }
+        let original_lhs = eq.lhs.clone();
+        let original_rhs = eq.rhs.clone();
         let rhs = apply_substitutions_in_order_with_derivatives(
             &eq.rhs,
             substitutions,
@@ -53,6 +56,9 @@ pub(super) fn apply_substitutions_to_remaining_once(
         )?;
         let Some(lhs) = eq.lhs.as_ref() else {
             eq.rhs = rhs;
+            if eq.rhs != original_rhs {
+                touched_equations.push(i);
+            }
             continue;
         };
         let lhs_expr = Expression::VarRef {
@@ -71,7 +77,11 @@ pub(super) fn apply_substitutions_to_remaining_once(
             eq.lhs = None;
             eq.rhs = subtraction(substituted_lhs, rhs, eq.span);
         }
+        if eq.lhs != original_lhs || eq.rhs != original_rhs {
+            touched_equations.push(i);
+        }
     }
+    super::drop_structured_families_touching_equations(dae, &touched_equations);
     Ok(())
 }
 
@@ -83,11 +93,11 @@ pub(super) fn apply_substitutions_to_dae_partitions(
         return Ok(());
     }
     let derivative_source = dae.clone();
-    SubstitutionDaeRewriter {
+    let mut rewriter = SubstitutionDaeRewriter {
         substitutions,
         derivative_replacements: DerivativeReplacementCache::new(&derivative_source),
-    }
-    .rewrite_dae(dae)
+    };
+    rewriter.rewrite_dae(dae)
 }
 
 pub(super) fn apply_substitutions_in_order(
@@ -278,7 +288,9 @@ struct SubstitutionDaeRewriter<'a> {
 
 impl SubstitutionDaeRewriter<'_> {
     fn rewrite_dae(&mut self, dae: &mut Dae) -> Result<(), StructuralError> {
-        self.rewrite_equations(&mut dae.continuous.equations)?;
+        let touched_equations =
+            self.rewrite_equations_collecting_changes(&mut dae.continuous.equations)?;
+        super::drop_structured_families_touching_equations(dae, &touched_equations);
         self.rewrite_equations(&mut dae.initialization.equations)?;
         self.rewrite_equations(&mut dae.discrete.real_updates)?;
         self.rewrite_equations(&mut dae.discrete.valued_updates)?;
@@ -299,6 +311,22 @@ impl SubstitutionDaeRewriter<'_> {
             self.rewrite_equation(equation)?;
         }
         Ok(())
+    }
+
+    fn rewrite_equations_collecting_changes(
+        &mut self,
+        equations: &mut [rumoca_ir_dae::Equation],
+    ) -> Result<Vec<usize>, StructuralError> {
+        let mut touched = Vec::new();
+        for (index, equation) in equations.iter_mut().enumerate() {
+            let original_lhs = equation.lhs.clone();
+            let original_rhs = equation.rhs.clone();
+            self.rewrite_equation(equation)?;
+            if equation.lhs != original_lhs || equation.rhs != original_rhs {
+                touched.push(index);
+            }
+        }
+        Ok(touched)
     }
 
     fn rewrite_equation(

--- a/crates/rumoca-phase-structural/src/eliminate/substitution_target.rs
+++ b/crates/rumoca-phase-structural/src/eliminate/substitution_target.rs
@@ -1,0 +1,80 @@
+use rumoca_core::{BuiltinFunction, Expression, ExpressionVisitor, Reference};
+
+use super::{
+    Substitution, aggregate_subscript_ref_matches_var, der_call_matches_scalar_substitution,
+    embedded_alias_indices_for_substitution, var_ref_matches_unknown_for_substitution,
+};
+
+pub(super) fn expr_contains_substitution_target(
+    expr: &Expression,
+    substitution: &Substitution,
+) -> bool {
+    let mut checker = SubstitutionTargetChecker {
+        substitution,
+        found: false,
+    };
+    checker.visit_expression(expr);
+    checker.found
+}
+
+struct SubstitutionTargetChecker<'a> {
+    substitution: &'a Substitution,
+    found: bool,
+}
+
+impl ExpressionVisitor for SubstitutionTargetChecker<'_> {
+    fn visit_expression(&mut self, expr: &Expression) {
+        if !self.found {
+            self.walk_expression(expr);
+        }
+    }
+
+    fn visit_var_ref(&mut self, name: &Reference, subscripts: &[rumoca_core::Subscript]) {
+        if aggregate_subscript_ref_matches_var(name, subscripts, self.substitution)
+            || var_ref_matches_unknown_for_substitution(name, subscripts, self.substitution)
+            || embedded_alias_indices_for_substitution(name, subscripts, self.substitution)
+                .is_some()
+        {
+            self.found = true;
+            return;
+        }
+        for subscript in subscripts {
+            self.visit_subscript(subscript);
+        }
+    }
+}
+
+pub(super) fn expr_contains_derivative_substitution_target(
+    expr: &Expression,
+    substitution: &Substitution,
+) -> bool {
+    let mut checker = DerivativeSubstitutionTargetChecker {
+        substitution,
+        found: false,
+    };
+    checker.visit_expression(expr);
+    checker.found
+}
+
+struct DerivativeSubstitutionTargetChecker<'a> {
+    substitution: &'a Substitution,
+    found: bool,
+}
+
+impl ExpressionVisitor for DerivativeSubstitutionTargetChecker<'_> {
+    fn visit_expression(&mut self, expr: &Expression) {
+        if self.found {
+            return;
+        }
+        match expr {
+            Expression::BuiltinCall {
+                function: BuiltinFunction::Der,
+                args,
+                ..
+            } if der_call_matches_scalar_substitution(args, self.substitution) => {
+                self.found = true;
+            }
+            _ => self.walk_expression(expr),
+        }
+    }
+}

--- a/crates/rumoca-phase-structural/src/eliminate/tests.rs
+++ b/crates/rumoca-phase-structural/src/eliminate/tests.rs
@@ -1789,4 +1789,79 @@ fn shift_structured_families_drops_family_with_removed_interior_row() {
     );
 }
 
+/// A substitution can rewrite a structured family's row bodies while leaving the
+/// row count unchanged. The original family proof no longer applies, so the
+/// family must be dropped and lowered as scalar rows.
+#[test]
+fn drop_structured_families_touching_equations_drops_rewritten_family() {
+    let family = |first_equation_index: usize| dae::StructuredEquationFamily {
+        domain: rumoca_core::StructuredIndexDomain {
+            binders: vec![rumoca_core::StructuredIndexBinder {
+                id: 0,
+                display_name: "i".to_string(),
+                lower: 1,
+                upper: 2,
+                step: 1,
+            }],
+        },
+        first_equation_index,
+        equation_counts: vec![1, 1],
+        span: test_span(),
+        origin: "test".to_string(),
+        regular: None,
+        template: None,
+        interiors_materialized: true,
+    };
+    let mut dae = Dae::new();
+    dae.continuous.structured_equations = vec![family(1), family(4)];
+
+    drop_structured_families_touching_equations(&mut dae, &[2]);
+
+    assert_eq!(dae.continuous.structured_equations.len(), 1);
+    assert_eq!(
+        dae.continuous.structured_equations[0].first_equation_index,
+        4
+    );
+}
+
+/// Residual rows have no `lhs`, so substitution used to rewrite the RHS and
+/// return before recording the touched row. Structured metadata for that row
+/// must still be dropped because its compact body proof is now stale.
+#[test]
+fn substitution_drops_structured_family_for_rewritten_residual_row() {
+    let mut dae = Dae::new();
+    dae.continuous.equations.push(residual(
+        var_ref("x"),
+        var_ref("s"),
+        1,
+        "structured_residual",
+    ));
+    dae.continuous.structured_equations = vec![dae::StructuredEquationFamily {
+        domain: rumoca_core::StructuredIndexDomain {
+            binders: vec![rumoca_core::StructuredIndexBinder {
+                id: 0,
+                display_name: "i".to_string(),
+                lower: 1,
+                upper: 1,
+                step: 1,
+            }],
+        },
+        first_equation_index: 0,
+        equation_counts: vec![1],
+        span: test_span(),
+        origin: "test".to_string(),
+        regular: None,
+        template: None,
+        interiors_materialized: true,
+    }];
+
+    structural_ok(apply_substitutions_to_remaining_once(
+        &mut dae,
+        &[false],
+        &[test_substitution("s", real(1.0))],
+    ));
+
+    assert!(dae.continuous.structured_equations.is_empty());
+}
+
 mod boundary_cases;

--- a/crates/rumoca-sim/src/build_timing.rs
+++ b/crates/rumoca-sim/src/build_timing.rs
@@ -1,0 +1,14 @@
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BuildSimulationTimings {
+    pub ir_solve_structural_dae_seconds: f64,
+    pub ir_solve_lower_seconds: f64,
+    pub ir_solve_seconds: f64,
+    pub override_apply_seconds: f64,
+    pub backend_build_seconds: f64,
+}
+
+impl BuildSimulationTimings {
+    pub fn accounted_seconds(self) -> f64 {
+        self.ir_solve_seconds + self.override_apply_seconds + self.backend_build_seconds
+    }
+}

--- a/crates/rumoca-sim/src/diffsol.rs
+++ b/crates/rumoca-sim/src/diffsol.rs
@@ -4,6 +4,7 @@ use indexmap::IndexMap;
 use rumoca_ir_dae as dae;
 use rumoca_ir_solve as solve;
 
+use crate::BuildSimulationTimings;
 use crate::InteractiveStepper;
 use crate::solve_lowering::{
     SimulationDiagnosticError, lower_dae_for_simulation, lower_dae_for_simulation_with_stage_timing,
@@ -14,14 +15,6 @@ pub(crate) use rumoca_solver_diffsol::stepper::StepperState;
 
 pub struct PreparedSimulation {
     inner: rumoca_solver_diffsol::PreparedSimulation,
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-pub struct BuildSimulationTimings {
-    pub ir_solve_structural_dae_seconds: f64,
-    pub ir_solve_lower_seconds: f64,
-    pub ir_solve_seconds: f64,
-    pub backend_build_seconds: f64,
 }
 
 impl PreparedSimulation {
@@ -80,8 +73,11 @@ pub fn build_simulation_with_stage_timing_and_solve_model(
     let (mut solve_model, solve_timings) =
         lower_dae_for_simulation_with_stage_timing(dae_model, opts, &mut begin_stage)
             .map_err(solve_lowering_sim_error)?;
+    begin_stage("sim_overrides");
+    let override_apply_start = Instant::now();
     crate::solve_lowering::apply_simulation_overrides(&mut solve_model, dae_model, opts, true)
         .map_err(|err| SimError::SolverError(err.to_string()))?;
+    let override_apply_seconds = override_apply_start.elapsed().as_secs_f64();
     observe_solve_model(&solve_model);
     begin_stage("sim_build");
     let backend_build_start = Instant::now();
@@ -93,6 +89,7 @@ pub fn build_simulation_with_stage_timing_and_solve_model(
             ir_solve_structural_dae_seconds: solve_timings.structural_dae_seconds,
             ir_solve_lower_seconds: solve_timings.solve_ir_seconds,
             ir_solve_seconds: solve_timings.total_seconds(),
+            override_apply_seconds,
             backend_build_seconds,
         },
     ))

--- a/crates/rumoca-sim/src/lib.rs
+++ b/crates/rumoca-sim/src/lib.rs
@@ -26,6 +26,7 @@ pub use rumoca_solver::{
     trace_runtime_progress, trace_runtime_start, trace_runtime_step_fail, trace_runtime_timeout,
 };
 
+mod build_timing;
 pub mod bulk;
 mod interactive_stepper;
 #[cfg(any(feature = "solver-diffsol", feature = "solver-rk45"))]
@@ -38,12 +39,12 @@ mod diffsol;
 mod prepared_vectors;
 #[cfg(any(feature = "solver-diffsol", feature = "solver-rk45"))]
 mod solve_lowering;
+pub use build_timing::BuildSimulationTimings;
 #[cfg(feature = "solver-diffsol")]
 pub use diffsol::{
-    BuildSimulationTimings, PreparedSimulation, SimError, build_simulation,
-    build_simulation_with_stage_timing, build_simulation_with_stage_timing_and_solve_model,
-    check_initialization, check_prepared_initialization, run_prepared_simulation, simulate,
-    simulate_dae,
+    PreparedSimulation, SimError, build_simulation, build_simulation_with_stage_timing,
+    build_simulation_with_stage_timing_and_solve_model, check_initialization,
+    check_prepared_initialization, run_prepared_simulation, simulate, simulate_dae,
 };
 #[cfg(any(feature = "solver-diffsol", feature = "solver-rk45"))]
 pub use prepared_vectors::{PreparedVectorError, refresh_prepared_vectors};

--- a/crates/rumoca-sim/src/rk45.rs
+++ b/crates/rumoca-sim/src/rk45.rs
@@ -1,8 +1,13 @@
+use std::time::Instant;
+
 use indexmap::IndexMap;
 use rumoca_ir_dae as dae;
 
+use crate::BuildSimulationTimings;
 use crate::InteractiveStepper;
-use crate::solve_lowering::{SimulationDiagnosticError, lower_dae_for_simulation};
+use crate::solve_lowering::{
+    SimulationDiagnosticError, lower_dae_for_simulation, lower_dae_for_simulation_with_stage_timing,
+};
 
 pub use rumoca_solver_rk45::SimError;
 pub use rumoca_solver_rk45::StepperState;
@@ -35,12 +40,36 @@ pub struct SimStepper {
 
 impl SimStepper {
     pub fn new(dae_model: &dae::Dae, opts: rumoca_solver::SimOptions) -> Result<Self, SimError> {
-        let mut solve_model = lower_dae_for_simulation(dae_model, &opts)
-            .map_err(|err| SimError::SolveIr(err.to_string()))?;
+        Self::new_with_stage_timing(dae_model, opts, |_| {}).map(|(stepper, _)| stepper)
+    }
+
+    pub fn new_with_stage_timing(
+        dae_model: &dae::Dae,
+        opts: rumoca_solver::SimOptions,
+        mut begin_stage: impl FnMut(&'static str),
+    ) -> Result<(Self, BuildSimulationTimings), SimError> {
+        let (mut solve_model, solve_timings) =
+            lower_dae_for_simulation_with_stage_timing(dae_model, &opts, &mut begin_stage)
+                .map_err(|err| SimError::SolveIr(err.to_string()))?;
+        begin_stage("sim_overrides");
+        let override_apply_start = Instant::now();
         crate::solve_lowering::apply_simulation_overrides(&mut solve_model, dae_model, &opts, true)
             .map_err(|err| SimError::SolveIr(err.to_string()))?;
+        let override_apply_seconds = override_apply_start.elapsed().as_secs_f64();
+        begin_stage("sim_build");
+        let backend_build_start = Instant::now();
         let inner = rumoca_solver_rk45::SimStepper::new(&solve_model, opts)?;
-        Ok(Self { inner })
+        let backend_build_seconds = backend_build_start.elapsed().as_secs_f64();
+        Ok((
+            Self { inner },
+            BuildSimulationTimings {
+                ir_solve_structural_dae_seconds: solve_timings.structural_dae_seconds,
+                ir_solve_lower_seconds: solve_timings.solve_ir_seconds,
+                ir_solve_seconds: solve_timings.total_seconds(),
+                override_apply_seconds,
+                backend_build_seconds,
+            },
+        ))
     }
 
     pub fn new_with_diagnostics(

--- a/crates/rumoca-sim/src/solve_lowering.rs
+++ b/crates/rumoca-sim/src/solve_lowering.rs
@@ -42,8 +42,6 @@ pub use structure_report::{
     diagnose_structural_singularity, structural_report_for_dae,
 };
 
-// Only the diffsol build pipeline consumes the staged-timing entry point.
-#[cfg(feature = "solver-diffsol")]
 pub(crate) use entry::lower_dae_for_simulation_with_stage_timing;
 pub(crate) use overrides::apply_simulation_overrides;
 pub use overrides::lower_for_simulation_with_overrides;

--- a/crates/rumoca-sim/src/solve_lowering.rs
+++ b/crates/rumoca-sim/src/solve_lowering.rs
@@ -1,6 +1,7 @@
 //! DAE → simulation solve-model lowering, organized into cohesive stages:
 //!
 //! - [`diagnostics`] — the [`SimulationDiagnosticError`] surfaced by every entry.
+//! - [`direct`] — the guarded explicit/direct fast path before structural work.
 //! - [`overrides`] — solver-neutral tunable-parameter / state-start overrides.
 //! - [`entry`] — the public lowering entry points and per-stage timings.
 //! - [`probe`] — the `--inspect eval` / `--inspect jacobian` debug probes.
@@ -12,6 +13,7 @@
 //! facade (`lib.rs`) and the solver backends keep referring to the same paths.
 
 mod diagnostics;
+mod direct;
 mod entry;
 mod expr_util;
 mod overrides;

--- a/crates/rumoca-sim/src/solve_lowering/direct.rs
+++ b/crates/rumoca-sim/src/solve_lowering/direct.rs
@@ -1,0 +1,305 @@
+//! Guarded direct DAE -> Solve IR lowering for models that are already in an
+//! explicit runtime shape. Anything outside this narrow proof falls back to the
+//! structural Modelica path in [`super::entry`].
+
+use std::collections::{BTreeSet, HashMap};
+
+use rumoca_core::{Expression, VarName};
+use rumoca_ir_dae as dae;
+use rumoca_ir_solve as solve;
+use rumoca_solver::{SimOptions, SimSolverMode};
+
+use super::structural_lowering::metadata_attachment_lower_error;
+
+pub(super) fn lower_direct_dae_for_simulation(
+    dae_model: &dae::Dae,
+    opts: &SimOptions,
+    param_overrides: &HashMap<String, f64>,
+) -> Result<Option<solve::SolveModel>, rumoca_phase_solve::SolveModelLowerError> {
+    if opts.solver_mode != SimSolverMode::RkLike {
+        return Ok(None);
+    }
+
+    let metadata_dae = attach_reference_metadata(dae_model)?;
+    if let Some(reason) = projected_slot_rejection(&metadata_dae) {
+        trace_direct_rejection(reason);
+        return Ok(None);
+    }
+    if let Some(reason) = direct_state_value_assignment_rejection(&metadata_dae) {
+        trace_direct_rejection(reason);
+        return Ok(None);
+    }
+    let visible_expressions = match rumoca_phase_solve::visible_expressions_for_dae(&metadata_dae) {
+        Ok(expressions) => expressions,
+        Err(err) => {
+            trace_direct_rejection(format!("visible expression lowering failed: {err}"));
+            return Ok(None);
+        }
+    };
+    let lowered = metadata_dae.clone();
+    let solve_model =
+        match rumoca_phase_solve::lower_dae_to_solve_model_owned_value_only_with_visible_expressions_and_metadata_and_overrides(
+            lowered,
+            visible_expressions,
+            &metadata_dae,
+            param_overrides,
+        ) {
+            Ok(model) => model,
+            Err(err) => {
+                trace_direct_rejection(format!("direct solve lowering failed: {err}"));
+                return Ok(None);
+            }
+        };
+
+    match validate_direct_runtime_model(&solve_model) {
+        Ok(()) => Ok(Some(solve_model)),
+        Err(reason) => {
+            trace_direct_rejection(reason);
+            Ok(None)
+        }
+    }
+}
+
+pub(super) fn lower_direct_dae_for_gpu_preparation(
+    dae_model: &dae::Dae,
+) -> Result<Option<solve::SolveModel>, rumoca_phase_solve::SolveModelLowerError> {
+    let metadata_dae = attach_reference_metadata(dae_model)?;
+    let lowered = metadata_dae.clone();
+    match rumoca_phase_solve::lower_dae_to_solve_model_owned_for_gpu_preparation_with_metadata(
+        lowered,
+        &metadata_dae,
+    ) {
+        Ok(solve_model) => Ok(Some(solve_model)),
+        Err(err) => {
+            trace_direct_rejection(format!("direct GPU-preparation lowering failed: {err}"));
+            Ok(None)
+        }
+    }
+}
+
+fn attach_reference_metadata(
+    dae_model: &dae::Dae,
+) -> Result<dae::Dae, rumoca_phase_solve::SolveModelLowerError> {
+    let mut metadata_dae = dae_model.clone();
+    rumoca_phase_dae::attach_dae_reference_metadata(&mut metadata_dae)
+        .map_err(metadata_attachment_lower_error)?;
+    Ok(metadata_dae)
+}
+
+fn projected_slot_rejection(dae_model: &dae::Dae) -> Option<String> {
+    if !dae_model.variables.algebraics.is_empty() {
+        return Some(format!(
+            "model has {} algebraic variables",
+            dae_model.variables.algebraics.len()
+        ));
+    }
+    if !dae_model.variables.outputs.is_empty() {
+        return Some(format!(
+            "model has {} output variables",
+            dae_model.variables.outputs.len()
+        ));
+    }
+    None
+}
+
+fn direct_state_value_assignment_rejection(dae_model: &dae::Dae) -> Option<String> {
+    let state_names = dae_model
+        .variables
+        .states
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    if state_names.is_empty() {
+        return None;
+    }
+    for (eq_idx, eq) in dae_model.continuous.equations.iter().enumerate() {
+        if let Some(lhs) = &eq.lhs
+            && state_names
+                .iter()
+                .any(|state_name| lhs.var_name() == state_name)
+        {
+            return Some(format!(
+                "continuous equation {eq_idx} directly assigns state `{}`",
+                lhs.as_str()
+            ));
+        }
+        if let Some(state_name) = residual_direct_state_assignment(&eq.rhs, &state_names) {
+            return Some(format!(
+                "continuous residual equation {eq_idx} directly assigns state `{}`",
+                state_name.as_str()
+            ));
+        }
+    }
+    None
+}
+
+fn residual_direct_state_assignment<'a>(
+    expr: &'a Expression,
+    state_names: &'a [VarName],
+) -> Option<&'a VarName> {
+    match expr {
+        Expression::Binary {
+            op: rumoca_core::OpBinary::Sub,
+            lhs,
+            rhs,
+            ..
+        } => {
+            if let Some(state_name) = direct_state_ref(lhs, state_names)
+                && !dae::expr_contains_der_of(rhs, state_name)
+            {
+                return Some(state_name);
+            }
+            if let Some(state_name) = direct_state_ref(rhs, state_names)
+                && !dae::expr_contains_der_of(lhs, state_name)
+            {
+                return Some(state_name);
+            }
+            None
+        }
+        Expression::Unary {
+            op: rumoca_core::OpUnary::Minus,
+            rhs,
+            ..
+        } => residual_direct_state_assignment(rhs, state_names),
+        _ => None,
+    }
+}
+
+fn direct_state_ref<'a>(expr: &'a Expression, state_names: &'a [VarName]) -> Option<&'a VarName> {
+    let Expression::VarRef {
+        name, subscripts, ..
+    } = expr
+    else {
+        return None;
+    };
+    state_names
+        .iter()
+        .find(|state_name| dae::var_ref_matches_unknown(name, subscripts, state_name))
+}
+
+fn validate_direct_runtime_model(model: &solve::SolveModel) -> Result<(), String> {
+    let state_count = model.state_scalar_count();
+    if state_count == 0 {
+        return Err("model has no states".to_string());
+    }
+
+    let derivative_rhs_len = model
+        .problem
+        .continuous
+        .derivative_rhs
+        .len()
+        .map_err(|err| err.to_string())?;
+    if derivative_rhs_len != state_count {
+        return Err(format!(
+            "derivative RHS has {derivative_rhs_len} rows for {state_count} state scalars"
+        ));
+    }
+
+    validate_tail_residual_targets(model)?;
+    validate_no_projected_derivative_dependencies(model)
+}
+
+fn validate_tail_residual_targets(model: &solve::SolveModel) -> Result<(), String> {
+    let state_count = model.state_scalar_count();
+    let implicit_rhs_len = model
+        .problem
+        .continuous
+        .implicit_rhs
+        .len()
+        .map_err(|err| err.to_string())?;
+    if model.problem.continuous.implicit_row_targets.len() != implicit_rhs_len {
+        return Err(format!(
+            "implicit row target count {} does not match implicit RHS row count {implicit_rhs_len}",
+            model.problem.continuous.implicit_row_targets.len()
+        ));
+    }
+    if implicit_rhs_len < state_count {
+        return Err(format!(
+            "implicit RHS has {implicit_rhs_len} rows for {state_count} state scalars"
+        ));
+    }
+
+    for (row_idx, target) in model
+        .problem
+        .continuous
+        .implicit_row_targets
+        .iter()
+        .enumerate()
+        .skip(state_count)
+    {
+        match target {
+            Some(solve::ScalarSlot::Y { index, .. }) if *index < state_count => {
+                return Err(format!(
+                    "implicit residual row {row_idx} targets state Y[{index}]"
+                ));
+            }
+            Some(solve::ScalarSlot::Y { .. }) => {}
+            Some(other) => {
+                return Err(format!(
+                    "implicit residual row {row_idx} targets non-solver slot {other:?}"
+                ));
+            }
+            None => {
+                return Err(format!("implicit residual row {row_idx} has no target"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_no_projected_derivative_dependencies(model: &solve::SolveModel) -> Result<(), String> {
+    let derivative_rows =
+        rumoca_eval_solve::to_scalar_program_block(&model.problem.continuous.derivative_rhs)
+            .map_err(|err| err.to_string())?;
+    let direct_deps = derivative_non_state_loads(model, &derivative_rows);
+    if !direct_deps.is_empty() {
+        return Err(format!(
+            "derivative RHS reads projected non-state Y slots {:?}",
+            direct_deps.into_iter().collect::<Vec<_>>()
+        ));
+    }
+    Ok(())
+}
+
+fn derivative_non_state_loads(
+    model: &solve::SolveModel,
+    derivative_rows: &solve::ScalarProgramBlock,
+) -> BTreeSet<usize> {
+    let state_count = model.state_scalar_count();
+    let solver_count = model.solver_scalar_count();
+    derivative_rows
+        .programs
+        .iter()
+        .take(state_count)
+        .flat_map(|row| non_state_y_loads(row, state_count, solver_count))
+        .collect()
+}
+
+fn non_state_y_loads(
+    row: &[solve::LinearOp],
+    state_count: usize,
+    solver_count: usize,
+) -> Vec<usize> {
+    let mut loads = row
+        .iter()
+        .filter_map(|op| match *op {
+            solve::LinearOp::LoadY { index, .. }
+                if index >= state_count && index < solver_count =>
+            {
+                Some(index)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    loads.sort_unstable();
+    loads.dedup();
+    loads
+}
+
+fn trace_direct_rejection(reason: impl AsRef<str>) {
+    tracing::debug!(
+        target: "rumoca_sim::solve_lowering",
+        "direct simulation lowering rejected: {}",
+        reason.as_ref()
+    );
+}

--- a/crates/rumoca-sim/src/solve_lowering/entry.rs
+++ b/crates/rumoca-sim/src/solve_lowering/entry.rs
@@ -6,9 +6,8 @@ use rumoca_ir_dae as dae;
 use rumoca_ir_solve as solve;
 use rumoca_solver::{SimOptions, SimSolverMode};
 
-use super::structural_lowering::{
-    metadata_attachment_lower_error, structurally_lower_dae_for_simulation,
-};
+use super::direct::{lower_direct_dae_for_gpu_preparation, lower_direct_dae_for_simulation};
+use super::structural_lowering::structurally_lower_dae_for_simulation;
 use super::timing::{
     log_solve_lowering_done, log_solve_lowering_start, stage_timer_elapsed_seconds,
     stage_timer_start,
@@ -35,22 +34,6 @@ pub fn lower_dae_for_gpu_preparation(
     )
 }
 
-fn lower_direct_dae_for_gpu_preparation(
-    dae_model: &dae::Dae,
-) -> Result<Option<solve::SolveModel>, rumoca_phase_solve::SolveModelLowerError> {
-    let mut metadata_dae = dae_model.clone();
-    rumoca_phase_dae::attach_dae_reference_metadata(&mut metadata_dae)
-        .map_err(metadata_attachment_lower_error)?;
-    let lowered = metadata_dae.clone();
-    match rumoca_phase_solve::lower_dae_to_solve_model_owned_for_gpu_preparation_with_metadata(
-        lowered,
-        &metadata_dae,
-    ) {
-        Ok(solve_model) => Ok(Some(solve_model)),
-        Err(_) => Ok(None),
-    }
-}
-
 /// Lower for simulation while applying tunable scalar-parameter overrides during
 /// parameter-value computation, so parameter-derived quantities (including array
 /// masks such as the airfoil's `sc/nc/sig`) re-derive from the override at
@@ -61,6 +44,9 @@ pub(crate) fn lower_dae_for_simulation_with_param_overrides(
     opts: &SimOptions,
     param_overrides: &std::collections::HashMap<String, f64>,
 ) -> Result<solve::SolveModel, rumoca_phase_solve::SolveModelLowerError> {
+    if let Some(solve_model) = lower_direct_dae_for_simulation(dae_model, opts, param_overrides)? {
+        return Ok(solve_model);
+    }
     let structurally_lowered = structurally_lower_dae_for_simulation(dae_model, opts)?;
     lower_structured_dae_for_simulation(structurally_lowered, opts, param_overrides)
 }
@@ -84,6 +70,19 @@ pub(crate) fn lower_dae_for_simulation_with_stage_timing(
 ) -> Result<(solve::SolveModel, SolveLoweringTimings), rumoca_phase_solve::SolveModelLowerError> {
     let mut timings = SolveLoweringTimings::default();
 
+    begin_stage("ir_solve_direct");
+    log_solve_lowering_start("solve_ir.lower_direct_dae_to_solve_model");
+    let direct_start = stage_timer_start();
+    if let Some(solve_model) =
+        lower_direct_dae_for_simulation(dae_model, opts, &std::collections::HashMap::new())?
+    {
+        timings.solve_ir_seconds = stage_timer_elapsed_seconds(direct_start);
+        log_solve_lowering_done("solve_ir.lower_direct_dae_to_solve_model", direct_start);
+        trace_solve_model(&solve_model);
+        return Ok((solve_model, timings));
+    }
+    log_solve_lowering_done("solve_ir.lower_direct_dae_to_solve_model", direct_start);
+
     begin_stage("ir_solve_structural_dae");
     let structural_start = stage_timer_start();
     let structurally_lowered = structurally_lower_dae_for_simulation(dae_model, opts)?;
@@ -99,6 +98,11 @@ pub(crate) fn lower_dae_for_simulation_with_stage_timing(
     )?;
     timings.solve_ir_seconds = stage_timer_elapsed_seconds(solve_ir_start);
     log_solve_lowering_done("solve_ir.lower_dae_to_solve_model", solve_ir_start);
+    trace_solve_model(&solve_model);
+    Ok((solve_model, timings))
+}
+
+fn trace_solve_model(solve_model: &solve::SolveModel) {
     if tracing::enabled!(target: "rumoca_phase_structural", tracing::Level::DEBUG) {
         let layout = &solve_model.problem.layout;
         let mut names_by_y: std::collections::HashMap<usize, &str> =
@@ -151,7 +155,6 @@ pub(crate) fn lower_dae_for_simulation_with_stage_timing(
             );
         }
     }
-    Ok((solve_model, timings))
 }
 
 fn lower_structured_dae_for_simulation(

--- a/crates/rumoca-sim/src/solve_lowering/entry.rs
+++ b/crates/rumoca-sim/src/solve_lowering/entry.rs
@@ -4,7 +4,7 @@
 
 use rumoca_ir_dae as dae;
 use rumoca_ir_solve as solve;
-use rumoca_solver::SimOptions;
+use rumoca_solver::{SimOptions, SimSolverMode};
 
 use super::structural_lowering::{
     metadata_attachment_lower_error, structurally_lower_dae_for_simulation,
@@ -62,12 +62,7 @@ pub(crate) fn lower_dae_for_simulation_with_param_overrides(
     param_overrides: &std::collections::HashMap<String, f64>,
 ) -> Result<solve::SolveModel, rumoca_phase_solve::SolveModelLowerError> {
     let structurally_lowered = structurally_lower_dae_for_simulation(dae_model, opts)?;
-    rumoca_phase_solve::lower_dae_to_solve_model_owned_with_visible_expressions_and_metadata_and_overrides(
-        structurally_lowered.dae,
-        structurally_lowered.visible_expressions,
-        &structurally_lowered.metadata_dae,
-        param_overrides,
-    )
+    lower_structured_dae_for_simulation(structurally_lowered, opts, param_overrides)
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -77,7 +72,6 @@ pub(crate) struct SolveLoweringTimings {
 }
 
 impl SolveLoweringTimings {
-    #[cfg(feature = "solver-diffsol")]
     pub(crate) fn total_seconds(self) -> f64 {
         self.structural_dae_seconds + self.solve_ir_seconds
     }
@@ -98,12 +92,11 @@ pub(crate) fn lower_dae_for_simulation_with_stage_timing(
     begin_stage("ir_solve");
     log_solve_lowering_start("solve_ir.lower_dae_to_solve_model");
     let solve_ir_start = stage_timer_start();
-    let solve_model =
-        rumoca_phase_solve::lower_dae_to_solve_model_owned_with_visible_expressions_and_metadata(
-            structurally_lowered.dae,
-            structurally_lowered.visible_expressions,
-            &structurally_lowered.metadata_dae,
-        )?;
+    let solve_model = lower_structured_dae_for_simulation(
+        structurally_lowered,
+        opts,
+        &std::collections::HashMap::new(),
+    )?;
     timings.solve_ir_seconds = stage_timer_elapsed_seconds(solve_ir_start);
     log_solve_lowering_done("solve_ir.lower_dae_to_solve_model", solve_ir_start);
     if tracing::enabled!(target: "rumoca_phase_structural", tracing::Level::DEBUG) {
@@ -159,6 +152,31 @@ pub(crate) fn lower_dae_for_simulation_with_stage_timing(
         }
     }
     Ok((solve_model, timings))
+}
+
+fn lower_structured_dae_for_simulation(
+    structurally_lowered: super::structural_lowering::StructurallyLoweredDae,
+    opts: &SimOptions,
+    param_overrides: &std::collections::HashMap<String, f64>,
+) -> Result<solve::SolveModel, rumoca_phase_solve::SolveModelLowerError> {
+    match opts.solver_mode {
+        SimSolverMode::RkLike => {
+            rumoca_phase_solve::lower_dae_to_solve_model_owned_value_only_with_visible_expressions_and_metadata_and_overrides(
+                structurally_lowered.dae,
+                structurally_lowered.visible_expressions,
+                &structurally_lowered.metadata_dae,
+                param_overrides,
+            )
+        }
+        SimSolverMode::Auto | SimSolverMode::Bdf => {
+            rumoca_phase_solve::lower_dae_to_solve_model_owned_with_visible_expressions_and_metadata_and_overrides(
+                structurally_lowered.dae,
+                structurally_lowered.visible_expressions,
+                &structurally_lowered.metadata_dae,
+                param_overrides,
+            )
+        }
+    }
 }
 
 pub fn structurally_lowered_dae_for_simulation_artifact(

--- a/crates/rumoca-sim/src/solve_lowering/tests.rs
+++ b/crates/rumoca-sim/src/solve_lowering/tests.rs
@@ -4,10 +4,10 @@
 
 use rumoca_core::{BuiltinFunction, Expression, OpBinary, SourceId, Span, Subscript, VarName};
 use rumoca_ir_dae as dae;
-use rumoca_solver::SimOptions;
+use rumoca_solver::{SimOptions, SimSolverMode};
 
 use super::diagnostics::SimulationDiagnosticError;
-use super::entry::lower_dae_for_simulation;
+use super::entry::{lower_dae_for_simulation, lower_dae_for_simulation_with_stage_timing};
 use super::probe::{eval_dae_at, jacobian_for_dae};
 use super::structural_lowering::{
     metadata_attachment_lower_error, structurally_lower_dae_for_simulation,
@@ -183,6 +183,59 @@ fn simulation_structural_lowering_keeps_cross_coupled_ode_states() {
 
     assert_eq!(model.state_scalar_count(), 2);
     assert_eq!(model.problem.solve_layout.solver_maps.names, ["x", "v"]);
+}
+
+#[test]
+fn simulation_direct_lowering_accepts_state_only_ode() {
+    let dae = state_only_ode_dae();
+    let opts = SimOptions {
+        solver_mode: SimSolverMode::RkLike,
+        ..Default::default()
+    };
+    let mut stages = Vec::new();
+    let (model, timings) =
+        lower_dae_for_simulation_with_stage_timing(&dae, &opts, |stage| stages.push(stage))
+            .expect("state-only ODE should lower directly");
+
+    assert_eq!(timings.structural_dae_seconds, 0.0);
+    assert_eq!(model.state_scalar_count(), 1);
+    assert_eq!(model.problem.solve_layout.algebraic_scalar_count(), 0);
+    assert!(stages.contains(&"ir_solve_direct"));
+    assert!(!stages.contains(&"ir_solve_structural_dae"));
+}
+
+#[test]
+fn simulation_direct_lowering_falls_back_for_projected_derivative_dependency() {
+    let dae = explicit_algebraic_ode_dae();
+    let opts = SimOptions {
+        solver_mode: SimSolverMode::RkLike,
+        ..Default::default()
+    };
+    let mut stages = Vec::new();
+    let (model, _) =
+        lower_dae_for_simulation_with_stage_timing(&dae, &opts, |stage| stages.push(stage))
+            .expect("algebraic derivative dependency should structurally lower for now");
+
+    assert_eq!(model.state_scalar_count(), 1);
+    assert!(stages.contains(&"ir_solve_direct"));
+    assert!(stages.contains(&"ir_solve_structural_dae"));
+}
+
+#[test]
+fn simulation_direct_lowering_falls_back_for_state_selection() {
+    let dae = constrained_state_dae();
+    let opts = SimOptions {
+        solver_mode: SimSolverMode::RkLike,
+        ..Default::default()
+    };
+    let mut stages = Vec::new();
+    let (model, _) =
+        lower_dae_for_simulation_with_stage_timing(&dae, &opts, |stage| stages.push(stage))
+            .expect("constrained state model should fall back to structural lowering");
+
+    assert_eq!(model.state_scalar_count(), 1);
+    assert!(stages.contains(&"ir_solve_direct"));
+    assert!(stages.contains(&"ir_solve_structural_dae"));
 }
 
 #[test]
@@ -558,6 +611,49 @@ fn constrained_state_dae() -> dae::Dae {
         .continuous
         .equations
         .push(eq(sub(der(var("x3")), time())));
+    model
+}
+
+fn explicit_algebraic_ode_dae() -> dae::Dae {
+    let mut model = dae::Dae::new();
+    model.variables.states.insert(
+        VarName::new("x"),
+        dae::Variable::new(
+            VarName::new("x"),
+            rumoca_core::Span::from_offsets(rumoca_core::SourceId::from_source_name(file!()), 1, 2),
+        ),
+    );
+    model.variables.algebraics.insert(
+        VarName::new("a"),
+        dae::Variable::new(
+            VarName::new("a"),
+            rumoca_core::Span::from_offsets(rumoca_core::SourceId::from_source_name(file!()), 1, 2),
+        ),
+    );
+    model
+        .continuous
+        .equations
+        .push(eq(sub(var("a"), mul(real(2.0), var("x")))));
+    model
+        .continuous
+        .equations
+        .push(eq(sub(der(var("x")), var("a"))));
+    model
+}
+
+fn state_only_ode_dae() -> dae::Dae {
+    let mut model = dae::Dae::new();
+    model.variables.states.insert(
+        VarName::new("x"),
+        dae::Variable::new(
+            VarName::new("x"),
+            rumoca_core::Span::from_offsets(rumoca_core::SourceId::from_source_name(file!()), 1, 2),
+        ),
+    );
+    model
+        .continuous
+        .equations
+        .push(eq(sub(der(var("x")), mul(real(2.0), var("x")))));
     model
 }
 

--- a/crates/rumoca-sim/src/solve_lowering/timing.rs
+++ b/crates/rumoca-sim/src/solve_lowering/timing.rs
@@ -31,4 +31,11 @@ pub(super) fn stage_timer_elapsed_seconds(_start: StageTimer) -> f64 {
 
 pub(super) fn log_solve_lowering_start(_label: &str) {}
 
-pub(super) fn log_solve_lowering_done(_label: &str, _start: StageTimer) {}
+pub(super) fn log_solve_lowering_done(label: &str, start: StageTimer) {
+    tracing::debug!(
+        target: "rumoca_sim::solve_lowering",
+        phase = label,
+        elapsed_seconds = stage_timer_elapsed_seconds(start),
+        "solve lowering stage"
+    );
+}

--- a/crates/rumoca-solver-diffsol/src/init_projection.rs
+++ b/crates/rumoca-solver-diffsol/src/init_projection.rs
@@ -292,9 +292,10 @@ impl RuntimeEventBoundaryHandler for EventObservation<'_> {
     type Error = SimError;
 
     fn on_event_time(&mut self, event_t: f64, _event: RuntimeEventStop) -> Result<(), Self::Error> {
-        refresh_observation_discrete_rows(
+        refresh_observation_rows_and_relation_memory(
             self.model,
-            &self.equilibrium_model.runtime_state,
+            self.runtime,
+            self.equilibrium_model,
             self.y,
             self.params,
             event_t,
@@ -332,9 +333,10 @@ impl RuntimeEventBoundaryHandler for EventObservation<'_> {
             event_pre_y: self.event_pre_y,
             event_pre_p: self.event_pre_p,
         })?;
-        refresh_observation_discrete_rows(
+        refresh_observation_rows_and_relation_memory(
             self.model,
-            &self.equilibrium_model.runtime_state,
+            self.runtime,
+            self.equilibrium_model,
             self.y,
             self.params,
             right_t,

--- a/crates/rumoca-solver-diffsol/src/lib.rs
+++ b/crates/rumoca-solver-diffsol/src/lib.rs
@@ -217,6 +217,9 @@ fn simulate_with_states(
     };
     record_initial_samples(
         &mut samples,
+        runtime.as_ref(),
+        equilibrium_model,
+        opts.atol.max(1.0e-10),
         SamplePoint {
             y: &current_y,
             params: &params,
@@ -456,6 +459,9 @@ fn simulate_state_only_bdf(
     };
     record_initial_samples(
         &mut samples,
+        runtime.as_ref(),
+        equilibrium_model,
+        opts.atol.max(1.0e-10),
         SamplePoint {
             y: &current_y,
             params: &params,
@@ -875,6 +881,9 @@ pub(crate) fn record_sample_if_new(
 
 fn record_initial_samples(
     recorder: &mut SampleRecorder<'_>,
+    runtime: &SolveRuntime,
+    equilibrium_model: &OdeModel,
+    tol: f64,
     current: SamplePoint<'_>,
     observations: &[solve_eval::InitialEventObservation],
 ) -> Result<(), SimError> {
@@ -882,13 +891,69 @@ fn record_initial_samples(
         return record_sample_if_new(recorder, current);
     }
     for observation in observations {
-        record_sample_if_new(
+        record_prepared_observation_sample(
             recorder,
+            runtime,
+            equilibrium_model,
+            tol,
             SamplePoint {
                 y: &observation.y,
                 params: &observation.p,
                 t: observation.t,
             },
+        )?;
+    }
+    Ok(())
+}
+
+fn record_prepared_observation_sample(
+    recorder: &mut SampleRecorder<'_>,
+    runtime: &SolveRuntime,
+    equilibrium_model: &OdeModel,
+    tol: f64,
+    sample: SamplePoint<'_>,
+) -> Result<(), SimError> {
+    let mut y = sample.y.to_vec();
+    let mut p = sample.params.to_vec();
+    refresh_observation_rows_and_relation_memory(
+        recorder.model,
+        runtime,
+        equilibrium_model,
+        &mut y,
+        &mut p,
+        sample.t,
+        tol,
+    )?;
+    record_sample_if_new(
+        recorder,
+        SamplePoint {
+            y: &y,
+            params: &p,
+            t: sample.t,
+        },
+    )
+}
+
+fn refresh_observation_rows_and_relation_memory(
+    model: &solve::SolveModel,
+    runtime: &SolveRuntime,
+    equilibrium_model: &OdeModel,
+    y: &mut [f64],
+    p: &mut [f64],
+    t: f64,
+    tol: f64,
+) -> Result<(), SimError> {
+    let state_count = model.state_scalar_count();
+    settle_algebraics_and_relation_memory(runtime, equilibrium_model, y, p, t, state_count, tol)?;
+    if refresh_observation_discrete_rows(model, &equilibrium_model.runtime_state, y, p, t, tol)? {
+        settle_algebraics_and_relation_memory(
+            runtime,
+            equilibrium_model,
+            y,
+            p,
+            t,
+            state_count,
+            tol,
         )?;
     }
     Ok(())

--- a/crates/rumoca-solver-diffsol/src/runtime.rs
+++ b/crates/rumoca-solver-diffsol/src/runtime.rs
@@ -317,9 +317,10 @@ fn record_no_state_event_step(
     event_pre_p: &[f64],
 ) -> Result<(), SimError> {
     if step.root_event {
-        refresh_observation_discrete_rows(
+        refresh_observation_rows_and_relation_memory(
             model,
-            &runtime.equilibrium_model.runtime_state,
+            &runtime.runtime,
+            &runtime.equilibrium_model,
             &mut runtime.current_y,
             &mut runtime.params,
             runtime.current_t,
@@ -382,18 +383,10 @@ fn settle_and_record_no_state_output(
     opts: &SimOptions,
     runtime: &mut NoStateRuntime,
 ) -> Result<(), SimError> {
-    settle_algebraics_and_relation_memory(
+    refresh_observation_rows_and_relation_memory(
+        model,
         &runtime.runtime,
         &runtime.equilibrium_model,
-        &mut runtime.current_y,
-        &mut runtime.params,
-        runtime.current_t,
-        0,
-        opts.atol.max(1.0e-10),
-    )?;
-    refresh_observation_discrete_rows(
-        model,
-        &runtime.equilibrium_model.runtime_state,
         &mut runtime.current_y,
         &mut runtime.params,
         runtime.current_t,
@@ -456,6 +449,15 @@ fn initialize_no_state_runtime(
     )?;
     event_action_outcome_to_result(outcome.action, outcome.final_t)?;
     current_t = outcome.final_t;
+    refresh_observation_rows_and_relation_memory(
+        model,
+        &runtime,
+        &equilibrium_model,
+        &mut current_y,
+        &mut params,
+        current_t,
+        tol,
+    )?;
     commit_pre_params_after_event(model, &current_y, &mut params, tol);
     let mut data = vec![Vec::with_capacity(output_count); model.visible_names.len()];
     let mut recorded_times = Vec::with_capacity(output_count);
@@ -466,8 +468,11 @@ fn initialize_no_state_runtime(
             recorded_times: &mut recorded_times,
             data: &mut data,
         };
-        record_sample_if_new(
+        record_prepared_observation_sample(
             &mut samples,
+            &runtime,
+            &equilibrium_model,
+            tol,
             SamplePoint {
                 y: &observation.y,
                 params: &observation.p,

--- a/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_selection.rs
+++ b/crates/rumoca-test-msl/tests/balance_pipeline/balance_pipeline_selection.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::collections::BTreeSet;
 
 // =============================================================================
 // Focused simulation target selection and subset controls

--- a/crates/rumoca/src/sim_bench.rs
+++ b/crates/rumoca/src/sim_bench.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result, bail};
 use clap::Args;
 use serde::Serialize;
 
-use rumoca_sim::{SimOptions, SimSolverMode};
+use rumoca_sim::{BuildSimulationTimings, SimOptions, SimSolverMode};
 
 use crate::cli::{
     DiagnosticsArgs, ModelInputArgs, ModelOptions, SimulateSolverMode,
@@ -51,8 +51,8 @@ pub struct SimBenchArgs {
     #[arg(long)]
     pub(crate) dt: Option<f64>,
 
-    /// Solver mode. Prepared hot benchmarking uses the BDF/diffsol path; the
-    /// rk-like backend is not benchmarkable here, so it is not offered.
+    /// Solver mode. Hot benchmarking uses the prepared BDF/diffsol path or the
+    /// reusable rk-like stepper, depending on this selection.
     #[arg(long, value_enum)]
     pub(crate) solver: Option<BenchSolverMode>,
 
@@ -71,6 +71,8 @@ pub struct SimBenchArgs {
 pub(crate) enum BenchSolverMode {
     Auto,
     Bdf,
+    #[value(name = "rk-like")]
+    RkLike,
 }
 
 impl From<BenchSolverMode> for SimulateSolverMode {
@@ -78,6 +80,7 @@ impl From<BenchSolverMode> for SimulateSolverMode {
         match value {
             BenchSolverMode::Auto => SimulateSolverMode::Auto,
             BenchSolverMode::Bdf => SimulateSolverMode::Bdf,
+            BenchSolverMode::RkLike => SimulateSolverMode::RkLike,
         }
     }
 }
@@ -90,6 +93,22 @@ struct BenchInput {
     solver_label: String,
 }
 
+struct HotRunSummary {
+    points: usize,
+    final_time: Option<f64>,
+}
+
+enum PreparedHotBench {
+    Bdf(Box<rumoca_sim::PreparedSimulation>),
+    RkLike(Box<RkLikeHotBench>),
+}
+
+struct RkLikeHotBench {
+    stepper: rumoca_sim::rk45::SimStepper,
+    sample_times: Vec<f64>,
+    t_start: f64,
+}
+
 #[derive(Debug, Serialize)]
 struct SimBenchReport {
     model: String,
@@ -100,6 +119,13 @@ struct SimBenchReport {
     warmups: usize,
     compile_seconds: f64,
     prepare_seconds: f64,
+    prepare_ir_solve_structural_dae_seconds: f64,
+    prepare_ir_solve_lower_seconds: f64,
+    prepare_ir_solve_seconds: f64,
+    prepare_override_apply_seconds: f64,
+    prepare_backend_build_seconds: f64,
+    prepare_accounted_seconds: f64,
+    prepare_other_seconds: f64,
     hot_total_seconds: f64,
     hot_average_seconds: f64,
     hot_best_seconds: f64,
@@ -116,12 +142,6 @@ pub(crate) fn run_sim_bench(args: SimBenchArgs) -> Result<()> {
     }
 
     let bench = resolve_bench_input(&args)?;
-    if bench.solver_mode == SimSolverMode::RkLike {
-        bail!(
-            "rumoca sim bench measures the reusable prepared hot path, which currently uses \
-             the BDF/diffsol backend; pass --solver bdf or --solver auto"
-        );
-    }
 
     init_debug_tracing(&args.diagnostics)?;
 
@@ -137,13 +157,13 @@ pub(crate) fn run_sim_bench(args: SimBenchArgs) -> Result<()> {
     };
 
     let prepare_start = Instant::now();
-    let prepared = rumoca_sim::build_simulation(result.dae.as_ref(), &opts)
-        .map_err(|err| anyhow::anyhow!("failed to prepare simulation: {err}"))?;
+    let (mut prepared, prepare_timings) = PreparedHotBench::build(result.dae.as_ref(), &opts)?;
     let prepare_elapsed = prepare_start.elapsed();
+    let prepare_seconds = duration_secs(prepare_elapsed);
 
     for _ in 0..args.warmups {
         prepared
-            .run()
+            .run_hot()
             .map_err(|err| anyhow::anyhow!("warmup simulation failed: {err}"))?;
     }
 
@@ -152,13 +172,13 @@ pub(crate) fn run_sim_bench(args: SimBenchArgs) -> Result<()> {
     let mut last_final_time = None;
     for _ in 0..args.iterations {
         let run_start = Instant::now();
-        let sim = prepared
-            .run()
+        let summary = prepared
+            .run_hot()
             .map_err(|err| anyhow::anyhow!("hot simulation failed: {err}"))?;
         let elapsed = run_start.elapsed();
         run_seconds.push(duration_secs(elapsed));
-        last_points = sim.times.len();
-        last_final_time = sim.times.last().copied();
+        last_points = summary.points;
+        last_final_time = summary.final_time;
     }
 
     let hot_total_seconds = run_seconds.iter().sum::<f64>();
@@ -174,7 +194,14 @@ pub(crate) fn run_sim_bench(args: SimBenchArgs) -> Result<()> {
         iterations: args.iterations,
         warmups: args.warmups,
         compile_seconds: duration_secs(compile_elapsed),
-        prepare_seconds: duration_secs(prepare_elapsed),
+        prepare_seconds,
+        prepare_ir_solve_structural_dae_seconds: prepare_timings.ir_solve_structural_dae_seconds,
+        prepare_ir_solve_lower_seconds: prepare_timings.ir_solve_lower_seconds,
+        prepare_ir_solve_seconds: prepare_timings.ir_solve_seconds,
+        prepare_override_apply_seconds: prepare_timings.override_apply_seconds,
+        prepare_backend_build_seconds: prepare_timings.backend_build_seconds,
+        prepare_accounted_seconds: prepare_timings.accounted_seconds(),
+        prepare_other_seconds: prepare_other_seconds(prepare_seconds, prepare_timings),
         hot_total_seconds,
         hot_average_seconds,
         hot_best_seconds,
@@ -191,6 +218,75 @@ pub(crate) fn run_sim_bench(args: SimBenchArgs) -> Result<()> {
         print_human_report(&report);
     }
     Ok(())
+}
+
+impl PreparedHotBench {
+    fn build(
+        dae: &rumoca_compile::compile::Dae,
+        opts: &SimOptions,
+    ) -> Result<(Self, BuildSimulationTimings)> {
+        match opts.solver_mode {
+            SimSolverMode::RkLike => {
+                let (bench, timings) = RkLikeHotBench::build(dae, opts)?;
+                Ok((Self::RkLike(Box::new(bench)), timings))
+            }
+            SimSolverMode::Auto | SimSolverMode::Bdf => {
+                rumoca_sim::build_simulation_with_stage_timing(dae, opts, ignore_build_stage)
+                    .map(|(prepared, timings)| (Self::Bdf(Box::new(prepared)), timings))
+                    .map_err(|err| anyhow::anyhow!("failed to prepare simulation: {err}"))
+            }
+        }
+    }
+
+    fn run_hot(&mut self) -> Result<HotRunSummary> {
+        match self {
+            Self::Bdf(prepared) => {
+                let sim = prepared.run()?;
+                Ok(HotRunSummary {
+                    points: sim.times.len(),
+                    final_time: sim.times.last().copied(),
+                })
+            }
+            Self::RkLike(prepared) => prepared.run_hot(),
+        }
+    }
+}
+
+fn ignore_build_stage(_: &'static str) {}
+
+impl RkLikeHotBench {
+    fn build(
+        dae: &rumoca_compile::compile::Dae,
+        opts: &SimOptions,
+    ) -> Result<(Self, BuildSimulationTimings)> {
+        let (stepper, timings) =
+            rumoca_sim::rk45::SimStepper::new_with_stage_timing(dae, opts.clone(), |_| {})
+                .map_err(|err| anyhow::anyhow!("failed to prepare rk-like simulation: {err}"))?;
+        Ok((
+            Self {
+                stepper,
+                sample_times: build_output_times(opts.t_start, opts.t_end, bench_output_dt(opts)),
+                t_start: opts.t_start,
+            },
+            timings,
+        ))
+    }
+
+    fn run_hot(&mut self) -> Result<HotRunSummary> {
+        self.stepper
+            .reset(self.t_start)
+            .map_err(|err| anyhow::anyhow!("failed to reset rk-like simulation: {err}"))?;
+        for &target in self.sample_times.iter().skip(1) {
+            let dt = target - self.stepper.time();
+            self.stepper
+                .step(dt)
+                .map_err(|err| anyhow::anyhow!("failed to step rk-like simulation: {err}"))?;
+        }
+        Ok(HotRunSummary {
+            points: self.sample_times.len(),
+            final_time: Some(self.stepper.time()),
+        })
+    }
 }
 
 fn resolve_bench_input(args: &SimBenchArgs) -> Result<BenchInput> {
@@ -280,12 +376,64 @@ fn duration_secs(duration: Duration) -> f64 {
     duration.as_secs_f64()
 }
 
+fn bench_output_dt(opts: &SimOptions) -> f64 {
+    opts.dt
+        .filter(|dt| dt.is_finite() && *dt > 0.0)
+        .unwrap_or_else(|| ((opts.t_end - opts.t_start).abs() / 500.0).max(1.0e-3))
+}
+
+fn build_output_times(t_start: f64, t_end: f64, dt: f64) -> Vec<f64> {
+    if !dt.is_finite() || dt <= 0.0 {
+        return if sample_time_match(t_start, t_end) {
+            vec![t_start]
+        } else {
+            vec![t_start, t_end]
+        };
+    }
+
+    let mut times = Vec::new();
+    let mut k = 0usize;
+    loop {
+        let t_raw = t_start + (k as f64) * dt;
+        if t_raw > t_end && !sample_time_match(t_raw, t_end) {
+            break;
+        }
+        times.push(if sample_time_match(t_raw, t_end) {
+            t_end
+        } else {
+            t_raw
+        });
+        if times.last().copied().is_some_and(|time| time >= t_end) {
+            return times;
+        }
+        k += 1;
+    }
+    if times
+        .last()
+        .copied()
+        .is_none_or(|last| !sample_time_match(last, t_end))
+    {
+        times.push(t_end);
+    }
+    times
+}
+
+fn sample_time_match(a: f64, b: f64) -> bool {
+    let tol = 1e-12 * (1.0 + a.abs().max(b.abs()));
+    (a - b).abs() <= tol
+}
+
 fn realtime_factor(sim_seconds: f64, wall_seconds: f64) -> f64 {
     if wall_seconds > 0.0 {
         sim_seconds / wall_seconds
     } else {
         f64::INFINITY
     }
+}
+
+fn prepare_other_seconds(total: f64, timings: BuildSimulationTimings) -> f64 {
+    let other = total - timings.accounted_seconds();
+    if other > 0.0 { other } else { 0.0 }
 }
 
 fn print_human_report(report: &SimBenchReport) {
@@ -306,6 +454,23 @@ fn print_human_report(report: &SimBenchReport) {
     );
     println!("  Compile: {:.6}s", report.compile_seconds);
     println!("  Prepare: {:.6}s", report.prepare_seconds);
+    println!(
+        "    Solve structural DAE: {:.6}s",
+        report.prepare_ir_solve_structural_dae_seconds
+    );
+    println!(
+        "    Solve IR lowering: {:.6}s",
+        report.prepare_ir_solve_lower_seconds
+    );
+    println!(
+        "    Apply overrides: {:.6}s",
+        report.prepare_override_apply_seconds
+    );
+    println!(
+        "    Backend build: {:.6}s",
+        report.prepare_backend_build_seconds
+    );
+    println!("    Other: {:.6}s", report.prepare_other_seconds);
     println!(
         "  Hot run avg: {:.6}s ({:.2}x realtime)",
         report.hot_average_seconds, report.average_realtime_factor

--- a/crates/rumoca/tests/neural_ode_tensor_solve_ir.rs
+++ b/crates/rumoca/tests/neural_ode_tensor_solve_ir.rs
@@ -1,0 +1,237 @@
+use rumoca::Compiler;
+use rumoca_ir_solve::{ComputeBlock, ComputeNode, LinearOp, ScalarProgramBlock, SolveModel};
+use rumoca_sim::SimOptions;
+
+#[test]
+fn neural_ode_tensor_indexed_parameter_loads_stay_in_parameter_vector() {
+    let result = Compiler::new()
+        .model("NeuralODETensor")
+        .compile_file(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/models/NeuralODETensor.mo"
+        ))
+        .expect("NeuralODETensor should compile");
+    let opts = SimOptions {
+        t_end: 0.2,
+        dt: Some(0.02),
+        ..SimOptions::default()
+    };
+    let solve = rumoca_sim::lower_for_simulation_with_overrides(&result.dae, &opts)
+        .expect("NeuralODETensor should lower for simulation");
+
+    let p_len = solve.parameters.len();
+    let mut failures = Vec::new();
+    check_problem_blocks(&solve, p_len, &mut failures);
+    check_event_blocks(&solve, p_len, &mut failures);
+    check_artifact_blocks(&solve, p_len, &mut failures);
+    check_program(
+        "visible_value_rows",
+        &solve.visible_value_rows,
+        p_len,
+        &mut failures,
+    );
+
+    assert!(
+        failures.is_empty(),
+        "indexed parameter loads exceed p vector len {p_len}: {}",
+        failures.into_iter().take(20).collect::<Vec<_>>().join(", ")
+    );
+}
+
+fn check_problem_blocks(solve: &SolveModel, p_len: usize, failures: &mut Vec<String>) {
+    check_block(
+        "continuous.implicit_rhs",
+        &solve.problem.continuous.implicit_rhs,
+        p_len,
+        failures,
+    );
+    check_block(
+        "continuous.residual",
+        &solve.problem.continuous.residual,
+        p_len,
+        failures,
+    );
+    check_block(
+        "continuous.derivative_rhs",
+        &solve.problem.continuous.derivative_rhs,
+        p_len,
+        failures,
+    );
+    check_block(
+        "initialization.residual",
+        &solve.problem.initialization.residual,
+        p_len,
+        failures,
+    );
+    check_block(
+        "initialization.update_rhs",
+        &ComputeBlock::from_scalar_program_block(solve.problem.initialization.update_rhs.clone()),
+        p_len,
+        failures,
+    );
+}
+
+fn check_event_blocks(solve: &SolveModel, p_len: usize, failures: &mut Vec<String>) {
+    check_program(
+        "discrete.runtime_assignment_rhs",
+        &solve.problem.discrete.runtime_assignment_rhs,
+        p_len,
+        failures,
+    );
+    check_program("discrete.rhs", &solve.problem.discrete.rhs, p_len, failures);
+    check_program(
+        "events.root_conditions",
+        &solve.problem.events.root_conditions,
+        p_len,
+        failures,
+    );
+    check_program(
+        "events.dynamic_time_event_rhs",
+        &solve.problem.events.dynamic_time_event_rhs,
+        p_len,
+        failures,
+    );
+    check_program(
+        "events.action_conditions",
+        &solve.problem.events.action_conditions,
+        p_len,
+        failures,
+    );
+    for (action_idx, action) in solve.problem.events.actions.iter().enumerate() {
+        for (part_idx, part) in action.message.parts.iter().enumerate() {
+            if let rumoca_ir_solve::SolveEventMessagePart::Number(ops) = part {
+                check_ops(
+                    &format!("events.actions[{action_idx}].message[{part_idx}]"),
+                    ops,
+                    p_len,
+                    failures,
+                );
+            }
+        }
+    }
+}
+
+fn check_artifact_blocks(solve: &SolveModel, p_len: usize, failures: &mut Vec<String>) {
+    check_block(
+        "artifacts.continuous.implicit_jacobian_v",
+        &solve.artifacts.continuous.implicit_jacobian_v,
+        p_len,
+        failures,
+    );
+    check_program(
+        "artifacts.continuous.implicit_jacobian_v_scalar",
+        &solve.artifacts.continuous.implicit_jacobian_v_scalar,
+        p_len,
+        failures,
+    );
+    check_program(
+        "artifacts.continuous.full_jacobian_v",
+        &solve.artifacts.continuous.full_jacobian_v,
+        p_len,
+        failures,
+    );
+}
+
+fn check_program(
+    label: &str,
+    program: &ScalarProgramBlock,
+    p_len: usize,
+    failures: &mut Vec<String>,
+) {
+    for (row_idx, row) in program.programs.iter().enumerate() {
+        check_ops(&format!("{label}.row[{row_idx}]"), row, p_len, failures);
+    }
+}
+
+fn check_block(label: &str, block: &ComputeBlock, p_len: usize, failures: &mut Vec<String>) {
+    for (node_idx, node) in block.nodes.iter().enumerate() {
+        let node_label = format!("{label}.node[{node_idx}]");
+        match node {
+            ComputeNode::ScalarPrograms(programs) => {
+                for (row_idx, row) in programs.programs.iter().enumerate() {
+                    check_ops(
+                        &format!("{node_label}.row[{row_idx}]"),
+                        row,
+                        p_len,
+                        failures,
+                    );
+                }
+            }
+            ComputeNode::MatMul {
+                lhs_ops, rhs_ops, ..
+            } => {
+                check_ops(&format!("{node_label}.lhs"), lhs_ops, p_len, failures);
+                check_ops(&format!("{node_label}.rhs"), rhs_ops, p_len, failures);
+            }
+            ComputeNode::LinSolve { setup_ops, .. } => {
+                check_ops(&format!("{node_label}.setup"), setup_ops, p_len, failures);
+            }
+            ComputeNode::Map { base_ops, .. } | ComputeNode::AffineStencil { base_ops, .. } => {
+                check_ops(&format!("{node_label}.base"), base_ops, p_len, failures);
+                let scalarized = ComputeBlock {
+                    nodes: vec![node.clone()],
+                };
+                match rumoca_eval_solve::to_scalar_program_block(&scalarized) {
+                    Ok(program) => check_program(
+                        &format!("{node_label}.scalarized"),
+                        &program,
+                        p_len,
+                        failures,
+                    ),
+                    Err(err) => failures.push(format!("{node_label}: scalarize failed: {err}")),
+                }
+            }
+        }
+    }
+}
+
+fn check_ops(label: &str, ops: &[LinearOp], p_len: usize, failures: &mut Vec<String>) {
+    for op in ops {
+        match *op {
+            LinearOp::LoadP { index, .. } if index >= p_len => {
+                failures.push(format!("{label}: {op:?}; {}", ops_summary(ops)));
+            }
+            LinearOp::LoadIndexedP { base, count, .. } => {
+                let end = base.saturating_add(count);
+                if base >= p_len || end > p_len {
+                    failures.push(format!("{label}: {op:?}; {}", ops_summary(ops)));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn ops_summary(ops: &[LinearOp]) -> String {
+    let mut load_p_min = None;
+    let mut load_p_max = None;
+    let mut load_seed_min = None;
+    let mut load_seed_max = None;
+    let mut load_p_count = 0usize;
+    let mut load_seed_count = 0usize;
+    for op in ops {
+        match *op {
+            LinearOp::LoadP { index, .. } => {
+                load_p_min = Some(load_p_min.map_or(index, |value: usize| value.min(index)));
+                load_p_max = Some(load_p_max.map_or(index, |value: usize| value.max(index)));
+                load_p_count += 1;
+            }
+            LinearOp::LoadSeed { index, .. } => {
+                load_seed_min = Some(load_seed_min.map_or(index, |value: usize| value.min(index)));
+                load_seed_max = Some(load_seed_max.map_or(index, |value: usize| value.max(index)));
+                load_seed_count += 1;
+            }
+            _ => {}
+        }
+    }
+    format!(
+        "ops={}, LoadP={} {:?}..{:?}, LoadSeed={} {:?}..{:?}",
+        ops.len(),
+        load_p_count,
+        load_p_min,
+        load_p_max,
+        load_seed_count,
+        load_seed_min,
+        load_seed_max
+    )
+}

--- a/crates/xtask/src/vscode_cmd.rs
+++ b/crates/xtask/src/vscode_cmd.rs
@@ -1485,12 +1485,11 @@ fn cargo_target_cc_env_suffix(target: &str) -> String {
 mod tests {
     use super::{
         VscodeMslSmokeSummary, VscodeNpmDependencyMode, VscodeNpmInstallPlan, VscodePackageTarget,
-        VscodeSmokeEnvironment, VscodeSmokeLaunchMode, VscodeSmokeOptions,
-        cargo_target_cc_env_suffix, cargo_target_linker_env_suffix,
-        mirror_cached_vscode_smoke_install, prepare_install_check_workspace, replace_staged_binary,
-        resolve_install_check_document, resolve_install_check_profile_root,
-        resolve_vscode_npm_install_plan, resolve_workspace_dir, select_vscode_smoke_launch_mode,
-        should_copy_vscode_smoke_root_entry, should_install_vscode_smoke_prereqs,
+        VscodeSmokeEnvironment, VscodeSmokeLaunchMode, cargo_target_cc_env_suffix,
+        cargo_target_linker_env_suffix, mirror_cached_vscode_smoke_install,
+        prepare_install_check_workspace, replace_staged_binary, resolve_install_check_document,
+        resolve_install_check_profile_root, resolve_vscode_npm_install_plan, resolve_workspace_dir,
+        select_vscode_smoke_launch_mode, should_copy_vscode_smoke_root_entry,
         should_retry_vscode_npm_ci_after_clean, stage_vscode_smoke_workspace,
     };
     use anyhow::anyhow;

--- a/docs/dev-guide/src/architecture/crate-boundaries.md
+++ b/docs/dev-guide/src/architecture/crate-boundaries.md
@@ -16,6 +16,7 @@ this page is the orientation map.
 | Facade | `rumoca-compile` | Session/compilation API the tools use |
 | Evaluators | `rumoca-eval-ast`, `-eval-flat`, `-eval-dae`, `-eval-solve` | Stage-appropriate evaluation |
 | Runtime | `rumoca-sim`, `rumoca-solver`, `rumoca-solver-rk45`, `rumoca-solver-diffsol`, `rumoca-worker` | Simulation orchestration and solver backends |
+| Optimization | `rumoca-opt` | Training and optimization over differentiable Solve runtime |
 | Execution adapters | `rumoca-exec-cranelift`, `rumoca-exec-mlir`, `rumoca-exec-wasm` | JIT/compiled execution over Solve |
 | Interactive I/O | `rumoca-input`, `rumoca-input-keyboard`, `rumoca-input-gamepad`, `rumoca-signal-frame`, `rumoca-transport-udp`, `rumoca-transport-websocket`, `rumoca-web` | Devices, signals, transports, viewer |
 | Tools | `rumoca-tool-fmt`, `rumoca-tool-lint`, `rumoca-tool-lsp` | Formatter, linter, language server logic |

--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [Modeling with Equations](./language/overview.md)
 - [Events and Discrete Behavior](./language/events.md)
 - [Arrays and Discretized PDEs](./language/arrays-pde.md)
+- [Neural ODEs](./language/neural-odes.md)
 - [Using Modelica Libraries](./language/libraries.md)
 - [Language Support Status](./language/support-status.md)
 

--- a/docs/user-guide/src/language/neural-odes.md
+++ b/docs/user-guide/src/language/neural-odes.md
@@ -1,0 +1,291 @@
+# Neural ODEs
+
+A Neural ODE replaces a hand-written right-hand side with a neural network:
+
+```text
+der(x) = f_theta(x, time, inputs)
+```
+
+The model is still an ODE. The difference is that `f_theta` is an MLP, CNN,
+or other differentiable computation with trained weights `theta`. In Rumoca,
+those weights are ordinary Modelica parameters, and the state trajectory is
+simulated with the same solver/runtime path used by physical models.
+
+The [Correll Lab Neural ODE review][correll-neural-odes] uses the common
+spiral demonstration: train a network to describe a two-dimensional rotating
+trajectory, then integrate the learned vector field. The repository example
+below follows that shape. It is not a training loop; it is the deploy/simulate
+side of the workflow, where a trained or initialized network is written as
+tensor-shaped Modelica arrays.
+
+```modelica,interactive
+// rumoca-live-scenario: ../repo-examples/simulation/rumoca-scenario.neural_ode_tensor.toml
+```
+
+Run the same scenario from the repository root:
+
+```bash
+rumoca sim -c examples/simulation/rumoca-scenario.neural_ode_tensor.toml
+```
+
+## What the Model Does
+
+The core equations are three matrix-vector layers with smooth activations:
+
+```modelica
+z1 = W1 * x;
+a1[i] = tanh(z1[i] + b1[i]);
+z2 = Wmid * a1;
+a2[i] = tanh(z2[i] + bmid[i]);
+der(x) = W2 * a2 + b2;
+```
+
+`x[1]` and `x[2]` are the latent state coordinates. The default parameters
+seed the first two hidden channels with a damped spiral vector field and add
+small dense tensor layers around it, so the phase portrait behaves like the
+blog-post spiral without requiring an external training step.
+
+The useful part for larger models is the array shape:
+
+- `W1 * x`, `Wmid * a1`, and `W2 * a2` are Modelica matrix-vector products.
+- Rumoca lowers these as native tensor operations in Solve IR instead of
+  requiring you to write every scalar multiply-add by hand.
+- CPU, browser, and codegen paths still have scalar fallback behavior, but the
+  model source keeps the neural network structure visible.
+
+## Parameter Count
+
+For this two-hidden-layer network with `nState = 2` and hidden width `H`:
+
+```text
+W1:   H x 2
+b1:   H
+Wmid: H x H
+bmid: H
+W2:   2 x H
+b2:   2
+total = H^2 + 6H + 2
+```
+
+The committed scenario uses `H = 32`, which is small enough for a quick browser
+run and gives `1186` trainable parameters. To exercise a roughly 100k-parameter
+model, edit `nHidden` in `examples/models/NeuralODETensor.mo`:
+
+```modelica
+parameter Integer nHidden(min = 2) = 314;
+```
+
+That instantiates `100482` trainable parameters. For this size, prefer the CLI
+over the browser guide page, because the report and default plots can dominate
+runtime and memory.
+
+## Training and Backpropagation
+
+The examples above are simulation/deployment examples. They keep weights as
+Modelica parameters and run the learned vector field. Rumoca's long-term
+training surface lives one layer above Modelica in the `rumoca-opt` crate:
+Modelica defines the differentiable model, while `rumoca-opt` defines the
+trainables, objective, gradient method, and optimizer.
+
+The first supported API shape is RHS fitting, which is the core Neural ODE
+vector-field training problem:
+
+```rust
+let mut model = rumoca_opt::DifferentiableModel::from_dae_default(
+    &compiled.dae,
+    &rumoca_solver::SimOptions::default(),
+)?;
+let trainables = rumoca_opt::TrainableSet::by_names(&model, &["W[1,1]", "b[1]"])?;
+let objective = rumoca_opt::RhsMseObjective::new(0.0, target_derivatives);
+let gradient = rumoca_opt::rhs_mse_value_and_gradient(
+    &model,
+    &objective,
+    &trainables,
+    rumoca_opt::GradientMode::Auto,
+)?;
+```
+
+`GradientMode::Auto` uses reverse-mode VJP for pure ODE models and falls back
+to forward-mode parameter Jacobians for models with solver algebraics. That
+keeps backpropagation correct now while preserving a clear extension point for
+future algebraic-projection reverse mode. A simple optimizer loop is available
+through `rumoca_opt::GradientDescent`.
+
+`NeuralODEBackprop.mo` is also included as a native-equation demonstration:
+the trainable weights are states and the backprop equations are written
+directly in Modelica. It proves the tensor math and training dynamics can run
+inside Rumoca, but it is intentionally not the preferred public API.
+
+```modelica,interactive
+// rumoca-live-scenario: ../repo-examples/simulation/rumoca-scenario.neural_ode_backprop.toml
+```
+
+## Benchmarking Against JAX
+
+The repository includes a reproducible Neural ODE parity benchmark:
+
+```bash
+python3 -m venv target/jax-bench-venv
+target/jax-bench-venv/bin/python -m pip install --upgrade pip
+target/jax-bench-venv/bin/python -m pip install jax numpy
+target/jax-bench-venv/bin/python examples/benchmarks/neural_ode_jax_parity.py --platform cpu
+```
+
+For CUDA-capable JAX installs, use `--platform gpu`. The script compares
+`NeuralODEBackprop1k` against an equivalent JAX implementation with x64
+enabled. It reports:
+
+- Rumoca front-end `compile_seconds`, Solve IR/runtime `prepare_seconds`, and
+  hot simulation time.
+- JAX JIT compile-plus-first-execute time for the reverse-mode RHS, manual RHS,
+  diagnostics, and full integration.
+- A `comparison` block with Rumoca ready time versus JAX integrated compile
+  time, hot-loop ratio, structural-prepare fraction, and max parity error.
+- Accuracy checks for initial parameters, observables, gradients, final
+  parameters, and JAX manual gradients versus `jax.value_and_grad`.
+
+Use Rumoca `ready_seconds` versus JAX `integrate_compile_seconds` when you care
+about first-run wait time. The benchmark also makes clear which Rumoca path is
+being measured: the native Solve IR CPU simulator executes the Modelica
+backpropagation equations, while the JAX side uses `jax.value_and_grad` for the
+same RHS.
+
+## Using Trained Weights
+
+A typical workflow is:
+
+1. Train the Neural ODE in Python/JAX/PyTorch using your preferred optimizer.
+2. Export the learned arrays with the same shapes as `W1`, `b1`, `Wmid`,
+   `bmid`, `W2`, and `b2`.
+3. Replace the parameter declarations in the Modelica model, or generate a
+   small Modelica package containing those parameter arrays.
+4. Simulate, inspect, or generate code from the scenario.
+
+Keep activation functions smooth when possible. `tanh` is a good default for
+simulation because it is continuous and differentiable. If your training code
+uses piecewise activations, check event behavior and solver step size before
+scaling up.
+
+## Predator-Prey Neural ODE
+
+Lotka-Volterra predator-prey dynamics are a more interesting Neural ODE test
+case because the state has physical meaning, nonlinear interaction, and a phase
+portrait that should remain coherent over long horizons. The
+[original Neural ODE paper][neural-ode-paper] frames these models as
+continuous-depth dynamics, while [recent SciML examples][lotka-volterra-sciml]
+use Lotka-Volterra systems as benchmarks for both full Neural ODEs and hybrid
+Universal Differential Equations.
+
+This second repository example takes the hybrid view. The state stores
+normalized prey and predator populations. The neural network reads normalized
+prey, normalized predator, and a seasonal forcing term, then outputs per-capita
+growth rates:
+
+```modelica
+features[1] = population[1] / preyEquilibrium - 1.0;
+features[2] = population[2] / predatorEquilibrium - 1.0;
+features[3] = sin(seasonRate * time);
+z1 = W1 * features;
+z2 = Wmid * a1;
+growth = W2 * a2 + b2;
+der(population[1]) = population[1] * growth[1];
+der(population[2]) = population[2] * growth[2];
+```
+
+Run it in the guide:
+
+```modelica,interactive
+// rumoca-live-scenario: ../repo-examples/simulation/rumoca-scenario.neural_predator_prey.toml
+```
+
+Or from the repository root:
+
+```bash
+rumoca sim -c examples/simulation/rumoca-scenario.neural_predator_prey.toml
+```
+
+The default width is small for report size. With hidden width `H`, this
+network has:
+
+```text
+W1:   H x 3
+b1:   H
+Wmid: H x H
+bmid: H
+W2:   2 x H
+b2:   2
+total = H^2 + 7H + 2
+```
+
+`H = 313` instantiates `100162` trainable parameters. The two large matrix
+products, `W1 * features` and `Wmid * a1`, remain tensor-shaped in the model
+source, so the same example scales from a small guide run to a much larger
+compiled model.
+
+## Larger Latent Neural ODE
+
+The [Latent ODE][latent-ode-paper] idea is to evolve a hidden continuous state
+with an ODE and decode that latent trajectory into observed signals. That shape
+needs more parameters than the two-state examples above: the vector field lives
+in latent space, and the decoder is another learned map.
+
+`NeuralLatentOscillator` uses eight latent states, three decoded output
+channels, time features, a large recurrent tensor block, and a learned decoder:
+
+```modelica
+z1 = W1 * features;
+z2 = Wmid * a1;
+latentResidual = Wdyn * a2 + bdyn;
+observed = Wobs * a2 + bobs;
+```
+
+The baseline dynamics are four lightly damped oscillator pairs. The neural
+network adds a learned residual to the latent derivative and decodes the hidden
+trajectory into three observable signals:
+
+```modelica
+der(latent[2 * k - 1]) =
+  -damping * latent[2 * k - 1] - freq[k] * latent[2 * k]
+  + residualGain * latentResidual[2 * k - 1];
+der(latent[2 * k]) =
+  freq[k] * latent[2 * k - 1] - damping * latent[2 * k]
+  + residualGain * latentResidual[2 * k];
+```
+
+Run it in the guide:
+
+```modelica,interactive
+// rumoca-live-scenario: ../repo-examples/simulation/rumoca-scenario.neural_latent_oscillator.toml
+```
+
+Or from the repository root:
+
+```bash
+rumoca sim -c examples/simulation/rumoca-scenario.neural_latent_oscillator.toml
+```
+
+With `nLatent = 8`, `nFeature = 10`, and `nObserved = 3`, hidden width `H`
+gives:
+
+```text
+W1:   H x 10
+b1:   H
+Wmid: H x H
+bmid: H
+Wdyn: 8 x H
+bdyn: 8
+Wobs: 3 x H
+bobs: 3
+total = H^2 + 23H + 11
+```
+
+The committed default `H = 128` instantiates `19339` trainable parameters, so
+this is already much larger than the spiral and predator-prey guide examples
+while staying reasonable for the examples smoke gate. For heavier runs, set
+`nHidden = 256` for `71435` trainable parameters, or `nHidden = 512` for
+`273931` trainable parameters while keeping the same source structure.
+
+[correll-neural-odes]: https://medium.com/correll-lab/neural-odes-a-review-35457d66ea2b
+[neural-ode-paper]: https://papers.neurips.cc/paper/7892-neural-ordinary-differential-equations
+[lotka-volterra-sciml]: https://arxiv.org/html/2411.06858v1
+[latent-ode-paper]: https://arxiv.org/abs/1907.03907

--- a/docs/user-guide/src/simulation/running.md
+++ b/docs/user-guide/src/simulation/running.md
@@ -77,6 +77,62 @@ A compact circuit-style example with switching behavior:
 rumoca sim -c examples/simulation/rumoca-scenario.switched_rlc.toml
 ```
 
+### NeuralODETensor
+
+A tensor-shaped Neural ODE with matrix-vector network layers and a phase
+portrait plot:
+
+```modelica,interactive
+// rumoca-live-scenario: ../repo-examples/simulation/rumoca-scenario.neural_ode_tensor.toml
+```
+
+```bash
+rumoca sim -c examples/simulation/rumoca-scenario.neural_ode_tensor.toml
+```
+
+See [Neural ODEs](../language/neural-odes.md) for the model structure and
+parameter-count formula.
+
+### NeuralPredatorPrey
+
+A Lotka-Volterra-style Neural ODE whose tensor network predicts per-capita
+growth rates for prey and predator populations:
+
+```modelica,interactive
+// rumoca-live-scenario: ../repo-examples/simulation/rumoca-scenario.neural_predator_prey.toml
+```
+
+```bash
+rumoca sim -c examples/simulation/rumoca-scenario.neural_predator_prey.toml
+```
+
+### NeuralLatentOscillator
+
+A larger latent Neural ODE with eight hidden states, a learned residual vector
+field, a learned decoder, and about 19k trainable parameters by default:
+
+```modelica,interactive
+// rumoca-live-scenario: ../repo-examples/simulation/rumoca-scenario.neural_latent_oscillator.toml
+```
+
+```bash
+rumoca sim -c examples/simulation/rumoca-scenario.neural_latent_oscillator.toml
+```
+
+### NeuralODEBackprop
+
+A native backpropagation training demonstration. The model makes weights into
+states, computes mini-batch vector-field loss, and integrates gradient-descent
+updates directly:
+
+```modelica,interactive
+// rumoca-live-scenario: ../repo-examples/simulation/rumoca-scenario.neural_ode_backprop.toml
+```
+
+```bash
+rumoca sim -c examples/simulation/rumoca-scenario.neural_ode_backprop.toml
+```
+
 ## What a Run Produces
 
 - **Batch runs** write an HTML report with time-series plots of all

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,11 +5,33 @@ Examples are organized by workflow:
 - `models/`: shared Modelica models used by multiple examples.
 - `simulation/`: batch simulation scenarios that produce plots or reports.
 - `interactive/`: browser or input-driven simulations with scene assets.
+- `benchmarks/`: reproducible cross-runtime comparisons for selected models.
 - `codegen/`: code generation scenarios and custom target bundles.
 - `codegen/custom_casadi.jinja`: direct raw-template codegen example.
 
 Generated code from `codegen/` scenarios goes under `codegen/gen/`, which is
 ignored by git.
+
+The Neural ODE example in `models/NeuralODETensor.mo` is written as tensor
+array equations. Its derivative RHS follows the blog-style spiral Neural ODE
+shape with `W1 * x`, `Wmid * a1`, and `W2 * a2` matrix-vector products that
+Solve IR preserves as `MatMul` tensor nodes. The runnable simulation profile
+keeps `nHidden` small; edit that structural parameter to re-instantiate larger
+networks.
+
+`models/NeuralPredatorPrey.mo` applies the same tensor setup to a
+Lotka-Volterra-style Neural ODE. The network predicts prey/predator
+per-capita growth rates from normalized populations and a seasonal input.
+
+`models/NeuralLatentOscillator.mo` is the larger Neural ODE example: an
+eight-state latent oscillator with a learned residual vector field and decoder.
+Its default hidden width instantiates 19339 trainable parameters; increasing
+`nHidden` to 256 instantiates 71435 parameters.
+
+`models/NeuralODEBackprop.mo` is a native training demonstration. It treats
+network weights as states, computes mini-batch spiral vector-field loss, and
+evaluates the backpropagation equations directly in Rumoca. Public training
+APIs should use `rumoca-opt`; this model is a transparent equation-level demo.
 
 ## Modelica Dependencies
 

--- a/examples/benchmarks/README.md
+++ b/examples/benchmarks/README.md
@@ -1,0 +1,42 @@
+# Benchmark Examples
+
+This directory contains reproducible comparison scripts for the example models.
+
+## Neural ODE JAX Parity
+
+`neural_ode_jax_parity.py` compares `examples/models/NeuralODEBackprop.mo`
+with an equivalent JAX implementation. It reports:
+
+- Rumoca front-end compile, Solve IR/runtime prepare, and hot stepping time.
+- JAX JIT compile-plus-first-execute and hot execution time.
+- Initial loss/gradient parity against Rumoca CSV output.
+- JAX manual backpropagation equations versus `jax.value_and_grad`.
+
+Use a disposable virtualenv under `target/`. For CPU-only runs, install the
+plain JAX package:
+
+```bash
+python3 -m venv target/jax-bench-venv
+target/jax-bench-venv/bin/python -m pip install --upgrade pip
+target/jax-bench-venv/bin/python -m pip install jax numpy
+```
+
+Run the CPU comparison:
+
+```bash
+target/jax-bench-venv/bin/python examples/benchmarks/neural_ode_jax_parity.py --platform cpu
+```
+
+For GPU runs, install a CUDA-enabled JAX wheel instead:
+
+```bash
+target/jax-bench-venv/bin/python -m pip install --upgrade "jax[cuda12]" numpy
+target/jax-bench-venv/bin/python examples/benchmarks/neural_ode_jax_parity.py --platform gpu
+```
+
+The JSON report distinguishes Rumoca `compile_seconds`, Rumoca
+`prepare_seconds`, and JAX JIT compile time. For the user's first-run wait,
+compare Rumoca `ready_seconds` with JAX `integrate_compile_seconds`. When both
+runtimes are enabled, the `comparison` block reports the ready-time ratio,
+hot-loop ratio, structural-prepare fraction, and the maximum accuracy error
+across the parity checks.

--- a/examples/benchmarks/neural_ode_jax_parity.py
+++ b/examples/benchmarks/neural_ode_jax_parity.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+"""Compare Rumoca's native NeuralODEBackprop example with a JAX equivalent.
+
+The script checks three things:
+
+1. Rumoca prepare/hot simulation timings from `rumoca sim bench`.
+2. JAX JIT compile-plus-first-execute and hot execution timings.
+3. Numeric parity for initial loss/gradient values and final integrated values.
+
+It intentionally keeps the JAX implementation in this file so the formulas can
+be audited against examples/models/NeuralODEBackprop.mo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import pathlib
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    hidden: int
+    batch: int
+    state: int = 2
+    learning_rate: float = 0.35
+    weight_decay: float = 1.0e-4
+    omega: float = 2.2
+    damping: float = 0.18
+    data_rate: float = 0.55
+    pi: float = math.pi
+
+    @property
+    def trainable_params(self) -> int:
+        return (
+            self.hidden * self.state
+            + self.hidden
+            + self.hidden * self.hidden
+            + self.hidden
+            + self.state * self.hidden
+            + self.state
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark NeuralODEBackprop against an equivalent JAX model."
+    )
+    parser.add_argument("--hidden", type=int, default=30)
+    parser.add_argument("--batch", type=int, default=8)
+    parser.add_argument("--model-file", default="examples/models/NeuralODEBackprop.mo")
+    parser.add_argument("--model", default="NeuralODEBackprop1k")
+    parser.add_argument("--solver", default="rk-like")
+    parser.add_argument("--t-end", type=float, default=0.2)
+    parser.add_argument("--dt", type=float, default=0.02)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--platform", choices=("auto", "cpu", "gpu"), default="auto")
+    parser.add_argument("--output", default="target/neural_ode_backprop1k_rumoca.csv")
+    parser.add_argument("--skip-rumoca", action="store_true")
+    parser.add_argument("--skip-jax", action="store_true")
+    parser.add_argument(
+        "--json-output",
+        default=None,
+        help="Optional path for the JSON report. The report is always printed.",
+    )
+    return parser.parse_args()
+
+
+def run_command(command: list[str], *, cwd: pathlib.Path) -> str:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=True,
+    )
+    return completed.stdout
+
+
+def parse_last_json(stdout: str) -> dict[str, Any]:
+    start = stdout.rfind("{")
+    if start < 0:
+        raise RuntimeError(f"command did not print a JSON object:\n{stdout}")
+    return json.loads(stdout[start:])
+
+
+def run_rumoca(args: argparse.Namespace) -> dict[str, Any]:
+    model_file = str(REPO_ROOT / args.model_file)
+    bench_output = run_command(
+        [
+            "cargo",
+            "run",
+            "--release",
+            "-p",
+            "rumoca",
+            "--",
+            "sim",
+            "bench",
+            model_file,
+            "--model",
+            args.model,
+            "--solver",
+            args.solver,
+            "--t-end",
+            str(args.t_end),
+            "--dt",
+            str(args.dt),
+            "--iterations",
+            str(args.iterations),
+            "--warmups",
+            str(args.warmups),
+            "--json",
+        ],
+        cwd=REPO_ROOT,
+    )
+    bench = parse_last_json(bench_output)
+    output_path = REPO_ROOT / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "cargo",
+            "run",
+            "--release",
+            "-p",
+            "rumoca",
+            "--",
+            "sim",
+            model_file,
+            "--model",
+            args.model,
+            "--solver",
+            args.solver,
+            "--t-end",
+            str(args.t_end),
+            "--dt",
+            str(args.dt),
+            "--output",
+            str(output_path),
+        ],
+        cwd=REPO_ROOT,
+    )
+    return {
+        "bench": bench,
+        "csv": str(output_path.relative_to(REPO_ROOT)),
+    }
+
+
+def load_rumoca_rows(csv_path: pathlib.Path) -> tuple[dict[str, float], dict[str, float]]:
+    with csv_path.open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    if not rows:
+        raise RuntimeError(f"no samples found in {csv_path}")
+    return row_to_float_map(rows[0]), row_to_float_map(rows[-1])
+
+
+def row_to_float_map(row: dict[str, str]) -> dict[str, float]:
+    return {name: float(value) for name, value in row.items()}
+
+
+def initial_state_np(cfg: ModelConfig) -> np.ndarray:
+    hidden = cfg.hidden
+    state = cfg.state
+    input_scale = 0.6 / math.sqrt(state)
+    recurrent_scale = 0.22 / math.sqrt(hidden)
+    output_scale = 0.12 / math.sqrt(hidden)
+
+    i = np.arange(1, hidden + 1, dtype=np.float64)[:, None]
+    j = np.arange(1, state + 1, dtype=np.float64)[None, :]
+    w1 = np.where(
+        i == j,
+        input_scale,
+        0.10
+        * input_scale
+        * (np.sin(0.17 * i + 0.31 * j) + 0.5 * np.cos(0.11 * i - 0.23 * j)),
+    )
+    b1 = 0.02 * np.sin(0.19 * np.arange(1, hidden + 1, dtype=np.float64))
+
+    row = np.arange(1, hidden + 1, dtype=np.float64)[:, None]
+    col = np.arange(1, hidden + 1, dtype=np.float64)[None, :]
+    wmid = np.where(
+        row == col,
+        recurrent_scale,
+        0.04
+        * recurrent_scale
+        * (
+            np.sin(0.07 * row + 0.13 * col)
+            - 0.3 * np.cos(0.05 * row - 0.17 * col)
+        ),
+    )
+    bmid = 0.01 * np.cos(0.17 * np.arange(1, hidden + 1, dtype=np.float64))
+
+    out = np.arange(1, state + 1, dtype=np.float64)[:, None]
+    hid = np.arange(1, hidden + 1, dtype=np.float64)[None, :]
+    w2 = output_scale * (
+        np.sin(0.23 * out + 0.07 * hid) - 0.4 * np.cos(0.13 * out - 0.11 * hid)
+    )
+    b2 = np.zeros(state, dtype=np.float64)
+    return pack_np((w1, b1, wmid, bmid, w2, b2))
+
+
+def pack_np(parts: tuple[np.ndarray, ...]) -> np.ndarray:
+    return np.concatenate([part.reshape(-1) for part in parts])
+
+
+def state_names(cfg: ModelConfig) -> list[str]:
+    names: list[str] = []
+    names.extend(
+        f"W1[{i},{j}]"
+        for i in range(1, cfg.hidden + 1)
+        for j in range(1, cfg.state + 1)
+    )
+    names.extend(f"b1[{i}]" for i in range(1, cfg.hidden + 1))
+    names.extend(
+        f"Wmid[{i},{j}]"
+        for i in range(1, cfg.hidden + 1)
+        for j in range(1, cfg.hidden + 1)
+    )
+    names.extend(f"bmid[{i}]" for i in range(1, cfg.hidden + 1))
+    names.extend(
+        f"W2[{i},{j}]"
+        for i in range(1, cfg.state + 1)
+        for j in range(1, cfg.hidden + 1)
+    )
+    names.extend(f"b2[{i}]" for i in range(1, cfg.state + 1))
+    return names
+
+
+def grad_names(cfg: ModelConfig) -> list[str]:
+    names: list[str] = []
+    names.extend(
+        f"gradW1[{i},{j}]"
+        for i in range(1, cfg.hidden + 1)
+        for j in range(1, cfg.state + 1)
+    )
+    names.extend(f"gradb1[{i}]" for i in range(1, cfg.hidden + 1))
+    names.extend(
+        f"gradWmid[{i},{j}]"
+        for i in range(1, cfg.hidden + 1)
+        for j in range(1, cfg.hidden + 1)
+    )
+    names.extend(f"gradbmid[{i}]" for i in range(1, cfg.hidden + 1))
+    names.extend(
+        f"gradW2[{i},{j}]"
+        for i in range(1, cfg.state + 1)
+        for j in range(1, cfg.hidden + 1)
+    )
+    names.extend(f"gradb2[{i}]" for i in range(1, cfg.state + 1))
+    return names
+
+
+def observable_names() -> list[str]:
+    return [
+        "loss",
+        "rmsError",
+        "learnedDX[1]",
+        "learnedDX[2]",
+        "targetFirst[1]",
+        "targetFirst[2]",
+    ]
+
+
+def max_abs_diff_from_row(
+    row: dict[str, float], names: list[str], values: np.ndarray
+) -> tuple[float, list[dict[str, float]]]:
+    diffs = []
+    max_abs = 0.0
+    for name, actual in zip(names, values, strict=True):
+        if name not in row:
+            continue
+        expected = row[name]
+        abs_error = abs(expected - float(actual))
+        max_abs = max(max_abs, abs_error)
+        diffs.append(
+            {
+                "name": name,
+                "rumoca": expected,
+                "jax": float(actual),
+                "abs_error": abs_error,
+            }
+        )
+    diffs.sort(key=lambda item: item["abs_error"], reverse=True)
+    return max_abs, diffs[:10]
+
+
+def import_jax(platform: str):
+    if platform == "cpu":
+        os.environ["JAX_PLATFORMS"] = "cpu"
+        os.environ["JAX_PLATFORM_NAME"] = "cpu"
+    elif platform == "gpu":
+        os.environ["JAX_PLATFORMS"] = "cuda"
+        os.environ["JAX_PLATFORM_NAME"] = "gpu"
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    return jax, jnp
+
+
+def run_jax(
+    args: argparse.Namespace,
+    cfg: ModelConfig,
+    initial_state: np.ndarray,
+) -> dict[str, Any]:
+    jax, jnp = import_jax(args.platform)
+
+    hidden = cfg.hidden
+    state = cfg.state
+    batch = cfg.batch
+
+    def unpack(y):
+        offset = 0
+        w1 = y[offset : offset + hidden * state].reshape((hidden, state))
+        offset += hidden * state
+        b1 = y[offset : offset + hidden]
+        offset += hidden
+        wmid = y[offset : offset + hidden * hidden].reshape((hidden, hidden))
+        offset += hidden * hidden
+        bmid = y[offset : offset + hidden]
+        offset += hidden
+        w2 = y[offset : offset + state * hidden].reshape((state, hidden))
+        offset += state * hidden
+        b2 = y[offset : offset + state]
+        return w1, b1, wmid, bmid, w2, b2
+
+    def pack(parts):
+        return jnp.concatenate([part.reshape(-1) for part in parts])
+
+    def batch_samples(t):
+        b = jnp.arange(batch, dtype=jnp.float64)
+        angle = cfg.data_rate * t + 2.0 * cfg.pi * b / batch
+        sample = jnp.stack((jnp.cos(angle), jnp.sin(angle)), axis=0)
+        target = jnp.stack(
+            (
+                -cfg.damping * sample[0] - cfg.omega * sample[1],
+                cfg.omega * sample[0] - cfg.damping * sample[1],
+            ),
+            axis=0,
+        )
+        return sample, target
+
+    def forward(parts, t):
+        w1, b1, wmid, bmid, w2, b2 = parts
+        sample, target = batch_samples(t)
+        z1 = w1 @ sample
+        a1 = jnp.tanh(z1 + b1[:, None])
+        z2 = wmid @ a1
+        a2 = jnp.tanh(z2 + bmid[:, None])
+        pred = w2 @ a2
+        prediction = pred + b2[:, None]
+        error = prediction - target
+        loss = 0.5 * jnp.sum(error * error) / batch
+        rms_error = jnp.sqrt(2.0 * loss / state)
+        observables = jnp.concatenate(
+            (
+                jnp.array([loss, rms_error], dtype=jnp.float64),
+                prediction[:, 0],
+                target[:, 0],
+            )
+        )
+        return loss, observables, (sample, a1, a2, error)
+
+    def manual_grads(parts, t):
+        w1, _b1, wmid, _bmid, w2, _b2 = parts
+        _loss, observables, (sample, a1, a2, error) = forward(parts, t)
+        gradb2 = jnp.sum(error, axis=1) / batch
+        gradw2 = error @ a2.T / batch
+        delta2 = (w2.T @ error) * (1.0 - a2 * a2)
+        gradbmid = jnp.sum(delta2, axis=1) / batch
+        gradwmid = delta2 @ a1.T / batch
+        delta1 = (wmid.T @ delta2) * (1.0 - a1 * a1)
+        gradb1 = jnp.sum(delta1, axis=1) / batch
+        gradw1 = delta1 @ sample.T / batch
+        grads = (gradw1, gradb1, gradwmid, gradbmid, gradw2, gradb2)
+        return observables, grads
+
+    def derivatives_from_grads(parts, grads):
+        return tuple(
+            -cfg.learning_rate * (grad + cfg.weight_decay * value)
+            for value, grad in zip(parts, grads, strict=True)
+        )
+
+    def reverse_rhs(y, t):
+        parts = unpack(y)
+
+        def loss_from_parts(candidate_parts):
+            loss, _observables, _aux = forward(candidate_parts, t)
+            return loss
+
+        _loss, grads = jax.value_and_grad(loss_from_parts)(parts)
+        return pack(derivatives_from_grads(parts, grads))
+
+    def manual_rhs(y, t):
+        parts = unpack(y)
+        _observables, grads = manual_grads(parts, t)
+        return pack(derivatives_from_grads(parts, grads))
+
+    def diagnostic_values(y, t):
+        parts = unpack(y)
+        observables, grads = manual_grads(parts, t)
+
+        def loss_from_parts(candidate_parts):
+            loss, _observables, _aux = forward(candidate_parts, t)
+            return loss
+
+        _loss, reverse_grads = jax.value_and_grad(loss_from_parts)(parts)
+        return observables, pack(grads), pack(reverse_grads)
+
+    def dopri5_step(y, t, h):
+        k1 = reverse_rhs(y, t)
+        k2 = reverse_rhs(y + h * (1.0 / 5.0) * k1, t + h * (1.0 / 5.0))
+        k3 = reverse_rhs(
+            y + h * ((3.0 / 40.0) * k1 + (9.0 / 40.0) * k2),
+            t + h * (3.0 / 10.0),
+        )
+        k4 = reverse_rhs(
+            y + h * ((44.0 / 45.0) * k1 + (-56.0 / 15.0) * k2 + (32.0 / 9.0) * k3),
+            t + h * (4.0 / 5.0),
+        )
+        k5 = reverse_rhs(
+            y
+            + h
+            * (
+                (19372.0 / 6561.0) * k1
+                + (-25360.0 / 2187.0) * k2
+                + (64448.0 / 6561.0) * k3
+                + (-212.0 / 729.0) * k4
+            ),
+            t + h * (8.0 / 9.0),
+        )
+        k6 = reverse_rhs(
+            y
+            + h
+            * (
+                (9017.0 / 3168.0) * k1
+                + (-355.0 / 33.0) * k2
+                + (46732.0 / 5247.0) * k3
+                + (49.0 / 176.0) * k4
+                + (-5103.0 / 18656.0) * k5
+            ),
+            t + h,
+        )
+        y5 = y + h * (
+            (35.0 / 384.0) * k1
+            + (500.0 / 1113.0) * k3
+            + (125.0 / 192.0) * k4
+            + (-2187.0 / 6784.0) * k5
+            + (11.0 / 84.0) * k6
+        )
+        k7 = reverse_rhs(y5, t + h)
+        y4 = y + h * (
+            (5179.0 / 57600.0) * k1
+            + (7571.0 / 16695.0) * k3
+            + (393.0 / 640.0) * k4
+            + (-92097.0 / 339200.0) * k5
+            + (187.0 / 2100.0) * k6
+            + (1.0 / 40.0) * k7
+        )
+        scale = 1.0e-6 + 1.0e-6 * jnp.maximum(jnp.abs(y), jnp.abs(y5))
+        error_norm = jnp.max(jnp.abs(y5 - y4) / jnp.maximum(scale, 1.0e-30))
+        return y5, error_norm
+
+    def adapt_step(h, error_norm):
+        factor = jnp.where(
+            error_norm <= 0.0,
+            5.0,
+            jnp.clip(0.9 * error_norm ** -0.2, 0.2, 5.0),
+        )
+        return jnp.maximum(h * factor, 1.0e-12)
+
+    def advance_to(carry, target_t):
+        def cond(inner):
+            t, _y, _h = inner
+            return t < target_t - 1.0e-15
+
+        def body(inner):
+            t, y, h = inner
+            step_h = jnp.minimum(jnp.maximum(h, 1.0e-12), target_t - t)
+            y_next, error_norm = dopri5_step(y, t, step_h)
+            accepted = error_norm <= 1.0
+            next_t = jnp.where(accepted, t + step_h, t)
+            next_y = jnp.where(accepted, y_next, y)
+            next_h = adapt_step(step_h, error_norm)
+            return next_t, next_y, next_h
+
+        return jax.lax.while_loop(cond, body, carry)
+
+    def integrate(y0):
+        sample_times = jnp.linspace(0.0, args.t_end, int(round(args.t_end / args.dt)) + 1)
+        initial_h = min(args.dt, 0.01)
+
+        def scan_step(carry, target_t):
+            next_carry = advance_to(carry, target_t)
+            _t, y, _h = next_carry
+            return next_carry, y
+
+        carry0 = (jnp.array(0.0, dtype=jnp.float64), y0, jnp.array(initial_h, dtype=jnp.float64))
+        final_carry, trajectory = jax.lax.scan(scan_step, carry0, sample_times[1:])
+        _t, final_y, _h = final_carry
+        return final_y, trajectory
+
+    def block_until_ready(value):
+        return jax.block_until_ready(value)
+
+    y0 = jnp.asarray(initial_state, dtype=jnp.float64)
+    t0 = jnp.array(0.0, dtype=jnp.float64)
+    jit_reverse_rhs = jax.jit(reverse_rhs)
+    jit_manual_rhs = jax.jit(manual_rhs)
+    jit_diagnostics = jax.jit(diagnostic_values)
+    jit_integrate = jax.jit(integrate)
+
+    reverse_rhs_compile_seconds, _ = time_first_call(
+        lambda: block_until_ready(jit_reverse_rhs(y0, t0))
+    )
+    manual_rhs_compile_seconds, _ = time_first_call(
+        lambda: block_until_ready(jit_manual_rhs(y0, t0))
+    )
+    diagnostics_compile_seconds, diagnostic_result = time_first_call(
+        lambda: block_until_ready(jit_diagnostics(y0, t0))
+    )
+    integrate_compile_seconds, integrate_result = time_first_call(
+        lambda: block_until_ready(jit_integrate(y0))
+    )
+
+    reverse_rhs_hot = time_hot_loop(
+        lambda: block_until_ready(jit_reverse_rhs(y0, t0)),
+        args.warmups,
+        args.iterations,
+    )
+    integrate_hot = time_hot_loop(
+        lambda: block_until_ready(jit_integrate(y0)),
+        args.warmups,
+        args.iterations,
+    )
+
+    observables, manual_grad_flat, reverse_grad_flat = diagnostic_result
+    final_y, _trajectory = integrate_result
+    final_observables, final_manual_grad_flat, _final_reverse_grad_flat = block_until_ready(
+        jit_diagnostics(final_y, jnp.asarray(args.t_end, dtype=jnp.float64))
+    )
+    manual_reverse_error = float(
+        np.max(np.abs(np.asarray(manual_grad_flat) - np.asarray(reverse_grad_flat)))
+    )
+    final_manual_reverse_error = float(
+        np.max(np.abs(np.asarray(final_manual_grad_flat) - np.asarray(_final_reverse_grad_flat)))
+    )
+
+    return {
+        "platform": jax.default_backend(),
+        "devices": [str(device) for device in jax.devices()],
+        "trainable_params": cfg.trainable_params,
+        "reverse_rhs_compile_seconds": reverse_rhs_compile_seconds,
+        "manual_rhs_compile_seconds": manual_rhs_compile_seconds,
+        "diagnostics_compile_seconds": diagnostics_compile_seconds,
+        "integrate_compile_seconds": integrate_compile_seconds,
+        "reverse_rhs_hot_average_seconds": reverse_rhs_hot["average_seconds"],
+        "reverse_rhs_hot_best_seconds": reverse_rhs_hot["best_seconds"],
+        "integrate_hot_average_seconds": integrate_hot["average_seconds"],
+        "integrate_hot_best_seconds": integrate_hot["best_seconds"],
+        "initial_observables": np.asarray(observables).tolist(),
+        "initial_manual_gradients": np.asarray(manual_grad_flat).tolist(),
+        "initial_reverse_gradients": np.asarray(reverse_grad_flat).tolist(),
+        "final_observables": np.asarray(final_observables).tolist(),
+        "final_state": np.asarray(final_y).tolist(),
+        "manual_vs_reverse_grad_max_abs_error": manual_reverse_error,
+        "final_manual_vs_reverse_grad_max_abs_error": final_manual_reverse_error,
+    }
+
+
+def time_first_call(func):
+    start = time.perf_counter()
+    value = func()
+    return time.perf_counter() - start, value
+
+
+def time_hot_loop(func, warmups: int, iterations: int) -> dict[str, float]:
+    for _ in range(warmups):
+        func()
+    samples: list[float] = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        func()
+        samples.append(time.perf_counter() - start)
+    return {
+        "average_seconds": statistics.mean(samples),
+        "best_seconds": min(samples),
+        "worst_seconds": max(samples),
+    }
+
+
+def build_accuracy_report(
+    cfg: ModelConfig,
+    initial_state: np.ndarray,
+    rumoca_initial: dict[str, float],
+    rumoca_final: dict[str, float],
+    jax_report: dict[str, Any],
+) -> dict[str, Any]:
+    state_error, state_diffs = max_abs_diff_from_row(
+        rumoca_initial, state_names(cfg), initial_state
+    )
+    observable_error, observable_diffs = max_abs_diff_from_row(
+        rumoca_initial,
+        observable_names(),
+        np.asarray(jax_report["initial_observables"], dtype=np.float64),
+    )
+    grad_error, grad_diffs = max_abs_diff_from_row(
+        rumoca_initial,
+        grad_names(cfg),
+        np.asarray(jax_report["initial_manual_gradients"], dtype=np.float64),
+    )
+    final_observable_error, final_observable_diffs = max_abs_diff_from_row(
+        rumoca_final,
+        observable_names(),
+        np.asarray(jax_report["final_observables"], dtype=np.float64),
+    )
+    final_state_error, final_state_diffs = max_abs_diff_from_row(
+        rumoca_final,
+        state_names(cfg),
+        np.asarray(jax_report["final_state"], dtype=np.float64),
+    )
+    return {
+        "initial_state_max_abs_error": state_error,
+        "initial_state_worst": state_diffs,
+        "initial_observable_max_abs_error": observable_error,
+        "initial_observable_worst": observable_diffs,
+        "initial_gradient_max_abs_error": grad_error,
+        "initial_gradient_worst": grad_diffs,
+        "final_observable_max_abs_error": final_observable_error,
+        "final_observable_worst": final_observable_diffs,
+        "final_state_max_abs_error": final_state_error,
+        "final_state_worst": final_state_diffs,
+        "jax_manual_vs_reverse_grad_max_abs_error": jax_report[
+            "manual_vs_reverse_grad_max_abs_error"
+        ],
+        "jax_final_manual_vs_reverse_grad_max_abs_error": jax_report[
+            "final_manual_vs_reverse_grad_max_abs_error"
+        ],
+    }
+
+
+def slim_jax_report(report: dict[str, Any]) -> dict[str, Any]:
+    hidden_keys = {
+        "initial_observables",
+        "initial_manual_gradients",
+        "initial_reverse_gradients",
+        "final_observables",
+        "final_state",
+    }
+    return {key: value for key, value in report.items() if key not in hidden_keys}
+
+
+def build_comparison_report(
+    rumoca_report: dict[str, Any],
+    jax_report: dict[str, Any],
+    accuracy_report: dict[str, Any],
+) -> dict[str, Any]:
+    bench = rumoca_report["bench"]
+    ready_seconds = float(bench["ready_seconds"])
+    prepare_seconds = float(bench.get("prepare_seconds", 0.0))
+    structural_seconds = float(bench.get("prepare_ir_solve_structural_dae_seconds", 0.0))
+    jax_integrate_compile = float(jax_report["integrate_compile_seconds"])
+    rumoca_hot = float(bench["hot_average_seconds"])
+    jax_hot = float(jax_report["integrate_hot_average_seconds"])
+    accuracy_keys = [
+        "initial_state_max_abs_error",
+        "initial_observable_max_abs_error",
+        "initial_gradient_max_abs_error",
+        "final_state_max_abs_error",
+        "final_observable_max_abs_error",
+        "jax_manual_vs_reverse_grad_max_abs_error",
+        "jax_final_manual_vs_reverse_grad_max_abs_error",
+    ]
+    max_accuracy = max(float(accuracy_report[key]) for key in accuracy_keys)
+    return {
+        "rumoca_ready_seconds": ready_seconds,
+        "jax_integrate_compile_seconds": jax_integrate_compile,
+        "rumoca_ready_over_jax_integrate_compile": ready_seconds
+        / max(jax_integrate_compile, 1.0e-30),
+        "rumoca_hot_average_seconds": rumoca_hot,
+        "jax_integrate_hot_average_seconds": jax_hot,
+        "rumoca_hot_average_over_jax_integrate_hot_average": rumoca_hot
+        / max(jax_hot, 1.0e-30),
+        "rumoca_prepare_seconds": prepare_seconds,
+        "rumoca_structural_prepare_seconds": structural_seconds,
+        "rumoca_structural_prepare_fraction": structural_seconds
+        / max(prepare_seconds, 1.0e-30),
+        "max_accuracy_abs_error": max_accuracy,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    cfg = ModelConfig(hidden=args.hidden, batch=args.batch)
+    initial_state = initial_state_np(cfg)
+    report: dict[str, Any] = {
+        "model": args.model,
+        "hidden": cfg.hidden,
+        "batch": cfg.batch,
+        "trainable_params": cfg.trainable_params,
+        "t_end": args.t_end,
+        "dt": args.dt,
+        "notes": {
+            "rumoca_ready_seconds": "compile_seconds + prepare_seconds from sim bench.",
+            "rumoca_prepare_seconds": "DAE-to-Solve lowering plus runtime preparation paid before hot stepping.",
+            "jax_compile_seconds": "JIT compile plus first execute for the named JAX function.",
+            "jax_backprop": "JAX reverse-mode value_and_grad RHS; Rumoca model uses explicit Modelica backprop equations.",
+        },
+    }
+
+    rumoca_report = None
+    if not args.skip_rumoca:
+        rumoca_report = run_rumoca(args)
+        bench = rumoca_report["bench"]
+        bench["ready_seconds"] = bench.get("compile_seconds", 0.0) + bench.get(
+            "prepare_seconds", 0.0
+        )
+        report["rumoca"] = rumoca_report
+
+    jax_report = None
+    if not args.skip_jax:
+        jax_report = run_jax(args, cfg, initial_state)
+        report["jax"] = slim_jax_report(jax_report)
+
+    if rumoca_report is not None and jax_report is not None:
+        initial_row, final_row = load_rumoca_rows(REPO_ROOT / rumoca_report["csv"])
+        accuracy_report = build_accuracy_report(
+            cfg, initial_state, initial_row, final_row, jax_report
+        )
+        report["accuracy"] = accuracy_report
+        report["comparison"] = build_comparison_report(
+            rumoca_report, jax_report, accuracy_report
+        )
+
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.json_output:
+        output = pathlib.Path(args.json_output)
+        if not output.is_absolute():
+            output = REPO_ROOT / output
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/models/NeuralLatentOscillator.mo
+++ b/examples/models/NeuralLatentOscillator.mo
@@ -1,0 +1,84 @@
+model NeuralLatentOscillator
+  final parameter Integer nLatent = 8 "Continuous latent state dimension";
+  final parameter Integer nFeature = nLatent + 2 "Latent state plus time features";
+  final parameter Integer nObserved = 3 "Decoded observable channels";
+  parameter Integer nHidden(min = nFeature) = 128
+    "Hidden width; nHidden=256 gives 71435 trainable parameters";
+  final parameter Integer trainableParams =
+    nHidden * nFeature + nHidden
+    + nHidden * nHidden + nHidden
+    + nLatent * nHidden + nLatent
+    + nObserved * nHidden + nObserved;
+  parameter Real residualGain = 0.08 "Scale for learned latent residual";
+  parameter Real damping = 0.035 "Baseline latent damping";
+  parameter Real featureScale = 0.75 / sqrt(nFeature);
+  parameter Real recurrentScale = 0.025 / sqrt(nHidden);
+  parameter Real dynScale = 0.045 / sqrt(nHidden);
+  parameter Real obsScale = 0.18 / sqrt(nHidden);
+  parameter Real freq[nLatent / 2] = {0.55, 0.85, 1.25, 1.7};
+
+  parameter Real W1[nHidden, nFeature] =
+    {{if i == j then featureScale
+      else featureScale * 0.12 * (sin(0.017 * i + 0.13 * j)
+                                + 0.3 * cos(0.011 * i - 0.19 * j))
+      for j in 1:nFeature} for i in 1:nHidden};
+  parameter Real b1[nHidden] =
+    {if i <= nFeature then 0.0 else 0.025 * sin(0.041 * i) for i in 1:nHidden};
+  parameter Real Wmid[nHidden, nHidden] =
+    {{if i == j then 1.0
+      else recurrentScale * (sin(0.007 * i + 0.011 * j)
+                           - 0.25 * cos(0.013 * i - 0.017 * j))
+      for j in 1:nHidden} for i in 1:nHidden};
+  parameter Real bmid[nHidden] =
+    {if i <= nFeature then 0.0 else 0.015 * cos(0.029 * i) for i in 1:nHidden};
+  parameter Real Wdyn[nLatent, nHidden] =
+    {{if j == i then 0.65
+      else dynScale * (cos(0.031 * j + 0.23 * i)
+                     - 0.4 * sin(0.017 * j - 0.09 * i))
+      for j in 1:nHidden} for i in 1:nLatent};
+  parameter Real bdyn[nLatent] = {0.0 for i in 1:nLatent};
+  parameter Real Wobs[nObserved, nHidden] =
+    {{if j == i then 1.0
+      elseif j == i + 4 then 0.45
+      else obsScale * (sin(0.021 * j + 0.31 * i)
+                     + 0.2 * cos(0.009 * j - 0.17 * i))
+      for j in 1:nHidden} for i in 1:nObserved};
+  parameter Real bobs[nObserved] = {0.0 for i in 1:nObserved};
+
+  Real latent[nLatent](start = {1.0, 0.0, 0.45, 0.25, -0.35, 0.8, 0.2, -0.55},
+                       each fixed = true) "Continuous latent state";
+  Real features[nFeature] "Neural vector-field inputs";
+  Real z1[nHidden] "First affine layer output";
+  Real a1[nHidden] "First hidden activation";
+  Real z2[nHidden] "Recurrent affine layer output";
+  Real a2[nHidden] "Second hidden activation";
+  Real latentResidual[nLatent] "Learned latent derivative residual";
+  output Real observed[nObserved] "Decoded observable signal";
+  output Real latentEnergy "Squared latent-state norm";
+equation
+  for i in 1:nLatent loop
+    features[i] = latent[i];
+  end for;
+  features[nLatent + 1] = sin(0.35 * time);
+  features[nLatent + 2] = cos(0.35 * time);
+  z1 = W1 * features;
+  for i in 1:nHidden loop
+    a1[i] = tanh(z1[i] + b1[i]);
+  end for;
+  z2 = Wmid * a1;
+  for i in 1:nHidden loop
+    a2[i] = tanh(z2[i] + bmid[i]);
+  end for;
+  latentResidual = Wdyn * a2 + bdyn;
+  observed = Wobs * a2 + bobs;
+  for k in 1:nLatent / 2 loop
+    der(latent[2 * k - 1]) =
+      -damping * latent[2 * k - 1] - freq[k] * latent[2 * k]
+      + residualGain * latentResidual[2 * k - 1];
+    der(latent[2 * k]) =
+      freq[k] * latent[2 * k - 1] - damping * latent[2 * k]
+      + residualGain * latentResidual[2 * k];
+  end for;
+  latentEnergy = sum(latent[i] * latent[i] for i in 1:nLatent);
+  annotation(experiment(StopTime = 16.0, Interval = 0.04, Solver = "rk-like"));
+end NeuralLatentOscillator;

--- a/examples/models/NeuralODEBackprop.mo
+++ b/examples/models/NeuralODEBackprop.mo
@@ -1,0 +1,157 @@
+model NeuralODEBackprop
+  final parameter Integer nState = 2 "Spiral state dimension";
+  parameter Integer nHidden(min = 2) = 12
+    "Hidden width; nHidden=314 gives about 100k trainable states";
+  parameter Integer nBatch(min = 2) = 8 "Streaming training batch size";
+  final parameter Integer trainableParams =
+    nHidden * nState + nHidden
+    + nHidden * nHidden + nHidden
+    + nState * nHidden + nState;
+  parameter Real learningRate = 0.35 "Continuous-time gradient descent gain";
+  parameter Real weightDecay = 1.0e-4 "Small L2 regularization";
+  parameter Real omega = 2.2 "Target spiral angular rate";
+  parameter Real damping = 0.18 "Target spiral contraction rate";
+  parameter Real dataRate = 0.55 "Rotates the training batch over time";
+  parameter Real pi = 3.141592653589793;
+  parameter Real inputScale = 0.6 / sqrt(nState);
+  parameter Real recurrentScale = 0.22 / sqrt(nHidden);
+  parameter Real outputScale = 0.12 / sqrt(nHidden);
+
+  Real W1[nHidden, nState](
+    start = {{if i == j then inputScale
+      else 0.10 * inputScale * (sin(0.17 * i + 0.31 * j)
+                              + 0.5 * cos(0.11 * i - 0.23 * j))
+      for j in 1:nState} for i in 1:nHidden},
+    fixed = true) "Trainable first-layer weights";
+  Real b1[nHidden](
+    start = {0.02 * sin(0.19 * i) for i in 1:nHidden},
+    fixed = true) "Trainable first-layer bias";
+  Real Wmid[nHidden, nHidden](
+    start = {{if i == j then recurrentScale
+      else 0.04 * recurrentScale * (sin(0.07 * i + 0.13 * j)
+                                  - 0.3 * cos(0.05 * i - 0.17 * j))
+      for j in 1:nHidden} for i in 1:nHidden},
+    fixed = true) "Trainable hidden-layer weights";
+  Real bmid[nHidden](
+    start = {0.01 * cos(0.17 * i) for i in 1:nHidden},
+    fixed = true) "Trainable hidden-layer bias";
+  Real W2[nState, nHidden](
+    start = {{outputScale * (sin(0.23 * i + 0.07 * j)
+                           - 0.4 * cos(0.13 * i - 0.11 * j))
+      for j in 1:nHidden} for i in 1:nState},
+    fixed = true) "Trainable output weights";
+  Real b2[nState](start = {0.0 for i in 1:nState}, fixed = true)
+    "Trainable output bias";
+
+  Real angle[nBatch] "Training sample phase";
+  Real sampleX[nState, nBatch] "Mini-batch state samples";
+  Real targetDX[nState, nBatch] "Target spiral vector field";
+  Real z1[nHidden, nBatch] "First affine layer output";
+  Real a1[nHidden, nBatch] "First hidden activation";
+  Real z2[nHidden, nBatch] "Second affine layer output";
+  Real a2[nHidden, nBatch] "Second hidden activation";
+  Real pred[nState, nBatch] "Network vector-field prediction before bias";
+  Real error[nState, nBatch] "Prediction error";
+
+  Real delta2[nHidden, nBatch] "Backprop signal at second hidden layer";
+  Real delta1[nHidden, nBatch] "Backprop signal at first hidden layer";
+  Real gradW1[nHidden, nState] "Gradient of loss with respect to W1";
+  Real gradb1[nHidden] "Gradient of loss with respect to b1";
+  Real gradWmid[nHidden, nHidden] "Gradient of loss with respect to Wmid";
+  Real gradbmid[nHidden] "Gradient of loss with respect to bmid";
+  Real gradW2[nState, nHidden] "Gradient of loss with respect to W2";
+  Real gradb2[nState] "Gradient of loss with respect to b2";
+
+  output Real loss "Mean mini-batch squared vector-field loss";
+  output Real rmsError "Root-mean-square vector-field error";
+  output Real learnedDX[nState] "Prediction for the first training sample";
+  output Real targetFirst[nState] "Target derivative for the first training sample";
+equation
+  for b in 1:nBatch loop
+    angle[b] = dataRate * time + 2.0 * pi * (b - 1) / nBatch;
+    sampleX[1, b] = cos(angle[b]);
+    sampleX[2, b] = sin(angle[b]);
+    targetDX[1, b] = -damping * sampleX[1, b] - omega * sampleX[2, b];
+    targetDX[2, b] = omega * sampleX[1, b] - damping * sampleX[2, b];
+  end for;
+
+  z1 = W1 * sampleX;
+  for i in 1:nHidden loop
+    for b in 1:nBatch loop
+      a1[i, b] = tanh(z1[i, b] + b1[i]);
+    end for;
+  end for;
+
+  z2 = Wmid * a1;
+  for i in 1:nHidden loop
+    for b in 1:nBatch loop
+      a2[i, b] = tanh(z2[i, b] + bmid[i]);
+    end for;
+  end for;
+
+  pred = W2 * a2;
+  for j in 1:nState loop
+    for b in 1:nBatch loop
+      error[j, b] = pred[j, b] + b2[j] - targetDX[j, b];
+    end for;
+  end for;
+
+  loss = 0.5 * sum(sum(error[j, b] * error[j, b] for j in 1:nState)
+                   for b in 1:nBatch) / nBatch;
+  rmsError = sqrt(2.0 * loss / nState);
+
+  for j in 1:nState loop
+    learnedDX[j] = pred[j, 1] + b2[j];
+    targetFirst[j] = targetDX[j, 1];
+    gradb2[j] = sum(error[j, b] for b in 1:nBatch) / nBatch;
+    der(b2[j]) = -learningRate * (gradb2[j] + weightDecay * b2[j]);
+    for i in 1:nHidden loop
+      gradW2[j, i] = sum(error[j, b] * a2[i, b] for b in 1:nBatch) / nBatch;
+      der(W2[j, i]) = -learningRate * (gradW2[j, i] + weightDecay * W2[j, i]);
+    end for;
+  end for;
+
+  for i in 1:nHidden loop
+    for b in 1:nBatch loop
+      delta2[i, b] =
+        sum(W2[j, i] * error[j, b] for j in 1:nState)
+        * (1.0 - a2[i, b] * a2[i, b]);
+    end for;
+  end for;
+
+  for i in 1:nHidden loop
+    gradbmid[i] = sum(delta2[i, b] for b in 1:nBatch) / nBatch;
+    der(bmid[i]) = -learningRate * (gradbmid[i] + weightDecay * bmid[i]);
+    for k in 1:nHidden loop
+      gradWmid[i, k] = sum(delta2[i, b] * a1[k, b] for b in 1:nBatch)
+        / nBatch;
+      der(Wmid[i, k]) =
+        -learningRate * (gradWmid[i, k] + weightDecay * Wmid[i, k]);
+    end for;
+  end for;
+
+  for i in 1:nHidden loop
+    for b in 1:nBatch loop
+      delta1[i, b] =
+        sum(Wmid[k, i] * delta2[k, b] for k in 1:nHidden)
+        * (1.0 - a1[i, b] * a1[i, b]);
+    end for;
+  end for;
+
+  for i in 1:nHidden loop
+    gradb1[i] = sum(delta1[i, b] for b in 1:nBatch) / nBatch;
+    der(b1[i]) = -learningRate * (gradb1[i] + weightDecay * b1[i]);
+    for j in 1:nState loop
+      gradW1[i, j] = sum(delta1[i, b] * sampleX[j, b] for b in 1:nBatch)
+        / nBatch;
+      der(W1[i, j]) = -learningRate * (gradW1[i, j] + weightDecay * W1[i, j]);
+    end for;
+  end for;
+
+  annotation(experiment(StopTime = 8.0, Interval = 0.05, Solver = "rk-like"));
+end NeuralODEBackprop;
+
+model NeuralODEBackprop1k
+  extends NeuralODEBackprop(nHidden = 30);
+  annotation(experiment(StopTime = 0.2, Interval = 0.02, Solver = "rk-like"));
+end NeuralODEBackprop1k;

--- a/examples/models/NeuralODETensor.mo
+++ b/examples/models/NeuralODETensor.mo
@@ -1,0 +1,63 @@
+model NeuralODETensor
+  final parameter Integer nState = 2 "Latent state dimension";
+  parameter Integer nHidden(min = 2) = 32
+    "Hidden width; nHidden=314 gives about 100k trainable parameters";
+  final parameter Integer trainableParams =
+    nHidden * nState + nHidden
+    + nHidden * nHidden + nHidden
+    + nState * nHidden + nState;
+  parameter Real omega = 2.2 "Base spiral angular rate";
+  parameter Real damping = 0.18 "Base spiral contraction rate";
+  parameter Real hiddenScale = 0.35 / sqrt(nState);
+  parameter Real recurrentScale = 0.04 / sqrt(nHidden);
+  parameter Real outputScale = 0.04 / sqrt(nHidden);
+
+  parameter Real W1[nHidden, nState] =
+    {{if i == 1 and j == 1 then 1.0
+      elseif i == 2 and j == 2 then 1.0
+      else hiddenScale * (sin(0.013 * i + 0.37 * j)
+                        + 0.5 * cos(0.017 * i - 0.11 * j))
+      for j in 1:nState} for i in 1:nHidden};
+  parameter Real b1[nHidden] =
+    {if i <= 2 then 0.0 else 0.05 * sin(0.019 * i) for i in 1:nHidden};
+  parameter Real Wmid[nHidden, nHidden] =
+    {{if i == j then 1.0
+      else recurrentScale * (sin(0.011 * i + 0.007 * j)
+                           + 0.25 * cos(0.019 * i - 0.013 * j))
+      for j in 1:nHidden} for i in 1:nHidden};
+  parameter Real bmid[nHidden] =
+    {if i <= 2 then 0.0 else 0.02 * cos(0.021 * i) for i in 1:nHidden};
+  parameter Real W2[nState, nHidden] =
+    {{if j == 1 then (if i == 1 then -damping else omega)
+      elseif j == 2 then (if i == 1 then -omega else -damping)
+      else outputScale * (cos(0.023 * j + 0.29 * i)
+                        - 0.4 * sin(0.005 * j - 0.13 * i))
+      for j in 1:nHidden} for i in 1:nState};
+  parameter Real b2[nState] = {0.0 for i in 1:nState};
+
+  Real x[nState](start = {1.0, 0.0}, each fixed = true) "ODE state";
+  Real z1[nHidden] "First affine layer output before bias";
+  Real a1[nHidden] "First hidden activation";
+  Real z2[nHidden] "Second affine layer output before bias";
+  Real a2[nHidden] "Second hidden activation";
+  output Real dx[nState] "Neural ODE right-hand side";
+  output Real radius "State radius";
+equation
+  z1 = W1 * x;
+  for i in 1:nHidden loop
+    a1[i] = tanh(z1[i] + b1[i]);
+  end for;
+  z2 = Wmid * a1;
+  for i in 1:nHidden loop
+    a2[i] = tanh(z2[i] + bmid[i]);
+  end for;
+  dx = W2 * a2 + b2;
+  der(x) = W2 * a2 + b2;
+  radius = sqrt(x[1] * x[1] + x[2] * x[2]);
+  annotation(experiment(StopTime = 8.0, Interval = 0.02, Solver = "rk-like"));
+end NeuralODETensor;
+
+model NeuralODETensor100k
+  extends NeuralODETensor(nHidden = 314);
+  annotation(experiment(StopTime = 0.2, Interval = 0.02, Solver = "rk-like"));
+end NeuralODETensor100k;

--- a/examples/models/NeuralPredatorPrey.mo
+++ b/examples/models/NeuralPredatorPrey.mo
@@ -1,0 +1,69 @@
+model NeuralPredatorPrey
+  final parameter Integer nState = 2 "prey, predator";
+  final parameter Integer nInput = 3 "normalized prey, predator, seasonal forcing";
+  parameter Integer nHidden(min = 3) = 24
+    "Hidden width; nHidden=313 gives about 100k trainable parameters";
+  final parameter Integer trainableParams =
+    nHidden * nInput + nHidden
+    + nHidden * nHidden + nHidden
+    + nState * nHidden + nState;
+  parameter Real preyEquilibrium = 1.0;
+  parameter Real predatorEquilibrium = 1.0;
+  parameter Real cycleGain = 1.25 "Predator-prey coupling around equilibrium";
+  parameter Real seasonalGain = 0.18 "Seasonal perturbation strength";
+  parameter Real seasonRate = 0.45 "Seasonal forcing frequency";
+  parameter Real inputScale = 0.8;
+  parameter Real hiddenScale = 0.05 / sqrt(nHidden);
+  parameter Real recurrentScale = 0.035 / sqrt(nHidden);
+  parameter Real outputScale = 0.03 / sqrt(nHidden);
+
+  parameter Real W1[nHidden, nInput] =
+    {{if i == j then inputScale
+      else hiddenScale * (sin(0.031 * i + 0.17 * j)
+                        + 0.35 * cos(0.019 * i - 0.11 * j))
+      for j in 1:nInput} for i in 1:nHidden};
+  parameter Real b1[nHidden] =
+    {if i <= nInput then 0.0 else 0.03 * sin(0.07 * i) for i in 1:nHidden};
+  parameter Real Wmid[nHidden, nHidden] =
+    {{if i == j then 1.0
+      else recurrentScale * (sin(0.009 * i + 0.013 * j)
+                           - 0.25 * cos(0.021 * i - 0.005 * j))
+      for j in 1:nHidden} for i in 1:nHidden};
+  parameter Real bmid[nHidden] =
+    {if i <= nInput then 0.0 else 0.02 * cos(0.041 * i) for i in 1:nHidden};
+  parameter Real W2[nState, nHidden] =
+    {{if j == 1 then (if i == 2 then cycleGain else 0.0)
+      elseif j == 2 then (if i == 1 then -cycleGain else 0.0)
+      elseif j == 3 then (if i == 1 then seasonalGain else -0.5 * seasonalGain)
+      else outputScale * (cos(0.029 * j + 0.23 * i)
+                        - 0.4 * sin(0.017 * j - 0.09 * i))
+      for j in 1:nHidden} for i in 1:nState};
+  parameter Real b2[nState] = {0.0 for i in 1:nState};
+
+  Real population[nState](start = {1.35, 0.72}, each fixed = true)
+    "Normalized prey and predator populations";
+  Real features[nInput] "Network inputs";
+  Real z1[nHidden] "First affine layer output";
+  Real a1[nHidden] "First hidden activation";
+  Real z2[nHidden] "Second affine layer output";
+  Real a2[nHidden] "Second hidden activation";
+  output Real growth[nState] "Neural per-capita growth rates";
+  output Real interactionIndex "Product of normalized populations";
+equation
+  features[1] = population[1] / preyEquilibrium - 1.0;
+  features[2] = population[2] / predatorEquilibrium - 1.0;
+  features[3] = sin(seasonRate * time);
+  z1 = W1 * features;
+  for i in 1:nHidden loop
+    a1[i] = tanh(z1[i] + b1[i]);
+  end for;
+  z2 = Wmid * a1;
+  for i in 1:nHidden loop
+    a2[i] = tanh(z2[i] + bmid[i]);
+  end for;
+  growth = W2 * a2 + b2;
+  der(population[1]) = population[1] * growth[1];
+  der(population[2]) = population[2] * growth[2];
+  interactionIndex = population[1] * population[2];
+  annotation(experiment(StopTime = 24.0, Interval = 0.04, Solver = "rk-like"));
+end NeuralPredatorPrey;

--- a/examples/models/README.md
+++ b/examples/models/README.md
@@ -8,6 +8,10 @@ at the model it needs.
 - `Ball.mo`: bouncing ball with `reinit` event behavior.
 - `Circuit.mo`: small package-style circuit model.
 - `KalmanFilterStepTest.mo`: MSL-backed Kalman filter step test.
+- `NeuralLatentOscillator.mo`: larger latent Neural ODE with learned decoder.
+- `NeuralODEBackprop.mo`: native backpropagation training demonstration.
+- `NeuralODETensor.mo`: tensor-shaped spiral Neural ODE with matrix-vector layers.
+- `NeuralPredatorPrey.mo`: tensor-shaped predator-prey Neural ODE.
 - `PIDMSL.mo`: MSL-backed PID example.
 - `SwitchedRLC.mo`: local switched RLC model.
 - `SwitchedRLC_MSL.mo`: MSL-backed switched RLC model.

--- a/examples/simulation/README.md
+++ b/examples/simulation/README.md
@@ -9,6 +9,10 @@ cargo run -p rumoca --release -- sim -c examples/simulation/rumoca-scenario.ball
 Scenarios:
 
 - `rumoca-scenario.ball.toml`: bouncing ball with a browser results view.
+- `rumoca-scenario.neural_latent_oscillator.toml`: larger latent Neural ODE with learned decoder.
+- `rumoca-scenario.neural_ode_backprop.toml`: native backpropagation training demonstration.
+- `rumoca-scenario.neural_ode_tensor.toml`: tensor-shaped spiral Neural ODE with matrix-vector layers.
+- `rumoca-scenario.neural_predator_prey.toml`: tensor-shaped predator-prey Neural ODE.
 - `rumoca-scenario.sympy_decay.toml`: small scalar decay model.
 - `rumoca-scenario.switched_rlc.toml`: local switched RLC model.
 - `rumoca-scenario.switched_rlc_msl.toml`: MSL-backed switched RLC model.
@@ -17,3 +21,12 @@ Scenarios:
 
 MSL-backed scenarios use `source_roots` that point at the pinned cache under
 `target/msl/`. Run `cargo xtask repo modelica-deps ensure` first.
+
+The Neural ODE scenario uses a modest default hidden width for report size.
+Edit `nHidden` in `examples/models/NeuralODETensor.mo` to re-instantiate a
+larger tensor network; `nHidden = 314` gives about 100000 trainable parameters.
+The predator-prey Neural ODE has a similar large-model knob; `nHidden = 313`
+gives about 100000 trainable parameters.
+The latent Neural ODE is larger by default with 19339 trainable parameters;
+`nHidden = 256` gives 71435 and `nHidden = 512` gives 273931 trainable
+parameters.

--- a/examples/simulation/rumoca-scenario.neural_latent_oscillator.toml
+++ b/examples/simulation/rumoca-scenario.neural_latent_oscillator.toml
@@ -1,0 +1,36 @@
+[rumoca]
+version = "1"
+task = "simulate"
+
+[model]
+file = "../models/NeuralLatentOscillator.mo"
+name = "NeuralLatentOscillator"
+
+[viewer]
+mode = "results_panel"
+
+[sim]
+solver = "rk-like"
+dt = 0.06
+t_end = 12.0
+
+[[plot.views]]
+id = "decoded_time"
+title = "Decoded Latent ODE Signals"
+type = "timeseries"
+x = "time"
+y = ["observed[1]", "observed[2]", "observed[3]", "latentEnergy"]
+
+[[plot.views]]
+id = "latent_pairs"
+title = "Latent Oscillator Pairs"
+type = "timeseries"
+x = "time"
+y = ["latent[1]", "latent[2]", "latent[3]", "latent[4]"]
+
+[[plot.views]]
+id = "decoded_phase"
+title = "Decoded Phase Portrait"
+type = "scatter"
+x = "observed[1]"
+y = ["observed[2]", "observed[3]"]

--- a/examples/simulation/rumoca-scenario.neural_ode_backprop.toml
+++ b/examples/simulation/rumoca-scenario.neural_ode_backprop.toml
@@ -1,0 +1,36 @@
+[rumoca]
+version = "1"
+task = "simulate"
+
+[model]
+file = "../models/NeuralODEBackprop.mo"
+name = "NeuralODEBackprop"
+
+[viewer]
+mode = "results_panel"
+
+[sim]
+solver = "rk-like"
+dt = 0.05
+t_end = 8.0
+
+[[plot.views]]
+id = "training_loss"
+title = "Native Backprop Training Loss"
+type = "timeseries"
+x = "time"
+y = ["loss", "rmsError"]
+
+[[plot.views]]
+id = "dx1_fit"
+title = "First Sample dx[1] Fit"
+type = "timeseries"
+x = "time"
+y = ["learnedDX[1]", "targetFirst[1]"]
+
+[[plot.views]]
+id = "dx2_fit"
+title = "First Sample dx[2] Fit"
+type = "timeseries"
+x = "time"
+y = ["learnedDX[2]", "targetFirst[2]"]

--- a/examples/simulation/rumoca-scenario.neural_ode_tensor.toml
+++ b/examples/simulation/rumoca-scenario.neural_ode_tensor.toml
@@ -1,0 +1,36 @@
+[rumoca]
+version = "1"
+task = "simulate"
+
+[model]
+file = "../models/NeuralODETensor.mo"
+name = "NeuralODETensor"
+
+[viewer]
+mode = "results_panel"
+
+[sim]
+solver = "rk-like"
+dt = 0.02
+t_end = 8.0
+
+[[plot.views]]
+id = "states_time"
+title = "States vs Time"
+type = "timeseries"
+x = "time"
+y = ["x[1]", "x[2]", "radius"]
+
+[[plot.views]]
+id = "rhs_time"
+title = "Neural Spiral RHS vs Time"
+type = "timeseries"
+x = "time"
+y = ["dx[1]", "dx[2]"]
+
+[[plot.views]]
+id = "phase_portrait"
+title = "Phase Portrait"
+type = "scatter"
+x = "x[1]"
+y = ["x[2]"]

--- a/examples/simulation/rumoca-scenario.neural_predator_prey.toml
+++ b/examples/simulation/rumoca-scenario.neural_predator_prey.toml
@@ -1,0 +1,36 @@
+[rumoca]
+version = "1"
+task = "simulate"
+
+[model]
+file = "../models/NeuralPredatorPrey.mo"
+name = "NeuralPredatorPrey"
+
+[viewer]
+mode = "results_panel"
+
+[sim]
+solver = "rk-like"
+dt = 0.02
+t_end = 24.0
+
+[[plot.views]]
+id = "populations_time"
+title = "Predator-Prey Populations"
+type = "timeseries"
+x = "time"
+y = ["population[1]", "population[2]", "interactionIndex"]
+
+[[plot.views]]
+id = "growth_time"
+title = "Neural Growth Rates"
+type = "timeseries"
+x = "time"
+y = ["growth[1]", "growth[2]"]
+
+[[plot.views]]
+id = "phase_portrait"
+title = "Predator-Prey Phase Portrait"
+type = "scatter"
+x = "population[1]"
+y = ["population[2]"]

--- a/spec/SPEC_0029_CRATE_BOUNDARIES.md
+++ b/spec/SPEC_0029_CRATE_BOUNDARIES.md
@@ -242,8 +242,9 @@ compiler/session → DAE structural → solve-IR lowering → runtime contracts 
 | DAE structural analysis (Pantelides, BLT, tearing, demotion) | `rumoca-phase-structural` | SPEC_0007 §Structural Transformation Scope |
 | Solver-facing prepared data + row ops | `rumoca-ir-solve` | Backend-neutral execution IR |
 | DAE → solve-IR lowering | `rumoca-phase-solve` | Lowering only, not structural mutation |
-| Textual generated artifacts and templates | `rumoca-phase-codegen` | Jinja/minijinja rendering owns generated C, Rust, CUDA C, MLIR, FMI, and packaging text |
-| Compiled/JIT execution adapter crates | `rumoca-exec-*` | Invoke tools, load artifacts, wrap Cranelift/LLVM/CUDA/NVRTC APIs, expose ergonomic runtime calls; no compiler semantics |
+| Optimization/training orchestration | `rumoca-opt` | Consumes Solve/eval APIs; no Modelica semantics |
+| Textual generated artifacts and templates | `rumoca-phase-codegen` | Rendering owns generated C, Rust, CUDA C, MLIR, FMI, and packaging text |
+| Compiled/JIT execution adapter crates | `rumoca-exec-*` | Invoke tools, load artifacts, wrap Cranelift/LLVM/CUDA/NVRTC APIs; no compiler semantics |
 | Backend-neutral solver interface types | `rumoca-solver` | Single contract shared across backends |
 | Concrete solver backends | `rumoca-solver-{diffsol,rk45,...}` | MUST consume solve-IR only; no DAE/phase deps |
 | Simulation facade/runner | `rumoca-sim` | Composes solvers/reporting/viz behind features |
@@ -256,8 +257,8 @@ compiler/session → DAE structural → solve-IR lowering → runtime contracts 
 Execution adapter crates are not compiler phases. Textual C/Rust/CUDA
 C/MLIR/FMI artifacts are rendered by `rumoca-phase-codegen`; `rumoca-exec-*`
 crates wrap tool invocation, ABI adaptation, loading, GPU/accelerator
-integration, packaging, runtime compilation, or stable APIs over compiled
-artifacts. Text-only targets stay in codegen. Non-codegen phase crates MUST NOT
+integration, packaging, or runtime compilation. Text-only targets stay in
+codegen. Non-codegen phase crates MUST NOT
 depend on target encoder/JIT libraries such as `wasm-encoder`, Cranelift,
 Inkwell, LLVM ORC bindings, CUDA Driver APIs, or NVRTC; backend bytecode,
 native/JIT execution, runtime compilation, and device launch policy belong in
@@ -294,7 +295,7 @@ downward.
 
 ```
 Tier 6 — Binary & bindings: rumoca, bind-python, bind-wasm, contracts
-Tier 5 — Integration/runtime: codec/input/solver/sim/viz/tool-lsp families
+Tier 5 — Integration/runtime: codec/input/solver/sim/opt/viz/tool-lsp families
 Tier 4 — Orchestration: rumoca-compile, tool-fmt, tool-lint
 Tier 3 — Phases & evaluation: rumoca-phase-*, rumoca-eval-*
 Tier 2 — IR data: rumoca-ir-*


### PR DESCRIPTION
## Summary
- include the neural ODE optimization branch plus CI gate fixes required for current toolchain and architecture hardening
- replace unstable if-let match guard in array builtin lowering with stable helper-based lowering
- restore Appendix B solve artifact admission call inside lower_dae_to_solve_model_inner while keeping clippy line budget
- clean unused imports exposed by current branch linting

## Classification
The observed failures are implementation/maintainability issues, not missing test coverage:
- clippy failures came from code that violated current lint/toolchain rules
- the architecture hardening failure was a real mechanism placement regression for solve artifact admission
- the runtime.rs size failure was already fixed by the latest feature branch head before this repair commit

## Verification
- cargo fmt --check
- cargo clippy -p rumoca-phase-solve --all-targets --all-features -- -D warnings
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p rumoca --test architecture_hardening_test size_and_validation::span_debt::test_rs_files_stay_under_spec_0021_hard_limit -- --exact
- cargo test -p rumoca --test architecture_hardening_test size_and_validation::architecture_boundaries::test_solve_ir_appendix_b_validation_gate_exists -- --exact
- cargo test --workspace --verbose --exclude rumoca-bind-python --exclude rumoca-bind-wasm (local environment failed only at Docker-backed omc_differential_semantics after earlier tests passed: Docker temp mount input/output error)

Upstream feature branch push was attempted first but failed with 403 for hechuan9.