### PR TITLE
Add relative simulation session stepping

### DIFF
--- a/crates/rumoca-bind-wasm/src/simulation_session_api.rs
+++ b/crates/rumoca-bind-wasm/src/simulation_session_api.rs
@@ -75,6 +75,13 @@ impl WasmSimulationSession {
             .map_err(|e| JsValue::from_str(&format!("Advance error: {e}")))
     }
 
+    /// Advance the simulation by a relative time step in seconds.
+    pub fn step(&mut self, dt: f64) -> Result<(), JsValue> {
+        self.session
+            .step(dt)
+            .map_err(|e| JsValue::from_str(&format!("Step error: {e}")))
+    }
+
     /// Get the current simulation time.
     pub fn time(&self) -> f64 {
         self.session.time()

--- a/crates/rumoca-bind-wasm/src/tests.rs
+++ b/crates/rumoca-bind-wasm/src/tests.rs
@@ -523,16 +523,12 @@ fn test_interactive_session_runs_pure_discrete_model_with_guarded_dynamic_subscr
     )
     .expect("pure discrete session should build");
     session.set_input("u", 1.5).expect("set input u");
-    session
-        .advance_to(session.time() + 0.02)
-        .expect("first discrete tick");
+    session.step(0.02).expect("first discrete tick");
     assert_eq!(session.time(), 0.02);
     assert_eq!(session.get("y").expect("read y"), Some(1.5));
 
     session.set_input("u", 2.0).expect("set input u");
-    session
-        .advance_to(session.time() + 0.02)
-        .expect("second discrete tick");
+    session.step(0.02).expect("second discrete tick");
     assert_eq!(session.get("y").expect("read y"), Some(4.0));
 
     clear_source_root_cache().expect("clear source-root cache");

--- a/crates/rumoca-sim/src/diffsol.rs
+++ b/crates/rumoca-sim/src/diffsol.rs
@@ -168,6 +168,13 @@ impl SimulationSession {
         self.inner.advance_to(target_time)
     }
 
+    pub(crate) fn step(&mut self, dt: f64) -> Result<(), SimError> {
+        if dt <= 0.0 {
+            return Ok(());
+        }
+        self.advance_to(self.time() + dt)
+    }
+
     pub(crate) fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
         self.inner.reset(t_start)
     }

--- a/crates/rumoca-sim/src/rk45.rs
+++ b/crates/rumoca-sim/src/rk45.rs
@@ -114,6 +114,10 @@ impl SimulationSession {
         self.inner.advance_to(target_time)
     }
 
+    pub fn step(&mut self, dt: f64) -> Result<(), SimError> {
+        self.inner.step(dt)
+    }
+
     pub fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
         self.inner.reset(t_start)
     }

--- a/crates/rumoca-sim/src/simulation_session.rs
+++ b/crates/rumoca-sim/src/simulation_session.rs
@@ -88,6 +88,19 @@ impl SimulationSession {
         }
     }
 
+    pub fn step(&mut self, dt: f64) -> Result<(), SimulationDiagnosticError> {
+        match &mut self.inner {
+            #[cfg(feature = "solver-diffsol")]
+            SimulationSessionInner::Diffsol(session) => session
+                .step(dt)
+                .map_err(|err| SimulationDiagnosticError::Solver(err.to_string())),
+            #[cfg(feature = "solver-rk45")]
+            SimulationSessionInner::RkLike(session) => session
+                .step(dt)
+                .map_err(|err| SimulationDiagnosticError::Solver(err.to_string())),
+        }
+    }
+
     pub fn time(&self) -> f64 {
         match &self.inner {
             #[cfg(feature = "solver-diffsol")]

--- a/crates/rumoca-solver-rk45/src/lib.rs
+++ b/crates/rumoca-solver-rk45/src/lib.rs
@@ -148,6 +148,13 @@ impl SimulationSession {
         advance_backend_to(&mut self.backend, target_time)
     }
 
+    pub fn step(&mut self, dt: f64) -> Result<(), SimError> {
+        if dt <= 0.0 {
+            return Ok(());
+        }
+        self.advance_to(self.backend.time + dt)
+    }
+
     pub fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
         self.input_values.clear();
         self.backend

--- a/crates/rumoca-solver-rk45/src/tests.rs
+++ b/crates/rumoca-solver-rk45/src/tests.rs
@@ -12,8 +12,7 @@ macro_rules! fixture_span {
 }
 
 fn advance_by(session: &mut SimulationSession, dt: f64, context: &str) {
-    let target = session.time() + dt;
-    session.advance_to(target).expect(context);
+    session.step(dt).expect(context);
 }
 
 #[test]
@@ -561,8 +560,8 @@ fn rk45_session_advance_to_clamps_to_sim_options_end_time() {
 
     session.set_input("u", 4.0).expect("input should exist");
     session
-        .advance_to(0.1)
-        .expect("advance past final time should clamp");
+        .step(0.1)
+        .expect("step past final time should clamp");
 
     assert!(
         (session.time() - 0.05).abs() <= 1.0e-12,

--- a/packages/rumoca-web/runtime/rumoca_interactive.js
+++ b/packages/rumoca-web/runtime/rumoca_interactive.js
@@ -1045,7 +1045,11 @@ export async function createInteractiveSimulation(options) {
     for (const [name, value] of buildModelInputs(config, input, session, runtime)) {
       session.set_input(name, finiteNumber(value, 0));
     }
-    session.advance_to(Math.min(session.time() + simDt, session.end_time()));
+    if (typeof session.step === 'function') {
+      session.step(simDt);
+    } else {
+      session.advance_to(Math.min(session.time() + simDt, session.end_time()));
+    }
     refreshViewerSignals();
     frameNum += 1;
     if (simulationFinished()) {


### PR DESCRIPTION
## Summary
- add a relative `step(dt)` API to simulation sessions and expose it through wasm
- route the interactive web runtime through `step(dt)` when available, preserving `advance_to` fallback behavior
- update session tests to exercise relative stepping

## Tests
- `cargo test -p rumoca-solver-rk45`
- `cargo test -p rumoca-bind-wasm`
- `node --check packages/rumoca-web/runtime/rumoca_interactive.js`

## Local npm smoke
- built `@cognipilot/rumoca` full-web package locally
- verified fixed-wing plant, CubControl controller, and combined lockstep all advance past 5 simulated seconds without hanging