### PR TITLE
Fix GALEC helper projection cleanup issues

### DIFF
--- a/crates/rumoca-galec-codegen/src/lower/expr.rs
+++ b/crates/rumoca-galec-codegen/src/lower/expr.rs
@@ -1153,38 +1153,7 @@ impl<'a> ExprLowerer<'a> {
                 })
             }
             Expression::Binary { op, lhs, rhs, span } => {
-                let left = self.lower(lhs)?;
-                let right = self.lower(rhs)?;
-                if matches!(op, OpBinary::Mul) && vector_dot_shape(&left, &right).is_some() {
-                    return Err(unsupported(
-                        "scalar-indexed-expression".to_owned(),
-                        "indexed expression over a vector dot-product result".to_owned(),
-                        Some(*span),
-                    ));
-                }
-                if left.is_scalar() && right.is_scalar() {
-                    return Err(unsupported(
-                        "scalar-indexed-expression".to_owned(),
-                        "indexed expression over a scalar binary result".to_owned(),
-                        Some(*span),
-                    ));
-                }
-                let lhs = if left.is_scalar() {
-                    lhs.as_ref().clone()
-                } else {
-                    indexed_expression(lhs.as_ref().clone(), subscripts.to_vec(), *span)
-                };
-                let rhs = if right.is_scalar() {
-                    rhs.as_ref().clone()
-                } else {
-                    indexed_expression(rhs.as_ref().clone(), subscripts.to_vec(), *span)
-                };
-                self.lower(&Expression::Binary {
-                    op: op.clone(),
-                    lhs: Box::new(lhs),
-                    rhs: Box::new(rhs),
-                    span: *span,
-                })
+                self.lower_indexed_binary(op, lhs, rhs, *span, subscripts)
             }
             Expression::Unary { op, rhs, span } => {
                 let value = self.lower(rhs)?;
@@ -1205,6 +1174,19 @@ impl<'a> ExprLowerer<'a> {
                     span: *span,
                 })
             }
+            Expression::FunctionCall {
+                name,
+                args,
+                is_constructor,
+                span: call_span,
+            } => self.lower_indexed_function_call(
+                name,
+                args,
+                *is_constructor,
+                *call_span,
+                subscripts,
+                span,
+            ),
             _ => Err(unsupported(
                 "indexed-expression-base".to_owned(),
                 format!("indexed expression over {}", form_name(base)),
@@ -1213,12 +1195,91 @@ impl<'a> ExprLowerer<'a> {
         }
     }
 
+    fn lower_indexed_binary(
+        &mut self,
+        op: &OpBinary,
+        lhs: &Expression,
+        rhs: &Expression,
+        span: Span,
+        subscripts: &[Subscript],
+    ) -> Result<Typed, GalecTargetError> {
+        let left = self.lower(lhs)?;
+        let right = self.lower(rhs)?;
+        if matches!(op, OpBinary::Mul) && vector_dot_shape(&left, &right).is_some() {
+            return Err(unsupported(
+                "scalar-indexed-expression".to_owned(),
+                "indexed expression over a vector dot-product result".to_owned(),
+                Some(span),
+            ));
+        }
+        if left.is_scalar() && right.is_scalar() {
+            return Err(unsupported(
+                "scalar-indexed-expression".to_owned(),
+                "indexed expression over a scalar binary result".to_owned(),
+                Some(span),
+            ));
+        }
+        let lhs = if left.is_scalar() {
+            lhs.clone()
+        } else {
+            indexed_expression(lhs.clone(), subscripts.to_vec(), span)
+        };
+        let rhs = if right.is_scalar() {
+            rhs.clone()
+        } else {
+            indexed_expression(rhs.clone(), subscripts.to_vec(), span)
+        };
+        self.lower(&Expression::Binary {
+            op: op.clone(),
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
+            span,
+        })
+    }
+
+    fn lower_indexed_function_call(
+        &mut self,
+        name: &rumoca_core::Reference,
+        args: &[Expression],
+        is_constructor: bool,
+        call_span: Span,
+        subscripts: &[Subscript],
+        index_span: Span,
+    ) -> Result<Typed, GalecTargetError> {
+        self.lower_inlined_function_call(
+            name,
+            args,
+            is_constructor,
+            call_span,
+            |lowerer, expression| {
+                lowerer.lower(&indexed_expression(
+                    expression,
+                    subscripts.to_vec(),
+                    index_span,
+                ))
+            },
+        )
+    }
+
     fn lower_function_call(
         &mut self,
         name: &rumoca_core::Reference,
         args: &[Expression],
         is_constructor: bool,
         span: Span,
+    ) -> Result<Typed, GalecTargetError> {
+        self.lower_inlined_function_call(name, args, is_constructor, span, |lowerer, expression| {
+            lowerer.lower(&expression)
+        })
+    }
+
+    fn lower_inlined_function_call(
+        &mut self,
+        name: &rumoca_core::Reference,
+        args: &[Expression],
+        is_constructor: bool,
+        span: Span,
+        lower: impl FnOnce(&mut Self, Expression) -> Result<Typed, GalecTargetError>,
     ) -> Result<Typed, GalecTargetError> {
         if name.as_str() == rumoca_core::INTERNAL_SAMPLE_FUNCTION_NAME {
             return Err(unsupported(
@@ -1261,7 +1322,7 @@ impl<'a> ExprLowerer<'a> {
         self.inlined_functions.push(name.as_str().to_owned());
         let expression = inline_function_call(function, args, span);
         let result = match expression {
-            Ok(expression) => self.lower(&expression),
+            Ok(expression) => lower(self, expression),
             Err(error) => Err(error),
         };
         self.inlined_functions.pop();

--- a/crates/rumoca-galec-codegen/tests/spec_0034_battery.rs
+++ b/crates/rumoca-galec-codegen/tests/spec_0034_battery.rs
@@ -1081,6 +1081,55 @@ mod array_vector_regressions {
         assert!(!alg.contains("norm3("), "{alg}");
     }
 
+    #[test]
+    fn indexed_vector_user_function_call_inlines_before_subscript_lowering() {
+        let call = Expression::FunctionCall {
+            name: Reference::new("lowPass"),
+            args: vec![var("a"), var("b"), real(0.5)],
+            is_constructor: false,
+            span: Span::DUMMY,
+        };
+        let mut model = vector_model(index(call, vec![Subscript::index(2, Span::DUMMY)]));
+        let mut low_pass = Function::new("lowPass", Span::DUMMY);
+        low_pass
+            .inputs
+            .push(FunctionParam::new("sample", "Real", Span::DUMMY).with_dims(vec![3]));
+        low_pass
+            .inputs
+            .push(FunctionParam::new("previous", "Real", Span::DUMMY).with_dims(vec![3]));
+        low_pass
+            .inputs
+            .push(FunctionParam::new("sampleWeight", "Real", Span::DUMMY));
+        low_pass
+            .outputs
+            .push(FunctionParam::new("result", "Real", Span::DUMMY).with_dims(vec![3]));
+        low_pass.body.push(Statement::Assignment {
+            comp: ComponentReference::from_flat_segments("result", Span::DUMMY, None),
+            value: binary(
+                OpBinary::Add,
+                binary(OpBinary::Mul, var("sampleWeight"), var("sample")),
+                binary(
+                    OpBinary::Mul,
+                    binary(OpBinary::Sub, real(1.0), var("sampleWeight")),
+                    var("previous"),
+                ),
+            ),
+            span: Span::DUMMY,
+        });
+        model
+            .symbols
+            .functions
+            .insert(low_pass.name.clone(), low_pass);
+
+        let alg = render_algorithm_code(&lower(&model, &base_types())).expect("renders");
+        assert!(alg.contains("self.a[2]"), "{alg}");
+        assert!(alg.contains("self.b[2]"), "{alg}");
+        assert!(
+            !alg.contains("lowPass("),
+            "inlineable vector helper must not survive into GALEC:\n{alg}"
+        );
+    }
+
     fn production_c_lines(package: &AlgorithmCodePackage) -> String {
         let context = c_template_context(package, "Battery").expect("C context");
         ["startup", "recalibrate", "do_step"]

--- a/crates/rumoca/src/target_manifest.rs
+++ b/crates/rumoca/src/target_manifest.rs
@@ -2,13 +2,15 @@ use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::process::Command;
 
-use crate::{CompilationResult, TemplateIr};
+use crate::{CompilationResult, TemplateIr, error::CompilerError};
 use anyhow::{Context, Result, bail};
 use rumoca_compile::codegen::targets::{
     RenderedTargetFile, TargetBuildKind, TargetBundle, TargetCapabilities, TargetFile,
     TargetManifest, TargetTemplateIr, TargetTemplateSource, TensorCapability,
     ensure_target_has_rendered_files, safe_target_join, validate_dae_target_capabilities,
 };
+use rumoca_compile::compile::core::{Diagnostic as CommonDiagnostic, PrimaryLabel, SourceMap};
+use rumoca_compile::galec::{GalecExportError, GalecTargetError};
 
 pub(crate) fn compile_target(
     result: &CompilationResult,
@@ -142,7 +144,7 @@ fn build_galec_plan(
                 model_identifier,
                 model,
             )
-            .context("GALEC eFMU plan for target 'galec'")?,
+            .map_err(|error| galec_plan_error(result, error, "galec"))?,
         )),
         Some("galec-production") => Ok(Some(
             rumoca_compile::galec::plan_galec_production_export(
@@ -151,10 +153,70 @@ fn build_galec_plan(
                 model_identifier,
                 model,
             )
-            .context("eFMI Production Code eFMU plan for target 'galec-production'")?,
+            .map_err(|error| galec_plan_error(result, error, "galec-production"))?,
         )),
         _ => Ok(None),
     }
+}
+
+fn galec_plan_error(
+    result: &CompilationResult,
+    error: GalecExportError,
+    target: &'static str,
+) -> anyhow::Error {
+    match error {
+        GalecExportError::Projection(diagnostics) => {
+            if diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span().is_some())
+            {
+                return CompilerError::SourceDiagnosticsError {
+                    summary: format!("GALEC projection rejected target '{target}'"),
+                    diagnostics: diagnostics
+                        .iter()
+                        .map(galec_projection_diagnostic)
+                        .collect(),
+                    source_map: Box::new(source_map(result)),
+                }
+                .into();
+            }
+            anyhow::Error::new(GalecExportError::Projection(diagnostics))
+                .context(galec_plan_context(target))
+        }
+        other => anyhow::Error::new(other).context(galec_plan_context(target)),
+    }
+}
+
+fn galec_projection_diagnostic(error: &GalecTargetError) -> CommonDiagnostic {
+    let Some(span) = error.span() else {
+        return CommonDiagnostic::global_error(error.code(), error.to_string());
+    };
+    CommonDiagnostic::error(
+        error.code(),
+        error.to_string(),
+        PrimaryLabel::new(span).with_message(galec_projection_label(error)),
+    )
+}
+
+fn galec_projection_label(error: &GalecTargetError) -> String {
+    match error {
+        GalecTargetError::UnsupportedFeature { feature, .. } => {
+            format!("unsupported GALEC projection feature `{feature}`")
+        }
+        _ => "GALEC projection rejected this construct".to_owned(),
+    }
+}
+
+fn galec_plan_context(target: &'static str) -> &'static str {
+    match target {
+        "galec" => "GALEC eFMU plan for target 'galec'",
+        "galec-production" => "eFMI Production Code eFMU plan for target 'galec-production'",
+        _ => "GALEC target plan",
+    }
+}
+
+fn source_map(result: &CompilationResult) -> SourceMap {
+    result.resolved.0.source_map.clone()
 }
 
 /// The per-file render closure driving the declarative eFMU build step for a

--- a/crates/rumoca/tests/cli_target_galec_production.rs
+++ b/crates/rumoca/tests/cli_target_galec_production.rs
@@ -120,6 +120,69 @@ algorithm
 end GalecProdAlgebraicComponent;
 ";
 
+const HELPER_IDIOMS_FIXTURE: &str = "\
+function clip
+  input Real value;
+  input Real lower;
+  input Real upper;
+  output Real result;
+algorithm
+  result := min(max(value, lower), upper);
+annotation(
+  Inline = true);
+end clip;
+
+function wrapAngle
+  input Real angle(unit = \"rad\");
+  output Real result(unit = \"rad\");
+algorithm
+  result := atan2(sin(angle), cos(angle));
+annotation(
+  Inline = true);
+end wrapAngle;
+
+function lowPass
+  input Real sample[:];
+  input Real previous[size(sample, 1)];
+  input Real sampleWeight;
+  output Real result[size(sample, 1)];
+algorithm
+  result := sampleWeight * sample + (1.0 - sampleWeight) * previous;
+annotation(
+  Inline = true);
+end lowPass;
+
+model GalecProdHelperIdioms
+  constant Real dt = 0.02;
+  parameter Real waypoints[2, 3] = [0.0, 0.0, 0.0; 1.0, 2.0, 3.0];
+  input Real sample[3];
+  discrete output Real filtered[3](each start = 0.0);
+  discrete output Real segmentStart[3](each start = 0.0);
+  discrete output Real bounded(start = 0.0);
+  discrete output Real yaw(start = 0.0);
+  discrete output Integer currentWaypoint(min = 1, max = 2, start = 1);
+algorithm
+  when sample(0.0, dt) then
+    filtered := lowPass(sample, pre(filtered), 0.5);
+    segmentStart := waypoints[currentWaypoint, :];
+    bounded := clip(filtered[1], -1.0, 1.0);
+    yaw := wrapAngle(pre(yaw) + 0.25);
+    currentWaypoint := pre(currentWaypoint);
+  end when;
+end GalecProdHelperIdioms;
+";
+
+const UNSUPPORTED_GALEC_BUILTIN_FIXTURE: &str = "\
+model GalecProdUnsupportedBuiltin
+  constant Real dt = 0.02;
+  discrete output Integer y(start = 0);
+algorithm
+  when sample(0.0, dt) then
+    y := mod(3, 2);
+  end when;
+end GalecProdUnsupportedBuiltin;
+";
+
 /// Driver exercising the packaged block: startup, recalibrate, then three
 /// dostep ticks of `y = gain * (pre(y) + 1)` with `gain = 2`, `y0 = 0`
 /// (expected 2, 6, 14) — row E6.
@@ -261,6 +324,54 @@ fn algebraic_component_output_read_by_sampled_parent_compiles() {
     );
     assert!(out_dir.join(model).join("__content.xml").is_file());
     assert!(out_dir.join(format!("{model}.efmu")).is_file());
+}
+
+#[test]
+fn inline_helpers_vector_return_and_row_slice_compile() {
+    let dir = tempdir().expect("tempdir");
+    let out_dir = dir.path().join("out");
+    let model = "GalecProdHelperIdioms";
+    let file = write_fixture(dir.path(), model, HELPER_IDIOMS_FIXTURE);
+    let output = run_compile_galec_production(&file, &out_dir);
+    assert!(
+        output.status.success(),
+        "GALEC production target should compile inline scalar helpers, \
+         vector-returning helpers, and row slices.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let alg = fs::read_to_string(
+        out_dir
+            .join(model)
+            .join("AlgorithmCode")
+            .join(format!("{model}.alg")),
+    )
+    .expect("read generated Algorithm Code");
+    assert!(alg.contains("self.sample[1]"), "{alg}");
+    assert!(alg.contains("self.waypoints["), "{alg}");
+    assert!(!alg.contains("lowPass("), "{alg}");
+    assert!(!alg.contains("clip("), "{alg}");
+    assert!(!alg.contains("wrapAngle("), "{alg}");
+}
+
+#[test]
+fn unsupported_galec_projection_diagnostic_points_at_source_expression() {
+    let dir = tempdir().expect("tempdir");
+    let out_dir = dir.path().join("out");
+    let model = "GalecProdUnsupportedBuiltin";
+    let file = write_fixture(dir.path(), model, UNSUPPORTED_GALEC_BUILTIN_FIXTURE);
+    let output = run_compile_galec_production(&file, &out_dir);
+    assert!(
+        !output.status.success(),
+        "unsupported GALEC builtin should be rejected"
+    );
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(stderr.contains("[ET017]"), "{stderr}");
+    assert!(stderr.contains("builtin:mod"), "{stderr}");
+    assert!(
+        stderr.contains("mod(3, 2)"),
+        "projection diagnostic should show the source expression:\n{stderr}"
+    );
 }
 
 /// Attribute name → value maps for every element called `element_name`,


### PR DESCRIPTION
## Summary

- Inline indexed GALEC user-function calls before subscript lowering, fixing vector-returning helpers such as `lowPass(...)[i]`.
- Add end-to-end coverage for scalar inline helpers, vector-returning helpers, and waypoint row slicing through `galec-production`.
- Render span-bearing GALEC ET017 projection failures as source-backed CLI diagnostics.

## Validation

- `cargo test -p rumoca-galec-codegen --test spec_0034_battery`
- `cargo test -p rumoca --test cli_target_galec_production`
- `cargo clippy -p rumoca-galec-codegen -p rumoca --tests --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `target/debug/rumoca compile ~/git/cerebri_cubs2/src/FixedWingOuterLoop.mo --model FixedWingOuterLoop --target galec-production -o /tmp/rumoca-cubs2-galec-check`
