### PR TITLE
Fix CI publishing and VS Code warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,8 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          determinate: false
 
       - name: Cachix (rumoca binary cache)
         uses: cachix/cachix-action@v17
@@ -651,6 +653,8 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          determinate: false
 
       - name: Cachix (rumoca binary cache)
         uses: cachix/cachix-action@v17
@@ -757,6 +761,8 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          determinate: false
 
       - name: Cachix (rumoca binary cache)
         uses: cachix/cachix-action@v17
@@ -823,13 +829,15 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Download shard results
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: shard-*
           path: target/msl/shards
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          determinate: false
 
       - name: Cachix (rumoca binary cache)
         uses: cachix/cachix-action@v17
@@ -1187,6 +1195,8 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          determinate: false
 
       - name: Cachix (rumoca binary cache)
         uses: cachix/cachix-action@v17
@@ -1886,7 +1896,7 @@ jobs:
           echo "As of v0.8.0, Rust distribution is via GitHub Releases binaries (not crates.io)."
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ members = [
 version = "0.9.13"
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/cognipilot/rumoca"
-homepage = "https://github.com/cognipilot/rumoca"
+repository = "https://github.com/CogniPilot/rumoca"
+homepage = "https://github.com/CogniPilot/rumoca"
 
 [workspace.metadata.crane]
 name = "rumoca"

--- a/packages/rumoca-web/package.json
+++ b/packages/rumoca-web/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cognipilot/rumoca.git",
+    "url": "https://github.com/CogniPilot/rumoca",
     "directory": "packages/rumoca-web"
   },
   "exports": {

--- a/packages/rumoca/patch-wasm-pkg.mjs
+++ b/packages/rumoca/patch-wasm-pkg.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 // `@cognipilot/rumoca-core` is the same minus the bundled solver runtime. Any
 // other variant (only used for local/experimental builds) appends its name.
 const NPM_SCOPE = "@cognipilot";
+const REPOSITORY_URL = "https://github.com/CogniPilot/rumoca";
 const packageNameForVariant = (variant) => {
   switch (variant) {
     case "full-web":
@@ -33,6 +34,7 @@ export const patchWasmPackageJson = async (pkgDir, variant, runtimeFiles = []) =
   };
 
   pkg.name = packageNameForVariant(variant);
+  pkg.repository = { type: "git", url: REPOSITORY_URL };
   // Scoped packages default to restricted; force public so `npm publish`
   // (both the manual scripts and CI) publishes openly without a flag.
   pkg.publishConfig = { ...(pkg.publishConfig || {}), access: "public" };

--- a/packages/rumoca/tests/patch_wasm_pkg.test.mjs
+++ b/packages/rumoca/tests/patch_wasm_pkg.test.mjs
@@ -33,4 +33,8 @@ test("patched wasm package includes staged runtime dependencies", async () => {
   for (const file of runtimeFiles) {
     assert(patched.files.includes(file), `expected ${file} in package files`);
   }
+  assert.deepEqual(patched.repository, {
+    type: "git",
+    url: "https://github.com/CogniPilot/rumoca",
+  });
 });

--- a/packages/vscode/eslint.config.mjs
+++ b/packages/vscode/eslint.config.mjs
@@ -22,7 +22,7 @@ export default [
     rules: {
       ...tsPlugin.configs.recommended.rules,
       "no-undef": "off",
-      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
       "@typescript-eslint/no-explicit-any": "warn",
     },
   },

--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rumoca-modelica",
-  "version": "0.9.4",
+  "version": "0.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rumoca-modelica",
-      "version": "0.9.4",
+      "version": "0.9.13",
       "license": "Apache-2.0",
       "dependencies": {
         "three": "^0.160.0",
@@ -2970,17 +2970,17 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3204,9 +3204,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3540,10 +3540,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3756,10 +3766,20 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -3901,15 +3921,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -5596,9 +5626,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -37,14 +37,6 @@ const pendingSimulationJobs = new Map<string, {
         metrics?: unknown;
     }) => void;
 }>();
-const pendingPrepareSimulationJobs = new Map<string, {
-    resolve: (response: {
-        ok?: boolean;
-        preparedModels?: string[];
-        failures?: Array<{ model?: string; error?: string }>;
-        error?: string;
-    }) => void;
-}>();
 
 // ============================================================================
 // Virtual Document Provider for %%modelica blocks in Python cells
@@ -870,27 +862,6 @@ async function getSimulationModelState(
     return normalizeSimulationModelState(response);
 }
 
-async function setSelectedSimulationModel(
-    documentUri: string,
-    model: string,
-    defaultModel?: string,
-): Promise<{
-    ok: boolean;
-    models: string[];
-    selectedModel?: string;
-    error?: string;
-}> {
-    const response = await sendScenarioCommand<SimulationModelStateResponse>(
-        'rumoca.scenario.setSelectedSimulationModel',
-        {
-            uri: documentUri,
-            model,
-            defaultModel: defaultModel?.trim() || null,
-        },
-    );
-    return normalizeSimulationModelState(response);
-}
-
 function resolveSourceRootPaths(config: vscode.WorkspaceConfiguration): SourceRootPathSources {
     return resolveSourceRootPathsForEntries(
         config.get<string[]>('sourceRootPaths') ?? [],
@@ -915,21 +886,6 @@ function getSimulationSettings(config: vscode.WorkspaceConfiguration): Simulatio
             || DEFAULT_WEB_RESULTS_OUTPUT_DIR,
         sourceRootPaths: sourceRootPaths.mergedPaths,
     };
-}
-
-function getConfiguredWorkspaceSourceRootPaths(): string[] {
-    return vscode.workspace
-        .getConfiguration('rumoca')
-        .get<string[]>('sourceRootPaths') ?? [];
-}
-
-async function setConfiguredWorkspaceSourceRootPaths(paths: string[]): Promise<void> {
-    const normalized = Array.from(
-        new Set(paths.map((entry) => entry.trim()).filter(Boolean)),
-    );
-    await vscode.workspace
-        .getConfiguration('rumoca')
-        .update('sourceRootPaths', normalized, vscode.ConfigurationTarget.Workspace);
 }
 
 function isSimulationRunnableDocument(document: vscode.TextDocument): boolean {
@@ -1111,26 +1067,6 @@ interface SimulationCompleteNotification {
     diagnostic?: unknown;
 }
 
-interface PrepareSimulationModelsCompleteNotification {
-    requestId?: string;
-    ok?: boolean;
-    preparedModels?: string[];
-    failures?: Array<{ model?: string; error?: string }>;
-    error?: string;
-}
-
-interface BuiltinCodegenTemplate {
-    id: string;
-    label: string;
-    manifest: string;
-}
-
-interface CodegenSettings {
-    mode: 'target' | 'custom-target';
-    builtinTargetId: string;
-    customTargetPath: string;
-}
-
 interface CodegenTargetFile {
     path: string;
     content: string;
@@ -1271,8 +1207,6 @@ function benchmarkServerArgs(config: vscode.WorkspaceConfiguration): string[] {
     }
     return args;
 }
-let builtInCodegenTemplatesCache: BuiltinCodegenTemplate[] | undefined;
-
 function wireSimulationJobNotifications(activeClient: LanguageClient) {
     activeClient.onNotification('rumoca/simulationComplete', (payload: SimulationCompleteNotification) => {
         const requestId = typeof payload?.requestId === 'string' ? payload.requestId : '';
@@ -1286,82 +1220,10 @@ function wireSimulationJobNotifications(activeClient: LanguageClient) {
         pendingSimulationJobs.delete(requestId);
         pending.resolve(payload);
     });
-    activeClient.onNotification(
-        'rumoca/prepareSimulationModelsComplete',
-        (payload: PrepareSimulationModelsCompleteNotification) => {
-            const requestId = typeof payload?.requestId === 'string' ? payload.requestId : '';
-            if (!requestId) {
-                return;
-            }
-            const pending = pendingPrepareSimulationJobs.get(requestId);
-            if (!pending) {
-                return;
-            }
-            pendingPrepareSimulationJobs.delete(requestId);
-            pending.resolve(payload);
-        },
-    );
 }
 
 function trimMaybeString(value: unknown): string {
     return typeof value === 'string' ? value.trim() : '';
-}
-
-function defaultCodegenSettings(): CodegenSettings {
-    return {
-        mode: 'target',
-        builtinTargetId: DEFAULT_CODEGEN_TARGET_ID,
-        customTargetPath: '',
-    };
-}
-
-function normalizeCodegenSettings(raw: unknown): CodegenSettings {
-    const next = raw && typeof raw === 'object' && !Array.isArray(raw)
-        ? raw as Record<string, unknown>
-        : {};
-    const mode = next.mode === 'custom-target'
-            ? 'custom-target'
-            : 'target';
-    return {
-        mode,
-        builtinTargetId: trimMaybeString(next.builtinTargetId) || DEFAULT_CODEGEN_TARGET_ID,
-        customTargetPath: trimMaybeString(next.customTargetPath),
-    };
-}
-
-function codegenSettingsFromScenarioConfig(
-    raw: unknown,
-    templates: BuiltinCodegenTemplate[],
-): CodegenSettings {
-    const config = raw && typeof raw === 'object' && !Array.isArray(raw)
-        ? raw as Record<string, unknown>
-        : {};
-    const target = trimMaybeString(config.target) || DEFAULT_CODEGEN_TARGET_ID;
-    const builtin = templates.find((template) => template.id === target);
-    if (builtin) {
-        return {
-            mode: 'target',
-            builtinTargetId: builtin.id,
-            customTargetPath: '',
-        };
-    }
-    return {
-        mode: 'custom-target',
-        builtinTargetId: findBuiltinCodegenTemplate(templates, DEFAULT_CODEGEN_TARGET_ID)?.id
-            ?? templates[0]?.id
-            ?? DEFAULT_CODEGEN_TARGET_ID,
-        customTargetPath: target,
-    };
-}
-
-function codegenConfigFromSettings(raw: unknown): { target: string } {
-    const settings = normalizeCodegenSettings(raw);
-    const target = settings.mode === 'custom-target'
-        ? settings.customTargetPath
-        : settings.builtinTargetId;
-    return {
-        target: trimMaybeString(target) || DEFAULT_CODEGEN_TARGET_ID,
-    };
 }
 
 function normalizeSelectedSimulationModels(raw: unknown): Record<string, string> {
@@ -1377,20 +1239,6 @@ function normalizeSelectedSimulationModels(raw: unknown): Record<string, string>
         }
     }
     return out;
-}
-
-function loadStoredSelectedSimulationModel(
-    context: vscode.ExtensionContext,
-    documentUri: string | undefined,
-): string | undefined {
-    const uri = trimMaybeString(documentUri);
-    if (!uri) {
-        return undefined;
-    }
-    const models = normalizeSelectedSimulationModels(
-        context.workspaceState.get(SELECTED_SIMULATION_MODELS_STATE_KEY),
-    );
-    return models[uri];
 }
 
 async function storeSelectedSimulationModel(
@@ -1415,35 +1263,6 @@ async function storeSelectedSimulationModel(
         SELECTED_SIMULATION_MODELS_STATE_KEY,
         Object.keys(models).length > 0 ? models : undefined,
     );
-}
-
-function normalizeBuiltinCodegenTemplates(raw: unknown): BuiltinCodegenTemplate[] {
-    if (!Array.isArray(raw)) {
-        return [];
-    }
-    return raw
-        .map((entry) => {
-            const next = entry && typeof entry === 'object' && !Array.isArray(entry)
-                ? entry as Record<string, unknown>
-                : {};
-            return {
-                id: trimMaybeString(next.id),
-                label: trimMaybeString(next.label),
-                manifest: typeof next.manifest === 'string' ? next.manifest : '',
-            };
-        })
-        .filter((entry) => entry.id.length > 0 && entry.label.length > 0);
-}
-
-function findBuiltinCodegenTemplate(
-    templates: BuiltinCodegenTemplate[],
-    templateId: string,
-): BuiltinCodegenTemplate | undefined {
-    const preferredId = trimMaybeString(templateId);
-    if (!preferredId) {
-        return templates[0];
-    }
-    return templates.find((template) => template.id === preferredId) ?? templates[0];
 }
 
 function scenarioDefaultOutputDir(document: vscode.TextDocument): string {
@@ -1528,88 +1347,6 @@ async function sendWorkspaceCommand<T>(
     return await sendExecuteCommand<T>(command, payload);
 }
 
-async function loadBuiltInCodegenTemplates(
-    forceReload = false,
-): Promise<BuiltinCodegenTemplate[]> {
-    if (!forceReload && builtInCodegenTemplatesCache) {
-        return builtInCodegenTemplatesCache;
-    }
-    const response = await sendWorkspaceCommand<unknown>('rumoca.workspace.getBuiltinTargets', {});
-    const templates = normalizeBuiltinCodegenTemplates(response);
-    if (templates.length === 0) {
-        throw new Error('No built-in codegen targets are available from rumoca-lsp.');
-    }
-    builtInCodegenTemplatesCache = templates;
-    return templates;
-}
-
-async function getScenarioCodegenConfig(
-    model: string,
-    workspaceRoot: string | undefined,
-): Promise<unknown> {
-    if (!workspaceRoot) {
-        return undefined;
-    }
-    return await sendScenarioCommand<unknown>(
-        'rumoca.scenario.getCodegenConfig',
-        {
-            workspaceRoot,
-            model,
-        },
-    );
-}
-
-async function setScenarioCodegenConfig(
-    model: string,
-    workspaceRoot: string | undefined,
-    settings: CodegenSettings,
-): Promise<boolean> {
-    if (!workspaceRoot) {
-        return false;
-    }
-    const response = await sendScenarioCommand<{ ok?: boolean }>(
-        'rumoca.scenario.setCodegenConfig',
-        {
-            workspaceRoot,
-            model,
-            config: codegenConfigFromSettings(settings),
-        },
-    );
-    return response?.ok === true;
-}
-
-async function setScenarioSourceRoots(
-    model: string,
-    workspaceRoot: string | undefined,
-    sourceRootPaths: string[],
-): Promise<boolean> {
-    if (!workspaceRoot) {
-        return false;
-    }
-    const response = await sendScenarioCommand<{ ok?: boolean }>(
-        'rumoca.scenario.setSourceRoots',
-        {
-            workspaceRoot,
-            model,
-            task: 'codegen',
-            config: { sourceRootPaths },
-        },
-    );
-    return response?.ok === true;
-}
-
-async function loadCurrentCodegenSettingsState(
-    model: string,
-    workspaceRoot: string | undefined,
-): Promise<{ settings: CodegenSettings; templates: BuiltinCodegenTemplate[] }> {
-    const templates = await loadBuiltInCodegenTemplates();
-    const settings = codegenSettingsFromScenarioConfig(
-        await getScenarioCodegenConfig(model, workspaceRoot),
-        templates,
-    );
-    return { settings, templates };
-}
-
 function workspaceRelativeTemplatePath(
     workspaceRoot: string | undefined,
     absolutePath: string,
@@ -1625,13 +1362,6 @@ function workspaceRelativeTemplatePath(
         return absolutePath;
     }
     return relativePath.split(path.sep).join('/');
-}
-
-function workspaceRelativeSourceRootPath(
-    workspaceRoot: string | undefined,
-    absolutePath: string,
-): string {
-    return workspaceRelativeTemplatePath(workspaceRoot, absolutePath);
 }
 
 async function getScenarioSimulationConfig(
@@ -1857,42 +1587,6 @@ async function reopenEmbeddedModelicaDocuments() {
     }
 }
 
-async function setScenarioSimulationPreset(
-    model: string,
-    workspaceRoot: string | undefined,
-    preset: ModelSimulationPreset
-): Promise<boolean> {
-    if (!workspaceRoot) {
-        return false;
-    }
-    const response = await sendScenarioCommand<{ ok?: boolean }>(
-        'rumoca.scenario.setSimulationPreset',
-        {
-            workspaceRoot,
-            model,
-            preset,
-        }
-    );
-    return response?.ok === true;
-}
-
-async function resetScenarioSimulationPreset(
-    model: string,
-    workspaceRoot: string | undefined
-): Promise<boolean> {
-    if (!workspaceRoot) {
-        return false;
-    }
-    const response = await sendScenarioCommand<{ ok?: boolean }>(
-        'rumoca.scenario.resetSimulationPreset',
-        {
-            workspaceRoot,
-            model,
-        }
-    );
-    return response?.ok === true;
-}
-
 function defaultThreeDimensionalViewerScript(): string {
     return loadVisualizationShared().defaultThreeDimensionalViewerScript();
 }
@@ -1917,25 +1611,6 @@ async function getScenarioVisualizationConfig(
         }
     );
     return normalizeVisualizationViews(response?.views);
-}
-
-async function setScenarioVisualizationConfig(
-    model: string,
-    workspaceRoot: string | undefined,
-    views: VisualizationView[]
-): Promise<boolean> {
-    if (!workspaceRoot) {
-        return false;
-    }
-    const response = await sendScenarioCommand<{ ok?: boolean }>(
-        'rumoca.scenario.setVisualizationConfig',
-        {
-            workspaceRoot,
-            model,
-            views,
-        }
-    );
-    return response?.ok === true;
 }
 
 function resolveWorkspaceVisualizationScriptPath(
@@ -2081,56 +1756,6 @@ async function runRumocaSimulation(
         payload,
         metrics,
         diagnostic,
-    };
-}
-
-async function prepareRumocaSimulationModels(
-    modelUri: string,
-    models: string[],
-    settings: SimulationExecutionSettings,
-): Promise<{
-    ok: boolean;
-    preparedModels: string[];
-    failures: Array<{ model?: string; error?: string }>;
-    error?: string;
-}> {
-    const accepted = await sendScenarioCommand<BackgroundRequestAccepted>(
-        'rumoca.scenario.prepareSimulationModels',
-        {
-            uri: modelUri,
-            models,
-            settings: {
-                solver: settings.solver,
-                tEnd: settings.tEnd,
-                dt: settings.dt ?? null,
-                sourceRootPaths: settings.sourceRootPaths ?? [],
-            },
-        },
-    );
-    if (!accepted) {
-        return {
-            ok: false,
-            preparedModels: [],
-            failures: [],
-            error: 'No response from rumoca-lsp prepare request.',
-        };
-    }
-    if (!accepted.ok || !accepted.requestId) {
-        return {
-            ok: false,
-            preparedModels: [],
-            failures: [],
-            error: accepted.error ?? 'rumoca-lsp rejected the prepare request.',
-        };
-    }
-    const response = await new Promise<PrepareSimulationModelsCompleteNotification>((resolve) => {
-        pendingPrepareSimulationJobs.set(accepted.requestId!, { resolve });
-    });
-    return {
-        ok: response.ok === true,
-        preparedModels: response.preparedModels ?? [],
-        failures: response.failures ?? [],
-        error: response.error,
     };
 }
 
@@ -2683,7 +2308,6 @@ export async function activate(context: vscode.ExtensionContext) {
         getClient: () => client,
         setClient: (nextClient) => {
             client = nextClient;
-            builtInCodegenTemplatesCache = undefined;
         },
         startLanguageClient,
         stopLanguageClient: async (existingClient) => {
@@ -2882,7 +2506,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         }
                         return { views: defaultVisualizationViews() };
                     },
-                    saveViews: async ({ modelRef, payload }) => {
+                    saveViews: async ({ payload }) => {
                         const rawPayload = payload && typeof payload === 'object'
                             ? payload as Record<string, unknown>
                             : {};
@@ -3503,14 +3127,6 @@ export async function activate(context: vscode.ExtensionContext) {
             },
         ),
     );
-
-    const currentModelicaEditor = (): vscode.TextEditor | undefined => {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor || editor.document.languageId !== 'modelica') {
-            return undefined;
-        }
-        return editor;
-    };
 
     const simulationDiagnostics = vscode.languages.createDiagnosticCollection('rumoca simulation');
     context.subscriptions.push(simulationDiagnostics);

--- a/packages/vscode/tests/extension_surface_contract.test.mjs
+++ b/packages/vscode/tests/extension_surface_contract.test.mjs
@@ -208,7 +208,7 @@ function inventoryExtensionSurface(source) {
   const scenarioConfigProvider = sliceFrom(
     source,
     "const scenarioEditorProvider: vscode.CustomTextEditorProvider = {",
-    "const currentModelicaEditor = (): vscode.TextEditor | undefined => {",
+    "const simulationDiagnostics = vscode.languages.createDiagnosticCollection('rumoca simulation');",
   );
 
   return {
@@ -527,7 +527,7 @@ test("surface contract: VS Code has shared scenario GUI command primitives", () 
   const scenarioProviderBlock = sliceFrom(
     source,
     "const scenarioEditorProvider: vscode.CustomTextEditorProvider = {",
-    "const currentModelicaEditor = (): vscode.TextEditor | undefined => {",
+    "const simulationDiagnostics = vscode.languages.createDiagnosticCollection('rumoca simulation');",
   );
   assert.ok(
     scenarioProviderBlock.includes("getScenarioConfigFull(document.uri.toString(), document.getText())"),
@@ -559,6 +559,16 @@ test("surface contract: VS Code has shared scenario GUI command primitives", () 
 test("surface contract: VS Code codegen settings are scenario-owned", () => {
   const source = readExtensionSource();
   const sharedSource = readSharedVisualizationSource();
+  const scenarioProviderBlock = sliceFrom(
+    source,
+    "const scenarioEditorProvider: vscode.CustomTextEditorProvider = {",
+    "const simulationDiagnostics = vscode.languages.createDiagnosticCollection('rumoca simulation');",
+  );
+  const renderCodegenBlock = sliceFrom(
+    source,
+    "const renderConfiguredCodegenScenario = async (",
+    "const simulateCommand = vscode.commands.registerCommand('rumoca.simulateModel'",
+  );
 
   assert.equal(
     source.includes("CODEGEN_SETTINGS_STATE_KEY"),
@@ -571,10 +581,14 @@ test("surface contract: VS Code codegen settings are scenario-owned", () => {
     "VS Code should not keep legacy codegen settings workspace state",
   );
   assert.ok(
-    source.includes("rumoca.scenario.getCodegenConfig")
-      && source.includes("rumoca.scenario.setCodegenConfig")
-      && source.includes("rumoca.scenario.setSourceRoots"),
-    "VS Code should load and save codegen scenario settings through scenario commands",
+    scenarioProviderBlock.includes("loadVisualizationShared().applyScenarioConfigEdits")
+      && scenarioProviderBlock.includes("await setScenarioConfig(document.uri.toString(), config, {"),
+    "VS Code should save codegen settings through full scenario config edits",
+  );
+  assert.ok(
+    renderCodegenBlock.includes("const target = trimMaybeString(scenario.target);")
+      && renderCodegenBlock.includes("'rumoca.workspace.renderTarget'"),
+    "VS Code should render codegen scenarios from the scenario-owned target",
   );
   assert.ok(
     source.includes("async function getScenarioConfigFull(")

--- a/packages/vscode/tests/simulation_command_resync.test.mjs
+++ b/packages/vscode/tests/simulation_command_resync.test.mjs
@@ -106,7 +106,7 @@ test("web simulation clients default persisted results to results directory", ()
   const settingsBlock = sliceFrom(
     source,
     "function getSimulationSettings(",
-    "function getConfiguredWorkspaceSourceRootPaths(",
+    "function isSimulationRunnableDocument(",
   );
   const resultDirectoryBlock = sliceFrom(
     source,

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -7,6 +7,7 @@
     "rootDir": "src",
     "sourceMap": true,
     "strict": true,
+    "noUnusedLocals": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
## Summary

- Fix npm trusted publishing provenance by matching package repository metadata to the canonical GitHub repository casing.
- Remove unused VS Code extension helpers and promote unused TypeScript/ESLint findings to blocking errors.
- Remove FlakeHub login from Nix installer steps, update download-artifact actions, and refresh VS Code transitive dependency locks to clear npm audit warnings.

## Root Cause

The npm release publish was using trusted publishing correctly, but npm rejected the provenance bundle because package metadata used `https://github.com/cognipilot/rumoca` / `git+...` while GitHub provenance reported `https://github.com/CogniPilot/rumoca`. VS Code unused-variable diagnostics were only warnings because ESLint reported them at warning level and TypeScript did not enable `noUnusedLocals`.

## Validation

- `cargo xtask vscode test`
- `node --test packages/rumoca/tests/patch_wasm_pkg.test.mjs`
- `cargo metadata --no-deps --format-version 1 >/tmp/rumoca-metadata.json`
- `npm --prefix packages/vscode audit --audit-level=moderate`
- parsed `.github/workflows/ci.yml` with PyYAML
- `git diff --check`
