### PR TITLE
Support zero-state RK45 simulation sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,6 +531,25 @@ jobs:
           test -f "$msl_dir/Complex.mo"
           test -f "$msl_dir/Modelica 4.1.0/package.mo"
 
+      - name: Reclaim runner disk before editor gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "== disk before cleanup =="
+          df -h . / /tmp || true
+          du -sh /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+
+          echo "== disk after cleanup =="
+          df -h . / /tmp || true
+
       - name: Run unified full-MSL LSP/editor gate
         run: cargo xtask verify lsp-msl-completion-timings --require-runtimes
 

--- a/crates/rumoca-solver-rk45/src/lib.rs
+++ b/crates/rumoca-solver-rk45/src/lib.rs
@@ -19,9 +19,11 @@ use rumoca_solver::{
     runtime_event_horizon, timeline,
 };
 
+mod no_state;
 mod reset;
 mod trace;
 
+use no_state::NoStateSession;
 use reset::Rk45ResetSnapshot;
 use trace::{
     record_derivative_eval_trace, record_root_eval_trace, reset_rk_eval_trace,
@@ -90,6 +92,15 @@ pub struct SessionState {
 }
 
 pub struct SimulationSession {
+    inner: SimulationSessionInner,
+}
+
+enum SimulationSessionInner {
+    NoState(Box<NoStateSession>),
+    State(Box<StateSession>),
+}
+
+struct StateSession {
     runtime: &'static SolveRuntime,
     backend: Rk45Backend<'static>,
     reset_snapshot: Rk45ResetSnapshot,
@@ -102,7 +113,97 @@ impl SimulationSession {
             SimSolverMode::Auto | SimSolverMode::RkLike => {}
             requested => return Err(SimError::UnsupportedSolverMode { requested }),
         }
+        if model.state_scalar_count() == 0 {
+            return NoStateSession::new(model, opts).map(|session| Self {
+                inner: SimulationSessionInner::NoState(Box::new(session)),
+            });
+        }
         validate_explicit_solve_model(model)?;
+        StateSession::new(model, opts).map(|session| Self {
+            inner: SimulationSessionInner::State(Box::new(session)),
+        })
+    }
+
+    pub fn set_input(&mut self, name: &str, value: f64) -> Result<(), SimError> {
+        match &mut self.inner {
+            SimulationSessionInner::NoState(session) => session.set_input(name, value),
+            SimulationSessionInner::State(session) => session.set_input(name, value),
+        }
+    }
+
+    pub fn set_inputs(&mut self, inputs: &[(&str, f64)]) -> Result<(), SimError> {
+        match &mut self.inner {
+            SimulationSessionInner::NoState(session) => session.set_inputs(inputs),
+            SimulationSessionInner::State(session) => session.set_inputs(inputs),
+        }
+    }
+
+    pub fn advance_to(&mut self, target_time: f64) -> Result<(), SimError> {
+        match &mut self.inner {
+            SimulationSessionInner::NoState(session) => session.advance_to(target_time),
+            SimulationSessionInner::State(session) => session.advance_to(target_time),
+        }
+    }
+
+    pub fn step(&mut self, dt: f64) -> Result<(), SimError> {
+        match &mut self.inner {
+            SimulationSessionInner::NoState(session) => session.step(dt),
+            SimulationSessionInner::State(session) => session.step(dt),
+        }
+    }
+
+    pub fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
+        match &mut self.inner {
+            SimulationSessionInner::NoState(session) => session.reset(t_start),
+            SimulationSessionInner::State(session) => session.reset(t_start),
+        }
+    }
+
+    pub fn time(&self) -> f64 {
+        match &self.inner {
+            SimulationSessionInner::NoState(session) => session.time(),
+            SimulationSessionInner::State(session) => session.time(),
+        }
+    }
+
+    pub fn get(&self, name: &str) -> Result<Option<f64>, SimError> {
+        match &self.inner {
+            SimulationSessionInner::NoState(session) => session.get(name),
+            SimulationSessionInner::State(session) => session.get(name),
+        }
+    }
+
+    pub fn state(&self) -> Result<SessionState, SimError> {
+        match &self.inner {
+            SimulationSessionInner::NoState(session) => session.state(),
+            SimulationSessionInner::State(session) => session.state(),
+        }
+    }
+
+    pub fn values_for(&self, names: &[String]) -> Result<IndexMap<String, f64>, SimError> {
+        match &self.inner {
+            SimulationSessionInner::NoState(session) => session.values_for(names),
+            SimulationSessionInner::State(session) => session.values_for(names),
+        }
+    }
+
+    pub fn input_names(&self) -> &[String] {
+        match &self.inner {
+            SimulationSessionInner::NoState(session) => session.input_names(),
+            SimulationSessionInner::State(session) => session.input_names(),
+        }
+    }
+
+    pub fn variable_names(&self) -> &[String] {
+        match &self.inner {
+            SimulationSessionInner::NoState(session) => session.variable_names(),
+            SimulationSessionInner::State(session) => session.variable_names(),
+        }
+    }
+}
+
+impl StateSession {
+    fn new(model: &solve::SolveModel, opts: SimOptions) -> Result<Self, SimError> {
         let runtime = Box::leak(Box::new(SolveRuntime::new(model)?));
         let mut backend = Rk45Backend::new(runtime, &opts)?;
         backend.init()?;
@@ -115,7 +216,7 @@ impl SimulationSession {
         })
     }
 
-    pub fn set_input(&mut self, name: &str, value: f64) -> Result<(), SimError> {
+    fn set_input(&mut self, name: &str, value: f64) -> Result<(), SimError> {
         let Some(param_idx) = self
             .runtime
             .model
@@ -133,14 +234,14 @@ impl SimulationSession {
         Ok(())
     }
 
-    pub fn set_inputs(&mut self, inputs: &[(&str, f64)]) -> Result<(), SimError> {
+    fn set_inputs(&mut self, inputs: &[(&str, f64)]) -> Result<(), SimError> {
         for (name, value) in inputs {
             self.set_input(name, *value)?;
         }
         Ok(())
     }
 
-    pub fn advance_to(&mut self, target_time: f64) -> Result<(), SimError> {
+    fn advance_to(&mut self, target_time: f64) -> Result<(), SimError> {
         let target_time = target_time.min(self.backend.t_end);
         if target_time <= self.backend.time {
             return Ok(());
@@ -148,25 +249,25 @@ impl SimulationSession {
         advance_backend_to(&mut self.backend, target_time)
     }
 
-    pub fn step(&mut self, dt: f64) -> Result<(), SimError> {
+    fn step(&mut self, dt: f64) -> Result<(), SimError> {
         if dt <= 0.0 {
             return Ok(());
         }
         self.advance_to(self.backend.time + dt)
     }
 
-    pub fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
+    fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
         self.input_values.clear();
         self.backend
             .reset_to_snapshot(&self.reset_snapshot, t_start);
         Ok(())
     }
 
-    pub fn time(&self) -> f64 {
+    fn time(&self) -> f64 {
         self.backend.time
     }
 
-    pub fn get(&self, name: &str) -> Result<Option<f64>, SimError> {
+    fn get(&self, name: &str) -> Result<Option<f64>, SimError> {
         if let Some(value) = self.input_values.get(name).copied() {
             return Ok(Some(value));
         }
@@ -193,14 +294,14 @@ impl SimulationSession {
         })
     }
 
-    pub fn state(&self) -> Result<SessionState, SimError> {
+    fn state(&self) -> Result<SessionState, SimError> {
         Ok(SessionState {
             time: self.time(),
             values: self.session_visible_values()?,
         })
     }
 
-    pub fn values_for(&self, names: &[String]) -> Result<IndexMap<String, f64>, SimError> {
+    fn values_for(&self, names: &[String]) -> Result<IndexMap<String, f64>, SimError> {
         let visible_values = self.session_visible_values()?;
         let mut values = IndexMap::with_capacity(names.len());
         for name in names {
@@ -211,11 +312,11 @@ impl SimulationSession {
         Ok(values)
     }
 
-    pub fn input_names(&self) -> &[String] {
+    fn input_names(&self) -> &[String] {
         self.runtime.model.problem.solve_layout.input_scalar_names()
     }
 
-    pub fn variable_names(&self) -> &[String] {
+    fn variable_names(&self) -> &[String] {
         &self.runtime.model.visible_names
     }
 

--- a/crates/rumoca-solver-rk45/src/no_state.rs
+++ b/crates/rumoca-solver-rk45/src/no_state.rs
@@ -1,0 +1,634 @@
+use indexmap::IndexMap;
+use rumoca_eval_solve::{
+    EventUpdateRowFilter, ProjectedEventUpdateInput, ProjectedInitialEventInput, SolveRuntime,
+    apply_discrete_slot_values,
+};
+use rumoca_ir_solve as solve;
+use rumoca_solver::{
+    EventActionOutcome, EventPreMode, NoStateEventStep, NoStateOrchestrationBackend,
+    NoStateScheduledStop, RuntimeEventBoundary, RuntimeEventBoundaryHandler, RuntimeEventStop,
+    RuntimeSolveError, SimOptions, SimTermination, SolveStopSchedule,
+    commit_pre_params_after_event, process_runtime_event_boundary, run_no_state_output_schedule,
+    runtime_event_horizon, runtime_root_event_application_time,
+    timeline::{event_left_limit_time, sample_time_match_with_tol},
+};
+
+use crate::{SessionState, SimError};
+
+const NO_STATE_EVENT_UPDATE_MAX_ITERS: usize = 256;
+const ROOT_BISECTION_ITERS: usize = 64;
+
+pub(crate) struct NoStateSession {
+    model: solve::SolveModel,
+    opts: SimOptions,
+    runtime: NoStateRuntime,
+    input_values: IndexMap<String, f64>,
+}
+
+struct NoStateRuntime {
+    runtime: SolveRuntime,
+    params: Vec<f64>,
+    current_y: Vec<f64>,
+    current_t: f64,
+    last_event_t: Option<f64>,
+    termination: Option<SimTermination>,
+    stop_schedule: SolveStopSchedule,
+}
+
+impl NoStateSession {
+    pub(crate) fn new(model: &solve::SolveModel, opts: SimOptions) -> Result<Self, SimError> {
+        if model.state_scalar_count() != 0 {
+            return Err(SimError::UnsupportedModel {
+                reason: "no-state session requires a model with zero continuous states".to_string(),
+            });
+        }
+        let model = model.clone();
+        let runtime = initialize_no_state_runtime(&model, &opts)?;
+        Ok(Self {
+            model,
+            opts,
+            runtime,
+            input_values: IndexMap::new(),
+        })
+    }
+
+    pub(crate) fn set_input(&mut self, name: &str, value: f64) -> Result<(), SimError> {
+        let Some(param_idx) = self.model.problem.solve_layout.input_parameter_index(name) else {
+            return Err(SimError::SolveIr(format!("unknown input '{name}'")));
+        };
+        self.input_values.insert(name.to_string(), value);
+        if let Some(slot) = self.runtime.params.get_mut(param_idx) {
+            *slot = value;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn set_inputs(&mut self, inputs: &[(&str, f64)]) -> Result<(), SimError> {
+        for (name, value) in inputs {
+            self.set_input(name, *value)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn advance_to(&mut self, target_time: f64) -> Result<(), SimError> {
+        let target_time = target_time.min(self.opts.t_end);
+        if target_time <= self.runtime.current_t || self.runtime.termination.is_some() {
+            return Ok(());
+        }
+        let tol = self.tol();
+        run_no_state_output_schedule(
+            &mut Rk45NoStateOrchestration {
+                model: &self.model,
+                opts: &self.opts,
+                runtime: &mut self.runtime,
+            },
+            [target_time],
+            tol,
+        )?;
+        let can_tick_at_target = self.runtime.current_t < target_time
+            || sample_time_match_with_tol(self.runtime.current_t, target_time);
+        let event_at_target = self
+            .runtime
+            .last_event_t
+            .is_some_and(|event_t| sample_time_match_with_tol(event_t, target_time));
+        if can_tick_at_target && !event_at_target && self.runtime.termination.is_none() {
+            apply_no_state_deadline_tick(&self.model, &mut self.runtime, target_time, tol)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn step(&mut self, dt: f64) -> Result<(), SimError> {
+        if dt <= 0.0 {
+            return Ok(());
+        }
+        self.advance_to(self.runtime.current_t + dt)
+    }
+
+    pub(crate) fn reset(&mut self, t_start: f64) -> Result<(), SimError> {
+        self.input_values.clear();
+        let mut opts = self.opts.clone();
+        opts.t_start = t_start;
+        self.runtime = initialize_no_state_runtime(&self.model, &opts)?;
+        self.opts = opts;
+        Ok(())
+    }
+
+    pub(crate) fn time(&self) -> f64 {
+        self.runtime.current_t
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Result<Option<f64>, SimError> {
+        if let Some(value) = self.input_values.get(name).copied() {
+            return Ok(Some(value));
+        }
+        let values = self.session_visible_values()?;
+        Ok(values.get(name).copied())
+    }
+
+    pub(crate) fn state(&self) -> Result<SessionState, SimError> {
+        Ok(SessionState {
+            time: self.time(),
+            values: self.session_visible_values()?,
+        })
+    }
+
+    pub(crate) fn values_for(&self, names: &[String]) -> Result<IndexMap<String, f64>, SimError> {
+        let visible_values = self.session_visible_values()?;
+        let mut values = IndexMap::with_capacity(names.len());
+        for name in names {
+            if let Some(value) = visible_values.get(name).copied() {
+                values.insert(name.clone(), value);
+            }
+        }
+        Ok(values)
+    }
+
+    pub(crate) fn input_names(&self) -> &[String] {
+        self.model.problem.solve_layout.input_scalar_names()
+    }
+
+    pub(crate) fn variable_names(&self) -> &[String] {
+        &self.model.visible_names
+    }
+
+    fn session_visible_values(&self) -> Result<IndexMap<String, f64>, SimError> {
+        let visible_values = self.runtime.runtime.visible_values(
+            &self.runtime.current_y,
+            &self.runtime.params,
+            self.runtime.current_t,
+        )?;
+        let mut values = collect_visible_values(&self.model.visible_names, visible_values)?;
+        values.extend(
+            self.input_values
+                .iter()
+                .map(|(name, value)| (name.clone(), *value)),
+        );
+        Ok(values)
+    }
+
+    fn tol(&self) -> f64 {
+        self.opts.atol.max(1.0e-10)
+    }
+}
+
+struct Rk45NoStateOrchestration<'a> {
+    model: &'a solve::SolveModel,
+    opts: &'a SimOptions,
+    runtime: &'a mut NoStateRuntime,
+}
+
+impl NoStateOrchestrationBackend for Rk45NoStateOrchestration<'_> {
+    type Error = SimError;
+
+    fn current_time(&self) -> f64 {
+        self.runtime.current_t
+    }
+
+    fn set_current_time(&mut self, time: f64) {
+        self.runtime.current_t = time;
+    }
+
+    fn next_scheduled_stop(&mut self, target: f64) -> Result<NoStateScheduledStop, Self::Error> {
+        let (stop_time, event_stop) = self.runtime.runtime.next_runtime_event_stop(
+            &self.runtime.current_y,
+            &self.runtime.params,
+            &mut self.runtime.stop_schedule,
+            self.runtime.current_t,
+            target,
+        )?;
+        Ok(NoStateScheduledStop {
+            stop_time,
+            event_stop,
+        })
+    }
+
+    fn next_root_event_time(&mut self, target: f64, tol: f64) -> Result<Option<f64>, Self::Error> {
+        next_no_state_root_event_time(
+            &self.runtime.runtime,
+            &self.runtime.current_y,
+            &self.runtime.params,
+            self.runtime.current_t,
+            target,
+            tol,
+        )
+    }
+
+    fn handle_event_step(&mut self, step: NoStateEventStep) -> Result<(), Self::Error> {
+        apply_no_state_event_step(self.model, self.opts, self.runtime, step)
+    }
+
+    fn settle_and_record_output(&mut self) -> Result<(), Self::Error> {
+        refresh_observation_rows_and_relation_memory(
+            &self.runtime.runtime,
+            &mut self.runtime.current_y,
+            &mut self.runtime.params,
+            self.runtime.current_t,
+            self.opts.atol.max(1.0e-10),
+        )
+    }
+}
+
+fn initialize_no_state_runtime(
+    model: &solve::SolveModel,
+    opts: &SimOptions,
+) -> Result<NoStateRuntime, SimError> {
+    let runtime = SolveRuntime::new(model)?;
+    let mut params = model.parameters.clone();
+    let mut current_y = model.initial_y.clone();
+    let mut current_t = opts.t_start;
+    let tol = opts.atol.max(1.0e-10);
+    runtime.set_initial_event_flag(&mut params, true);
+    settle_algebraics_and_relation_memory(&runtime, &mut current_y, &mut params, current_t, tol)?;
+    let dynamic_event = runtime.current_dynamic_time_event_stop(&current_y, &params, current_t)?;
+    let event_pre_y = current_y.clone();
+    let event_pre_p = params.clone();
+    let outcome = runtime.apply_projected_initial_event_boundary(
+        ProjectedInitialEventInput {
+            y: &mut current_y,
+            p: &mut params,
+            t_start: current_t,
+            t_end: opts.t_end,
+            tol,
+            event_pre_y: &event_pre_y,
+            event_pre_p: &event_pre_p,
+            max_iters: NO_STATE_EVENT_UPDATE_MAX_ITERS,
+            dynamic_event,
+            apply_without_initial_event: false,
+        },
+        |y, p, t| refresh_algebraics_and_detect_changes(&runtime, y, p, t, tol),
+    )?;
+    current_t = outcome.final_t;
+    let mut termination = None;
+    apply_event_action_outcome(&mut termination, outcome.action, current_t)?;
+    if !outcome.observations.is_empty() {
+        refresh_observation_rows_and_relation_memory(
+            &runtime,
+            &mut current_y,
+            &mut params,
+            current_t,
+            tol,
+        )?;
+    }
+    commit_pre_params_after_event(model, &current_y, &mut params, tol);
+    Ok(NoStateRuntime {
+        runtime,
+        params,
+        current_y,
+        current_t,
+        last_event_t: None,
+        termination,
+        stop_schedule: SolveStopSchedule::new(&model.problem, opts.t_start, opts.t_end),
+    })
+}
+
+fn apply_no_state_event_step(
+    model: &solve::SolveModel,
+    opts: &SimOptions,
+    runtime: &mut NoStateRuntime,
+    step: NoStateEventStep,
+) -> Result<(), SimError> {
+    let event_t = step.event_time();
+    runtime.last_event_t = Some(event_t);
+    let event = if step.root_event {
+        RuntimeEventStop::static_event(EventPreMode::EventEntry)
+    } else {
+        step.event_stop.unwrap_or(RuntimeEventStop {
+            pre_mode: step.pre_mode(),
+            observe_right_limit: false,
+        })
+    };
+    let outcome = {
+        let mut handler = NoStateEventBoundary {
+            runtime: &runtime.runtime,
+            y: &mut runtime.current_y,
+            p: &mut runtime.params,
+            tol: step.tol,
+            event_pre_y: Vec::new(),
+            event_pre_p: Vec::new(),
+            termination: &mut runtime.termination,
+            root_event: step.root_event,
+        };
+        process_runtime_event_boundary(
+            RuntimeEventBoundary {
+                event_t,
+                horizon_t: if step.root_event {
+                    event_t.min(step.target)
+                } else {
+                    runtime_event_horizon(event, step.target, opts.t_end)
+                },
+                event,
+            },
+            &mut handler,
+        )?
+    };
+    runtime.current_t = if step.root_event {
+        runtime_root_event_application_time(outcome.final_t, step.target)
+    } else {
+        outcome.final_t
+    };
+    commit_pre_params_after_event(model, &runtime.current_y, &mut runtime.params, step.tol);
+    runtime.stop_schedule.advance_past(runtime.current_t);
+    Ok(())
+}
+
+struct NoStateEventBoundary<'a> {
+    runtime: &'a SolveRuntime,
+    y: &'a mut [f64],
+    p: &'a mut [f64],
+    tol: f64,
+    event_pre_y: Vec<f64>,
+    event_pre_p: Vec<f64>,
+    termination: &'a mut Option<SimTermination>,
+    root_event: bool,
+}
+
+impl RuntimeEventBoundaryHandler for NoStateEventBoundary<'_> {
+    type Error = SimError;
+
+    fn on_event_time(&mut self, event_t: f64, event: RuntimeEventStop) -> Result<(), Self::Error> {
+        if !self.root_event
+            && matches!(
+                event.pre_mode,
+                EventPreMode::EventEntry | EventPreMode::Fixed
+            )
+        {
+            let left_t = event_left_limit_time(event_t);
+            refresh_observation_rows_and_relation_memory(
+                self.runtime,
+                self.y,
+                self.p,
+                left_t,
+                self.tol,
+            )?;
+        }
+        self.event_pre_y = self.y.to_vec();
+        self.event_pre_p = self.p.to_vec();
+        self.apply_event_updates(event_t)?;
+        refresh_observation_rows_and_relation_memory(
+            self.runtime,
+            self.y,
+            self.p,
+            event_t,
+            self.tol,
+        )
+    }
+
+    fn on_event_right_limit(
+        &mut self,
+        right_t: f64,
+        _event: RuntimeEventStop,
+    ) -> Result<(), Self::Error> {
+        self.apply_event_updates(right_t)?;
+        refresh_observation_rows_and_relation_memory(
+            self.runtime,
+            self.y,
+            self.p,
+            right_t,
+            self.tol,
+        )
+    }
+}
+
+impl NoStateEventBoundary<'_> {
+    fn apply_event_updates(&mut self, t: f64) -> Result<(), SimError> {
+        let outcome = self.runtime.apply_projected_event_update(
+            ProjectedEventUpdateInput {
+                y: self.y,
+                p: self.p,
+                t,
+                tol: self.tol,
+                event_pre_y: &self.event_pre_y,
+                event_pre_p: &self.event_pre_p,
+                max_iters: NO_STATE_EVENT_UPDATE_MAX_ITERS,
+                row_filter: EventUpdateRowFilter::All,
+                root_relation_overrides: &[],
+            },
+            |y, p| refresh_algebraics_and_detect_changes(self.runtime, y, p, t, self.tol),
+        )?;
+        apply_event_action_outcome(self.termination, outcome, t)
+    }
+}
+
+fn apply_no_state_deadline_tick(
+    model: &solve::SolveModel,
+    runtime: &mut NoStateRuntime,
+    target: f64,
+    tol: f64,
+) -> Result<(), SimError> {
+    runtime.current_t = target;
+    let values = runtime.runtime.eval_scalar_program_block(
+        &model.problem.discrete.rhs,
+        &runtime.current_y,
+        &runtime.params,
+        target,
+    )?;
+    apply_discrete_slot_values(
+        &model.problem.discrete.update_targets,
+        &values,
+        &mut runtime.current_y,
+        &mut runtime.params,
+        tol,
+    )?;
+    runtime.runtime.apply_runtime_assignments_once(
+        &mut runtime.current_y,
+        &mut runtime.params,
+        target,
+    )?;
+    settle_algebraics_and_relation_memory(
+        &runtime.runtime,
+        &mut runtime.current_y,
+        &mut runtime.params,
+        target,
+        tol,
+    )?;
+    commit_pre_params_after_event(model, &runtime.current_y, &mut runtime.params, tol);
+    Ok(())
+}
+
+fn refresh_observation_rows_and_relation_memory(
+    runtime: &SolveRuntime,
+    y: &mut [f64],
+    p: &mut [f64],
+    t: f64,
+    tol: f64,
+) -> Result<(), SimError> {
+    settle_algebraics_and_relation_memory(runtime, y, p, t, tol)?;
+    if runtime.refresh_observation_discrete_rows(y, p, t, tol, NO_STATE_EVENT_UPDATE_MAX_ITERS)? {
+        settle_algebraics_and_relation_memory(runtime, y, p, t, tol)?;
+    }
+    Ok(())
+}
+
+fn settle_algebraics_and_relation_memory(
+    runtime: &SolveRuntime,
+    y: &mut [f64],
+    p: &mut [f64],
+    t: f64,
+    tol: f64,
+) -> Result<(), SimError> {
+    runtime.settle_projected_runtime_and_relation_memory(
+        y,
+        p,
+        t,
+        tol,
+        NO_STATE_EVENT_UPDATE_MAX_ITERS,
+        |y, p| refresh_algebraics_and_detect_changes(runtime, y, p, t, tol),
+    )?;
+    Ok(())
+}
+
+fn refresh_algebraics_and_detect_changes(
+    runtime: &SolveRuntime,
+    y: &mut [f64],
+    p: &mut [f64],
+    t: f64,
+    tol: f64,
+) -> Result<bool, RuntimeSolveError> {
+    let before = y.to_vec();
+    runtime.refresh_algebraic_and_output_slots(t, y, p, tol, NO_STATE_EVENT_UPDATE_MAX_ITERS)?;
+    Ok(values_changed(&before, y, tol))
+}
+
+fn apply_event_action_outcome(
+    termination: &mut Option<SimTermination>,
+    outcome: EventActionOutcome,
+    event_t: f64,
+) -> Result<(), SimError> {
+    match outcome {
+        EventActionOutcome::Continue => Ok(()),
+        EventActionOutcome::AssertionFailed { time, message } => Err(SimError::AssertionFailed {
+            time: if time.is_finite() { time } else { event_t },
+            message,
+        }),
+        EventActionOutcome::Terminated { time, message } => {
+            *termination = Some(SimTermination {
+                time: if time.is_finite() { time } else { event_t },
+                message,
+            });
+            Ok(())
+        }
+    }
+}
+
+fn next_no_state_root_event_time(
+    runtime: &SolveRuntime,
+    y: &[f64],
+    p: &[f64],
+    current_t: f64,
+    target: f64,
+    tol: f64,
+) -> Result<Option<f64>, SimError> {
+    if let Some(root_time) = runtime.next_planned_time_root(p, current_t, target, tol)? {
+        return Ok(Some(root_time));
+    }
+    let Some(root_time) = first_root_crossing_time(runtime, y, p, current_t, target, tol)? else {
+        return Ok(None);
+    };
+    if root_time > current_t + tol
+        && (root_time < target || sample_time_match_with_tol(root_time, target))
+    {
+        Ok(Some(root_time))
+    } else {
+        Ok(None)
+    }
+}
+
+fn first_root_crossing_time(
+    runtime: &SolveRuntime,
+    y: &[f64],
+    p: &[f64],
+    t_start: f64,
+    t_end: f64,
+    tol: f64,
+) -> Result<Option<f64>, SimError> {
+    if runtime.model.problem.events.root_conditions.is_empty() {
+        return Ok(None);
+    }
+    let root_count = runtime.model.problem.events.root_conditions.len();
+    let mut start = vec![0.0; root_count];
+    let mut end = vec![0.0; root_count];
+    eval_refreshed_roots(runtime, y, p, t_start, tol, &mut start)?;
+    eval_refreshed_roots(runtime, y, p, t_end, tol, &mut end)?;
+
+    let mut crossing = None;
+    for (a, b) in start.iter().zip(end.iter()) {
+        if root_surface_crossed_or_near(*a, *b, tol) {
+            let root = bisect_first_root(runtime, y, p, t_start, t_end, tol, root_count)?;
+            crossing = Some(crossing.map_or(root, |current: f64| current.min(root)));
+        }
+    }
+    Ok(crossing)
+}
+
+fn eval_refreshed_roots(
+    runtime: &SolveRuntime,
+    y: &[f64],
+    p: &[f64],
+    t: f64,
+    tol: f64,
+    out: &mut [f64],
+) -> Result<(), SimError> {
+    runtime.eval_root_search_conditions_into(t, y, p, tol, NO_STATE_EVENT_UPDATE_MAX_ITERS, out)?;
+    Ok(())
+}
+
+fn bisect_first_root(
+    runtime: &SolveRuntime,
+    y: &[f64],
+    p: &[f64],
+    mut lo: f64,
+    mut hi: f64,
+    tol: f64,
+    root_count: usize,
+) -> Result<f64, SimError> {
+    let mut lo_roots = vec![0.0; root_count];
+    eval_refreshed_roots(runtime, y, p, lo, tol, &mut lo_roots)?;
+    for _ in 0..ROOT_BISECTION_ITERS {
+        let mid = lo + 0.5 * (hi - lo);
+        let mut mid_roots = vec![0.0; root_count];
+        eval_refreshed_roots(runtime, y, p, mid, tol, &mut mid_roots)?;
+        if lo_roots
+            .iter()
+            .zip(mid_roots.iter())
+            .any(|(a, b)| a.signum() != b.signum() || root_surface_near_zero(*b, tol))
+        {
+            hi = mid;
+        } else {
+            lo = mid;
+            lo_roots = mid_roots;
+        }
+    }
+    Ok(hi)
+}
+
+fn collect_visible_values(
+    names: &[String],
+    values: Vec<f64>,
+) -> Result<IndexMap<String, f64>, SimError> {
+    if names.len() != values.len() {
+        return Err(SimError::RuntimeContract {
+            reason: format!(
+                "runtime returned {} visible values for {} visible names",
+                values.len(),
+                names.len()
+            ),
+        });
+    }
+    Ok(names.iter().cloned().zip(values).collect())
+}
+
+fn root_surface_crossed_or_near(a: f64, b: f64, tol: f64) -> bool {
+    root_surface_near_zero(a, tol) || root_surface_near_zero(b, tol) || a.signum() != b.signum()
+}
+
+fn root_surface_near_zero(value: f64, tol: f64) -> bool {
+    value.abs() <= tol
+}
+
+fn values_changed(before: &[f64], after: &[f64], tol: f64) -> bool {
+    before.len() != after.len()
+        || before
+            .iter()
+            .zip(after.iter())
+            .any(|(before, after)| (*before - *after).abs() > tol)
+}

--- a/crates/rumoca-solver-rk45/src/tests.rs
+++ b/crates/rumoca-solver-rk45/src/tests.rs
@@ -571,6 +571,38 @@ fn rk45_session_advance_to_clamps_to_sim_options_end_time() {
 }
 
 #[test]
+fn rk45_session_runs_no_state_discrete_controller() {
+    let model = no_state_input_accumulator_model();
+    let mut session = SimulationSession::new(
+        &model,
+        SimOptions {
+            t_end: 0.05,
+            solver_mode: SimSolverMode::RkLike,
+            ..Default::default()
+        },
+    )
+    .expect("no-state session should build");
+
+    session.set_input("u", 1.5).expect("input should exist");
+    session.step(0.02).expect("first controller tick");
+    assert!((session.time() - 0.02).abs() <= 1.0e-12);
+    assert_eq!(session.get("y").expect("read y"), Some(1.5));
+
+    session.set_input("u", 2.0).expect("input should update");
+    session.step(0.02).expect("second controller tick");
+    assert_eq!(session.get("y").expect("read y"), Some(3.5));
+
+    session.step(1.0).expect("step should clamp at t_end");
+    assert!((session.time() - 0.05).abs() <= 1.0e-12);
+    assert_eq!(session.get("y").expect("read y"), Some(5.5));
+
+    session
+        .step(1.0)
+        .expect("further steps at t_end should be stable");
+    assert_eq!(session.get("y").expect("read y"), Some(5.5));
+}
+
+#[test]
 fn rk45_session_uses_adaptive_event_integration_for_stiff_contact() {
     let model = stiff_contact_model();
     let mut session = SimulationSession::new(
@@ -901,4 +933,89 @@ fn const_scalar_program_block(value: f64) -> ScalarProgramBlock {
         ]],
         fixture_span!(),
     )
+}
+
+fn no_state_input_accumulator_model() -> solve::SolveModel {
+    let zero = const_scalar_program_block(0.0);
+    let preserve_y = ScalarProgramBlock::with_source_span(
+        vec![vec![
+            LinearOp::LoadY { dst: 0, index: 0 },
+            LinearOp::StoreOutput { src: 0 },
+        ]],
+        fixture_span!(),
+    );
+    solve::SolveModel {
+        problem: SolveProblem {
+            schema_version: solve::SOLVE_SCHEMA_VERSION,
+            layout: solve::VarLayout::from_parts(Default::default(), 0, 1),
+            continuous: solve::ContinuousSolveSystem {
+                implicit_rhs: ComputeBlock::from_scalar_program_block(preserve_y.clone()),
+                implicit_row_targets: vec![Some(solve::scalar_slot_y(0))],
+                residual: ComputeBlock::from_scalar_program_block(preserve_y.clone()),
+                derivative_rhs: ComputeBlock::from_scalar_program_block(
+                    ScalarProgramBlock::default(),
+                ),
+                algebraic_projection_plan: solve::AlgebraicProjectionPlan::default(),
+            },
+            initialization: solve::InitializationSolveSystem::default(),
+            discrete: solve::DiscreteSolveSystem {
+                rhs: ScalarProgramBlock::with_source_span(
+                    vec![vec![
+                        LinearOp::LoadY { dst: 0, index: 0 },
+                        LinearOp::LoadP { dst: 1, index: 0 },
+                        LinearOp::Binary {
+                            dst: 2,
+                            op: solve::BinaryOp::Add,
+                            lhs: 0,
+                            rhs: 1,
+                        },
+                        LinearOp::StoreOutput { src: 2 },
+                    ]],
+                    fixture_span!(),
+                ),
+                update_targets: vec![solve::scalar_slot_y(0)],
+                ..Default::default()
+            },
+            events: solve::SolveEventPartition::default(),
+            clocks: solve::SolveClockPartition::default(),
+            solve_layout: SolveLayout {
+                solver_maps: SolverNameIndexMaps {
+                    names: vec!["y".to_string()],
+                    name_to_idx: IndexMap::from([("y".to_string(), 0)]),
+                    base_to_indices: IndexMap::from([("y".to_string(), vec![0])]),
+                },
+                state_scalar_count: 0,
+                algebraic_scalar_count: 0,
+                output_scalar_count: 1,
+                parameter_count: 0,
+                compiled_parameter_len: 1,
+                input_scalar_names: vec!["u".to_string()],
+                discrete_real_scalar_names: vec!["y".to_string()],
+                discrete_valued_scalar_names: Vec::new(),
+                relation_memory_parameter_indices: Vec::new(),
+                initial_event_parameter_index: None,
+                pre_param_bindings: Vec::new(),
+            },
+        },
+        artifacts: solve::SolveArtifacts {
+            continuous: solve::ContinuousSolveArtifacts {
+                mass_matrix: Vec::new(),
+                implicit_jacobian_v: ComputeBlock::from_scalar_program_block(zero.clone()),
+                implicit_jacobian_v_scalar: zero,
+                full_jacobian_v: ScalarProgramBlock::default(),
+            },
+        },
+        initial_y: vec![0.0],
+        parameters: vec![0.0],
+        external_tables: solve::ExternalTables::default(),
+        visible_names: vec!["y".to_string()],
+        visible_value_rows: ScalarProgramBlock::with_source_span(
+            vec![vec![
+                LinearOp::LoadY { dst: 0, index: 0 },
+                LinearOp::StoreOutput { src: 0 },
+            ]],
+            fixture_span!(),
+        ),
+        variable_meta: Vec::new(),
+    }
 }


### PR DESCRIPTION
## Summary

- Enables `rumoca_solver_rk45::SimulationSession` to build and advance Solve-IR models with zero continuous states, so explicit RK-like/WASM simulation sessions can run pure-discrete controllers instead of failing with `empty system`.
- Replaces #304 with a solver-owned implementation that keeps scheduling policy in `rumoca-solver` and avoids adding facade-level runner/session duplication.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0021, SPEC_0025, SPEC_0029, SPEC_0032.
- Relevant MLS section(s), if semantics changed: none; this preserves existing Solve-IR event/update/`pre(...)` runtime semantics for a previously unsupported session shape.
- Crate/phase owner: `rumoca-solver-rk45` simulation session backend, using shared solver runtime scheduling contracts from `rumoca-solver`.

## Risk and Design Notes

- Main correctness risk: zero-state deadline ticks and event-boundary handling must not double-apply event rows or skip `pre(...)` snapshots.
- Main maintenance risk: no-state runtime mechanics now exist in both concrete solver backends because the current shared crate owns the schedule contract, not `SolveRuntime` execution state. This patch keeps the RK45 implementation private and routes scheduling/event-boundary policy through existing shared helpers.
- Why the change belongs in these crate(s): explicit `RkLike` sessions are owned by `rumoca-solver-rk45`; the WASM `sim-rk45` build cannot fall back to Diffsol, and facade-level solver switching would violate an explicit solver request.
- Any new abstraction, public API, or migration path: no new public API; `SimulationSession` keeps the same methods and privately dispatches between stateful and zero-state session implementations.

## Testing

- Key command(s) run (fmt, clippy, workspace test, doc):
  - `nix develop --quiet --option warn-dirty false -c cargo fmt --check`
  - `nix develop --quiet --option warn-dirty false -c cargo clippy -p rumoca-solver-rk45 --all-targets -- -D warnings`
  - `nix develop --quiet --option warn-dirty false -c cargo test -p rumoca-solver-rk45`
  - `nix develop --quiet --option warn-dirty false -c cargo test -p rumoca-bind-wasm --features sim-rk45 test_interactive_session_runs_pure_discrete_model_with_guarded_dynamic_subscript -- --nocapture`
  - `nix develop --quiet --option warn-dirty false -c cargo check -p rumoca-bind-wasm --features sim-rk45`
  - `nix develop --quiet --option warn-dirty false -c cargo check -p rumoca-sim --all-features`
  - `nix develop --quiet --option warn-dirty false -c cargo doc -p rumoca-solver-rk45 --no-deps`
  - `nix develop --quiet --option warn-dirty false -c git diff --check`
- Behavior or regression covered: RK45 simulation sessions now run a zero-state discrete controller with inputs, deadline ticks, `t_end` clamping, and stable no-op steps after `t_end`; the WASM pure-discrete guarded dynamic-subscript session regression passes.
- Commands NOT run and why: full workspace clippy/test/doc and full MSL gate were not run locally; this is a scoped solver-session regression and the broader gates should run in CI.
- For compiler/simulator changes: MSL gate was not run locally; no Modelica language semantics or lowering behavior changed.

## Code Size Budget (required)

- production_lines_added: 746
- production_lines_deleted: 11
- test_lines_added: 117
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 3
- net_added_lines: 852

- Why this net growth is required: RK45 sessions previously rejected zero-state models; supporting them requires private runtime state, scheduled/root-event handling, deadline ticks, input updates, visible-value reads, and reset behavior for the no-continuous-state case.
- Which code was removed/merged as part of the first compression pass: this replaces #304's facade-level direction with a solver-owned branch inside `rumoca-solver-rk45`, reuses `run_no_state_output_schedule`, `process_runtime_event_boundary`, and shared pre-parameter helpers, and leaves the public session API unchanged.
- Follow-up cleanup ticket/commit for remaining growth (if any): no separate cleanup ticket filed here; a broader cross-backend no-state runtime extraction would be a larger spec-backed refactor after Diffsol/RK45 equivalence is proven.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.