### PR TITLE
Add fixed Rust solve target

### DIFF
--- a/crates/rumoca-compile/src/codegen_target.rs
+++ b/crates/rumoca-compile/src/codegen_target.rs
@@ -94,6 +94,7 @@ pub struct TensorCapabilities {
 pub enum TensorCapability {
     Native,
     Scalar,
+    Unsupported,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
@@ -388,6 +389,7 @@ fn tensor_feature_support(
         Some(TensorCapability::Native) => TargetFeatureSupport::Native,
         Some(TensorCapability::Scalar) if scalar_fallback => TargetFeatureSupport::Scalar,
         Some(TensorCapability::Scalar) => TargetFeatureSupport::Unsupported,
+        Some(TensorCapability::Unsupported) => TargetFeatureSupport::Unsupported,
         None => TargetFeatureSupport::Unknown,
     }
 }
@@ -1157,6 +1159,8 @@ host_callbacks = false
         assert_eq!(rust_fixed_solve.readiness_level, Some(2));
         assert_eq!(rust_fixed_solve.deployment_class.as_deref(), Some("cpu"));
         assert_eq!(rust_fixed_solve.execution_mode.as_deref(), Some("compiled"));
+        assert_eq!(rust_fixed_solve.matmul, TargetFeatureSupport::Scalar);
+        assert_eq!(rust_fixed_solve.linsolve, TargetFeatureSupport::Unsupported);
         assert_eq!(rust_fixed_solve.sparse, TargetFeatureSupport::Unsupported);
         assert_eq!(rust_fixed_solve.dtypes, vec!["f64"]);
 

--- a/crates/rumoca-compile/src/codegen_target.rs
+++ b/crates/rumoca-compile/src/codegen_target.rs
@@ -1150,6 +1150,16 @@ host_callbacks = false
         assert_eq!(rust_solve.readiness_level, Some(2));
         assert_eq!(rust_solve.matmul, TargetFeatureSupport::Scalar);
 
+        let rust_fixed_solve = matrix
+            .iter()
+            .find(|entry| entry.id == "rust-fixed-solve")
+            .expect("rust-fixed-solve target should be listed");
+        assert_eq!(rust_fixed_solve.readiness_level, Some(2));
+        assert_eq!(rust_fixed_solve.deployment_class.as_deref(), Some("cpu"));
+        assert_eq!(rust_fixed_solve.execution_mode.as_deref(), Some("compiled"));
+        assert_eq!(rust_fixed_solve.sparse, TargetFeatureSupport::Unsupported);
+        assert_eq!(rust_fixed_solve.dtypes, vec!["f64"]);
+
         let cuda_c = matrix
             .iter()
             .find(|entry| entry.id == "cuda-c")

--- a/crates/rumoca-ir-solve/src/compute_block_tests.rs
+++ b/crates/rumoca-ir-solve/src/compute_block_tests.rs
@@ -376,3 +376,36 @@ fn compute_node_counts_cover_blocks_and_problem() {
     assert_eq!(problem_counts.affine_stencil, 2);
     assert_eq!(problem_counts.tensor_nodes(), 8);
 }
+
+#[test]
+fn linear_solve_component_query_covers_scalar_programs_and_nodes() {
+    let scalar_linsolve = ScalarProgramBlock::with_source_span(
+        vec![vec![
+            LinearOp::Const { dst: 0, value: 1.0 },
+            LinearOp::LinearSolveComponent {
+                dst: 1,
+                matrix_start: 0,
+                rhs_start: 1,
+                n: 1,
+                component: 0,
+            },
+            LinearOp::StoreOutput { src: 1 },
+        ]],
+        fixture_span(),
+    );
+    assert!(scalar_linsolve.uses_linear_solve_component());
+
+    let scalar_block = ComputeBlock {
+        nodes: vec![ComputeNode::ScalarPrograms(scalar_linsolve)],
+    };
+    assert!(scalar_block.uses_linear_solve_component());
+
+    let tensor_block = ComputeBlock {
+        nodes: vec![linsolve_node()],
+    };
+    assert!(tensor_block.uses_linear_solve_component());
+
+    let mut problem = SolveProblem::default();
+    problem.continuous.derivative_rhs = scalar_block;
+    assert!(problem.uses_linear_solve_component());
+}

--- a/crates/rumoca-ir-solve/src/lib.rs
+++ b/crates/rumoca-ir-solve/src/lib.rs
@@ -182,6 +182,12 @@ impl ScalarProgramBlock {
             .sum()
     }
 
+    pub fn uses_linear_solve_component(&self) -> bool {
+        self.programs
+            .iter()
+            .any(|program| linear_ops_use_linear_solve_component(program))
+    }
+
     /// Map a dense output slot to the program that produces it.
     ///
     /// `output_indices` may be sparse, so this first maps the output slot to
@@ -771,6 +777,17 @@ impl ComputeBlock {
         counts
     }
 
+    pub fn uses_linear_solve_component(&self) -> bool {
+        self.nodes.iter().any(|node| match node {
+            ComputeNode::ScalarPrograms(block) => block.uses_linear_solve_component(),
+            ComputeNode::LinSolve { .. } => true,
+            ComputeNode::Map { base_ops, .. } | ComputeNode::AffineStencil { base_ops, .. } => {
+                linear_ops_use_linear_solve_component(base_ops)
+            }
+            ComputeNode::MatMul { .. } => false,
+        })
+    }
+
     pub fn tensor_node_count(&self) -> usize {
         self.compute_node_counts().tensor_nodes()
     }
@@ -1211,6 +1228,12 @@ impl SolveProblem {
         counts
     }
 
+    pub fn uses_linear_solve_component(&self) -> bool {
+        self.continuous.implicit_rhs.uses_linear_solve_component()
+            || self.continuous.residual.uses_linear_solve_component()
+            || self.continuous.derivative_rhs.uses_linear_solve_component()
+    }
+
     pub fn validate_shape_contract(&self) -> Result<(), SolveProblemShapeContractError> {
         if self.schema_version != SOLVE_SCHEMA_VERSION {
             return Err(SolveProblemShapeContractError::SchemaVersion {
@@ -1294,6 +1317,11 @@ impl SolveProblem {
         )?;
         Ok(())
     }
+}
+
+fn linear_ops_use_linear_solve_component(ops: &[LinearOp]) -> bool {
+    ops.iter()
+        .any(|op| matches!(op, LinearOp::LinearSolveComponent { .. }))
 }
 
 fn validate_count(

--- a/crates/rumoca-phase-codegen/src/codegen/codegen_tests.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/codegen_tests.rs
@@ -378,6 +378,71 @@ fn test_rust_solve_builtin_target_syntax_checks_when_rustc_available() {
 }
 
 #[test]
+fn test_rust_fixed_solve_builtin_target_renders_fixed_derivative_kernel() {
+    let problem = solve_problem_with_one_by_one_matmul_derivative();
+    let artifacts = solve::SolveArtifacts::default();
+    let rendered = render_solve_template_with_name(
+        &problem,
+        &artifacts,
+        builtin_template("rust-fixed-solve", "model_fixed_solve.rs.jinja"),
+        "TensorDemo",
+    )
+    .expect("rust-fixed-solve template should render");
+
+    assert!(rendered.contains("pub type State = [Scalar; Y_LEN];"));
+    assert!(rendered.contains("pub type Parameters = [Scalar; P_LEN];"));
+    assert!(rendered.contains("pub fn derivative_rhs_into"));
+    assert!(rendered.contains("out[0] ="));
+    assert!(!rendered.contains("Vec<"));
+    assert!(!rendered.contains("to_vec"));
+}
+
+#[test]
+fn test_rust_fixed_solve_builtin_target_syntax_checks_when_rustc_available() {
+    if std::process::Command::new("rustc")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping rust-fixed-solve syntax smoke: rustc not available");
+        return;
+    }
+
+    let problem = solve_problem_with_one_by_one_matmul_derivative();
+    let artifacts = solve::SolveArtifacts::default();
+    let source = render_solve_template_with_name(
+        &problem,
+        &artifacts,
+        builtin_template("rust-fixed-solve", "model_fixed_solve.rs.jinja"),
+        "TensorDemo",
+    )
+    .expect("rust-fixed-solve source should render");
+    let dir = std::env::temp_dir().join(format!(
+        "rumoca_rust_fixed_solve_smoke_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create rust-fixed-solve smoke dir");
+    let source_path = dir.join("TensorDemo_fixed_solve.rs");
+    std::fs::write(&source_path, source).expect("write generated rust-fixed-solve source");
+
+    let output = std::process::Command::new("rustc")
+        .arg("--crate-type")
+        .arg("lib")
+        .arg(&source_path)
+        .current_dir(&dir)
+        .output()
+        .expect("run rustc syntax check");
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(
+        output.status.success(),
+        "generated rust-fixed-solve source must pass rustc syntax check\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_mlir_builtin_target_renders_tensor_scalar_fallback_rows() {
     let problem = solve_problem_with_one_by_one_matmul_derivative();
     let artifacts = solve::SolveArtifacts::default();

--- a/crates/rumoca-phase-codegen/src/codegen/codegen_tests.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/codegen_tests.rs
@@ -398,6 +398,26 @@ fn test_rust_fixed_solve_builtin_target_renders_fixed_derivative_kernel() {
 }
 
 #[test]
+fn test_rust_fixed_solve_builtin_target_rejects_linsolve_render() {
+    let problem = solve_problem_with_two_by_two_linsolve_derivative();
+    let artifacts = solve::SolveArtifacts::default();
+    let err = render_solve_template_with_name(
+        &problem,
+        &artifacts,
+        builtin_template("rust-fixed-solve", "model_fixed_solve.rs.jinja"),
+        "TensorDemo",
+    )
+    .expect_err("rust-fixed-solve should reject LinSolve during template rendering");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("unsupported-feature:tensor.linsolve")
+            && message.contains("rust-fixed-solve does not support scalar-fallback LinSolve"),
+        "{message}"
+    );
+}
+
+#[test]
 fn test_rust_fixed_solve_builtin_target_syntax_checks_when_rustc_available() {
     if std::process::Command::new("rustc")
         .arg("--version")

--- a/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/model_fixed_solve.rs.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/model_fixed_solve.rs.jinja
@@ -1,4 +1,4 @@
-#![allow(non_snake_case, unused_parens)]
+#![allow(dead_code, non_snake_case, unused_parens)]
 
 pub type Scalar = f64;
 

--- a/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/model_fixed_solve.rs.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/model_fixed_solve.rs.jinja
@@ -1,0 +1,38 @@
+#![allow(non_snake_case, unused_parens)]
+
+pub type Scalar = f64;
+
+pub const Y_LEN: usize = {{ solve.layout.y_scalars }};
+pub const P_LEN: usize = {{ solve.layout.p_scalars }};
+pub const DERIVATIVE_LEN: usize = {{ solve_blocks.continuous.derivative_rhs.output_count }};
+
+pub type State = [Scalar; Y_LEN];
+pub type Parameters = [Scalar; P_LEN];
+pub type Derivative = [Scalar; DERIVATIVE_LEN];
+
+#[inline]
+pub fn derivative_rhs(time: Scalar, y: &State, p: &Parameters) -> Derivative {
+    let mut out = [0.0; DERIVATIVE_LEN];
+    derivative_rhs_into(time, y, p, &mut out);
+    out
+}
+
+#[inline]
+pub fn derivative_rhs_into(time: Scalar, y: &State, p: &Parameters, out: &mut Derivative) {
+    let _ = time;
+    let _ = y;
+    let _ = p;
+{%- set cfg = {"time": "time", "y": "y[{}]", "p": "p[{}]"} %}
+{%- set output_indices = solve_blocks.continuous.derivative_rhs.scalar_programs.output_indices %}
+    out.fill(0.0);
+{%- if solve_blocks.continuous.derivative_rhs.scalar_programs_use_linear_solve_component %}
+    compile_error!("rust-fixed-solve does not support scalar-fallback LinSolve; use rust-solve or add a native fixed-size linsolve target");
+{%- else %}
+{%- set solve_body = render_solve_block_rust(solve_blocks.continuous.derivative_rhs.scalar_programs.programs, cfg, "out[{}] = {}", output_indices) %}
+{%- if solve_body %}
+{{ solve_body }}
+{%- else %}
+    let _ = out;
+{%- endif %}
+{%- endif %}
+}

--- a/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/model_fixed_solve.rs.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/model_fixed_solve.rs.jinja
@@ -26,7 +26,7 @@ pub fn derivative_rhs_into(time: Scalar, y: &State, p: &Parameters, out: &mut De
 {%- set output_indices = solve_blocks.continuous.derivative_rhs.scalar_programs.output_indices %}
     out.fill(0.0);
 {%- if solve_blocks.continuous.derivative_rhs.scalar_programs_use_linear_solve_component %}
-    compile_error!("rust-fixed-solve does not support scalar-fallback LinSolve; use rust-solve or add a native fixed-size linsolve target");
+{{ fail("unsupported-feature:tensor.linsolve: rust-fixed-solve does not support scalar-fallback LinSolve; use rust-solve or add a native fixed-size linsolve target") }}
 {%- else %}
 {%- set solve_body = render_solve_block_rust(solve_blocks.continuous.derivative_rhs.scalar_programs.programs, cfg, "out[{}] = {}", output_indices) %}
 {%- if solve_body %}

--- a/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/target.toml
+++ b/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/target.toml
@@ -9,7 +9,7 @@ completion_message = """Fixed Rust Solve kernel source compiled to: {{ out_dir }
 Compile: rustc --crate-type lib {{ out_dir }}/{{ model_name }}_fixed_solve.rs"""
 
 [capabilities]
-scalar_fallback = false
+scalar_fallback = true
 events = false
 runtime_events = false
 forward_ad = false
@@ -18,6 +18,8 @@ dynamic_control_flow = false
 host_callbacks = false
 
 [capabilities.tensor]
+matmul = "scalar"
+linsolve = "unsupported"
 layout = "row-major"
 supports_dynamic_shapes = false
 sparse = false

--- a/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/target.toml
+++ b/crates/rumoca-phase-codegen/src/templates/rust-fixed-solve/target.toml
@@ -1,0 +1,28 @@
+version = 1
+ir = "solve"
+name = "rust-fixed-solve"
+description = "Fixed-size Rust Solve-IR derivative kernel for no-alloc CPU hot paths"
+execution_mode = "compiled"
+deployment_class = "cpu"
+readiness_level = 2
+completion_message = """Fixed Rust Solve kernel source compiled to: {{ out_dir }}
+Compile: rustc --crate-type lib {{ out_dir }}/{{ model_name }}_fixed_solve.rs"""
+
+[capabilities]
+scalar_fallback = false
+events = false
+runtime_events = false
+forward_ad = false
+reverse_ad = false
+dynamic_control_flow = false
+host_callbacks = false
+
+[capabilities.tensor]
+layout = "row-major"
+supports_dynamic_shapes = false
+sparse = false
+dtypes = ["f64"]
+
+[[files]]
+path = "{{ model_name }}_fixed_solve.rs"
+template = "model_fixed_solve.rs.jinja"

--- a/crates/rumoca/src/target_manifest.rs
+++ b/crates/rumoca/src/target_manifest.rs
@@ -539,51 +539,72 @@ fn validate_solve_target_capabilities(
     capabilities: &TargetCapabilities,
 ) -> Result<()> {
     let scalar_fallback = capabilities.scalar_fallback.unwrap_or(true);
-    if scalar_fallback {
-        return Ok(());
-    }
     let tensor = capabilities.tensor.as_ref();
     let solve = rumoca_sim::lower_solve_problem(&result.dae)
         .context("Lower Solve IR for target capability validation")?;
     let inventory = solve.compute_node_counts();
-    let matmul_capability = tensor.and_then(|tensor| tensor.matmul);
-    let linsolve_capability = tensor.and_then(|tensor| tensor.linsolve);
 
-    if inventory.matmul > 0 && matmul_capability.is_none() && !scalar_fallback {
-        unsupported_tensor_feature(
-            manifest,
-            "tensor.matmul",
-            "MatMul nodes are present but the target does not declare native MatMul support and scalar fallback is disabled",
-        )?;
-    }
-    if inventory.linsolve > 0 && linsolve_capability.is_none() && !scalar_fallback {
-        unsupported_tensor_feature(
-            manifest,
-            "tensor.linsolve",
-            "LinSolve nodes are present but the target does not declare native LinSolve support and scalar fallback is disabled",
-        )?;
-    }
-    if inventory.matmul > 0
-        && matmul_capability == Some(TensorCapability::Scalar)
-        && !scalar_fallback
-    {
-        unsupported_tensor_feature(
-            manifest,
-            "tensor.matmul",
-            "MatMul is configured for scalar fallback but scalar fallback is disabled",
-        )?;
-    }
-    if inventory.linsolve > 0
-        && linsolve_capability == Some(TensorCapability::Scalar)
-        && !scalar_fallback
-    {
-        unsupported_tensor_feature(
-            manifest,
-            "tensor.linsolve",
-            "LinSolve is configured for scalar fallback but scalar fallback is disabled",
-        )?;
-    }
+    validate_solve_tensor_feature(
+        manifest,
+        "tensor.matmul",
+        "MatMul",
+        inventory.matmul,
+        tensor.and_then(|tensor| tensor.matmul),
+        scalar_fallback,
+    )?;
+    validate_solve_tensor_feature(
+        manifest,
+        "tensor.linsolve",
+        "LinSolve",
+        inventory.linsolve
+            + if solve.uses_linear_solve_component() {
+                1
+            } else {
+                0
+            },
+        tensor.and_then(|tensor| tensor.linsolve),
+        scalar_fallback,
+    )?;
     Ok(())
+}
+
+fn validate_solve_tensor_feature(
+    manifest: &TargetManifest,
+    feature: &str,
+    display_name: &str,
+    count: usize,
+    capability: Option<TensorCapability>,
+    scalar_fallback: bool,
+) -> Result<()> {
+    if count == 0 {
+        return Ok(());
+    }
+    match capability {
+        Some(TensorCapability::Native) => Ok(()),
+        Some(TensorCapability::Scalar) if scalar_fallback => Ok(()),
+        Some(TensorCapability::Scalar) => unsupported_tensor_feature(
+            manifest,
+            feature,
+            format!(
+                "{display_name} is configured for scalar fallback but scalar fallback is disabled"
+            ),
+        ),
+        Some(TensorCapability::Unsupported) => unsupported_tensor_feature(
+            manifest,
+            feature,
+            format!(
+                "{display_name} nodes are present but the target declares {feature} unsupported"
+            ),
+        ),
+        None if scalar_fallback => Ok(()),
+        None => unsupported_tensor_feature(
+            manifest,
+            feature,
+            format!(
+                "{display_name} nodes are present but the target does not declare native {display_name} support and scalar fallback is disabled"
+            ),
+        ),
+    }
 }
 
 fn unsupported_tensor_feature(
@@ -874,6 +895,22 @@ end TensorTargetDemo;
             .expect("tensor target demo should compile")
     }
 
+    fn compile_matmul_derivative_target_demo() -> CompilationResult {
+        let source = r#"
+model MatMulDerivativeTargetDemo
+  Real x[2](start={1, 2});
+  parameter Real A[2,2] = [1, 0; 0, 2];
+equation
+  der(x) = A * x;
+end MatMulDerivativeTargetDemo;
+"#;
+
+        Compiler::new()
+            .model("MatMulDerivativeTargetDemo")
+            .compile_str(source, "MatMulDerivativeTargetDemo.mo")
+            .expect("MatMul derivative target demo should compile")
+    }
+
     fn compile_scalar_cuda_smoke_demo() -> CompilationResult {
         let source = r#"
 model ScalarCudaSmoke
@@ -928,6 +965,68 @@ matmul = "native"
         let message = err.to_string();
         assert!(message.contains("tensor.linsolve"), "{message}");
         assert!(message.contains("scalar fallback is disabled"), "{message}");
+    }
+
+    #[test]
+    fn rust_fixed_solve_builtin_target_accepts_scalarized_matmul() {
+        let result = compile_matmul_derivative_target_demo();
+        let bundle =
+            TargetBundle::load("rust-fixed-solve").expect("load built-in rust-fixed-solve target");
+        let manifest = bundle
+            .parse_manifest()
+            .expect("parse rust-fixed-solve manifest");
+        let out_dir = tempfile::tempdir().expect("temp output dir");
+
+        compile_manifest_target(
+            &result,
+            "MatMulDerivativeTargetDemo",
+            &bundle,
+            &manifest,
+            Some(out_dir.path().to_path_buf()),
+        )
+        .expect("rust-fixed-solve should render scalarized MatMul derivative sources");
+
+        let generated = std::fs::read_to_string(
+            out_dir
+                .path()
+                .join("MatMulDerivativeTargetDemo_fixed_solve.rs"),
+        )
+        .expect("read generated fixed Rust source");
+        assert!(generated.contains("pub type State = [Scalar; Y_LEN];"));
+        assert!(generated.contains("pub fn derivative_rhs_into"));
+        assert!(!generated.contains("Vec<"));
+    }
+
+    #[test]
+    fn rust_fixed_solve_builtin_target_rejects_linsolve_before_writing_source() {
+        let result = compile_tensor_target_demo();
+        let bundle =
+            TargetBundle::load("rust-fixed-solve").expect("load built-in rust-fixed-solve target");
+        let manifest = bundle
+            .parse_manifest()
+            .expect("parse rust-fixed-solve manifest");
+        let out_dir = tempfile::tempdir().expect("temp output dir");
+
+        let err = compile_manifest_target(
+            &result,
+            "TensorTargetDemo",
+            &bundle,
+            &manifest,
+            Some(out_dir.path().to_path_buf()),
+        )
+        .expect_err("rust-fixed-solve must reject LinSolve before writing source");
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("unsupported-feature:tensor.linsolve"),
+            "{message}"
+        );
+        assert!(
+            !out_dir
+                .path()
+                .join("TensorTargetDemo_fixed_solve.rs")
+                .exists(),
+            "target validation must fail before rendering an uncompilable source file"
+        );
     }
 
     #[test]

--- a/docs/user-guide/src/codegen/targets.md
+++ b/docs/user-guide/src/codegen/targets.md
@@ -22,7 +22,8 @@ Built-in targets include:
 | `julia-mtk` | dae | symbolic | ModelingToolkit.jl |
 | `symforce` | dae | symbolic | SymForce, with native AD support |
 | `onnx` | dae | symbolic | ONNX graph |
-| `rust-fixed-solve` / `rust-solve` / `c-solve` / `embedded-c` | solve | compiled | Self-contained simulation kernels |
+| `rust-fixed-solve` | solve | compiled | Fixed-size Rust derivative kernel with `State`, `Parameters`, `Derivative`, and `derivative_rhs_into` |
+| `rust-solve` / `c-solve` / `embedded-c` | solve | compiled | Self-contained simulation kernels |
 | `cuda-c` / `cuda-nvrtc-solve-jit` | solve | compiled/JIT | GPU kernels |
 | `wgsl-solve` | solve | compiled | Experimental WebGPU kernels for browser runs |
 | `cranelift-solve-jit` / `mlir` | solve | JIT/compiled | In-process execution backends |

--- a/docs/user-guide/src/codegen/targets.md
+++ b/docs/user-guide/src/codegen/targets.md
@@ -22,7 +22,7 @@ Built-in targets include:
 | `julia-mtk` | dae | symbolic | ModelingToolkit.jl |
 | `symforce` | dae | symbolic | SymForce, with native AD support |
 | `onnx` | dae | symbolic | ONNX graph |
-| `rust-solve` / `c-solve` / `embedded-c` | solve | compiled | Self-contained simulation kernels |
+| `rust-fixed-solve` / `rust-solve` / `c-solve` / `embedded-c` | solve | compiled | Self-contained simulation kernels |
 | `cuda-c` / `cuda-nvrtc-solve-jit` | solve | compiled/JIT | GPU kernels |
 | `wgsl-solve` | solve | compiled | Experimental WebGPU kernels for browser runs |
 | `cranelift-solve-jit` / `mlir` | solve | JIT/compiled | In-process execution backends |


### PR DESCRIPTION
## Summary

- Adds a CPU-first `rust-fixed-solve` codegen target for fixed-size generated Rust Solve kernels.
- The generated target exposes fixed `Scalar`, `State`, `Parameters`, and `Derivative` array types plus `derivative_rhs` and `derivative_rhs_into` for caller-owned output storage.
- Fixes the target capability contract so `rust-fixed-solve` accepts scalarized MatMul, declares LinSolve unsupported, and rejects LinSolve before writing uncompilable generated Rust.
- Addresses the target/IR contracts in SPEC_0007, SPEC_0029, and SPEC_0032.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0007_IR_PIPELINE, SPEC_0021_CODE_COMPLEXITY, SPEC_0025_PR_REVIEW_PROCESS, SPEC_0029_CRATE_BOUNDARIES, SPEC_0032_RANGE_PRESERVING_TENSORS.
- Relevant MLS section(s), if semantics changed: none. This PR adds a Solve-IR codegen target and target capability validation; it does not change Modelica language semantics.
- Crate/phase owner: `rumoca-phase-codegen` owns the target template, `rumoca-compile` owns target manifest schema/matrix reporting, `rumoca` owns CLI target invocation validation, and `rumoca-ir-solve` exposes read-only Solve IR inventory queries.

## Risk and Design Notes

- Main correctness risk: the fixed target could silently claim support for tensor forms it cannot render. Mitigation: `rust-fixed-solve` now declares `tensor.matmul = "scalar"` and `tensor.linsolve = "unsupported"`; target validation and template rendering both reject LinSolve with `unsupported-feature:tensor.linsolve`.
- Main maintenance risk: target capability checks can drift from template behavior. Mitigation: matrix, template-render, and manifest-invocation tests cover the declared capability rows and both accept/reject paths.
- Why the change belongs in these crate(s): target metadata remains in `rumoca-compile`; generated source remains target-local in `rumoca-phase-codegen`; CLI compile-time validation remains in `rumoca`; Solve IR only gains read-only inventory helpers, consistent with SPEC_0029's read-only query exception.
- Any new abstraction, public API, or migration path: new public manifest enum variant `TensorCapability::Unsupported`; new read-only `uses_linear_solve_component()` helpers on `ScalarProgramBlock`, `ComputeBlock`, and `SolveProblem`; new built-in target id `rust-fixed-solve`; generated target API includes `Scalar`, `Y_LEN`, `P_LEN`, `DERIVATIVE_LEN`, `State`, `Parameters`, `Derivative`, `derivative_rhs`, and `derivative_rhs_into`.

## Testing

- Key command(s) run (fmt, clippy, workspace test, doc):
  - `git diff --check`
  - `cargo fmt --all -- --check`
  - `cargo test -p rumoca-ir-solve linear_solve_component_query -- --nocapture`
  - `cargo test -p rumoca-phase-codegen rust_fixed_solve -- --nocapture`
  - `cargo test -p rumoca-compile builtin_target_compatibility_matrix -- --nocapture`
  - `cargo test -p rumoca --no-default-features --features scheduled-sim,scenario-config,input-keyboard,transport-udp,transport-zenoh,viewer-web,process-control,native-allocator,fmu-packaging rust_fixed_solve -- --nocapture`
  - `cargo clippy -p rumoca-ir-solve -p rumoca-phase-codegen -p rumoca-compile --all-targets -- -D warnings`
  - `cargo clippy -p rumoca --no-default-features --features scheduled-sim,scenario-config,input-keyboard,transport-udp,transport-zenoh,viewer-web,process-control,native-allocator,fmu-packaging --lib --tests -- -D warnings`
  - `cargo test -p rumoca-ir-solve -p rumoca-phase-codegen -p rumoca-compile --all-targets`
  - `cargo doc -p rumoca-ir-solve -p rumoca-phase-codegen -p rumoca-compile --no-deps`
  - `cargo doc -p rumoca --no-default-features --features scheduled-sim,scenario-config,input-keyboard,transport-udp,transport-zenoh,viewer-web,process-control,native-allocator,fmu-packaging --no-deps`
- Behavior or regression covered: fixed-size Rust derivative source renders without `Vec` for scalarized MatMul; `rust-fixed-solve` rejects LinSolve before writing source; target matrix reports MatMul as scalar and LinSolve as unsupported; generated Rust syntax smoke passes when `rustc` is available.
- Commands NOT run and why: full `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, `cargo doc --no-deps`, and `cargo xtask verify quick/full` were not run locally because this host lacks the default-feature `libudev.pc` dependency used by `input-gamepad` and does not have every full-CI prerequisite installed. GitHub CI installs those prerequisites and is the full-workspace gate.
- For compiler/simulator changes: MSL and ModelicaTest semantic gates were not run locally. This PR does not change parser/instantiate/flatten/DAE semantics or simulator numerics; it adds a target template and target capability validation. Full CI remains the merge gate.

## Code Size Budget

- production_lines_added: 154
- production_lines_deleted: 35
- test_lines_added: 208
- test_lines_deleted: 0
- public_items_added: 4 crate API items; generated target API adds 9 rendered public Rust items
- public_items_removed: 0
- files_touched: 8
- net_added_lines: 328

Positive net growth is required because this PR adds a new built-in target, its manifest/template, and target-specific behavior coverage. The first compression pass removed the original stale `compile_error!` path in favor of manifest/template validation and consolidated duplicated tensor capability checks into `validate_solve_tensor_feature()`. Remaining growth is mostly the new target surface and regression tests; no separate cleanup ticket is needed for this slice.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section, or no MLS-sensitive change is present.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes, or not applicable with rationale above.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.
