### PR TITLE
Fix scheduled sample root events

### DIFF
--- a/crates/rumoca-eval-solve/src/runtime.rs
+++ b/crates/rumoca-eval-solve/src/runtime.rs
@@ -1400,7 +1400,9 @@ impl SolveRuntime {
                     &mut project_algebraics,
                 )?;
             }
-            changed |= self.update_relation_memory_from_solver_y(t, y, p, tol)?;
+            if root_relation_overrides.is_empty() {
+                changed |= self.update_relation_memory_from_solver_y(t, y, p, tol)?;
+            }
             changed |=
                 self.apply_root_relation_memory_overrides(root_relation_overrides, y, p, tol)?;
             changed |= project_algebraics(y, p)?;

--- a/crates/rumoca-ir-dae/src/lib.rs
+++ b/crates/rumoca-ir-dae/src/lib.rs
@@ -27,7 +27,7 @@ use rumoca_core::{
 use serde::ser::{SerializeStruct, SerializeTuple};
 use serde::{Deserialize, Serialize};
 
-pub const DAE_SCHEMA_VERSION: u16 = 5;
+pub const DAE_SCHEMA_VERSION: u16 = 6;
 
 mod event_threshold;
 mod expr_query;
@@ -143,6 +143,7 @@ struct DaeWire {
     relations: Vec<Expression>,
     synthetic_root_conditions: Vec<Expression>,
     scheduled_time_events: Vec<f64>,
+    scheduled_root_conditions: Vec<DaeScheduledRootCondition>,
     event_actions: Vec<DaeEventAction>,
     constructor_exprs: Vec<Expression>,
     schedules: Vec<ClockSchedule>,
@@ -181,7 +182,7 @@ impl Serialize for Dae {
         S: serde::Serializer,
     {
         if !serializer.is_human_readable() {
-            let mut tuple = serializer.serialize_tuple(28)?;
+            let mut tuple = serializer.serialize_tuple(29)?;
             tuple.serialize_element(&self.schema_version)?;
             tuple.serialize_element(&self.variables.states)?;
             tuple.serialize_element(&self.variables.algebraics)?;
@@ -201,6 +202,7 @@ impl Serialize for Dae {
             tuple.serialize_element(&self.conditions.relations)?;
             tuple.serialize_element(&self.events.synthetic_root_conditions)?;
             tuple.serialize_element(&self.events.scheduled_time_events)?;
+            tuple.serialize_element(&self.events.scheduled_root_conditions)?;
             tuple.serialize_element(&self.events.event_actions)?;
             tuple.serialize_element(&self.clocks.constructor_exprs)?;
             tuple.serialize_element(&self.clocks.schedules)?;
@@ -213,7 +215,7 @@ impl Serialize for Dae {
             return tuple.end();
         }
 
-        let mut state = serializer.serialize_struct("Dae", 28)?;
+        let mut state = serializer.serialize_struct("Dae", 29)?;
         state.serialize_field("schema_version", &self.schema_version)?;
         state.serialize_field("x", &self.variables.states)?;
         state.serialize_field("y", &self.variables.algebraics)?;
@@ -242,6 +244,10 @@ impl Serialize for Dae {
             &self.events.synthetic_root_conditions,
         )?;
         state.serialize_field("scheduled_time_events", &self.events.scheduled_time_events)?;
+        state.serialize_field(
+            "scheduled_root_conditions",
+            &self.events.scheduled_root_conditions,
+        )?;
         state.serialize_field("event_actions", &self.events.event_actions)?;
         state.serialize_field("constructor_exprs", &self.clocks.constructor_exprs)?;
         state.serialize_field("schedules", &self.clocks.schedules)?;
@@ -299,6 +305,7 @@ impl<'de> Deserialize<'de> for Dae {
             events: DaeEventPartition {
                 synthetic_root_conditions: wire.synthetic_root_conditions,
                 scheduled_time_events: wire.scheduled_time_events,
+                scheduled_root_conditions: wire.scheduled_root_conditions,
                 event_actions: wire.event_actions,
             },
             clocks: DaeClockPartition {
@@ -527,12 +534,26 @@ pub struct DaeEventPartition {
     /// Scheduled discontinuity instants derived at compile time.
     /// This is canonical runtime metadata (always present in DAE schema).
     pub scheduled_time_events: Vec<f64>,
+    /// Root rows that correspond to periodic sample schedules.
+    ///
+    /// `root_index` is in Solve root-condition order:
+    /// `conditions.relations`, followed by `events.synthetic_root_conditions`,
+    /// followed by triggered clock conditions. The schedule fields identify
+    /// which periodic tick may activate the root at runtime.
+    pub scheduled_root_conditions: Vec<DaeScheduledRootCondition>,
     /// Runtime actions evaluated at event instants.
     ///
     /// `assert` and `terminate` are integration-flow constructs, not numeric
     /// residual expressions. `reinit` is lowered earlier into guarded discrete
     /// state-update equations and must not appear here.
     pub event_actions: Vec<DaeEventAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DaeScheduledRootCondition {
+    pub root_index: usize,
+    pub period_seconds: f64,
+    pub phase_seconds: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/rumoca-ir-dae/tests/golden/modelica_blocks_examples_logical_network1.dae.json
+++ b/crates/rumoca-ir-dae/tests/golden/modelica_blocks_examples_logical_network1.dae.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "x": {},
   "y": {},
   "u": {},
@@ -498,6 +498,7 @@
   "scheduled_time_events": [
     0.1
   ],
+  "scheduled_root_conditions": [],
   "event_actions": [],
   "constructor_exprs": [],
   "schedules": [

--- a/crates/rumoca-ir-solve/src/lib.rs
+++ b/crates/rumoca-ir-solve/src/lib.rs
@@ -33,7 +33,7 @@ pub use visitor::{
     walk_scalar_program_block, walk_solve_artifacts, walk_solve_model, walk_solve_problem,
 };
 
-pub const SOLVE_SCHEMA_VERSION: u16 = 14;
+pub const SOLVE_SCHEMA_VERSION: u16 = 15;
 
 pub fn source_span_from_offsets(source: u64, start: usize, end: usize) -> Span {
     Span::from_offsets(SourceId(source), start, end)
@@ -1304,6 +1304,11 @@ impl SolveProblem {
         self.events
             .root_conditions
             .validate_shape_contract("events.root_conditions")?;
+        validate_scheduled_root_conditions(
+            "events.scheduled_root_conditions",
+            &self.events.scheduled_root_conditions,
+            self.events.root_conditions.len(),
+        )?;
         self.events
             .dynamic_time_event_rhs
             .validate_shape_contract("events.dynamic_time_event_rhs")?;
@@ -1353,6 +1358,28 @@ fn validate_indices(
             context,
             index,
             upper_bound,
+            span: None,
+        });
+    }
+    Ok(())
+}
+
+fn validate_scheduled_root_conditions(
+    context: &'static str,
+    roots: &[ScheduledRootCondition],
+    upper_bound: usize,
+) -> Result<(), SolveProblemShapeContractError> {
+    for root in roots {
+        validate_indices(context, &[root.root_index], upper_bound)?;
+        if root.period_seconds.is_finite()
+            && root.period_seconds > 0.0
+            && root.phase_seconds.is_finite()
+        {
+            continue;
+        }
+        return Err(SolveProblemShapeContractError::InvalidScheduledRootTiming {
+            context,
+            root_index: root.root_index,
             span: None,
         });
     }
@@ -1442,6 +1469,11 @@ pub enum SolveProblemShapeContractError {
         upper_bound: usize,
         span: Option<Span>,
     },
+    InvalidScheduledRootTiming {
+        context: &'static str,
+        root_index: usize,
+        span: Option<Span>,
+    },
 }
 
 impl SolveProblemShapeContractError {
@@ -1453,7 +1485,8 @@ impl SolveProblemShapeContractError {
             | Self::ScalarProgramOutputIndexMismatch { span, .. }
             | Self::ScalarProgramCountMismatch { span, .. }
             | Self::OutputIndexOverflow { span, .. }
-            | Self::SolverIndexOutOfBounds { span, .. } => *span,
+            | Self::SolverIndexOutOfBounds { span, .. }
+            | Self::InvalidScheduledRootTiming { span, .. } => *span,
             Self::ZeroTensorDimension { span, .. }
             | Self::StructuredIndexDomain { span, .. }
             | Self::TensorOutputMapDimension { span, .. }
@@ -1557,6 +1590,11 @@ impl std::fmt::Display for SolveProblemShapeContractError {
                 f,
                 "{context} references solver index {index}, but upper bound is {upper_bound}"
             ),
+            Self::InvalidScheduledRootTiming {
+                context,
+                root_index,
+                ..
+            } => write!(f, "{context} root {root_index} has invalid periodic timing"),
         }
     }
 }
@@ -1646,11 +1684,19 @@ pub struct DiscreteSolveSystem {
 pub struct SolveEventPartition {
     pub root_conditions: ScalarProgramBlock,
     pub root_relation_memory_targets: Vec<Option<ScalarSlot>>,
+    pub scheduled_root_conditions: Vec<ScheduledRootCondition>,
     pub scheduled_time_events: Vec<f64>,
     pub dynamic_time_event_names: Vec<String>,
     pub dynamic_time_event_rhs: ScalarProgramBlock,
     pub action_conditions: ScalarProgramBlock,
     pub actions: Vec<SolveEventAction>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ScheduledRootCondition {
+    pub root_index: usize,
+    pub period_seconds: f64,
+    pub phase_seconds: f64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/rumoca-ir-solve/tests/golden/representative_solve_problem.solve.json
+++ b/crates/rumoca-ir-solve/tests/golden/representative_solve_problem.solve.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 14,
+  "schema_version": 15,
   "layout": {
     "bindings": {
       "x": {
@@ -433,6 +433,7 @@
       ]
     },
     "root_relation_memory_targets": [],
+    "scheduled_root_conditions": [],
     "scheduled_time_events": [
       0.1
     ],

--- a/crates/rumoca-phase-codegen/src/codegen/solve_lazy.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/solve_lazy.rs
@@ -378,6 +378,7 @@ fn events_value(problem: Arc<solve::SolveProblem>) -> Value {
         &[
             "root_conditions",
             "root_relation_memory_targets",
+            "scheduled_root_conditions",
             "scheduled_time_events",
             "dynamic_time_event_names",
             "dynamic_time_event_rhs",
@@ -398,6 +399,9 @@ fn events_value(problem: Arc<solve::SolveProblem>) -> Value {
                 ))),
                 "root_relation_memory_targets" => {
                     Some(Value::from_serialize(&e.root_relation_memory_targets))
+                }
+                "scheduled_root_conditions" => {
+                    Some(Value::from_serialize(&e.scheduled_root_conditions))
                 }
                 "scheduled_time_events" => Some(Value::from_serialize(&e.scheduled_time_events)),
                 "dynamic_time_event_names" => {

--- a/crates/rumoca-phase-dae/src/appendix_b_validation.rs
+++ b/crates/rumoca-phase-dae/src/appendix_b_validation.rs
@@ -805,6 +805,33 @@ fn validate_runtime_metadata_invariants(dae_model: &dae::Dae) -> Result<(), ToDa
         }
     }
 
+    let root_condition_count = dae_model
+        .conditions
+        .relations
+        .len()
+        .checked_add(dae_model.events.synthetic_root_conditions.len())
+        .and_then(|count| count.checked_add(dae_model.clocks.triggered_conditions.len()))
+        .ok_or_else(|| {
+            ToDaeError::runtime_metadata_violation("root condition count overflowed host index")
+        })?;
+    for root in &dae_model.events.scheduled_root_conditions {
+        if root.root_index >= root_condition_count {
+            return Err(ToDaeError::runtime_metadata_violation(format!(
+                "scheduled_root_conditions root index {} is outside {} root conditions",
+                root.root_index, root_condition_count
+            )));
+        }
+        if !root.period_seconds.is_finite()
+            || root.period_seconds <= 0.0
+            || !root.phase_seconds.is_finite()
+        {
+            return Err(ToDaeError::runtime_metadata_violation(format!(
+                "scheduled_root_conditions entry {} has invalid timing period={} phase={}",
+                root.root_index, root.period_seconds, root.phase_seconds
+            )));
+        }
+    }
+
     let mut seen_roots: Vec<&rumoca_core::Expression> = Vec::new();
     for root in &dae_model.events.synthetic_root_conditions {
         if seen_roots.contains(&root) {

--- a/crates/rumoca-phase-dae/src/runtime_precompute/clock.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/clock.rs
@@ -609,6 +609,41 @@ fn requires_static_clock_schedule(expr: &rumoca_core::Expression) -> bool {
     }
 }
 
+pub(super) fn scheduled_sample_root_schedule<'a>(
+    expr: &rumoca_core::Expression,
+    clock_schedules: &'a [dae::ClockSchedule],
+    constants: &HashMap<String, f64>,
+) -> Option<&'a dae::ClockSchedule> {
+    let (period_seconds, phase_seconds) = scheduled_sample_root_timing(expr, constants)?;
+    clock_schedules.iter().find(|schedule| {
+        clock_schedules_equivalent(
+            schedule,
+            &dae::ClockSchedule {
+                period_seconds,
+                phase_seconds,
+                source_span: schedule.source_span,
+            },
+        )
+    })
+}
+
+fn scheduled_sample_root_timing(
+    expr: &rumoca_core::Expression,
+    constants: &HashMap<String, f64>,
+) -> Option<(f64, f64)> {
+    match expr {
+        rumoca_core::Expression::BuiltinCall {
+            function: rumoca_core::BuiltinFunction::Sample,
+            args,
+            ..
+        } => sample_start_interval_timing(args, constants),
+        rumoca_core::Expression::FunctionCall { name, args, .. } => {
+            function_sample_start_interval_timing(name.last_segment(), args, constants)
+        }
+        _ => None,
+    }
+}
+
 fn is_non_static_inferred_clock_composition(
     expr: &rumoca_core::Expression,
     constants: &HashMap<String, f64>,

--- a/crates/rumoca-phase-dae/src/runtime_precompute/clock/timing_inference.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/clock/timing_inference.rs
@@ -521,6 +521,15 @@ pub(super) fn infer_clock_timing_from_function_call_expr(
 ) -> Option<(f64, f64)> {
     let short = name.last_segment();
     if is_sample_timing_function_name(short) && args.len() >= 2 {
+        if let Some(sample_args) = internal_sample_start_interval_args(short, args) {
+            return infer_sample_start_interval_timing(
+                sample_args,
+                constants,
+                sources,
+                remaining_depth,
+                visiting,
+            );
+        }
         return infer_clock_timing_next(&args[1], constants, sources, remaining_depth, visiting)
             .or_else(|| {
                 infer_sample_start_interval_timing(
@@ -748,7 +757,7 @@ impl ClockConstructorExprCollector<'_> {
     ) {
         let short = name.last_segment();
         if is_sample_timing_function_name(short) {
-            if sample_start_interval_timing(args, self.constants).is_some() {
+            if function_sample_start_interval_timing(short, args, self.constants).is_some() {
                 self.out.push(rumoca_core::Expression::FunctionCall {
                     name: name.clone(),
                     args: args.to_vec(),
@@ -784,6 +793,28 @@ pub(super) fn static_sample_start_interval_timing(
         return None;
     }
     sample_start_interval_timing(args, constants)
+}
+
+pub(super) fn function_sample_start_interval_timing(
+    short: &str,
+    args: &[rumoca_core::Expression],
+    constants: &HashMap<String, f64>,
+) -> Option<(f64, f64)> {
+    if short != rumoca_core::INTERNAL_SAMPLE_FUNCTION_NAME
+        && rumoca_core::source_temporal_function_short_name(short)
+            .is_none_or(|name| name != "sample")
+    {
+        return None;
+    }
+    let args = internal_sample_start_interval_args(short, args).unwrap_or(args);
+    sample_start_interval_timing(args, constants)
+}
+
+fn internal_sample_start_interval_args<'a>(
+    short: &str,
+    args: &'a [rumoca_core::Expression],
+) -> Option<&'a [rumoca_core::Expression]> {
+    (short == rumoca_core::INTERNAL_SAMPLE_FUNCTION_NAME && args.len() >= 3).then_some(&args[1..])
 }
 
 fn is_sample_timing_function_name(short: &str) -> bool {

--- a/crates/rumoca-phase-dae/src/runtime_precompute/mod.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/mod.rs
@@ -114,15 +114,70 @@ pub(crate) fn populate_runtime_precompute(dae_model: &mut dae::Dae) -> Result<()
     let prune_start = maybe_start_timer_if(profile);
     prune_unreferenced_condition_memory(dae_model, &compile_time_scalars)?;
     remove_relation_duplicate_synthetic_roots(dae_model, &mut synthetic_roots);
+    let scheduled_root_conditions = collect_scheduled_root_conditions(
+        dae_model,
+        &synthetic_roots,
+        &clock_schedules,
+        &clock_compile_time_scalars,
+    );
     log_runtime_precompute_profile("prune_condition_memory", prune_start);
     dae_model.events.synthetic_root_conditions = synthetic_roots;
     dae_model.events.scheduled_time_events = scheduled_time_events;
+    dae_model.events.scheduled_root_conditions = scheduled_root_conditions;
     dae_model.clocks.constructor_exprs = clock_constructor_exprs;
     dae_model.clocks.schedules = clock_schedules;
     dae_model.clocks.intervals = clock_intervals;
     dae_model.clocks.timings = clock_timings;
     dae_model.clocks.triggered_conditions = triggered_clock_conditions;
     Ok(())
+}
+
+fn collect_scheduled_root_conditions(
+    dae_model: &dae::Dae,
+    synthetic_roots: &[rumoca_core::Expression],
+    clock_schedules: &[dae::ClockSchedule],
+    compile_time_scalars: &HashMap<String, f64>,
+) -> Vec<dae::DaeScheduledRootCondition> {
+    let mut roots = Vec::new();
+    for (root_index, expr) in dae_model.conditions.relations.iter().enumerate() {
+        push_scheduled_root_condition(
+            &mut roots,
+            root_index,
+            expr,
+            clock_schedules,
+            compile_time_scalars,
+        );
+    }
+    let synthetic_offset = dae_model.conditions.relations.len();
+    for (index, expr) in synthetic_roots.iter().enumerate() {
+        push_scheduled_root_condition(
+            &mut roots,
+            synthetic_offset + index,
+            expr,
+            clock_schedules,
+            compile_time_scalars,
+        );
+    }
+    roots
+}
+
+fn push_scheduled_root_condition(
+    roots: &mut Vec<dae::DaeScheduledRootCondition>,
+    root_index: usize,
+    expr: &rumoca_core::Expression,
+    clock_schedules: &[dae::ClockSchedule],
+    compile_time_scalars: &HashMap<String, f64>,
+) {
+    let Some(schedule) =
+        clock::scheduled_sample_root_schedule(expr, clock_schedules, compile_time_scalars)
+    else {
+        return;
+    };
+    roots.push(dae::DaeScheduledRootCondition {
+        root_index,
+        period_seconds: schedule.period_seconds,
+        phase_seconds: schedule.phase_seconds,
+    });
 }
 
 fn remove_relation_duplicate_synthetic_roots(

--- a/crates/rumoca-phase-dae/src/runtime_precompute/tests/mod.rs
+++ b/crates/rumoca-phase-dae/src/runtime_precompute/tests/mod.rs
@@ -1127,6 +1127,32 @@ fn test_runtime_precompute_collects_sample_start_interval_schedule() {
 }
 
 #[test]
+fn test_runtime_precompute_marks_schedule_backed_sample_root_condition() {
+    let mut dae_model = dae::Dae::default();
+    let relation = rumoca_core::Expression::FunctionCall {
+        name: rumoca_core::VarName::new(rumoca_core::INTERNAL_SAMPLE_FUNCTION_NAME).into(),
+        args: vec![lit(42.0), lit(0.05), lit(0.1)],
+        is_constructor: false,
+        span: test_span(120, 149),
+    };
+    dae_model.conditions.relations.push(relation.clone());
+    dae_model.conditions.equations.push(dae::Equation::explicit(
+        condition_lhs("c", 1),
+        relation,
+        test_span(1, 2),
+        "scheduled sample condition memory",
+    ));
+
+    populate_runtime_precompute(&mut dae_model).expect("runtime precompute should succeed");
+
+    assert_eq!(dae_model.events.scheduled_root_conditions.len(), 1);
+    let root = &dae_model.events.scheduled_root_conditions[0];
+    assert_eq!(root.root_index, 0);
+    assert!((root.period_seconds - 0.1).abs() <= 1e-12);
+    assert!((root.phase_seconds - 0.05).abs() <= 1e-12);
+}
+
+#[test]
 fn test_runtime_precompute_collects_sample_schedule_from_initial_time_parameter() {
     let mut dae_model = dae::Dae::default();
     let mut frequency = dae::Variable::new(

--- a/crates/rumoca-phase-solve/src/lib.rs
+++ b/crates/rumoca-phase-solve/src/lib.rs
@@ -578,6 +578,8 @@ fn lower_event_partition_for_profile(
         )?,
         root_relation_memory_targets: lower::lower_root_relation_memory_targets(dae_model, layout)
             .map_err(|err| lower_problem_context(err, "lower root relation memory targets"))?,
+        scheduled_root_conditions: lower::lower_scheduled_root_conditions(dae_model)
+            .map_err(|err| lower_problem_context(err, "lower scheduled root conditions"))?,
         scheduled_time_events: dae_model.events.scheduled_time_events.clone(),
         dynamic_time_event_names: dynamic_events::collect_dynamic_time_event_names(dae_model),
         dynamic_time_event_rhs: solve::ScalarProgramBlock::with_program_spans(

--- a/crates/rumoca-phase-solve/src/lower.rs
+++ b/crates/rumoca-phase-solve/src/lower.rs
@@ -362,6 +362,12 @@ pub fn lower_root_relation_memory_targets(
     root_conditions::lower_root_relation_memory_targets(dae_model, layout)
 }
 
+pub fn lower_scheduled_root_conditions(
+    dae_model: &dae::Dae,
+) -> Result<Vec<rumoca_ir_solve::ScheduledRootCondition>, LowerError> {
+    root_conditions::lower_scheduled_root_conditions(dae_model)
+}
+
 struct LowerBuilder<'a> {
     layout: &'a VarLayout,
     functions: &'a IndexMap<rumoca_core::VarName, rumoca_core::Function>,

--- a/crates/rumoca-phase-solve/src/lower/root_conditions.rs
+++ b/crates/rumoca-phase-solve/src/lower/root_conditions.rs
@@ -84,6 +84,32 @@ pub(super) fn lower_root_relation_memory_targets(
     Ok(targets)
 }
 
+pub(super) fn lower_scheduled_root_conditions(
+    dae_model: &dae::Dae,
+) -> Result<Vec<rumoca_ir_solve::ScheduledRootCondition>, LowerError> {
+    let span = root_condition_context_span(dae_model);
+    let root_count = root_condition_count(dae_model, span)?;
+    let mut roots =
+        root_vec_with_capacity(root_count, "scheduled root condition metadata count", span)?;
+    for root in &dae_model.events.scheduled_root_conditions {
+        if root.root_index >= root_count {
+            return Err(root_contract_error(
+                format!(
+                    "scheduled root condition index {} is outside {root_count} root conditions",
+                    root.root_index
+                ),
+                span,
+            ));
+        }
+        roots.push(rumoca_ir_solve::ScheduledRootCondition {
+            root_index: root.root_index,
+            period_seconds: root.period_seconds,
+            phase_seconds: root.phase_seconds,
+        });
+    }
+    Ok(roots)
+}
+
 fn root_condition_count(
     dae_model: &dae::Dae,
     span: Option<rumoca_core::Span>,

--- a/crates/rumoca-phase-solve/src/lower/tests/root_condition_tests.rs
+++ b/crates/rumoca-phase-solve/src/lower/tests/root_condition_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::lower::lower_scheduled_root_conditions;
 
 #[test]
 fn lower_discrete_rhs_skips_untargeted_condition_rows() {
@@ -212,5 +213,73 @@ fn lower_root_conditions_keep_enum_literal_relations_active() {
     assert!(
         false_output.expect("non-matching enum relation should evaluate") > 0.0,
         "non-matching enum literal equality must be an active false root"
+    );
+}
+
+#[test]
+fn lower_root_conditions_marks_schedule_backed_sample_roots() {
+    let mut dae_model = dae::Dae::default();
+    let span = lower_test_span();
+    let mut dt = source_scalar_var("dt");
+    dt.start = Some(real_lit(0.02));
+    dae_model
+        .variables
+        .parameters
+        .insert(rumoca_core::VarName::new("dt"), dt);
+    dae_model.clocks.schedules.push(dae::ClockSchedule {
+        period_seconds: 0.02,
+        phase_seconds: 0.0,
+        source_span: span,
+    });
+    dae_model
+        .events
+        .scheduled_root_conditions
+        .push(dae::DaeScheduledRootCondition {
+            root_index: 0,
+            period_seconds: 0.02,
+            phase_seconds: 0.0,
+        });
+    dae_model
+        .variables
+        .discrete_valued
+        .insert(rumoca_core::VarName::new("c"), source_scalar_var("c"));
+    let relation = rumoca_core::Expression::FunctionCall {
+        name: rumoca_core::VarName::new(rumoca_core::INTERNAL_SAMPLE_FUNCTION_NAME).into(),
+        args: vec![real_lit(0.0), var("dt")],
+        is_constructor: false,
+        span,
+    };
+    dae_model.conditions.relations.push(relation.clone());
+    dae_model.conditions.equations.push(dae::Equation::explicit(
+        source_ref("c"),
+        relation,
+        span,
+        "schedule-backed sample condition memory",
+    ));
+
+    let layout = build_var_layout(&dae_model).expect("test DAE layout should build");
+    let rows = lower_root_conditions(&dae_model, &layout).expect("root lowering should succeed");
+    let scheduled_roots = lower_scheduled_root_conditions(&dae_model)
+        .expect("scheduled root lowering should succeed");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(scheduled_roots.len(), 1);
+    assert_eq!(scheduled_roots[0].root_index, 0);
+    assert!((scheduled_roots[0].period_seconds - 0.02).abs() <= 1e-12);
+    assert!((scheduled_roots[0].phase_seconds - 0.0).abs() <= 1e-12);
+    let outputs = [0.0, 0.01, 0.02, 0.04]
+        .into_iter()
+        .map(|time| {
+            let (_, output) = eval_linear_ops(&rows[0], &[], &[], time);
+            output.expect("scheduled sample row should emit an output")
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        outputs.iter().any(|value| *value < 0.0),
+        "scheduled sample roots must keep their event-time active value: {outputs:?}"
+    );
+    assert!(
+        outputs.iter().any(|value| *value > 0.0),
+        "scheduled sample roots must not be lowered to an always-active root: {outputs:?}"
     );
 }

--- a/crates/rumoca-solver-rk45/src/lib.rs
+++ b/crates/rumoca-solver-rk45/src/lib.rs
@@ -14,7 +14,8 @@ use rumoca_solver::{
     BackendState, EventActionOutcome, EventPreMode, RootCrossing, RuntimeEventBoundary,
     RuntimeEventBoundaryHandler, RuntimeEventStop, RuntimeSolveError, SimOptions, SimResult,
     SimSolverMode, SimTermination, SimulationBackend, SolveStopSchedule, StepUntilOutcome,
-    TimeoutBudget, TimeoutExceeded, commit_pre_params_after_event, convert_variable_meta,
+    TimeoutBudget, TimeoutExceeded, clear_scheduled_root_relation_memory,
+    commit_pre_params_after_event, convert_variable_meta, filter_scheduled_root_crossings,
     process_runtime_event_boundary, root_crossings_with_relation_memory, root_value_crossed,
     runtime_event_horizon, timeline,
 };
@@ -605,10 +606,14 @@ impl<'a> Rk45Backend<'a> {
     }
 
     fn current_solver_y(&self) -> Result<Vec<f64>, SimError> {
+        self.solver_y_at_time(self.public_time_eval_time(self.time))
+    }
+
+    fn solver_y_at_time(&self, time: f64) -> Result<Vec<f64>, SimError> {
         let mut guess = self.solver_y_guess.borrow_mut();
         self.model
             .full_solver_y_with_guess(
-                self.public_time_eval_time(self.time),
+                time,
                 &self.state,
                 &self.params,
                 &mut guess,
@@ -858,12 +863,16 @@ impl<'a> Rk45Backend<'a> {
             self.continuous_eval_time(new_t, context.event_boundary),
             &trial.y_next,
         )?;
-        let crossings = root_crossings_with_relation_memory(
+        let mut crossings = root_crossings_with_relation_memory(
             context.old_roots,
             &new_roots,
             self.atol,
             &self.model.model.problem.events.root_relation_memory_targets,
             &self.params,
+        );
+        filter_scheduled_root_crossings(
+            &mut crossings,
+            &self.model.model.problem.events.scheduled_root_conditions,
         );
         if let Some(crossing) = crossings.first().copied() {
             let root = self.bisect_root(
@@ -1126,6 +1135,7 @@ impl<'a> Rk45Backend<'a> {
         )?;
         self.post_event_eval_time = outcome.right_limit_t;
         self.apply_event_actions(outcome.final_t)?;
+        self.clear_event_entry_scheduled_root_relation_memory(outcome.final_t, event)?;
         self.clear_runtime_caches();
         Ok(Some(
             self.termination
@@ -1238,6 +1248,7 @@ impl SimulationBackend for Rk45Backend<'_> {
             &mut self.params,
             self.atol,
         );
+        self.clear_all_scheduled_root_relation_memory()?;
         self.clear_runtime_caches();
         Ok(())
     }
@@ -1260,11 +1271,12 @@ impl RuntimeEventBoundaryHandler for Rk45Backend<'_> {
         event: RuntimeEventStop,
     ) -> Result<(), Self::Error> {
         self.time = event_time.max(self.time);
-        let (event_pre_y, event_pre_p) = self.event_pre_for_update()?;
+        let (event_pre_y, event_pre_p) = self.event_pre_for_update(event_time, event)?;
         self.boundary_event_pre_y = Some(event_pre_y.clone());
         self.boundary_event_pre_p = Some(event_pre_p.clone());
         self.pending_event_pre_y = Some(event_pre_y);
         self.pending_event_pre_p = Some(event_pre_p);
+        self.seed_scheduled_root_relation_overrides(event_time, event)?;
         self.apply_discrete_event_updates(self.time, event)?;
         Ok(())
     }
@@ -1292,17 +1304,88 @@ impl RuntimeEventBoundaryHandler for Rk45Backend<'_> {
 }
 
 impl Rk45Backend<'_> {
-    fn event_pre_for_update(&mut self) -> Result<(Vec<f64>, Vec<f64>), SimError> {
-        let event_pre_y = self
-            .pending_event_pre_y
-            .take()
-            .map(Ok)
-            .unwrap_or_else(|| self.current_solver_y())?;
-        let event_pre_p = self
-            .pending_event_pre_p
-            .take()
-            .unwrap_or_else(|| self.params.clone());
+    fn event_pre_for_update(
+        &mut self,
+        event_time: f64,
+        event: RuntimeEventStop,
+    ) -> Result<(Vec<f64>, Vec<f64>), SimError> {
+        if let Some(event_pre_y) = self.pending_event_pre_y.take() {
+            let event_pre_p = self
+                .pending_event_pre_p
+                .take()
+                .unwrap_or_else(|| self.params.clone());
+            return Ok((event_pre_y, event_pre_p));
+        }
+        let pre_time = match event.pre_mode {
+            EventPreMode::EventEntry | EventPreMode::Fixed => {
+                timeline::event_left_limit_time(event_time)
+            }
+            EventPreMode::FollowCurrent => self.public_time_eval_time(self.time),
+        };
+        let event_pre_y = self.solver_y_at_time(pre_time)?;
+        let event_pre_p = self.params.clone();
         Ok((event_pre_y, event_pre_p))
+    }
+
+    fn clear_event_entry_scheduled_root_relation_memory(
+        &mut self,
+        event_time: f64,
+        event: RuntimeEventStop,
+    ) -> Result<(), SimError> {
+        if event.observe_right_limit || !matches!(event.pre_mode, EventPreMode::EventEntry) {
+            return Ok(());
+        }
+        let root_indices = self.scheduled_root_indices_at_time(event_time);
+        self.clear_scheduled_root_relation_memory(&root_indices)
+    }
+
+    fn clear_all_scheduled_root_relation_memory(&mut self) -> Result<(), SimError> {
+        let root_indices = self
+            .model
+            .model
+            .problem
+            .events
+            .scheduled_root_conditions
+            .iter()
+            .map(|root| root.root_index)
+            .collect::<Vec<_>>();
+        self.clear_scheduled_root_relation_memory(&root_indices)
+    }
+
+    fn clear_scheduled_root_relation_memory(
+        &mut self,
+        root_indices: &[usize],
+    ) -> Result<(), SimError> {
+        clear_scheduled_root_relation_memory(&self.model.model, root_indices, &mut self.params)
+            .map_err(runtime_contract_violation)
+    }
+
+    fn seed_scheduled_root_relation_overrides(
+        &mut self,
+        event_time: f64,
+        event: RuntimeEventStop,
+    ) -> Result<(), SimError> {
+        if event.observe_right_limit || !matches!(event.pre_mode, EventPreMode::EventEntry) {
+            return Ok(());
+        }
+        let scheduled_indices = self.scheduled_root_indices_at_time(event_time);
+        if scheduled_indices.is_empty() {
+            return Ok(());
+        }
+        for index in scheduled_indices {
+            self.pending_root_crossings.push(RootCrossing {
+                index,
+                post_relation_memory_value: 1.0,
+            });
+        }
+        Ok(())
+    }
+
+    fn scheduled_root_indices_at_time(&self, event_time: f64) -> Vec<usize> {
+        timeline::scheduled_root_indices_at_time(
+            &self.model.model.problem.events.scheduled_root_conditions,
+            event_time,
+        )
     }
 }
 

--- a/crates/rumoca-solver-rk45/src/tests.rs
+++ b/crates/rumoca-solver-rk45/src/tests.rs
@@ -441,6 +441,204 @@ fn rk45_applies_periodic_event_update() {
 }
 
 #[test]
+fn rk45_periodic_event_seeds_scheduled_sample_relation_memory() {
+    let mut model = single_state_model(vec![vec![
+        LinearOp::Const { dst: 0, value: 0.0 },
+        LinearOp::StoreOutput { src: 0 },
+    ]]);
+    model.problem.solve_layout.compiled_parameter_len = 3;
+    model.problem.solve_layout.discrete_valued_scalar_names = vec![
+        "sample_a".to_string(),
+        "sample_b".to_string(),
+        "m".to_string(),
+    ];
+    model.problem.solve_layout.relation_memory_parameter_indices = vec![0, 1];
+    model.problem.clocks.periodic_event_schedules = vec![
+        solve::PeriodicEventSchedule {
+            period_seconds: 0.05,
+            phase_seconds: 0.05,
+        },
+        solve::PeriodicEventSchedule {
+            period_seconds: 0.07,
+            phase_seconds: 0.07,
+        },
+    ];
+    model.problem.events.root_conditions = ScalarProgramBlock::with_source_span(
+        vec![
+            vec![
+                LinearOp::Const { dst: 0, value: 1.0 },
+                LinearOp::StoreOutput { src: 0 },
+            ],
+            vec![
+                LinearOp::Const { dst: 0, value: 1.0 },
+                LinearOp::StoreOutput { src: 0 },
+            ],
+        ],
+        fixture_span!(),
+    );
+    model.problem.events.root_relation_memory_targets =
+        vec![Some(solve::scalar_slot_p(0)), Some(solve::scalar_slot_p(1))];
+    model.problem.events.scheduled_root_conditions = vec![
+        solve::ScheduledRootCondition {
+            root_index: 0,
+            period_seconds: 0.05,
+            phase_seconds: 0.05,
+        },
+        solve::ScheduledRootCondition {
+            root_index: 1,
+            period_seconds: 0.07,
+            phase_seconds: 0.07,
+        },
+    ];
+    model.problem.discrete.update_targets = vec![solve::scalar_slot_p(2)];
+    model.problem.discrete.rhs = ScalarProgramBlock::with_source_span(
+        vec![vec![
+            LinearOp::LoadP { dst: 0, index: 0 },
+            LinearOp::Const {
+                dst: 1,
+                value: 10.0,
+            },
+            LinearOp::LoadP { dst: 2, index: 1 },
+            LinearOp::Binary {
+                dst: 3,
+                op: solve::BinaryOp::Mul,
+                lhs: 1,
+                rhs: 2,
+            },
+            LinearOp::Binary {
+                dst: 4,
+                op: solve::BinaryOp::Add,
+                lhs: 0,
+                rhs: 3,
+            },
+            LinearOp::StoreOutput { src: 4 },
+        ]],
+        fixture_span!(),
+    );
+    model.parameters = vec![0.0, 0.0, 0.0];
+    model.visible_names = vec![
+        "x".to_string(),
+        "sample_a".to_string(),
+        "sample_b".to_string(),
+        "m".to_string(),
+    ];
+
+    let result = simulate(
+        &model,
+        &SimOptions {
+            solver_mode: SimSolverMode::RkLike,
+            t_end: 0.06,
+            dt: Some(0.06),
+            ..Default::default()
+        },
+    )
+    .expect("rk45 should seed scheduled sample relation memory before event rows");
+
+    assert_eq!(result.data[3], vec![0.0, 1.0]);
+}
+
+#[test]
+fn rk45_clears_scheduled_sample_relation_memory_between_ticks() {
+    let mut model = single_state_model(vec![vec![
+        LinearOp::Const { dst: 0, value: 0.0 },
+        LinearOp::StoreOutput { src: 0 },
+    ]]);
+    model.problem.solve_layout.compiled_parameter_len = 4;
+    model.problem.solve_layout.discrete_valued_scalar_names = vec![
+        "__pre__.sample".to_string(),
+        "sample".to_string(),
+        "count".to_string(),
+        "__pre__.count".to_string(),
+    ];
+    model.problem.solve_layout.pre_param_bindings = vec![
+        solve::PreParamBinding {
+            dest_p_index: 0,
+            source: solve::PreParamSource::P { index: 1 },
+        },
+        solve::PreParamBinding {
+            dest_p_index: 3,
+            source: solve::PreParamSource::P { index: 2 },
+        },
+    ];
+    model.problem.clocks.periodic_event_schedules = vec![solve::PeriodicEventSchedule {
+        period_seconds: 0.05,
+        phase_seconds: 0.0,
+    }];
+    model.problem.events.root_conditions = ScalarProgramBlock::with_source_span(
+        vec![vec![
+            LinearOp::Const { dst: 0, value: 1.0 },
+            LinearOp::StoreOutput { src: 0 },
+        ]],
+        fixture_span!(),
+    );
+    model.problem.events.root_relation_memory_targets = vec![Some(solve::scalar_slot_p(1))];
+    model.problem.events.scheduled_root_conditions = vec![solve::ScheduledRootCondition {
+        root_index: 0,
+        period_seconds: 0.05,
+        phase_seconds: 0.0,
+    }];
+    model.problem.discrete.update_targets = vec![solve::scalar_slot_p(2)];
+    model.problem.discrete.pre_modes = vec![solve::DiscreteEventPreMode::Fixed];
+    model.problem.discrete.rhs = ScalarProgramBlock::with_source_span(
+        vec![vec![
+            LinearOp::LoadP { dst: 0, index: 1 },
+            LinearOp::LoadP { dst: 1, index: 0 },
+            LinearOp::Unary {
+                dst: 2,
+                op: solve::UnaryOp::Not,
+                arg: 1,
+            },
+            LinearOp::Binary {
+                dst: 3,
+                op: solve::BinaryOp::And,
+                lhs: 0,
+                rhs: 2,
+            },
+            LinearOp::LoadP { dst: 4, index: 3 },
+            LinearOp::Const { dst: 5, value: 1.0 },
+            LinearOp::Binary {
+                dst: 6,
+                op: solve::BinaryOp::Add,
+                lhs: 4,
+                rhs: 5,
+            },
+            LinearOp::Select {
+                dst: 7,
+                cond: 3,
+                if_true: 6,
+                if_false: 4,
+            },
+            LinearOp::StoreOutput { src: 7 },
+        ]],
+        fixture_span!(),
+    );
+    // Mimic a phase-zero sample that already fired during initialization:
+    // current sample memory is true and count has advanced once.
+    model.parameters = vec![0.0, 1.0, 1.0, 1.0];
+    model.visible_names = vec![
+        "x".to_string(),
+        "__pre__.sample".to_string(),
+        "sample".to_string(),
+        "count".to_string(),
+        "__pre__.count".to_string(),
+    ];
+
+    let result = simulate(
+        &model,
+        &SimOptions {
+            solver_mode: SimSolverMode::RkLike,
+            t_end: 0.11,
+            dt: Some(0.05),
+            ..Default::default()
+        },
+    )
+    .expect("rk45 should re-arm scheduled sample relation memory after each tick");
+
+    assert_eq!(result.times, vec![0.0, 0.05, 0.1, 0.11]);
+    assert_eq!(result.data[3], vec![1.0, 2.0, 3.0, 3.0]);
+}
+
+#[test]
 fn rk45_applies_dynamic_time_event_update() {
     let mut model = single_state_model(vec![vec![
         LinearOp::Const { dst: 0, value: 0.0 },

--- a/crates/rumoca-solver/src/lib.rs
+++ b/crates/rumoca-solver/src/lib.rs
@@ -22,7 +22,8 @@ pub use runtime::no_state::{
 };
 pub use runtime::orchestration::{LoopStats, run_with_runtime_schedule};
 pub use runtime::pre_params::{
-    commit_pre_params_after_event, update_slot, write_pre_params_from_sources,
+    clear_scheduled_root_relation_memory, commit_pre_params_after_event, update_slot,
+    write_pre_params_from_sources,
 };
 pub use runtime::projection::{
     AlgebraicProjectionModel, implicit_residual_is_zero,
@@ -41,10 +42,11 @@ pub use runtime::schedule::{
 pub use runtime::solve_ops::{
     EventActionOutcome, EventPreMode, EventPreSources, RootCrossing, RuntimeSolveError,
     build_sim_result_from_solve_model, convert_variable_meta, discrete_row_pre_mode,
-    event_eval_params_for_pre_mode, event_eval_params_for_row_pre_mode, first_root_crossing,
-    push_visible_values, relation_memory_value_from_root, replace_last_visible_values,
-    root_crossed, root_crossings, root_crossings_with_relation_memory, root_value_crossed,
-    row_reads_solver_or_time, update_relation_memory_slots,
+    event_eval_params_for_pre_mode, event_eval_params_for_row_pre_mode,
+    filter_scheduled_root_crossings, first_root_crossing, push_visible_values,
+    relation_memory_value_from_root, replace_last_visible_values, root_crossed, root_crossings,
+    root_crossings_with_relation_memory, root_value_crossed, row_reads_solver_or_time,
+    update_relation_memory_slots,
 };
 pub use runtime::tensor_policy::{
     LinearSolveKernel, MatMulKernel, TensorPolicyError, matrix_is_diagonal, matrix_nonzeros,

--- a/crates/rumoca-solver/src/runtime/pre_params.rs
+++ b/crates/rumoca-solver/src/runtime/pre_params.rs
@@ -32,6 +32,79 @@ pub fn commit_pre_params_after_event(
     write_pre_params_from_sources(model, y, &post_event_params, params, tol)
 }
 
+pub fn clear_scheduled_root_relation_memory(
+    model: &solve::SolveModel,
+    root_indices: &[usize],
+    params: &mut [f64],
+) -> Result<(), String> {
+    for &root_idx in root_indices {
+        let Some(Some(target)) = model
+            .problem
+            .events
+            .root_relation_memory_targets
+            .get(root_idx)
+            .copied()
+        else {
+            continue;
+        };
+        let solve::ScalarSlot::P { index, .. } = target else {
+            return Err(format!(
+                "scheduled sample root {root_idx} relation memory target is not a parameter slot"
+            ));
+        };
+        clear_param_slot(
+            params,
+            index,
+            format_args!(
+                "scheduled sample root {root_idx} relation memory parameter index {index}"
+            ),
+        )?;
+        clear_pre_params_from_source_p(model, params, root_idx, index)?;
+    }
+    Ok(())
+}
+
+fn clear_pre_params_from_source_p(
+    model: &solve::SolveModel,
+    params: &mut [f64],
+    root_idx: usize,
+    source_index: usize,
+) -> Result<(), String> {
+    let dest_indices: Vec<_> = model
+        .problem
+        .solve_layout
+        .pre_param_bindings
+        .iter()
+        .filter_map(|binding| match binding.source {
+            solve::PreParamSource::P { index } if index == source_index => {
+                Some(binding.dest_p_index)
+            }
+            _ => None,
+        })
+        .collect();
+    for dest_index in dest_indices {
+        clear_param_slot(
+            params,
+            dest_index,
+            format_args!("scheduled sample root {root_idx} pre parameter index {dest_index}"),
+        )?;
+    }
+    Ok(())
+}
+
+fn clear_param_slot(
+    params: &mut [f64],
+    index: usize,
+    label: std::fmt::Arguments<'_>,
+) -> Result<(), String> {
+    let param_len = params.len();
+    let Some(slot) = params.get_mut(index) else {
+        return Err(format!("{label} is outside {param_len} parameters"));
+    };
+    *slot = 0.0;
+    Ok(())
+}
+
 pub fn update_slot(slot: &mut f64, value: f64, tol: f64) -> bool {
     let changed = (*slot - value).abs() > tol;
     *slot = value;

--- a/crates/rumoca-solver/src/runtime/schedule.rs
+++ b/crates/rumoca-solver/src/runtime/schedule.rs
@@ -238,4 +238,25 @@ mod tests {
         assert!((stop - 0.1).abs() <= 1.0e-15);
         assert_eq!(mode, Some(EventPreMode::EventEntry));
     }
+
+    #[test]
+    fn solve_stop_schedule_includes_clock_event_at_horizon() {
+        let mut problem = solve::SolveProblem::default();
+        problem
+            .clocks
+            .periodic_event_schedules
+            .push(solve::PeriodicEventSchedule {
+                period_seconds: 0.05,
+                phase_seconds: 0.0,
+            });
+        let mut schedule = SolveStopSchedule::new(&problem, 0.0, 0.1);
+
+        let (first_stop, first_mode) = schedule.next_stop(0.0, 0.05);
+        let (horizon_stop, horizon_mode) = schedule.next_stop(0.05, 0.1);
+
+        assert!((first_stop - 0.05).abs() <= 1.0e-15);
+        assert_eq!(first_mode, Some(EventPreMode::EventEntry));
+        assert!((horizon_stop - 0.1).abs() <= 1.0e-15);
+        assert_eq!(horizon_mode, Some(EventPreMode::EventEntry));
+    }
 }

--- a/crates/rumoca-solver/src/runtime/solve_ops.rs
+++ b/crates/rumoca-solver/src/runtime/solve_ops.rs
@@ -2,6 +2,7 @@ use rumoca_ir_solve as solve;
 
 use crate::{
     SimResult, SimTermination, SimVariableMeta, runtime::pre_params::write_pre_params_from_sources,
+    timeline,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -277,17 +278,34 @@ pub fn root_crossings_with_relation_memory(
         .filter_map(|(index, (old, new))| {
             let target = root_relation_memory_targets.get(index).copied().flatten();
             if target.is_some() {
-                if let Some(crossing) = relation_memory_root_crossing(index, *new, target, params) {
-                    return Some(crossing);
+                if let Some(crossing) = signed_root_crossing(index, *old, *new, tol) {
+                    return relation_memory_target_toggled(
+                        crossing.post_relation_memory_value,
+                        target,
+                        params,
+                    )
+                    .then_some(crossing);
                 }
                 if relation_memory_value_from_signed_root(*new).is_some() {
                     return None;
                 }
-                return signed_root_crossing(index, *old, *new, tol);
+                return None;
             }
             root_crossing(index, *old, *new, tol)
         })
         .collect()
+}
+
+pub fn filter_scheduled_root_crossings(
+    crossings: &mut Vec<RootCrossing>,
+    scheduled_roots: &[solve::ScheduledRootCondition],
+) {
+    if scheduled_roots.is_empty() {
+        return;
+    }
+    crossings.retain(|crossing| {
+        !timeline::scheduled_root_index_is_known(scheduled_roots, crossing.index)
+    });
 }
 
 pub fn root_value_crossed(before: f64, after: f64, tol: f64) -> bool {
@@ -330,24 +348,21 @@ fn boolean_relation_value(value: f64, tol: f64) -> bool {
     value.abs() <= tol || (value - 1.0).abs() <= tol
 }
 
-fn relation_memory_root_crossing(
-    index: usize,
-    new: f64,
+fn relation_memory_target_toggled(
+    post: f64,
     target: Option<solve::ScalarSlot>,
     params: &[f64],
-) -> Option<RootCrossing> {
+) -> bool {
     let Some(solve::ScalarSlot::P {
         index: param_idx, ..
     }) = target
     else {
-        return None;
+        return false;
     };
-    let current = *params.get(param_idx)?;
-    let post = relation_memory_value_from_signed_root(new)?;
-    relation_toggled(current, post).then_some(RootCrossing {
-        index,
-        post_relation_memory_value: post,
-    })
+    let Some(current) = params.get(param_idx).copied() else {
+        return false;
+    };
+    relation_toggled(current, post)
 }
 
 fn relation_memory_value_from_signed_root(root: f64) -> Option<f64> {
@@ -433,6 +448,29 @@ mod tests {
         assert_eq!(
             root_crossings_with_relation_memory(&[0.0], &[0.1], 1.0e-6, &targets, &[0.0]),
             Vec::new()
+        );
+    }
+
+    #[test]
+    fn relation_memory_same_side_stale_value_does_not_request_bisection() {
+        let targets = [Some(solve::scalar_slot_p(0))];
+
+        assert_eq!(
+            root_crossings_with_relation_memory(&[1.0], &[1.0], 1.0e-6, &targets, &[1.0]),
+            Vec::new()
+        );
+    }
+
+    #[test]
+    fn relation_memory_signed_root_crossing_requests_bisection_when_post_value_changes() {
+        let targets = [Some(solve::scalar_slot_p(0))];
+
+        assert_eq!(
+            root_crossings_with_relation_memory(&[1.0], &[-1.0], 1.0e-6, &targets, &[0.0]),
+            vec![RootCrossing {
+                index: 0,
+                post_relation_memory_value: 1.0
+            }]
         );
     }
 

--- a/crates/rumoca-solver/src/timeline.rs
+++ b/crates/rumoca-solver/src/timeline.rs
@@ -127,8 +127,7 @@ pub fn event_time_in_window(event_t: f64, current_t: f64, target_t: f64) -> bool
 pub fn scheduled_time_in_horizon(event_t: f64, t_start: f64, t_end: f64) -> bool {
     event_t.is_finite()
         && (event_t > t_start || sample_time_match_with_tol(event_t, t_start))
-        && event_t < t_end
-        && !sample_time_match_with_tol(event_t, t_end)
+        && (event_t < t_end || sample_time_match_with_tol(event_t, t_end))
 }
 
 pub fn periodic_schedule_matches_time(schedule: &solve::PeriodicEventSchedule, t: f64) -> bool {
@@ -139,6 +138,34 @@ pub fn periodic_schedule_matches_time(schedule: &solve::PeriodicEventSchedule, t
     }
     let ticks = (t - phase) / period;
     ticks >= 0.0 && sample_time_match_with_tol(ticks, ticks.round())
+}
+
+pub fn scheduled_root_matches_time(root: &solve::ScheduledRootCondition, t: f64) -> bool {
+    periodic_schedule_matches_time(
+        &solve::PeriodicEventSchedule {
+            period_seconds: root.period_seconds,
+            phase_seconds: root.phase_seconds,
+        },
+        t,
+    )
+}
+
+pub fn scheduled_root_indices_at_time(
+    roots: &[solve::ScheduledRootCondition],
+    t: f64,
+) -> Vec<usize> {
+    roots
+        .iter()
+        .filter(|root| scheduled_root_matches_time(root, t))
+        .map(|root| root.root_index)
+        .collect()
+}
+
+pub fn scheduled_root_index_is_known(
+    roots: &[solve::ScheduledRootCondition],
+    root_index: usize,
+) -> bool {
+    roots.iter().any(|root| root.root_index == root_index)
 }
 
 pub fn runtime_parameter_index(layout: &solve::SolveLayout, name: &str) -> Option<usize> {

--- a/crates/rumoca/tests/clocked_sample_regression.rs
+++ b/crates/rumoca/tests/clocked_sample_regression.rs
@@ -8,7 +8,7 @@ use rumoca_phase_flatten::flatten_ref;
 use rumoca_phase_instantiate::instantiate_model;
 use rumoca_phase_resolve::resolve;
 use rumoca_phase_typecheck::typecheck_instanced;
-use rumoca_sim::{SimOptions, simulate_dae};
+use rumoca_sim::{SimOptions, SimSolverMode, simulate_dae};
 
 const SAMPLE_TIME_SOURCE: &str = r#"
 model SampleTime
@@ -159,6 +159,36 @@ fn native_simulation_updates_condition_memory_after_clocked_sample_time() {
     assert!(
         (y[1] - 0.1).abs() <= 1.0e-12,
         "MLS §16.5.1 sample(time) should refresh before dependent if-expression projection at the first clock tick; got {}",
+        y[1]
+    );
+}
+
+#[test]
+fn rk_like_simulation_updates_condition_memory_after_clocked_sample_time() {
+    let compiled = rumoca::Compiler::new()
+        .model("SampleTime")
+        .compile_str(SAMPLE_TIME_SOURCE, "sample_time.mo")
+        .expect("clocked sample(time) model should compile");
+    let sim = simulate_dae(
+        &compiled.dae,
+        &SimOptions {
+            solver_mode: SimSolverMode::RkLike,
+            t_end: 0.2,
+            dt: Some(0.1),
+            ..SimOptions::default()
+        },
+    )
+    .expect("clocked sample(time) model should simulate with RK-like solver");
+
+    let y = trace_values(&sim, "ramp.y");
+    assert!(
+        (y[0] - 0.0).abs() <= 1.0e-12,
+        "RK-like condition memory should select the true branch at initialization; got {}",
+        y[0]
+    );
+    assert!(
+        (y[1] - 0.1).abs() <= 1.0e-12,
+        "RK-like sample(time) should refresh before dependent projection at the first clock tick; got {}",
         y[1]
     );
 }

--- a/crates/rumoca/tests/periodic_source_counter_regression.rs
+++ b/crates/rumoca/tests/periodic_source_counter_regression.rs
@@ -32,7 +32,7 @@
 //!   9. Indexed array thresholds keep structured subscript information through
 //!      DAE/Solve lowering instead of being treated as opaque names.
 
-use rumoca_sim::{SimOptions, simulate_dae};
+use rumoca_sim::{SimOptions, SimSolverMode, simulate_dae};
 
 const CONST_THRESHOLD_COUNTER: &str = r#"
 model ConstThresholdCounter
@@ -91,6 +91,16 @@ equation
     count = pre(count) + 1;
   end when;
 end SampleCounter;
+"#;
+
+const ZERO_PHASE_SAMPLE_COUNTER: &str = r#"
+model ZeroPhaseSampleCounter
+  discrete Integer count(start = 0, fixed = true);
+equation
+  when sample(0.0, 0.1) then
+    count = pre(count) + 1;
+  end when;
+end ZeroPhaseSampleCounter;
 "#;
 
 const VECTOR_SELF_RESCHEDULING_COUNTER: &str = r#"
@@ -566,6 +576,68 @@ fn sample_when_accumulator_advances_once_per_tick() {
             (actual - expected).abs() <= 1.0e-9,
             "count at t={t} should be {expected}, got {actual} \
              (sample(start, interval) must fire once per tick)"
+        );
+    }
+}
+
+#[test]
+fn rk_like_sample_when_accumulator_advances_once_per_tick() {
+    let compiled = rumoca::Compiler::new()
+        .model("SampleCounter")
+        .compile_str(SAMPLE_COUNTER, "sample_counter.mo")
+        .expect("model should compile");
+    let sim = simulate_dae(
+        &compiled.dae,
+        &SimOptions {
+            solver_mode: SimSolverMode::RkLike,
+            t_end: 0.36,
+            dt: Some(0.02),
+            ..SimOptions::default()
+        },
+    )
+    .expect("model should simulate with RK-like solver");
+
+    let checks = [(0.05, 0.0), (0.15, 1.0), (0.25, 2.0), (0.35, 3.0)];
+    for (t, expected) in checks {
+        let actual = value_at(&sim, "count", t);
+        assert!(
+            (actual - expected).abs() <= 1.0e-9,
+            "RK-like count at t={t} should be {expected}, got {actual} \
+             (scheduled sample condition memory must clear between ticks)"
+        );
+    }
+}
+
+#[test]
+fn rk_like_zero_phase_sample_when_accumulator_advances_after_initial_tick() {
+    let compiled = rumoca::Compiler::new()
+        .model("ZeroPhaseSampleCounter")
+        .compile_str(ZERO_PHASE_SAMPLE_COUNTER, "zero_phase_sample_counter.mo")
+        .expect("model should compile");
+    let sim = simulate_dae(
+        &compiled.dae,
+        &SimOptions {
+            solver_mode: SimSolverMode::RkLike,
+            t_end: 0.36,
+            dt: Some(0.02),
+            ..SimOptions::default()
+        },
+    )
+    .expect("model should simulate with RK-like solver");
+
+    let checks = [
+        (0.00, 1.0),
+        (0.05, 1.0),
+        (0.15, 2.0),
+        (0.25, 3.0),
+        (0.35, 4.0),
+    ];
+    for (t, expected) in checks {
+        let actual = value_at(&sim, "count", t);
+        assert!(
+            (actual - expected).abs() <= 1.0e-9,
+            "RK-like zero-phase count at t={t} should be {expected}, got {actual} \
+             (sample(0, interval) must re-arm after the initialization tick)"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Fixes RK-like scheduled sample event handling so periodic sample roots are activated only by their matching clock schedule instead of being treated as ordinary bisection roots.
- Moves scheduled sample root ownership into DAE runtime metadata, carries it through Solve-IR, and shares runtime filtering/clearing helpers in `rumoca-solver`.
- Addresses SPEC_0007, SPEC_0022 SIM-001/SIM-008 and CLK-007/CLK-018, SPEC_0029, and SPEC_0032 for scheduled sample event semantics.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0007, SPEC_0021, SPEC_0022, SPEC_0025, SPEC_0029, SPEC_0032.
- Relevant MLS section(s), if semantics changed: MLS section 16.5.1 / section 16.3 for periodic `sample(start, interval)` clock ticks; MLS Appendix B / section 8.6 for event iteration and discrete variable stability.
- Crate/phase owner: `rumoca-phase-dae` owns scheduled root metadata; `rumoca-phase-solve` copies it into Solve-IR; `rumoca-solver` owns shared runtime schedule/pre-param policy; `rumoca-solver-rk45` consumes the shared policy.

## Risk and Design Notes

- Main correctness risk: matching scheduled roots to the wrong periodic tick could suppress or over-fire sample guarded updates.
- Main maintenance risk: the DAE and Solve schema bump adds public metadata that downstream serialized payload consumers must handle.
- Why the change belongs in these crate(s): DAE runtime precompute is the first owning layer for sample schedule metadata; Solve-IR is the backend-neutral carrier; shared solver runtime helpers own schedule matching and relation-memory clearing; RK45 only applies backend-local state changes.
- Any new abstraction, public API, or migration path: adds `DaeScheduledRootCondition` / `ScheduledRootCondition`, `scheduled_root_conditions` fields, shared scheduled-root timeline helpers, and shared relation-memory clearing. DAE schema version is now 6; Solve schema version is now 15.

## Testing

- Key command(s) run (fmt, clippy, workspace test, doc):
  - `git diff --check`
  - `cargo fmt --check`
  - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  - `cargo test --workspace`
  - `cargo doc --no-deps`
  - `cargo test -p rumoca-phase-dae runtime_precompute -- --nocapture`
  - `cargo test -p rumoca-phase-solve lower_root_conditions_marks_schedule_backed_sample_roots -- --nocapture`
  - `cargo test -p rumoca-solver`
  - `cargo test -p rumoca-solver-rk45`
  - `cargo test -p rumoca --test clocked_sample_regression`
  - `cargo test -p rumoca --test periodic_source_counter_regression`
  - `cargo test -p rumoca-eval-solve -p rumoca-phase-codegen`
  - `cargo test -p rumoca-ir-dae -p rumoca-ir-solve -p rumoca-solver -p rumoca-solver-rk45`
- Behavior or regression covered: DAE records schedule-backed sample roots; Solve lowering preserves scheduled-root metadata; RK45 seeds only matching scheduled roots, clears sample relation memory between ticks, includes horizon clock events, and RK-like simulations advance sample counters once per tick including zero-phase clocks.
- Commands NOT run and why: full release MSL gate and ModelicaTest semantic gate were not run locally due local runtime cost; this PR relies on focused scheduled-sample regressions plus full workspace fmt/clippy/test/doc locally.
- For compiler/simulator changes: did you run the MSL gate (`cargo test --release --package rumoca-test-msl --features msl-full-test --test msl_tests balance_pipeline::balance_pipeline_core::test_msl_all -- --nocapture`) and confirm no regression vs the resolved `msl_quality_baseline.json`? No, not run locally; should be covered by CI or run before merge.

## Code Size Budget (required)

- production_lines_added: 541
- production_lines_deleted: 42
- test_lines_added: 401
- test_lines_deleted: 4
- public_items_added: 16
- public_items_removed: 0
- files_touched: 24
- net_added_lines: 896

If `net_added_lines` is positive, add:

- Why this net growth is required: the fix adds explicit DAE/Solve schema metadata, shared runtime policy helpers, and regression coverage for scheduled sample roots rather than relying on backend-local expression rediscovery.
- Which code was removed/merged as part of the first compression pass: removed the Solve-lowering expression scan for schedule-backed sample roots and moved RK45-specific scheduled-root filtering/clearing policy into shared `rumoca-solver` helpers.
- Follow-up cleanup ticket/commit for remaining growth (if any): none filed; remaining growth is primarily schema surface and focused regression coverage.

## Reviewer Checklist

- [ ] Relevant active specs were checked.
- [ ] MLS-sensitive changes cite the right MLS section.
- [ ] Crate boundaries and phase ownership preserved (SPEC_0029).
- [ ] Tests prove behavior or explain the remaining gap.
- [ ] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [ ] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [ ] Size-budget section completed.
- [ ] Positive net diff has explicit compression justification.
- [ ] New APIs are required and minimal.
- [ ] Old/new parallel paths removed unless explicitly migrating.
- [ ] No `#[allow(clippy::...)]` added outside generated code.
- [ ] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [ ] External material (if any) attributed and Apache-2.0 compatible.
