### PR TITLE
Serialize template runtime test linking

### DIFF
--- a/crates/xtask/src/verify_cmd.rs
+++ b/crates/xtask/src/verify_cmd.rs
@@ -599,6 +599,8 @@ fn run_template_runtime_checks(root: &Path) -> Result<()> {
     let mut cmd = Command::new("cargo");
     cmd.arg("test")
         .arg("--verbose")
+        .arg("--jobs")
+        .arg("1")
         .arg("-p")
         .arg("rumoca")
         .arg("--features")


### PR DESCRIPTION
## Summary

Serializes the `cargo xtask verify template-runtimes` Rust compile/link step by passing `--jobs 1` to the underlying `cargo test` command.

Root cause: the latest `main` CI failure in `Template Runtime Tests` showed multiple heavyweight test binaries hitting linker `Bus error` failures within the same Cargo invocation. The tests themselves were not failing; the hosted runner was failing during concurrent link work.

## Spec / MLS Alignment

Relevant specs checked:
- `SPEC_0032_DEVELOPMENT_PROCESS.md`
- `SPEC_0025_PR_REVIEW_PROCESS.md`
- `SPEC_0021_CODE_COMPLEXITY.md`

Owner: `xtask` verification orchestration. No Modelica language semantics or MLS behavior changes.

## Risk and Design Notes

Correctness risk is low: this only changes build scheduling for the template-runtime verification command. The underlying Cargo-native test selection remains unchanged.

Maintenance risk is low: the change is a direct Cargo flag in the existing `xtask` wrapper and avoids adding new CI-specific script logic.

## Testing

- `cargo fmt --check`
- `cargo test -p xtask`
- `cargo test --verbose --jobs 1 -p rumoca --features template-runtime-tests --test symforce_template_regression --no-run`

Not run: full `cargo xtask verify template-runtimes`, because it requires the full Python/Julia runtime dependency path and was not needed to validate the linker-concurrency fix locally.

## Code Size Budget

```text
production_lines_added: 2
production_lines_deleted: 0
test_lines_added: 0
test_lines_deleted: 0
public_items_added: 0
public_items_removed: 0
files_touched: 1
net_added_lines: 2
```

Net-positive rationale: this is the minimal direct flag needed to serialize the CI-facing Cargo invocation. Compression plan: no new abstraction or follow-up cleanup is warranted for a two-line orchestration fix.