### PR TITLE
Split template runtime CI by backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,6 +392,8 @@ jobs:
     name: Template Runtime Tests
     runs-on: ubuntu-24.04
     env:
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
       JULIA_DEPOT_PATH: "${{ github.workspace }}/target/julia-depot:"
       JULIA_PKG_PRECOMPILE_AUTO: '0'
       JULIA_PROJECT: ${{ github.workspace }}/infra/julia
@@ -417,6 +419,27 @@ jobs:
           shared-key: template-runtime
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-targets: false
+
+      - name: Reclaim runner disk before template runtimes
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "== disk before cleanup =="
+          df -h . / /tmp /home/runner/actions-runner/cached 2>/dev/null || true
+          du -sh target target/debug ~/.cargo ~/.rustup /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /home/runner/actions-runner/cached/_diag 2>/dev/null || true
+
+          rm -rf target/debug/deps target/debug/build target/debug/incremental target/debug/.fingerprint
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+
+          echo "== disk after cleanup =="
+          df -h . / /tmp /home/runner/actions-runner/cached 2>/dev/null || true
+          du -sh target target/debug ~/.cargo ~/.rustup /home/runner/actions-runner/cached/_diag 2>/dev/null || true
 
       - name: Julia template runtime cache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,8 +389,32 @@ jobs:
         run: cargo xtask verify binaries
 
   template-runtime-tests:
-    name: Template Runtime Tests
+    name: Template Runtime (${{ matrix.backend }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: render
+            nix_shell: ci-template-core
+          - backend: native
+            nix_shell: ci-template-core
+          - backend: embedded-c
+            nix_shell: ci-template-core
+          - backend: fmi
+            nix_shell: ci-template-core
+          - backend: casadi
+            nix_shell: ci-template-python
+          - backend: sympy
+            nix_shell: ci-template-python
+          - backend: symforce
+            nix_shell: ci-template-python
+          - backend: onnx
+            nix_shell: ci-template-python
+          - backend: jax
+            nix_shell: ci-template-python
+          - backend: julia
+            nix_shell: ci-template-julia
     env:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
@@ -442,6 +466,7 @@ jobs:
           du -sh target target/debug ~/.cargo ~/.rustup /home/runner/actions-runner/cached/_diag 2>/dev/null || true
 
       - name: Julia template runtime cache
+        if: matrix.backend == 'julia'
         uses: actions/cache@v4
         with:
           path: target/julia-depot
@@ -450,29 +475,48 @@ jobs:
             ${{ runner.os }}-julia-template-
 
       - name: Prepare Python template runtime dependencies
+        if: matrix.nix_shell == 'ci-template-python'
+        env:
+          TEMPLATE_BACKEND: ${{ matrix.backend }}
         run: |
-          nix develop --command bash <<'EOF'
+          nix develop .#${{ matrix.nix_shell }} --command bash <<'EOF'
           set -euo pipefail
-          python -m venv target/template-runtime-venv
-          . target/template-runtime-venv/bin/activate
+          venv="target/template-runtime-venv-${TEMPLATE_BACKEND}"
+          python -m venv "$venv"
+          . "$venv/bin/activate"
           python -m pip install --upgrade pip
-          python -m pip install -r infra/python/core-requirements.txt
-          python - <<'PY'
-          import casadi
-          import diffrax
-          import jax
-          import numpy
-          import onnx
-          import onnxruntime
-          import symforce
-          import sympy
-          print("python template runtime deps ok")
-          PY
+          case "$TEMPLATE_BACKEND" in
+            casadi)
+              python -m pip install casadi==3.7.2 numpy==2.4.3
+              python -c 'import casadi, numpy; print("casadi template deps ok")'
+              ;;
+            sympy)
+              python -m pip install sympy==1.14.0
+              python -c 'import sympy; print("sympy template deps ok")'
+              ;;
+            symforce)
+              python -m pip install numpy==2.4.3 scipy==1.17.1 symforce==0.11.0 sympy==1.14.0
+              python -c 'import symforce; print("symforce template deps ok")'
+              ;;
+            onnx)
+              python -m pip install numpy==2.4.3 onnx==1.20.1 onnxruntime==1.24.3
+              python -c 'import numpy, onnx, onnxruntime; print("onnx template deps ok")'
+              ;;
+            jax)
+              python -m pip install diffrax==0.7.2 jax==0.9.2 numpy==2.4.3 scipy==1.17.1
+              python -c 'import diffrax, jax, numpy; print("jax template deps ok")'
+              ;;
+            *)
+              echo "::error::unexpected Python template backend: $TEMPLATE_BACKEND"
+              exit 1
+              ;;
+          esac
           EOF
 
       - name: Prepare Julia template runtime dependencies
+        if: matrix.backend == 'julia'
         run: |
-          nix develop --command bash <<'EOF'
+          nix develop .#${{ matrix.nix_shell }} --command bash <<'EOF'
           set -euo pipefail
           julia --project=infra/julia <<'JL'
           using Pkg
@@ -483,13 +527,18 @@ jobs:
           EOF
 
       - name: Run template runtime checks
+        env:
+          TEMPLATE_BACKEND: ${{ matrix.backend }}
         run: |
-          nix develop --command bash <<'EOF'
+          nix develop .#${{ matrix.nix_shell }} --command bash <<'EOF'
           set -euo pipefail
           mkdir -p target/template-runtimes
           touch target/template-runtimes/strict
-          . target/template-runtime-venv/bin/activate
-          cargo xtask verify template-runtimes
+          venv="target/template-runtime-venv-${TEMPLATE_BACKEND}"
+          if [ -d "$venv" ]; then
+            . "$venv/bin/activate"
+          fi
+          cargo xtask verify template-runtimes --backend "$TEMPLATE_BACKEND"
           EOF
 
   editor-msl-smoke:

--- a/crates/xtask/src/main_tests.rs
+++ b/crates/xtask/src/main_tests.rs
@@ -11,7 +11,7 @@ use crate::repo_cli_cmd::{
     shell_path_update_guidance, shell_profile_update, xtask_cli_launcher_contents,
     xtask_cli_launcher_path,
 };
-use crate::verify_cmd::VerifyCommand;
+use crate::verify_cmd::{TemplateRuntimeBackend, VerifyCommand};
 use clap::CommandFactory;
 use clap::Parser;
 use clap::error::ErrorKind;
@@ -131,7 +131,33 @@ fn cli_parses_verify_template_runtimes_job() {
     let cli = Cli::try_parse_from(["xtask", "verify", "template-runtimes"])
         .expect("parse verify template-runtimes");
     match cli.command {
-        Commands::Verify(args) => assert_eq!(args.command, VerifyCommand::TemplateRuntimes),
+        Commands::Verify(args) => match args.command {
+            VerifyCommand::TemplateRuntimes(args) => {
+                assert_eq!(args.backend, TemplateRuntimeBackend::All);
+            }
+            other => panic!("expected template runtimes command, got {other:?}"),
+        },
+        other => panic!("expected verify command, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_verify_template_runtimes_backend() {
+    let cli = Cli::try_parse_from([
+        "xtask",
+        "verify",
+        "template-runtimes",
+        "--backend",
+        "casadi",
+    ])
+    .expect("parse verify template-runtimes --backend casadi");
+    match cli.command {
+        Commands::Verify(args) => match args.command {
+            VerifyCommand::TemplateRuntimes(args) => {
+                assert_eq!(args.backend, TemplateRuntimeBackend::Casadi);
+            }
+            other => panic!("expected template runtimes command, got {other:?}"),
+        },
         other => panic!("expected verify command, got {other:?}"),
     }
 }

--- a/crates/xtask/src/verify_cmd.rs
+++ b/crates/xtask/src/verify_cmd.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result, ensure};
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 use std::ffi::OsStr;
 use std::fs;
@@ -54,6 +54,29 @@ pub(crate) struct VerifySuiteArgs {
     /// reporting an aggregate pass/fail summary at the end
     #[arg(long)]
     pub(crate) early_exit: bool,
+}
+
+#[derive(Debug, Args, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct VerifyTemplateRuntimeArgs {
+    /// Template backend group to verify. The default runs all backend groups.
+    #[arg(long, value_enum, default_value_t = TemplateRuntimeBackend::All)]
+    pub(crate) backend: TemplateRuntimeBackend,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
+pub(crate) enum TemplateRuntimeBackend {
+    #[default]
+    All,
+    Render,
+    Native,
+    EmbeddedC,
+    Fmi,
+    Casadi,
+    Sympy,
+    Symforce,
+    Onnx,
+    Jax,
+    Julia,
 }
 
 #[derive(Debug, Args, Clone, PartialEq, Eq, Default)]
@@ -298,7 +321,7 @@ pub(crate) enum VerifyCommand {
     /// Workspace tests that mirror the main test matrix
     Workspace(test_cmd::WorkspaceArgs),
     /// Environment-dependent example template runtime checks
-    TemplateRuntimes,
+    TemplateRuntimes(VerifyTemplateRuntimeArgs),
     /// Fetch example Modelica library caches and compile example models
     Examples,
     /// Real VS Code extension-host MSL smoke check
@@ -460,7 +483,7 @@ pub(crate) fn run(args: VerifyArgs, root: &Path) -> Result<()> {
     match args.command {
         VerifyCommand::Lint => run_lint_job(root),
         VerifyCommand::Workspace(args) => args.run(root),
-        VerifyCommand::TemplateRuntimes => run_template_runtime_checks(root),
+        VerifyCommand::TemplateRuntimes(args) => run_template_runtime_checks(root, args),
         VerifyCommand::Examples => run_examples_smoke(root),
         VerifyCommand::VscodeMsl(args) => run_vscode_editor_msl_smoke(root, args.install_prereqs),
         VerifyCommand::LspMslCompletionTimings(args) => {
@@ -593,9 +616,106 @@ fn run_flamegraph(model: &str, mode: &str, source_root: &Path) -> Result<()> {
     )
 }
 
-fn run_template_runtime_checks(root: &Path) -> Result<()> {
+#[derive(Debug, Clone, Copy)]
+struct TemplateRuntimeTestGroup {
+    backend: TemplateRuntimeBackend,
+    test: &'static str,
+    filters: &'static [&'static str],
+}
+
+const TEMPLATE_RUNTIME_GROUPS: &[TemplateRuntimeTestGroup] = &[
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Render,
+        test: "template_target_ci",
+        filters: &[],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Render,
+        test: "standalone_template_regression",
+        filters: &[],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Native,
+        test: "backend_template_runtime_regression",
+        filters: &["native_simulates"],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::EmbeddedC,
+        test: "backend_template_runtime_regression",
+        filters: &["embedded_c_"],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Fmi,
+        test: "backend_template_runtime_regression",
+        filters: &["fmi2_", "fmi3_"],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Casadi,
+        test: "backend_template_runtime_regression",
+        filters: &["casadi_"],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Sympy,
+        test: "sympy_template_regression",
+        filters: &[],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Sympy,
+        test: "backend_template_runtime_regression",
+        filters: &["sympy_"],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Symforce,
+        test: "symforce_template_regression",
+        filters: &[],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Onnx,
+        test: "backend_template_runtime_regression",
+        filters: &["onnx_"],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Jax,
+        test: "backend_template_runtime_regression",
+        filters: &["jax_"],
+    },
+    TemplateRuntimeTestGroup {
+        backend: TemplateRuntimeBackend::Julia,
+        test: "backend_template_runtime_regression",
+        filters: &["julia_"],
+    },
+];
+
+impl TemplateRuntimeTestGroup {
+    fn matches(self, backend: TemplateRuntimeBackend) -> bool {
+        backend == TemplateRuntimeBackend::All || self.backend == backend
+    }
+}
+
+fn run_template_runtime_checks(root: &Path, args: VerifyTemplateRuntimeArgs) -> Result<()> {
     trim_template_runtime_artifacts(root)?;
 
+    for group in TEMPLATE_RUNTIME_GROUPS
+        .iter()
+        .copied()
+        .filter(|group| group.matches(args.backend))
+    {
+        run_template_runtime_group(root, group)?;
+    }
+    trim_template_runtime_artifacts(root)
+}
+
+fn run_template_runtime_group(root: &Path, group: TemplateRuntimeTestGroup) -> Result<()> {
+    if group.filters.is_empty() {
+        return run_template_runtime_test(root, group.test, None);
+    }
+    for filter in group.filters {
+        run_template_runtime_test(root, group.test, Some(filter))?;
+    }
+    Ok(())
+}
+
+fn run_template_runtime_test(root: &Path, test: &str, filter: Option<&str>) -> Result<()> {
     let mut cmd = Command::new("cargo");
     cmd.arg("test")
         .arg("--verbose")
@@ -606,20 +726,12 @@ fn run_template_runtime_checks(root: &Path) -> Result<()> {
         .arg("--features")
         .arg("template-runtime-tests")
         .arg("--test")
-        .arg("template_target_ci")
-        .arg("--test")
-        .arg("standalone_template_regression")
-        .arg("--test")
-        .arg("sympy_template_regression")
-        .arg("--test")
-        .arg("symforce_template_regression")
-        .arg("--test")
-        .arg("backend_template_runtime_regression")
-        .arg("--")
-        .arg("--nocapture")
-        .current_dir(root);
-    run_status(cmd)?;
-    trim_template_runtime_artifacts(root)
+        .arg(test);
+    if let Some(filter) = filter {
+        cmd.arg(filter);
+    }
+    cmd.arg("--").arg("--nocapture").current_dir(root);
+    run_status(cmd)
 }
 
 fn trim_template_runtime_artifacts(root: &Path) -> Result<()> {

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,16 @@
             cp target/release/rumoca-msl-tools $out/bin/rumoca-msl-tools
           '';
         });
+        templateRuntimeShell = extraPackages: craneLib.devShell {
+          inputsFrom = [ rumoca ];
+          packages = extraPackages;
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.gfortran.cc.lib
+            pkgs.stdenv.cc.cc.lib
+            pkgs.zlib
+          ];
+        };
         # xtask itself is NOT built here: after the light-xtask split it carries no
         # compiler deps and compiles per-job in seconds, so build-once buys nothing.
         # The MSL merge and ModelicaTest jobs run reporting through the
@@ -164,5 +174,10 @@
             pkgs.zlib
           ];
         };
+        devShells.ci-template-core = templateRuntimeShell [];
+        devShells.ci-template-python = templateRuntimeShell [ ciPython ];
+        devShells.ci-template-julia = templateRuntimeShell (
+          pkgs.lib.optionals pkgs.stdenv.isLinux [ ciJulia ]
+        );
       });
 }


### PR DESCRIPTION
## Summary

Hardens template runtime CI against hosted-runner disk exhaustion by:

- splitting `Template Runtime Tests` into one matrix job per backend: `render`, `native`, `embedded-c`, `fmi`, `casadi`, `sympy`, `symforce`, `onnx`, `jax`, and `julia`
- using smaller backend-specific Nix dev shells so Python and Julia tooling are only present where needed
- installing only each Python backend's required packages instead of the full Python runtime stack
- keeping the earlier disk-headroom measures: Cargo debug info disabled for this heavy job, hosted-runner cleanup before runtime checks, and before/after disk snapshots
- adding `cargo xtask verify template-runtimes --backend <backend>` so CI and local validation can target one backend group

## Root Cause

The `main` push run for `85df9c6d` failed in `Template Runtime Tests` with the runner unable to append its diagnostic log due to `No space left on device` (`/home/runner/actions-runner/cached/2.335.1/_diag/Worker_20260709-190310-utc.log`). The preceding failure in the same job showed the template runtime link step dying under heavy disk/memory pressure while the job built every backend in one large environment.

Splitting the job by backend reduces per-job Nix closure, Python dependency, Julia cache, and Cargo test scope. The previous cleanup/debug-info changes remain as additional headroom.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml parses"'`
- `cargo fmt --check`
- `cargo test -p xtask cli_parses_verify_template_runtimes -- --nocapture`
- `cargo check -p xtask`
- `cargo run -p xtask --bin xtask -- verify template-runtimes --help`
- `cargo run -p xtask --bin xtask -- verify template-runtimes --backend native`
- `nix eval --raw .#devShells.x86_64-linux.ci-template-core.drvPath`
- `nix eval --raw .#devShells.x86_64-linux.ci-template-python.drvPath`
- `nix eval --raw .#devShells.x86_64-linux.ci-template-julia.drvPath`

Full backend coverage is intended to be validated by this PR's GitHub Actions matrix.
