### PR TITLE
Accelerate FMI generation and Solve IR execution

### DIFF
--- a/crates/rumoca-compile/src/codegen_api.rs
+++ b/crates/rumoca-compile/src/codegen_api.rs
@@ -22,15 +22,88 @@ pub fn dae_for_solve_template_context(dae_model: &dae::Dae) -> Result<dae::Dae, 
 pub fn dae_for_fmi_model_description_context(
     dae_model: &dae::Dae,
 ) -> Result<dae::Dae, CodegenError> {
-    let prepared = dae_for_solve_template_context(dae_model)?;
-    rumoca_phase_dae::prepare_dae_for_fmi_model_description(&prepared)
-        .map(|prepared| prepared.into_dae())
+    rumoca_phase_dae::project_dae_for_fmi_metadata(dae_model)
+        .map(|prepared| {
+            let mut prepared = prepared.into_dae();
+            retain_fmi_model_description_metadata(&mut prepared);
+            prepared
+        })
         .map_err(|err| {
             CodegenError::dae_preparation_failed(
                 format!("FMI modelDescription DAE preparation: {err}"),
                 err.source_span(),
             )
         })
+}
+
+fn retain_fmi_model_description_metadata(prepared: &mut dae::Dae) {
+    // modelDescription consumes variable attributes plus event/clock capability
+    // metadata. Numerical equations, function bodies, source ancestry, and
+    // runtime-only clock lookup tables make the generic DAE JSON much larger
+    // but cannot affect the XML document.
+    prepared.continuous.equations.clear();
+    prepared.continuous.structured_equations.clear();
+    prepared.initialization.equations.clear();
+    prepared.initialization.structured_equations.clear();
+    prepared.discrete.real_updates.clear();
+    prepared.discrete.valued_updates.clear();
+    prepared.conditions.equations.clear();
+    prepared.clocks.constructor_exprs.clear();
+    prepared.clocks.intervals.clear();
+    prepared.clocks.timings.clear();
+    prepared.symbols.functions.clear();
+    prepared.symbols.enum_literal_ordinals.clear();
+    prepared.metadata.variable_starts.clear();
+    prepared.metadata.symbol_ancestry.clear();
+}
+
+pub fn dae_for_fmi_implementation_context(dae_model: &dae::Dae) -> Result<dae::Dae, CodegenError> {
+    let mut prepared = rumoca_phase_dae::prepare_dae_for_fmi_model_description(dae_model)
+        .map(|prepared| prepared.into_dae())
+        .map_err(|err| {
+            CodegenError::dae_preparation_failed(
+                format!("FMI implementation default-value preparation: {err}"),
+                err.source_span(),
+            )
+        })?;
+    // FMI implementation kernels are rendered from fully lowered Solve IR,
+    // whose LinearOp programs cannot retain Modelica user-function calls. The
+    // attached DAE supplies only variable layout/defaults here. Preparing a
+    // second scalarized codegen DAE would clone the complete expression graph
+    // even though no DAE equation is part of the native kernel.
+    prepared.symbols.functions.clear();
+    prepared.symbols.enum_literal_ordinals.clear();
+    prepared.initialization.equations.clear();
+    prepared.initialization.structured_equations.clear();
+    prepared.discrete.real_updates.clear();
+    prepared.discrete.valued_updates.clear();
+    prepared.clocks.constructor_exprs.clear();
+    prepared.clocks.intervals.clear();
+    prepared.clocks.timings.clear();
+    prepared.metadata.variable_starts.clear();
+    Ok(prepared)
+}
+
+pub fn dae_for_fmi_native_implementation_context(
+    dae_model: &dae::Dae,
+) -> Result<dae::Dae, CodegenError> {
+    let mut prepared = rumoca_phase_dae::project_dae_for_fmi_metadata(dae_model)
+        .map(|prepared| prepared.into_dae())
+        .map_err(|err| {
+            CodegenError::dae_preparation_failed(
+                format!("FMI native implementation metadata preparation: {err}"),
+                err.source_span(),
+            )
+        })?;
+    // A complete native projection computes all algebraics from Solve IR. Keep
+    // variables and condition/event metadata, but do not serialize the unused
+    // continuous DAE equation graph into the C template context.
+    prepared.continuous.equations.clear();
+    prepared.continuous.structured_equations.clear();
+    prepared.clocks.constructor_exprs.clear();
+    prepared.clocks.intervals.clear();
+    prepared.clocks.timings.clear();
+    Ok(prepared)
 }
 
 pub fn render_dae_template(dae_model: &dae::Dae, template: &str) -> Result<String, CodegenError> {
@@ -76,7 +149,9 @@ pub fn render_ast_template_with_name(
     rumoca_phase_codegen::render_ast_template_with_name(ast_tree, template, model_name)
 }
 
-pub use rumoca_phase_codegen::{SolveTemplateRenderer, render_solve_template_with_name};
+pub use rumoca_phase_codegen::{
+    SolveTemplateRenderer, fmi3_native_projection_available, render_solve_template_with_name,
+};
 
 /// Built-in target metadata, re-exported from the codegen crate.
 pub mod templates {

--- a/crates/rumoca-compile/src/codegen_target.rs
+++ b/crates/rumoca-compile/src/codegen_target.rs
@@ -129,6 +129,7 @@ pub struct TargetFile {
 #[serde(rename_all = "kebab-case")]
 pub enum TargetFileRenderContext {
     FmiModelDescription,
+    FmiImplementation,
 }
 
 /// One consumer-declared checksum edge: "embed the producer `of`'s SHA-1
@@ -1109,6 +1110,28 @@ render_context = "fmi-model-description"
         assert_eq!(
             manifest.files[0].render_context,
             Some(TargetFileRenderContext::FmiModelDescription)
+        );
+    }
+
+    #[test]
+    fn target_manifest_parses_fmi_implementation_render_context() {
+        let manifest = super::parse_target_manifest(
+            r#"
+version = 1
+ir = "solve"
+name = "custom"
+
+[[files]]
+path = "sources/model.c"
+template = "model.c.jinja"
+render_context = "fmi-implementation"
+"#,
+        )
+        .expect("parse target manifest with FMI implementation context");
+
+        assert_eq!(
+            manifest.files[0].render_context,
+            Some(TargetFileRenderContext::FmiImplementation)
         );
     }
 

--- a/crates/rumoca-compile/src/lib.rs
+++ b/crates/rumoca-compile/src/lib.rs
@@ -136,11 +136,12 @@ pub mod workspace {
 pub mod codegen {
     pub use crate::codegen_api::templates;
     pub use crate::codegen_api::{
-        CodegenError, SolveTemplateRenderer, dae_for_fmi_model_description_context,
-        dae_for_solve_template_context, dae_to_template_json, render_ast_template_with_name,
-        render_dae_template, render_dae_template_with_json, render_dae_template_with_json_and_name,
-        render_dae_template_with_name, render_flat_template_with_name,
-        render_solve_template_with_name,
+        CodegenError, SolveTemplateRenderer, dae_for_fmi_implementation_context,
+        dae_for_fmi_model_description_context, dae_for_fmi_native_implementation_context,
+        dae_for_solve_template_context, dae_to_template_json, fmi3_native_projection_available,
+        render_ast_template_with_name, render_dae_template, render_dae_template_with_json,
+        render_dae_template_with_json_and_name, render_dae_template_with_name,
+        render_flat_template_with_name, render_solve_template_with_name,
     };
     pub mod targets {
         pub use crate::codegen_target::{

--- a/crates/rumoca-eval-dae/src/eval/array_helpers.rs
+++ b/crates/rumoca-eval-dae/src/eval/array_helpers.rs
@@ -166,7 +166,7 @@ pub(super) fn array_values_from_env_name_generic<T: SimFloat>(
 ) -> Result<Option<Vec<T>>, EvalError> {
     if let Some(dims) = env.dims.get(name) {
         let scalar_count = dims.iter().map(|&d| d.max(0) as usize).product::<usize>();
-        if scalar_count > 1 {
+        if scalar_count > 0 {
             if let Some(values) = collect_dense_shaped_values_generic(name, dims, scalar_count, env)
             {
                 return Ok(Some(values));
@@ -178,6 +178,15 @@ pub(super) fn array_values_from_env_name_generic<T: SimFloat>(
                 collect_dense_record_field_indexed_values_generic(name, scalar_count, env)
             {
                 return Ok(Some(values));
+            }
+            if env.vars.parent_namespace_is_hidden(name) {
+                let keys = cached_indexed_keys(&env.runtime, name, scalar_count);
+                let missing = keys
+                    .iter()
+                    .find(|key| env.vars.get(key.as_str()).is_none())
+                    .map(|key| key.as_str().to_string())
+                    .unwrap_or_else(|| name.to_string());
+                return Err(EvalError::MissingBinding { name: missing });
             }
         }
         if scalar_count == 0
@@ -199,7 +208,7 @@ pub(super) fn array_values_from_env_name_generic<T: SimFloat>(
 
     if let Some(dims) = env.dims.get(name)
         && !dims.is_empty()
-        && let Some(start_expr) = env.start_exprs.get(name)
+        && let Some(start_expr) = env.visible_start_expr(name)
         && !matches!(start_expr, Expression::VarRef { name: start_name, .. } if start_name.as_str() == name)
     {
         let values = if dims.len() >= 2 {
@@ -214,6 +223,10 @@ pub(super) fn array_values_from_env_name_generic<T: SimFloat>(
         if values.len() > 1 {
             return Ok(Some(values));
         }
+    }
+
+    if env.vars.local_scalar_shadows_parent_namespace(name) {
+        return Ok(None);
     }
 
     Ok(collect_indexed_array_values_generic(name, env)

--- a/crates/rumoca-eval-dae/src/eval/eval_expr_impl.rs
+++ b/crates/rumoca-eval-dae/src/eval/eval_expr_impl.rs
@@ -671,10 +671,8 @@ fn copy_selected_input_fields_for_validation<T: SimFloat>(
     let src_prefix = format!("{arg_path}.");
     let dst_prefix = format!("{input_name}.");
     let mut copied = false;
-    for (key, value) in &env.vars {
-        let Some(suffix) = key.strip_prefix(&src_prefix) else {
-            continue;
-        };
+    for (key, value) in env.vars.entries_with_prefix(&src_prefix) {
+        let suffix = &key[src_prefix.len()..];
         local_env.set(&format!("{dst_prefix}{suffix}"), *value);
         copied = true;
     }
@@ -975,6 +973,12 @@ pub(in crate::eval) fn validate_array_argument<T: SimFloat>(
             if args.len() == 1 && builtin_accepts_array_argument(*function) =>
         {
             validate_array_argument(&args[0], env)
+        }
+        // A subscripted reference may still be array-valued when a range or
+        // colon selects a slice. Validate it through the array evaluator instead
+        // of recursively treating the range expression as a scalar subscript.
+        rumoca_core::Expression::VarRef { subscripts, .. } if !subscripts.is_empty() => {
+            eval_array_values(expr, env).map(|_| ())
         }
         rumoca_core::Expression::VarRef {
             name, subscripts, ..
@@ -1323,6 +1327,17 @@ pub(super) fn try_eval_field_access_path<T: SimFloat>(
         } => {
             if subscripts.is_empty() {
                 Ok(Some(name.as_str().to_string()))
+            } else if subscripts.iter().any(|subscript| {
+                matches!(subscript, rumoca_core::Subscript::Colon { .. })
+                    || matches!(
+                        subscript,
+                        rumoca_core::Subscript::Expr { expr, .. }
+                            if matches!(expr.as_ref(), rumoca_core::Expression::Range { .. })
+                    )
+            }) {
+                // A range/colon denotes an array slice, not one scalar binding
+                // path. Let the caller fall back to array-value evaluation.
+                Ok(None)
             } else {
                 let indices = eval_subscript_indices(subscripts, env)?;
                 Ok(Some(dae::format_subscript_key(name.as_str(), &indices)))

--- a/crates/rumoca-eval-dae/src/eval/mod.rs
+++ b/crates/rumoca-eval-dae/src/eval/mod.rs
@@ -337,6 +337,7 @@ impl<T> Clone for VarScope<T> {
 struct VarScopeFrame<T> {
     local: IndexMap<String, T>,
     parent: Option<VarScope<T>>,
+    hidden_parent_namespaces: HashSet<String>,
 }
 
 pub struct VarScopeIter<'a, T> {
@@ -357,6 +358,7 @@ impl<T> Default for VarScope<T> {
             frame: Arc::new(VarScopeFrame {
                 local: IndexMap::new(),
                 parent: None,
+                hidden_parent_namespaces: HashSet::new(),
             }),
         }
     }
@@ -372,16 +374,21 @@ impl<T> VarScope<T> {
             frame: Arc::new(VarScopeFrame {
                 local: IndexMap::new(),
                 parent: Some(parent.clone()),
+                hidden_parent_namespaces: HashSet::new(),
             }),
         }
     }
 
     pub fn get(&self, name: &str) -> Option<&T> {
         self.frame.local.get(name).or_else(|| {
-            self.frame
-                .parent
-                .as_ref()
-                .and_then(|parent| parent.get(name))
+            (!self.parent_namespace_is_hidden(name))
+                .then(|| {
+                    self.frame
+                        .parent
+                        .as_ref()
+                        .and_then(|parent| parent.get(name))
+                })
+                .flatten()
         })
     }
 
@@ -415,6 +422,60 @@ impl<T> VarScope<T> {
         self.frame.local.iter()
     }
 
+    /// Visible entries whose names begin with `prefix`, in the same stable order and
+    /// with the same child-frame shadowing semantics as [`Self::iter`].
+    ///
+    /// Record argument binding commonly needs only a handful of fields from a scope
+    /// containing hundreds of unrelated model variables. Filtering each frame before
+    /// building the shadow-position map avoids hashing and materializing that entire
+    /// scope for every nested function call.
+    pub(crate) fn entries_with_prefix(&self, prefix: &str) -> Vec<(&String, &T)> {
+        let mut entries = Vec::new();
+        let mut positions = FxHashMap::default();
+        self.collect_entries_with_prefix(prefix, &mut entries, &mut positions);
+        entries
+    }
+
+    /// Whether a scalar in this frame hides array or record entries in a caller frame.
+    pub(crate) fn local_scalar_shadows_parent_namespace(&self, name: &str) -> bool {
+        if self.frame.parent.is_none() || !self.frame.local.contains_key(name) {
+            return false;
+        }
+
+        !self.frame.local.keys().any(|key| {
+            key.strip_prefix(name)
+                .is_some_and(|suffix| suffix.starts_with('[') || suffix.starts_with('.'))
+        })
+    }
+
+    pub(crate) fn parent_namespace_is_hidden(&self, name: &str) -> bool {
+        if self.frame.hidden_parent_namespaces.contains(name) {
+            return true;
+        }
+        name.char_indices().any(|(index, separator)| {
+            matches!(separator, '[' | '.')
+                && self.frame.hidden_parent_namespaces.contains(&name[..index])
+        })
+    }
+
+    fn remove_hidden_parent_entries<'a>(
+        &self,
+        entries: &mut Vec<(&'a String, &'a T)>,
+        positions: &mut FxHashMap<&'a str, usize>,
+    ) {
+        if self.frame.hidden_parent_namespaces.is_empty() {
+            return;
+        }
+        entries.retain(|(name, _)| !self.parent_namespace_is_hidden(name));
+        positions.clear();
+        positions.extend(
+            entries
+                .iter()
+                .enumerate()
+                .map(|(index, (name, _))| (name.as_str(), index)),
+        );
+    }
+
     fn ordered_entries(&self) -> Vec<(&String, &T)> {
         if self.frame.parent.is_none() {
             return self.frame.local.iter().collect();
@@ -432,8 +493,32 @@ impl<T> VarScope<T> {
     ) {
         if let Some(parent) = &self.frame.parent {
             parent.collect_ordered_entries(entries, positions);
+            self.remove_hidden_parent_entries(entries, positions);
         }
         for (name, value) in &self.frame.local {
+            if let Some(index) = positions.get(name.as_str()).copied() {
+                entries[index] = (name, value);
+            } else {
+                positions.insert(name.as_str(), entries.len());
+                entries.push((name, value));
+            }
+        }
+    }
+
+    fn collect_entries_with_prefix<'a>(
+        &'a self,
+        prefix: &str,
+        entries: &mut Vec<(&'a String, &'a T)>,
+        positions: &mut FxHashMap<&'a str, usize>,
+    ) {
+        if let Some(parent) = &self.frame.parent {
+            parent.collect_entries_with_prefix(prefix, entries, positions);
+            self.remove_hidden_parent_entries(entries, positions);
+        }
+        for (name, value) in &self.frame.local {
+            if !name.starts_with(prefix) {
+                continue;
+            }
             if let Some(index) = positions.get(name.as_str()).copied() {
                 entries[index] = (name, value);
             } else {
@@ -445,6 +530,12 @@ impl<T> VarScope<T> {
 }
 
 impl<T: Clone> VarScope<T> {
+    pub(crate) fn hide_parent_namespace(&mut self, name: &str) {
+        Arc::make_mut(&mut self.frame)
+            .hidden_parent_namespaces
+            .insert(name.to_string());
+    }
+
     pub fn insert(&mut self, name: String, value: T) -> Option<T> {
         Arc::make_mut(&mut self.frame).local.insert(name, value)
     }
@@ -563,6 +654,12 @@ impl<T: SimFloat> Default for VarEnv<T> {
 impl<T: SimFloat> VarEnv<T> {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub(crate) fn visible_start_expr(&self, name: &str) -> Option<&rumoca_core::Expression> {
+        (!self.vars.parent_namespace_is_hidden(name))
+            .then(|| self.start_exprs.get(name))
+            .flatten()
     }
 
     pub fn with_isolated_runtime(mut self) -> Self {
@@ -687,7 +784,7 @@ pub(super) fn previous_start_or_default<T: SimFloat>(
         return Ok(T::zero());
     };
 
-    if let Some(start) = env.start_exprs.get(name.as_str()) {
+    if let Some(start) = env.visible_start_expr(name.as_str()) {
         if !subscripts.is_empty() {
             let span = expression_source_span(arg)
                 .or_else(|| expression_source_span(start))
@@ -1179,8 +1276,7 @@ fn start_expr_is_nonnumeric_inner(
             if env.enum_literal_ordinals.contains_key(key) || !visited.insert(key.to_string()) {
                 return false;
             }
-            env.start_exprs
-                .get(key)
+            env.visible_start_expr(key)
                 .is_some_and(|start| start_expr_is_nonnumeric_inner(start, env, visited))
         }
         rumoca_core::Expression::VarRef { .. } | rumoca_core::Expression::Empty { .. } => false,

--- a/crates/rumoca-eval-dae/src/eval/special.rs
+++ b/crates/rumoca-eval-dae/src/eval/special.rs
@@ -201,12 +201,21 @@ fn try_enter_function_recursion_for(
     })
 }
 
-fn build_local_function_env<T: SimFloat>(env: &VarEnv<T>) -> VarEnv<T> {
+fn build_local_function_env<T: SimFloat>(
+    env: &VarEnv<T>,
+    inputs: &[FunctionParam],
+    outputs: &[FunctionParam],
+    locals: &[FunctionParam],
+) -> VarEnv<T> {
     let mut local_env = VarEnv::<T>::new();
     local_env.vars = crate::eval::VarScope::child_of(&env.vars);
+    for param in inputs.iter().chain(outputs).chain(locals) {
+        local_env.vars.hide_parent_namespace(&param.name);
+    }
     local_env.runtime = env.runtime.clone();
     local_env.functions = env.functions.clone();
-    local_env.dims = env.dims.clone();
+    // Function dimensions are lexical; the caller's local shapes must not leak
+    // into identically named inputs, outputs, or locals in this call frame.
     local_env.start_exprs = env.start_exprs.clone();
     local_env.clock_intervals = env.clock_intervals.clone();
     local_env.enum_literal_ordinals = env.enum_literal_ordinals.clone();
@@ -688,7 +697,7 @@ fn eval_user_function_call<T: SimFloat>(
     trace_function_call_summary(trace_call, name.var_name(), &resolved_name, &summary);
     trace_function_call_body_once(trace_call, &resolved_name, &body);
 
-    let mut local_env = build_local_function_env(env);
+    let mut local_env = build_local_function_env(env, &inputs, &outputs, &locals);
     seed_static_function_scope_dims(&mut local_env, &inputs, &outputs, &locals);
     // Bind arguments/defaults and execute the body under the call-stack context
     // so selected function calls (`*.re` / `*.im`) propagate correctly.
@@ -956,7 +965,7 @@ fn eval_user_function_local_env<T: SimFloat>(
         });
     };
 
-    let mut local_env = build_local_function_env(env);
+    let mut local_env = build_local_function_env(env, &inputs, &outputs, &locals);
     seed_static_function_scope_dims(&mut local_env, &inputs, &outputs, &locals);
     let trace_call = function_trace_match_enabled(name.as_str(), resolved_name.as_str());
     trace_function_call_summary(
@@ -1018,7 +1027,7 @@ pub fn eval_user_function_array_output_pub<T: SimFloat>(
         });
     };
 
-    let mut local_env = build_local_function_env(env);
+    let mut local_env = build_local_function_env(env, &inputs, &outputs, &locals);
     seed_static_function_scope_dims(&mut local_env, &inputs, &outputs, &locals);
     let complex_component = selection
         .as_ref()
@@ -1066,7 +1075,8 @@ pub fn resolve_user_function_output_dims_pub<T: SimFloat>(
         return Ok(None);
     }
 
-    let mut local_env = build_local_function_env(env);
+    let mut local_env =
+        build_local_function_env(env, &function.inputs, &function.outputs, &function.locals);
     seed_static_function_scope_dims(
         &mut local_env,
         &function.inputs,
@@ -1172,10 +1182,9 @@ fn selected_input_fields<T: SimFloat>(
     dst_prefix: &str,
 ) -> Vec<(String, T)> {
     let mut selected = Vec::new();
-    for (key, value) in &env.vars {
-        if let Some(suffix) = key.strip_prefix(src_prefix) {
-            selected.push((format!("{dst_prefix}{suffix}"), *value));
-        }
+    for (key, value) in env.vars.entries_with_prefix(src_prefix) {
+        let suffix = &key[src_prefix.len()..];
+        selected.push((format!("{dst_prefix}{suffix}"), *value));
     }
     selected
 }

--- a/crates/rumoca-eval-dae/src/eval/special/input_binding.rs
+++ b/crates/rumoca-eval-dae/src/eval/special/input_binding.rs
@@ -30,10 +30,17 @@ pub(super) fn bind_user_function_inputs<T: SimFloat>(
             if copy_record_constructor_input_fields(local_env, param, arg_expr, caller_env)? {
                 continue;
             }
-            if let Ok(value) = eval_expr::<T>(arg_expr, caller_env) {
+            let scalar_bound = if let Ok(value) = eval_expr::<T>(arg_expr, caller_env) {
                 bind_function_scalar_input(local_env, function_name, &param.name, value);
-            }
-            if let Some(arg_path) = try_eval_field_access_path(arg_expr, caller_env)? {
+                true
+            } else {
+                false
+            };
+            let may_need_record_fields = param.type_class == Some(rumoca_core::ClassType::Record)
+                || (!scalar_bound && param.dims.is_empty() && param.shape_expr.is_empty());
+            if may_need_record_fields
+                && let Some(arg_path) = try_eval_field_access_path(arg_expr, caller_env)?
+            {
                 copy_selected_input_fields(local_env, &param.name, &arg_path, caller_env)?;
             }
             let _ = copy_record_function_output_fields(local_env, param, arg_expr, caller_env)?;

--- a/crates/rumoca-eval-dae/src/eval/table_eval.rs
+++ b/crates/rumoca-eval-dae/src/eval/table_eval.rs
@@ -33,8 +33,7 @@ pub(super) fn eval_table_matrix_arg<T: SimFloat>(
         } if subscripts.is_empty() => {
             let Some(flat_values) = array_values_from_env_name(name.as_str(), env)? else {
                 return Ok(env
-                    .start_exprs
-                    .get(name.as_str())
+                    .visible_start_expr(name.as_str())
                     .map(|start_expr| eval_table_matrix_arg(start_expr, env))
                     .transpose()?
                     .flatten());
@@ -87,7 +86,7 @@ fn table_matrix_from_flat_values<T: SimFloat>(
         return Ok(start_matrix);
     }
     if flat_values.is_empty() {
-        if let Some(start_expr) = env.start_exprs.get(name)
+        if let Some(start_expr) = env.visible_start_expr(name)
             && let Some(start_matrix) = eval_table_matrix_arg(start_expr, env)?
         {
             return Ok(start_matrix);
@@ -107,7 +106,7 @@ fn richer_table_start_matrix<T: SimFloat>(
     flat_len: usize,
     env: &VarEnv<T>,
 ) -> Result<Option<Vec<Vec<f64>>>, EvalError> {
-    let Some(start_expr) = env.start_exprs.get(name) else {
+    let Some(start_expr) = env.visible_start_expr(name) else {
         return Ok(None);
     };
     if matches!(start_expr, rumoca_core::Expression::VarRef { name: start_name, .. } if start_name.as_str() == name)

--- a/crates/rumoca-eval-dae/src/eval/tests/mod.rs
+++ b/crates/rumoca-eval-dae/src/eval/tests/mod.rs
@@ -124,6 +124,54 @@ fn var_scope_child_falls_through_and_shadows_without_parent_copy() {
     assert_eq!(entries, vec![("a", 1.0), ("b", 20.0), ("c", 3.0)]);
 }
 
+#[test]
+fn var_scope_hidden_namespace_never_falls_through_to_parent_components() {
+    let mut parent = VarScope::new();
+    parent.insert("p".to_string(), 10.0);
+    parent.insert("p[1]".to_string(), 11.0);
+    parent.insert("p.field".to_string(), 12.0);
+    parent.insert("preserved".to_string(), 13.0);
+
+    let mut child = VarScope::child_of(&parent);
+    child.hide_parent_namespace("p");
+    child.insert("p[1]".to_string(), 21.0);
+
+    assert_eq!(child.get("p"), None);
+    assert_eq!(child.get("p[1]"), Some(&21.0));
+    assert_eq!(child.get("p.field"), None);
+    assert_eq!(child.get("preserved"), Some(&13.0));
+    assert_eq!(
+        child
+            .iter()
+            .map(|(name, value)| (name.as_str(), *value))
+            .collect::<Vec<_>>(),
+        vec![("preserved", 13.0), ("p[1]", 21.0)]
+    );
+}
+
+#[test]
+fn var_scope_prefix_entries_filter_before_preserving_child_shadowing() {
+    let mut parent = VarScope::new();
+    parent.insert("state.position.x".to_string(), 1.0);
+    parent.insert("unrelated".to_string(), 99.0);
+    parent.insert("state.position.y".to_string(), 2.0);
+
+    let mut child = VarScope::child_of(&parent);
+    child.insert("state.position.x".to_string(), 10.0);
+    child.insert("state.velocity.x".to_string(), 3.0);
+    child.insert("alsoUnrelated".to_string(), 100.0);
+
+    let entries = child
+        .entries_with_prefix("state.position.")
+        .into_iter()
+        .map(|(name, value)| (name.as_str(), *value))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        entries,
+        vec![("state.position.x", 10.0), ("state.position.y", 2.0)]
+    );
+}
+
 fn var(name: &str) -> rumoca_core::Expression {
     rumoca_core::Expression::VarRef {
         name: rumoca_core::Reference::new(name),
@@ -953,6 +1001,115 @@ fn range_subscript(start: i64, end: i64) -> rumoca_core::Subscript {
         }),
         rumoca_core::Span::DUMMY,
     )
+}
+
+#[test]
+fn scalar_function_local_shadows_caller_array_dimensions() {
+    let mut env = VarEnv::<f64>::new();
+    env.dims = Arc::new(IndexMap::from([
+        ("B".to_string(), vec![2, 2]),
+        ("rotation".to_string(), vec![3]),
+    ]));
+    set_array_entries(&mut env, "B", &[2, 2], &[0.0, 1.0, 0.0, 0.0]);
+    set_array_entries(&mut env, "rotation", &[3], &[1.0, 2.0, 3.0]);
+
+    let mut exp_map = Function::new("Pkg.expMap", rumoca_core::Span::DUMMY);
+    exp_map.add_input(
+        FunctionParam::new("v", "Real", rumoca_core::Span::source_free_serde_default())
+            .with_dims(vec![3]),
+    );
+    exp_map.add_output(
+        FunctionParam::new("q", "Real", rumoca_core::Span::source_free_serde_default())
+            .with_dims(vec![4]),
+    );
+    exp_map.locals.push(FunctionParam::new(
+        "B",
+        "Real",
+        rumoca_core::Span::source_free_serde_default(),
+    ));
+    exp_map.body = vec![
+        Statement::Assignment {
+            comp: comp_ref("B"),
+            value: lit(0.5),
+            span: rumoca_core::Span::DUMMY,
+        },
+        Statement::Assignment {
+            comp: comp_ref("q"),
+            value: arr(vec![var("B"), lit(1.0), lit(2.0), lit(3.0)], false),
+            span: rumoca_core::Span::DUMMY,
+        },
+    ];
+    env.functions = Arc::new(IndexMap::from([("Pkg.expMap".to_string(), exp_map)]));
+
+    let expression = fn_call("Pkg.expMap", vec![var("rotation")]);
+
+    assert_eq!(
+        eval_array_values::<f64>(&expression, &env),
+        Ok(vec![0.5, 1.0, 2.0, 3.0])
+    );
+}
+
+#[test]
+fn incomplete_function_local_array_never_falls_through_to_caller_array() {
+    let mut env = VarEnv::<f64>::new();
+    env.dims = Arc::new(IndexMap::from([("p".to_string(), vec![4])]));
+    set_array_entries(&mut env, "p", &[4], &[10.0, 20.0, 30.0, 40.0]);
+
+    let mut function = Function::new("Pkg.incomplete", rumoca_core::Span::DUMMY);
+    function.add_input(
+        FunctionParam::new("u", "Real", rumoca_core::Span::source_free_serde_default())
+            .with_dims(vec![3]),
+    );
+    function.add_output(
+        FunctionParam::new("r", "Real", rumoca_core::Span::source_free_serde_default())
+            .with_dims(vec![4]),
+    );
+    function.locals.push(
+        FunctionParam::new("p", "Real", rumoca_core::Span::source_free_serde_default())
+            .with_dims(vec![4]),
+    );
+    function.body = vec![
+        Statement::Assignment {
+            comp: comp_ref_index("p", 1),
+            value: indexed_var("u", &[1]),
+            span: rumoca_core::Span::DUMMY,
+        },
+        Statement::Assignment {
+            comp: comp_ref_index("p", 2),
+            value: indexed_var("u", &[2]),
+            span: rumoca_core::Span::DUMMY,
+        },
+        Statement::Assignment {
+            comp: comp_ref_index("p", 3),
+            value: indexed_var("u", &[3]),
+            span: rumoca_core::Span::DUMMY,
+        },
+        Statement::Assignment {
+            comp: comp_ref("r"),
+            value: Expression::VarRef {
+                name: Reference::new("p"),
+                subscripts: vec![Subscript::generated_colon(rumoca_core::Span::DUMMY)],
+                span: rumoca_core::Span::DUMMY,
+            },
+            span: rumoca_core::Span::DUMMY,
+        },
+    ];
+    env.functions = Arc::new(IndexMap::from([("Pkg.incomplete".to_string(), function)]));
+
+    let result = eval_array_values::<f64>(
+        &fn_call(
+            "Pkg.incomplete",
+            vec![arr(vec![lit(1.0), lit(2.0), lit(3.0)], false)],
+        ),
+        &env,
+    );
+    assert_eq!(
+        result
+            .as_ref()
+            .err()
+            .and_then(EvalError::missing_binding_name),
+        Some("p[4]")
+    );
 }
 
 #[test]

--- a/crates/rumoca-eval-dae/src/eval/tests/strict_eval_contract.rs
+++ b/crates/rumoca-eval-dae/src/eval/tests/strict_eval_contract.rs
@@ -76,6 +76,52 @@ fn production_statement_eval_does_not_call_default_evaluator() {
     );
 }
 
+#[test]
+fn array_argument_validation_accepts_range_slice_var_ref() {
+    let mut env = VarEnv::<f64>::new();
+    env.dims = Arc::new(IndexMap::from([("v".to_string(), vec![6])]));
+    set_array_entries(&mut env, "v", &[6], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let slice = rumoca_core::Expression::VarRef {
+        name: rumoca_core::Reference::new("v"),
+        subscripts: vec![rumoca_core::Subscript::expr(
+            Box::new(rumoca_core::Expression::Range {
+                start: Box::new(int_lit(2)),
+                step: None,
+                end: Box::new(int_lit(4)),
+                span: rumoca_core::Span::DUMMY,
+            }),
+            rumoca_core::Span::DUMMY,
+        )],
+        span: rumoca_core::Span::DUMMY,
+    };
+
+    validate_array_argument(&slice, &env).expect("range slice should be a valid array argument");
+    assert_eq!(eval_array_values(&slice, &env), Ok(vec![2.0, 3.0, 4.0]));
+
+    let mut sum_slice = Function::new("Pkg.sumSlice", rumoca_core::Span::DUMMY);
+    sum_slice.add_input(
+        FunctionParam::new("x", "Real", rumoca_core::Span::source_free_serde_default())
+            .with_dims(vec![3]),
+    );
+    sum_slice.add_output(
+        FunctionParam::new("y", "Real", rumoca_core::Span::source_free_serde_default())
+            .with_default(rumoca_core::Expression::BuiltinCall {
+                function: BuiltinFunction::Sum,
+                args: vec![var("x")],
+                span: rumoca_core::Span::DUMMY,
+            }),
+    );
+    sum_slice.body = vec![Statement::Empty {
+        span: rumoca_core::Span::DUMMY,
+    }];
+    env.functions = Arc::new(IndexMap::from([("Pkg.sumSlice".to_string(), sum_slice)]));
+
+    assert_eq!(
+        eval_expr::<f64>(&fn_call("Pkg.sumSlice", vec![slice]), &env),
+        Ok(9.0)
+    );
+}
+
 fn default_zero_match_count(source: &str) -> usize {
     let patterns = [
         "T::zero()",

--- a/crates/rumoca-eval-dae/src/statement.rs
+++ b/crates/rumoca-eval-dae/src/statement.rs
@@ -322,10 +322,11 @@ fn materialize_record_alias_assignment<T: SimFloat>(
     let target_prefix = format!("{target}.");
     let selected = env
         .vars
-        .iter()
-        .filter_map(|(key, value)| {
-            key.strip_prefix(source_prefix.as_str())
-                .map(|suffix| (format!("{target_prefix}{suffix}"), *value))
+        .entries_with_prefix(&source_prefix)
+        .into_iter()
+        .map(|(key, value)| {
+            let suffix = &key[source_prefix.len()..];
+            (format!("{target_prefix}{suffix}"), *value)
         })
         .collect::<Vec<_>>();
     if selected.is_empty() {

--- a/crates/rumoca-eval-solve/src/runtime.rs
+++ b/crates/rumoca-eval-solve/src/runtime.rs
@@ -118,7 +118,7 @@ impl SolveRuntime {
         trace_refresh_plan(model, "derivative", &derivative_refresh);
         trace_refresh_plan(model, "root", &root_refresh);
         let visible_value_plan = visible_value_plan(model);
-        let root_condition_plan = root_condition_plan(model);
+        let root_condition_plan = root_condition_plan(model, &root_refresh);
         Ok(Self {
             model: model.clone(),
             state_count: model.state_scalar_count(),

--- a/crates/rumoca-eval-solve/src/runtime/plans.rs
+++ b/crates/rumoca-eval-solve/src/runtime/plans.rs
@@ -1,6 +1,8 @@
 use rumoca_ir_solve as solve;
 use rumoca_solver::RuntimeSolveError;
+use std::collections::BTreeSet;
 
+use crate::refresh_plan::RefreshPlan;
 use crate::{self as solve_eval, RowEvalContext};
 
 #[derive(Clone, Copy)]
@@ -102,7 +104,10 @@ pub(super) fn visible_value_plan(model: &solve::SolveModel) -> Option<VisibleVal
     })
 }
 
-pub(super) fn root_condition_plan(model: &solve::SolveModel) -> Option<RootConditionPlan> {
+pub(super) fn root_condition_plan(
+    model: &solve::SolveModel,
+    root_refresh: &RefreshPlan,
+) -> Option<RootConditionPlan> {
     let roots = &model.problem.events.root_conditions;
     if roots.row_count() != roots.output_count() || !roots.uses_local_contiguous_output_indices() {
         return None;
@@ -110,6 +115,7 @@ pub(super) fn root_condition_plan(model: &solve::SolveModel) -> Option<RootCondi
     let mut entries = Vec::with_capacity(roots.row_count());
     let mut evaluated_rows = Vec::new();
     let mut search_rows = Vec::new();
+    let static_y = parameter_static_refresh_targets(root_refresh, model.state_scalar_count());
     for (row_idx, row) in roots.programs.iter().enumerate() {
         if solve::ScalarProgramBlock::program_output_count(row) != 1 {
             return None;
@@ -123,7 +129,7 @@ pub(super) fn root_condition_plan(model: &solve::SolveModel) -> Option<RootCondi
             entries.push(RootConditionPlanEntry::ConstantNonZero(value));
             continue;
         }
-        if parameter_static_root(row) {
+        if parameter_static_root(row, &static_y) {
             entries.push(RootConditionPlanEntry::StaticParameter);
             evaluated_rows.push(row_idx);
             continue;
@@ -223,8 +229,53 @@ fn constant_root_op_allowed(op: &solve::LinearOp) -> bool {
     )
 }
 
-fn parameter_static_root(row: &[solve::LinearOp]) -> bool {
-    row.iter().all(parameter_static_root_op_allowed)
+fn parameter_static_root(row: &[solve::LinearOp], static_y: &BTreeSet<usize>) -> bool {
+    row.iter().all(|op| match op {
+        solve::LinearOp::LoadY { index, .. } => static_y.contains(index),
+        _ => parameter_static_root_op_allowed(op),
+    })
+}
+
+fn parameter_static_refresh_targets(plan: &RefreshPlan, state_count: usize) -> BTreeSet<usize> {
+    let mut static_targets = BTreeSet::new();
+    loop {
+        let mut changed = false;
+        for refresh_row in &plan.rows {
+            if static_targets.contains(&refresh_row.target_index) {
+                continue;
+            }
+            let Some(row) = plan.source_block.programs.get(refresh_row.row_idx) else {
+                continue;
+            };
+            if parameter_static_refresh_row(
+                row,
+                refresh_row.target_index,
+                state_count,
+                &static_targets,
+            ) {
+                static_targets.insert(refresh_row.target_index);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    static_targets
+}
+
+fn parameter_static_refresh_row(
+    row: &[solve::LinearOp],
+    target_index: usize,
+    state_count: usize,
+    static_targets: &BTreeSet<usize>,
+) -> bool {
+    row.iter().all(|op| match op {
+        solve::LinearOp::LoadY { index, .. } => {
+            *index == target_index || (*index >= state_count && static_targets.contains(index))
+        }
+        _ => parameter_static_root_op_allowed(op),
+    })
 }
 
 fn parameter_static_root_op_allowed(op: &solve::LinearOp) -> bool {
@@ -232,6 +283,7 @@ fn parameter_static_root_op_allowed(op: &solve::LinearOp) -> bool {
         op,
         solve::LinearOp::Const { .. }
             | solve::LinearOp::LoadP { .. }
+            | solve::LinearOp::LoadIndexedP { .. }
             | solve::LinearOp::Move { .. }
             | solve::LinearOp::Unary { .. }
             | solve::LinearOp::Binary { .. }

--- a/crates/rumoca-eval-solve/src/runtime/tests.rs
+++ b/crates/rumoca-eval-solve/src/runtime/tests.rs
@@ -613,6 +613,7 @@ fn root_condition_plan_keeps_full_values_but_neutralizes_search_roots() {
                         constant_expression_root_row(),
                         param_minus_time_root_row(0),
                         direct_param_visible_value_row(1),
+                        indexed_param_root_row(),
                         time_plus_one_root_row(),
                     ],
                     "root_plan.mo",
@@ -630,19 +631,96 @@ fn root_condition_plan_keeps_full_values_but_neutralizes_search_roots() {
         .as_ref()
         .expect("root condition plan should build");
 
-    assert_eq!(plan.evaluated_rows, vec![2, 3]);
-    assert_eq!(plan.search_rows, vec![3]);
+    assert_eq!(plan.evaluated_rows, vec![2, 3, 4]);
+    assert_eq!(plan.search_rows, vec![4]);
 
     let full = runtime
         .eval_root_conditions_from_solver_y(1.0, &[], &model.parameters)
         .expect("full root values should evaluate");
-    assert_eq!(full, vec![5.0, 1.5, 9.0, 2.0]);
+    assert_eq!(full, vec![5.0, 1.5, 9.0, 9.0, 2.0]);
 
-    let mut search = vec![0.0; 4];
+    let mut search = vec![0.0; 5];
     runtime
         .eval_root_search_conditions_into(1.0, &[], &model.parameters, 1.0e-12, 1, &mut search)
         .expect("search root values should evaluate");
-    assert_eq!(search, vec![1.0, 1.0, 1.0, 2.0]);
+    assert_eq!(search, vec![1.0, 1.0, 1.0, 1.0, 2.0]);
+}
+
+#[test]
+fn root_condition_plan_neutralizes_parameter_static_algebraic_outputs() {
+    let model = algebraic_output_root_model(assignment_residual_row());
+    let runtime = SolveRuntime::new(&model).expect("valid runtime should prepare");
+    let plan = runtime
+        .root_condition_plan
+        .as_ref()
+        .expect("root condition plan should build");
+
+    assert_eq!(plan.evaluated_rows, vec![0]);
+    assert!(plan.search_rows.is_empty());
+
+    let full = runtime
+        .eval_root_conditions_from_solver_y(0.0, &[0.0, 2.0], &[])
+        .expect("full root value should evaluate");
+    assert_eq!(full, vec![2.0]);
+
+    let mut search = vec![0.0];
+    runtime
+        .eval_root_search_conditions_into(0.0, &[0.0], &[], 1.0e-12, 1, &mut search)
+        .expect("search root value should evaluate");
+    assert_eq!(search, vec![1.0]);
+}
+
+#[test]
+fn root_condition_plan_keeps_state_dependent_algebraic_outputs_dynamic() {
+    let model = algebraic_output_root_model(add_assignment_residual_row(1, 0, 1.0));
+    let runtime = SolveRuntime::new(&model).expect("valid runtime should prepare");
+    let plan = runtime
+        .root_condition_plan
+        .as_ref()
+        .expect("root condition plan should build");
+
+    assert_eq!(plan.evaluated_rows, vec![0]);
+    assert_eq!(plan.search_rows, vec![0]);
+
+    let mut search = vec![0.0];
+    runtime
+        .eval_root_search_conditions_into(0.0, &[3.0], &[], 1.0e-12, 1, &mut search)
+        .expect("search root value should evaluate");
+    assert_eq!(search, vec![4.0]);
+}
+
+fn algebraic_output_root_model(implicit_row: Vec<solve::LinearOp>) -> solve::SolveModel {
+    solve::SolveModel {
+        problem: solve::SolveProblem {
+            solve_layout: solve::SolveLayout {
+                solver_maps: solve::SolverNameIndexMaps {
+                    names: vec!["state".to_string(), "output".to_string()],
+                    ..Default::default()
+                },
+                state_scalar_count: 1,
+                algebraic_scalar_count: 1,
+                ..Default::default()
+            },
+            continuous: solve::ContinuousSolveSystem {
+                implicit_rhs: solve::ComputeBlock::from_scalar_program_block(spanned_block(
+                    vec![derivative_placeholder_row(0), implicit_row],
+                    "algebraic_output_root.mo",
+                )),
+                implicit_row_targets: vec![None, Some(solve::scalar_slot_y(1))],
+                ..Default::default()
+            },
+            events: solve::SolveEventPartition {
+                root_conditions: spanned_block(
+                    vec![direct_y_visible_value_row(1)],
+                    "algebraic_output_root.mo",
+                ),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        initial_y: vec![0.0, 2.0],
+        ..Default::default()
+    }
 }
 
 #[test]
@@ -879,6 +957,19 @@ fn direct_param_visible_value_row(index: usize) -> Vec<solve::LinearOp> {
     vec![
         solve::LinearOp::LoadP { dst: 0, index },
         solve::LinearOp::StoreOutput { src: 0 },
+    ]
+}
+
+fn indexed_param_root_row() -> Vec<solve::LinearOp> {
+    vec![
+        solve::LinearOp::Const { dst: 0, value: 1.0 },
+        solve::LinearOp::LoadIndexedP {
+            dst: 1,
+            base: 0,
+            count: 2,
+            index: 0,
+        },
+        solve::LinearOp::StoreOutput { src: 1 },
     ]
 }
 

--- a/crates/rumoca-phase-codegen/src/codegen/codegen_tests.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/codegen_tests.rs
@@ -998,6 +998,18 @@ fn test_fmi3_scalar_blt_projection_renders_from_solve_ir() {
             causal_steps: Vec::new(),
         }],
     };
+    assert!(fmi3_native_projection_available(&problem).unwrap());
+    let mut unsupported_problem = problem.clone();
+    unsupported_problem
+        .continuous
+        .algebraic_projection_plan
+        .blocks[0]
+        .causal_steps
+        .push(solve::AlgebraicProjectionStep { row: 1, y_index: 1 });
+    assert!(!fmi3_native_projection_available(&unsupported_problem).unwrap());
+    let mut incomplete_problem = problem.clone();
+    incomplete_problem.solve_layout.algebraic_scalar_count = 2;
+    assert!(!fmi3_native_projection_available(&incomplete_problem).unwrap());
     let object = dae_json.as_object_mut().unwrap();
     object.insert("__ir_kind".to_string(), serde_json::json!("solve"));
     object.insert("solve".to_string(), serde_json::to_value(problem).unwrap());
@@ -1011,11 +1023,28 @@ fn test_fmi3_scalar_blt_projection_renders_from_solve_ir() {
 
     assert!(!rendered.contains("static double __rumoca_implicit_row"));
     assert!(rendered.contains("const int y_index = 1;"), "{rendered}");
+    assert!(rendered.contains("const double __r2 ="), "{rendered}");
     assert!(rendered.contains("const double value = 2.0;"), "{rendered}");
     assert!(rendered.contains("__rumoca_solve_set_y(m, y_index, value)"));
     assert!(
         rendered.contains("The Solve-IR projection writes the algebraic and output Y segments")
     );
+
+    assert_fmi3_projection_fallbacks(&dae_json);
+}
+
+fn assert_fmi3_projection_fallbacks(dae_json: &serde_json::Value) {
+    let mut incomplete = dae_json.clone();
+    *incomplete
+        .pointer_mut("/solve/solve_layout/algebraic_scalar_count")
+        .unwrap() = serde_json::json!(2);
+    let rendered = render_template_with_dae_json_and_name(
+        &incomplete,
+        builtin_template("fmi3", "model.c.jinja"),
+        "M",
+    )
+    .unwrap();
+    assert!(!rendered.contains("const int y_index = 1;"), "{rendered}");
 
     let mut causal = dae_json.clone();
     *causal
@@ -1052,7 +1081,7 @@ fn test_fmi3_scalar_blt_projection_renders_from_solve_ir() {
         "{rendered}"
     );
 
-    let mut unmatched = dae_json;
+    let mut unmatched = dae_json.clone();
     *unmatched
         .pointer_mut("/solve/continuous/algebraic_projection_plan/blocks/0/rows/0")
         .unwrap() = serde_json::json!(99);

--- a/crates/rumoca-phase-codegen/src/codegen/codegen_tests/backend_template_tests.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/codegen_tests/backend_template_tests.rs
@@ -878,8 +878,8 @@ fn test_fmi3_cosimulation_uses_opt_in_fixed_rk4() {
         "the generic backend must not embed a vehicle-specific RK4 step"
     );
     assert!(
-        builtin_template("fmi3", "build.sh.jinja").contains("${CFLAGS:=-O2}"),
-        "the packaged FMU build should allow a caller-selected integration policy"
+        builtin_template("fmi3", "build.sh.jinja").contains("${CFLAGS:=-Og}"),
+        "the packaged FMU build should default to fast native compilation while allowing caller-selected flags"
     );
 }
 

--- a/crates/rumoca-phase-codegen/src/codegen/fmi3_projection.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/fmi3_projection.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use minijinja::Value;
 
@@ -6,6 +6,82 @@ use crate::errors::render_err;
 
 use super::render_expr::get_field;
 use super::render_solve::SolveRowValue;
+
+pub fn fmi3_native_projection_available(
+    problem: &rumoca_ir_solve::SolveProblem,
+) -> Result<bool, crate::CodegenError> {
+    let blocks = &problem.continuous.algebraic_projection_plan.blocks;
+    if blocks.is_empty() {
+        return Ok(false);
+    }
+    let scalar = rumoca_eval_solve::to_scalar_program_block(&problem.continuous.implicit_rhs)
+        .map_err(|error| crate::CodegenError::template(error.to_string()))?;
+    let mut program_for_output = BTreeMap::new();
+    let mut cursor = 0usize;
+    for (program_index, program) in scalar.programs.iter().enumerate() {
+        let output_count = rumoca_ir_solve::ScalarProgramBlock::program_output_count(program);
+        let end = cursor
+            .checked_add(output_count)
+            .ok_or_else(|| crate::CodegenError::template("FMI3 implicit output cursor overflow"))?;
+        let Some(indices) = scalar.output_indices.get(cursor..end) else {
+            return Ok(false);
+        };
+        if output_count != 1
+            && indices
+                .iter()
+                .any(|index| *index >= problem.solve_layout.state_scalar_count)
+        {
+            return Ok(false);
+        }
+        if let [output] = indices
+            && program_for_output.insert(*output, program_index).is_some()
+        {
+            return Ok(false);
+        }
+        cursor = end;
+    }
+    if cursor != scalar.output_indices.len() {
+        return Ok(false);
+    }
+    let projection_start = problem.solve_layout.state_scalar_count;
+    let projection_count = problem
+        .solve_layout
+        .algebraic_scalar_count
+        .checked_add(problem.solve_layout.output_scalar_count)
+        .ok_or_else(|| crate::CodegenError::template("FMI3 projection count overflow"))?;
+    let projection_end = projection_start
+        .checked_add(projection_count)
+        .ok_or_else(|| crate::CodegenError::template("FMI3 projection range overflow"))?;
+    let mut projected_y = BTreeSet::new();
+    for block in blocks {
+        let ([row_index], [y_index], []) = (
+            block.rows.as_slice(),
+            block.y_indices.as_slice(),
+            block.causal_steps.as_slice(),
+        ) else {
+            return Ok(false);
+        };
+        if !(projection_start..projection_end).contains(y_index) || !projected_y.insert(*y_index) {
+            return Ok(false);
+        }
+        let Some(program_index) = program_for_output.get(row_index).copied() else {
+            return Ok(false);
+        };
+        let program = &scalar.programs[program_index];
+        let supported = match rumoca_eval_solve::target_assignment_shape(program)
+            .map_err(|error| crate::CodegenError::template(error.to_string()))?
+        {
+            Some(shape) => shape.target_y_index() == *y_index,
+            None => !program.iter().any(
+                |op| matches!(op, rumoca_ir_solve::LinearOp::LoadY { index, .. } if index == y_index),
+            ),
+        };
+        if !supported {
+            return Ok(false);
+        }
+    }
+    Ok(projected_y.len() == projection_count)
+}
 
 fn usize_values(value: &Value, context: &str) -> Result<Vec<usize>, minijinja::Error> {
     value
@@ -50,15 +126,56 @@ fn supports_assignment(row: &SolveRowValue, target: usize) -> Result<bool, minij
     }
 }
 
+fn scalar_projection_schedule_miss<T>() -> Result<Option<T>, minijinja::Error> {
+    Ok(Option::None)
+}
+
+fn scalar_projection_rows(
+    blocks: &[Value],
+    state_count: usize,
+    projection_count: usize,
+) -> Result<Option<Vec<(usize, usize)>>, minijinja::Error> {
+    let projection_end = state_count
+        .checked_add(projection_count)
+        .ok_or_else(|| render_err("FMI3 projection range overflow"))?;
+    let mut rows = Vec::new();
+    rows.try_reserve_exact(blocks.len())
+        .map_err(|_| render_err("FMI3 projection schedule exceeds host memory limits"))?;
+    let mut projected_y = BTreeSet::new();
+    for block in blocks {
+        let block_rows = required_sequence_field(block, "rows")?;
+        let y_indices = required_sequence_field(block, "y_indices")?;
+        let causal_steps = required_sequence_field(block, "causal_steps")?;
+        if block_rows.len() != 1 || y_indices.len() != 1 || !causal_steps.is_empty() {
+            return scalar_projection_schedule_miss();
+        }
+        let row_index = block_rows[0]
+            .as_usize()
+            .ok_or_else(|| render_err("FMI3 projection row must be a non-negative integer"))?;
+        let y_index = y_indices[0]
+            .as_usize()
+            .ok_or_else(|| render_err("FMI3 projection target must be a non-negative integer"))?;
+        if !(state_count..projection_end).contains(&y_index) || !projected_y.insert(y_index) {
+            return scalar_projection_schedule_miss();
+        }
+        rows.push((row_index, y_index));
+    }
+    Ok((projected_y.len() == projection_count).then_some(rows))
+}
+
 pub(super) fn fmi3_scalar_projection_schedule_function(
     blocks: Value,
     programs: Value,
     output_indices: Value,
     state_count: Value,
+    projection_count: Value,
 ) -> Result<Value, minijinja::Error> {
     let state_count = state_count
         .as_usize()
         .ok_or_else(|| render_err("FMI3 Solve-IR state count must be a non-negative integer"))?;
+    let projection_count = projection_count.as_usize().ok_or_else(|| {
+        render_err("FMI3 Solve-IR projection count must be a non-negative integer")
+    })?;
     let blocks = blocks
         .try_iter()
         .map_err(|_| render_err("FMI3 algebraic projection blocks must be a sequence"))?
@@ -67,25 +184,10 @@ pub(super) fn fmi3_scalar_projection_schedule_function(
         return Ok(empty_schedule());
     }
 
-    let mut projection_rows = Vec::new();
-    projection_rows
-        .try_reserve_exact(blocks.len())
-        .map_err(|_| render_err("FMI3 projection schedule exceeds host memory limits"))?;
-    for block in &blocks {
-        let rows = required_sequence_field(block, "rows")?;
-        let y_indices = required_sequence_field(block, "y_indices")?;
-        let causal_steps = required_sequence_field(block, "causal_steps")?;
-        if rows.len() != 1 || y_indices.len() != 1 || !causal_steps.is_empty() {
-            return Ok(empty_schedule());
-        }
-        let row_index = rows[0]
-            .as_usize()
-            .ok_or_else(|| render_err("FMI3 projection row must be a non-negative integer"))?;
-        let y_index = y_indices[0]
-            .as_usize()
-            .ok_or_else(|| render_err("FMI3 projection target must be a non-negative integer"))?;
-        projection_rows.push((row_index, y_index));
-    }
+    let Some(projection_rows) = scalar_projection_rows(&blocks, state_count, projection_count)?
+    else {
+        return Ok(empty_schedule());
+    };
 
     let programs = programs
         .try_iter()

--- a/crates/rumoca-phase-codegen/src/codegen/mod.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/mod.rs
@@ -31,6 +31,7 @@ mod render_stmt;
 mod solve_lazy;
 mod symbol_alloc;
 
+pub use fmi3_projection::fmi3_native_projection_available;
 use fmi3_projection::fmi3_scalar_projection_schedule_function;
 use render_expr::{get_field, is_variant, render_expression};
 use render_solve::{
@@ -40,9 +41,8 @@ use render_solve::{
     render_solve_pre_param_binding_c_function, render_solve_row_c_function,
     render_solve_row_output_wgsl_function, render_solve_row_rust_function,
     render_solve_row_wgsl_function, render_solve_slot_assign_c_function,
-    render_solve_target_assignment_c_function, render_wgsl_kernel_schedule_json_function,
-    render_wgsl_kernel_workgroup_total_function, render_wgsl_native_family_inventory_json_function,
-    solve_block_output_count_function,
+    render_wgsl_kernel_schedule_json_function, render_wgsl_kernel_workgroup_total_function,
+    render_wgsl_native_family_inventory_json_function, solve_block_output_count_function,
 };
 use render_stmt::{render_equation, render_flat_equation, render_statement, render_statements};
 use symbol_alloc::{
@@ -1228,10 +1228,7 @@ fn create_environment() -> Environment<'static> {
         "fmi3_scalar_projection_schedule",
         fmi3_scalar_projection_schedule_function,
     );
-    env.add_function(
-        "render_solve_target_assignment_c",
-        render_solve_target_assignment_c_function,
-    );
+    render_solve::register_target_assignment_functions(&mut env);
     env.add_function("render_solve_row_rust", render_solve_row_rust_function);
     env.add_function("render_solve_block_c", render_solve_block_c_function);
     env.add_function("render_solve_block_rust", render_solve_block_rust_function);

--- a/crates/rumoca-phase-codegen/src/codegen/render_solve.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/render_solve.rs
@@ -7,8 +7,8 @@
 use std::sync::Arc;
 
 use crate::errors::render_err;
-use minijinja::Value;
 use minijinja::value::{Enumerator, Object, ObjectRepr};
+use minijinja::{Environment, Value};
 use rumoca_ir_solve as solve;
 
 use super::render_expr::get_field;
@@ -52,6 +52,17 @@ pub(super) use template_partition::{
     kernel_workgroup_count, scalar_kernel_chunk_count, scalar_program_block_source_span,
     scalar_program_row_span, wgsl_kernel_schedule_entry_count, wgsl_kernel_workgroup_total,
 };
+
+pub(super) fn register_target_assignment_functions(env: &mut Environment<'static>) {
+    env.add_function(
+        "render_solve_target_assignment_c",
+        render_solve_target_assignment_c_function,
+    );
+    env.add_function(
+        "render_solve_target_assignment_block_c",
+        render_solve_target_assignment_block_c_function,
+    );
+}
 
 // ─── Typed scalar-program rows ───────────────────────────────────────────────
 //
@@ -120,6 +131,15 @@ fn render_solve_target_assignment_typed_c(
     for op in ops {
         output = render_solve_op_typed(op, cfg, SolveRowDialect::C, &mut regs, output)?;
     }
+    render_solve_target_assignment_value(ops, target_y_index, &regs, output)
+}
+
+fn render_solve_target_assignment_value(
+    ops: &[solve::LinearOp],
+    target_y_index: usize,
+    regs: &[String],
+    output: Option<String>,
+) -> RenderResult {
     let output = output.ok_or_else(|| render_err("solve row did not contain StoreOutput"))?;
     let shape = rumoca_eval_solve::target_assignment_shape(ops)
         .map_err(|error| render_err(format!("invalid target-assignment row: {error}")))?;
@@ -129,7 +149,7 @@ fn render_solve_target_assignment_typed_c(
             expr_reg,
             ..
         }) if shape_target == target_y_index => solve_reg(
-            &regs,
+            regs,
             solve_reg_index(expr_reg, "target-assignment expression register")?,
         ),
         Some(rumoca_eval_solve::TargetAssignmentShape::Affine {
@@ -141,13 +161,13 @@ fn render_solve_target_assignment_typed_c(
             ..
         }) if shape_target == target_y_index => {
             let offset = solve_reg(
-                &regs,
+                regs,
                 solve_reg_index(offset_reg, "target-assignment offset register")?,
             )?;
             let coefficient = coefficient_reg
                 .map(|reg| {
                     solve_reg(
-                        &regs,
+                        regs,
                         solve_reg_index(reg, "target-assignment coefficient register")?,
                     )
                 })
@@ -171,6 +191,86 @@ fn render_solve_target_assignment_typed_c(
             "Solve-IR row cannot directly assign projection y[{target_y_index}]"
         ))),
     }
+}
+
+/// Render one scalar projection as bounded C statements rather than a deeply
+/// nested expression. Materializing every non-leaf register keeps C expression
+/// depth constant, which substantially reduces native compiler time for large
+/// Lie-group rows without changing the Solve IR evaluation order.
+fn render_solve_target_assignment_block_typed_c(
+    ops: &[solve::LinearOp],
+    target_y_index: usize,
+    cfg: &SolveRowCConfig,
+) -> RenderResult {
+    let mut regs = Vec::<String>::new();
+    let mut output = None;
+    let mut body = String::new();
+    for op in ops {
+        output = render_solve_op_typed(op, cfg, SolveRowDialect::C, &mut regs, output)?;
+        let Some(dst) = solve_typed_nonleaf_destination(op)? else {
+            continue;
+        };
+        let expr = solve_reg(&regs, dst)?;
+        let name = format!("__r{dst}");
+        body.push_str(&format!("        const double {name} = {expr};\n"));
+        store_solve_reg(&mut regs, dst, name)?;
+    }
+    let value = render_solve_target_assignment_value(ops, target_y_index, &regs, output)?;
+    body.push_str(&format!("        const double value = {value};\n"));
+    Ok(body)
+}
+
+fn solve_typed_nonleaf_destination(
+    op: &solve::LinearOp,
+) -> Result<Option<usize>, minijinja::Error> {
+    use solve::LinearOp;
+    let dst = match op {
+        LinearOp::LoadIndexedP { dst, .. }
+        | LinearOp::LoadIndexedSeed { dst, .. }
+        | LinearOp::LinearSolveComponent { dst, .. }
+        | LinearOp::Unary { dst, .. }
+        | LinearOp::Binary { dst, .. }
+        | LinearOp::Compare { dst, .. }
+        | LinearOp::Select { dst, .. } => *dst,
+        LinearOp::Const { .. }
+        | LinearOp::LoadTime { .. }
+        | LinearOp::LoadY { .. }
+        | LinearOp::LoadP { .. }
+        | LinearOp::LoadSeed { .. }
+        | LinearOp::Move { .. }
+        | LinearOp::StoreOutput { .. } => return optional_solve_render_miss(),
+        other => {
+            return Err(render_err(format!(
+                "unsupported solve LinearOp in target assignment: {}",
+                other.kind_name()
+            )));
+        }
+    };
+    Ok(Some(solve_reg_index(
+        dst,
+        "target-assignment temporary destination register",
+    )?))
+}
+
+fn optional_solve_render_miss<T>() -> Result<Option<T>, minijinja::Error> {
+    Ok(Option::None)
+}
+
+pub(in crate::codegen) fn render_solve_target_assignment_block_c_function(
+    row: Value,
+    target_y_index: Value,
+    config: Value,
+) -> RenderResult {
+    let target_y_index = target_y_index
+        .as_usize()
+        .ok_or_else(|| render_err("target-assignment Y index must be a non-negative integer"))?;
+    let Some(typed) = row.downcast_object_ref::<SolveRowValue>() else {
+        return Err(render_err(
+            "target-assignment block rendering requires a typed scalar Solve-IR row",
+        ));
+    };
+    let cfg = SolveRowCConfig::from_value(&config);
+    render_solve_target_assignment_block_typed_c(typed.ops(), target_y_index, &cfg)
 }
 
 fn render_solve_row_for(

--- a/crates/rumoca-phase-codegen/src/codegen/solve_renderer.rs
+++ b/crates/rumoca-phase-codegen/src/codegen/solve_renderer.rs
@@ -93,6 +93,37 @@ impl SolveTemplateRenderer {
         })
     }
 
+    /// Build a renderer by taking ownership of the lowered Solve IR. Target
+    /// builders that do not reuse these values avoid cloning the complete
+    /// program and artifact graphs into the lazy template context.
+    pub fn new_owned_with_dae(
+        problem: solve::SolveProblem,
+        artifacts: solve::SolveArtifacts,
+        dae_model: dae::Dae,
+    ) -> Result<Self, CodegenError> {
+        Self::new_owned_with_shared_dae(problem, artifacts, std::sync::Arc::new(dae_model))
+    }
+
+    pub fn new_owned_with_shared_dae(
+        problem: solve::SolveProblem,
+        artifacts: solve::SolveArtifacts,
+        dae_model: std::sync::Arc<dae::Dae>,
+    ) -> Result<Self, CodegenError> {
+        let dae_entry = Value::from_object(LazyDaeTemplateJson {
+            dae: dae_model.clone(),
+            value: std::sync::OnceLock::new(),
+        });
+        Ok(Self {
+            context: solve_render_context_value_with_arcs(
+                std::sync::Arc::new(problem),
+                std::sync::Arc::new(artifacts),
+                None,
+                dae_entry,
+            )?,
+            guard_dae: Some(dae_model),
+        })
+    }
+
     pub fn render(&self, template: &str) -> Result<String, CodegenError> {
         let mut env = create_environment();
         env.add_template("inline", template)?;
@@ -132,12 +163,26 @@ fn solve_render_context_value_with_dae(
     model_name: Option<&str>,
     dae_entry: Value,
 ) -> Result<Value, CodegenError> {
+    solve_render_context_value_with_arcs(
+        std::sync::Arc::new(solve_problem.clone()),
+        std::sync::Arc::new(artifacts.clone()),
+        model_name,
+        dae_entry,
+    )
+}
+
+fn solve_render_context_value_with_arcs(
+    problem_arc: std::sync::Arc<solve::SolveProblem>,
+    artifacts_arc: std::sync::Arc<solve::SolveArtifacts>,
+    model_name: Option<&str>,
+    dae_entry: Value,
+) -> Result<Value, CodegenError> {
     // Lazy `solve` / `solve_derivative_nodes` (see `solve_lazy`): structural
     // fields serialize on demand and op lists materialize one op at a time, so a
     // ~150k-op model costs O(one program) here instead of ~5 GB of eager `Value`
     // materialization (`from_serialize(solve_problem)` alone was ~4.7 GB).
-    let problem_arc = std::sync::Arc::new(solve_problem.clone());
-    let artifacts_arc = std::sync::Arc::new(artifacts.clone());
+    let solve_problem = problem_arc.as_ref();
+    let artifacts = artifacts_arc.as_ref();
     let solve_value = super::solve_lazy::solve_value(problem_arc.clone(), artifacts_arc.clone())?;
     let artifacts_value = super::solve_lazy::artifacts_value(artifacts_arc.clone())?;
     let solve_blocks = solve_template_blocks_value(solve_problem, artifacts)?;

--- a/crates/rumoca-phase-codegen/src/lib.rs
+++ b/crates/rumoca-phase-codegen/src/lib.rs
@@ -59,11 +59,12 @@ mod codegen;
 mod errors;
 
 pub use codegen::{
-    CodegenInput, SolveTemplateRenderer, dae_template_json, render_ast_template,
-    render_ast_template_with_name, render_flat_template_with_name, render_solve_template_with_name,
-    render_template, render_template_file, render_template_for_input,
-    render_template_with_dae_json, render_template_with_dae_json_and_name,
-    render_template_with_name, render_template_with_name_for_input,
+    CodegenInput, SolveTemplateRenderer, dae_template_json, fmi3_native_projection_available,
+    render_ast_template, render_ast_template_with_name, render_flat_template_with_name,
+    render_solve_template_with_name, render_template, render_template_file,
+    render_template_for_input, render_template_with_dae_json,
+    render_template_with_dae_json_and_name, render_template_with_name,
+    render_template_with_name_for_input,
 };
 pub use errors::CodegenError;
 

--- a/crates/rumoca-phase-codegen/src/templates/fmi3/build.sh.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/fmi3/build.sh.jinja
@@ -30,8 +30,9 @@ case "$(uname -s)" in
 esac
 
 mkdir -p binaries/$PLATFORM
-: "${CFLAGS:=-O2}"
-cc -shared -fPIC $CFLAGS -o binaries/$PLATFORM/{{ model_name }}.$LIB_EXT sources/{{ model_name }}.c -lm
+: "${CC:=cc}"
+: "${CFLAGS:=-Og}"
+"$CC" -shared -fPIC $CFLAGS -o binaries/$PLATFORM/{{ model_name }}.$LIB_EXT sources/{{ model_name }}.c -lm
 
 rm -f {{ model_name }}.fmu
 zip -r {{ model_name }}.fmu modelDescription.xml binaries/ sources/

--- a/crates/rumoca-phase-codegen/src/templates/fmi3/model.c.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/fmi3/model.c.jinja
@@ -44,8 +44,9 @@
 {% set solve_implicit_output_indices = solve_blocks.continuous.implicit_rhs.scalar_programs.output_indices if solve_blocks is defined and solve_blocks.continuous is defined and solve_blocks.continuous.implicit_rhs is defined and solve_blocks.continuous.implicit_rhs.scalar_programs is defined else [] %}
 {% set solve_projection_blocks = solve.continuous.algebraic_projection_plan.blocks if solve is defined and solve.continuous is defined and solve.continuous.algebraic_projection_plan is defined and solve.continuous.algebraic_projection_plan.blocks is defined else [] %}
 {% set solve_state_count = solve.solve_layout.state_scalar_count if solve is defined and solve.solve_layout is defined and solve.solve_layout.state_scalar_count is defined else 0 %}
+{% set solve_projection_count = (solve.solve_layout.algebraic_scalar_count + solve.solve_layout.output_scalar_count) if solve is defined and solve.solve_layout is defined and solve.solve_layout.algebraic_scalar_count is defined and solve.solve_layout.output_scalar_count is defined else 0 %}
 {# Rust validates and prepares the projection schedule before C emission. #}
-{% set solve_projection_schedule = fmi3_scalar_projection_schedule(solve_projection_blocks, solve_implicit_programs, solve_implicit_output_indices, solve_state_count) %}
+{% set solve_projection_schedule = fmi3_scalar_projection_schedule(solve_projection_blocks, solve_implicit_programs, solve_implicit_output_indices, solve_state_count, solve_projection_count) %}
 {% set solve_projection_fast = solve_projection_schedule | length > 0 %}
 {% set solve_full_jacobian_rows = solve_full_jacobian_rows if solve_full_jacobian_rows is defined else (solve.artifacts.continuous.full_jacobian_v.programs if solve is defined and solve.artifacts is defined and solve.artifacts.continuous is defined and solve.artifacts.continuous.full_jacobian_v is defined and solve.artifacts.continuous.full_jacobian_v.programs is defined else []) %}
 {% set solve_row_c_cfg = {"time": "m->time", "y": "__rumoca_solve_y(m, {})", "p": "__rumoca_solve_p(m, {})"} %}
@@ -233,17 +234,10 @@ static double Modelica_Blocks_Types_ExternalCombiTimeTable() { return 0.0; }
 #define __rumoca_named_arg___verboseRead(x) (x)
 #define __rumoca_named_arg___verboseExtrapolation(x) (x)
 
-/* =========================================================================
- * Enumeration literal constants
- * ========================================================================= */
-{% for name, ordinal in dae.enum_literal_ordinals | items %}
-#define {{ symbol(symbols, name) }} {{ ordinal }}
-{% endfor %}
-
-/* Enumeration type constructors — identity macros for enum type casts */
-{% for type_name in dae.enum_type_names | default([]) %}
-#define {{ symbol(symbols, type_name) }}(x) (x)
-{% endfor %}
+/* Enumeration literals have already been lowered to numeric Solve IR values,
+   and FMI implementation defaults are numeric literals. Emitting source-level
+   enum aliases here would pollute the C preprocessor namespace (for example,
+   Axis.x would otherwise collide with ModelInstance.x). */
 
 {#- Macro: compute total scalar size of a variable map -#}
 {% macro var_size(vars) -%}
@@ -697,8 +691,16 @@ static void initialize_defaults(ModelInstance* m) {
 
 {% set ns_idx = namespace(offset=0) %}
 {% for name, var in dae.constants | items %}
+{% if var.dims %}
+{% set sz = var.dims | product %}
+{% for i in range(sz) %}
+    double {{ symbol(symbols, source_ref(name, var.dims, i + 1)) }} = 0.0;
+{% set ns_idx.offset = ns_idx.offset + 1 %}
+{% endfor %}
+{% else %}
     double {{ symbol(symbols, name) }} = 0.0;
 {% set ns_idx.offset = ns_idx.offset + 1 %}
+{% endif %}
 {% endfor %}
 {% set ns_idx = namespace(offset=0) %}
 {% for name, var in dae.p | items %}
@@ -769,9 +771,18 @@ static void initialize_defaults(ModelInstance* m) {
 
 {% set ns_idx = namespace(offset=0) %}
 {% for name, var in dae.constants | items %}
+{% if var.dims %}
+{% set sz = var.dims | product %}
+{% for i in range(sz) %}
+    {{ symbol(symbols, source_ref(name, var.dims, i + 1)) }} = {% if var.start and is_string_literal(var.start) != "yes" %}{{ render_expr_at_index(var.start, i + 1, cfg) }}{% else %}0.0{% endif %};
+    m->constants[{{ ns_idx.offset }}] = {{ symbol(symbols, source_ref(name, var.dims, i + 1)) }};  /* {{ name }}[{{ i + 1 }}] */
+{% set ns_idx.offset = ns_idx.offset + 1 %}
+{% endfor %}
+{% else %}
     {{ symbol(symbols, name) }} = {% if var.start and is_string_literal(var.start) != "yes" %}{{ render_expr(var.start, cfg) }}{% else %}0.0{% endif %};
     m->constants[{{ ns_idx.offset }}] = {{ symbol(symbols, name) }};  /* {{ name }} */
 {% set ns_idx.offset = ns_idx.offset + 1 %}
+{% endif %}
 {% endfor %}
 
 {% set ns_idx = namespace(offset=0) %}
@@ -856,7 +867,7 @@ static void compute_algebraics(ModelInstance* m) {
 {% for assignment in solve_projection_schedule %}
     {
         const int y_index = {{ assignment.y_index }};
-        const double value = {{ render_solve_target_assignment_c(solve_implicit_programs[assignment.program_index], assignment.y_index, solve_row_c_cfg) }};
+{{ render_solve_target_assignment_block_c(solve_implicit_programs[assignment.program_index], assignment.y_index, solve_row_c_cfg) }}
         if (!isfinite(value)) {
             m->evaluation_error = 1;
             return;

--- a/crates/rumoca-phase-codegen/src/templates/fmi3/modelDescription.xml.jinja
+++ b/crates/rumoca-phase-codegen/src/templates/fmi3/modelDescription.xml.jinja
@@ -49,10 +49,7 @@
 {%- set n_clocks = n_periodic_clocks + n_triggered_clocks -%}
 {%- set vr_clk   = vr_m + nvar_m -%}
 {%- set vr_time  = vr_clk + n_clocks -%}
-{%- set solve_root_rows = solve.events.root_conditions.programs if solve is defined and solve.events is defined and solve.events.root_conditions is defined and solve.events.root_conditions.programs is defined else [] -%}
-{%- set solve_dynamic_time_rows = solve.events.dynamic_time_event_rhs.programs if solve is defined and solve.events is defined and solve.events.dynamic_time_event_rhs is defined and solve.events.dynamic_time_event_rhs.programs is defined else [] -%}
-{%- set solve_event_actions = solve.events.actions if solve is defined and solve.events is defined and solve.events.actions is defined else [] -%}
-{%- set cosim_supported = solve_root_rows | length == 0 and solve_dynamic_time_rows | length == 0 and solve_event_actions | length == 0 and dae.relation | default([]) | length == 0 and dae.synthetic_root_conditions | default([]) | length == 0 and dae.event_actions | default([]) | length == 0 and dae.scheduled_time_events | default([]) | length == 0 and dae.clock_schedules | default([]) | length == 0 and dae.triggered_clock_conditions | default([]) | length == 0 and dae.z | length == 0 and dae.m | length == 0 -%}
+{%- set cosim_supported = dae.relation | default([]) | length == 0 and dae.synthetic_root_conditions | default([]) | length == 0 and dae.event_actions | default([]) | length == 0 and dae.scheduled_time_events | default([]) | length == 0 and dae.clock_schedules | default([]) | length == 0 and dae.triggered_clock_conditions | default([]) | length == 0 and dae.z | length == 0 and dae.m | length == 0 -%}
 {%- set units = namespace(names=["s"]) -%}
 {%- for vars in [dae.x, dae.y, dae.u, dae.w, dae.p, dae.z, dae.m] -%}
 {%- for name, var in vars | items -%}

--- a/crates/rumoca-phase-codegen/src/templates/fmi3/target.toml
+++ b/crates/rumoca-phase-codegen/src/templates/fmi3/target.toml
@@ -16,6 +16,7 @@ render_context = "fmi-model-description"
 [[files]]
 path = "sources/{{ model_name }}.c"
 template = "model.c.jinja"
+render_context = "fmi-implementation"
 
 [[files]]
 path = "sources/fmi3PlatformTypes.h"

--- a/crates/rumoca-phase-dae/src/dae_lowering.rs
+++ b/crates/rumoca-phase-dae/src/dae_lowering.rs
@@ -64,6 +64,23 @@ pub fn prepare_dae_for_fmi_model_description(dae: &dae::Dae) -> Result<CodegenDa
     Ok(CodegenDae { dae: prepared })
 }
 
+/// Project the DAE to the metadata needed by FMI XML and native Solve-IR
+/// implementations before folding numeric attributes. Evaluation still uses
+/// the complete source DAE, so parameter and user-function starts retain their
+/// semantics without cloning numerical equation graphs into the result.
+pub fn project_dae_for_fmi_metadata(dae: &dae::Dae) -> Result<CodegenDae, ToDaeError> {
+    let mut projected = Dae::new();
+    projected.schema_version = dae.schema_version;
+    projected.variables = dae.variables.clone();
+    projected.conditions = dae.conditions.clone();
+    projected.events = dae.events.clone();
+    projected.clocks = dae.clocks.clone();
+    projected.metadata.model_description = dae.metadata.model_description.clone();
+    projected.metadata.symbol_ancestry = dae.metadata.symbol_ancestry.clone();
+    crate::fmi_metadata_values::fold_fmi_model_description_values_from_source(&mut projected, dae)?;
+    Ok(CodegenDae { dae: projected })
+}
+
 // =============================================================================
 // Record function parameter decomposition (DAE level)
 // =============================================================================

--- a/crates/rumoca-phase-dae/src/fmi_metadata_values.rs
+++ b/crates/rumoca-phase-dae/src/fmi_metadata_values.rs
@@ -14,6 +14,7 @@ use rumoca_ir_dae::{
     Dae, DaeVariableMutVisitor, DaeVariablePartition, DaeVisitor, Variable, VariableOrigin,
 };
 use std::collections::HashMap;
+use std::sync::Arc;
 
 type FmiEvalResult<T> = Result<T, FmiEvalError>;
 
@@ -24,7 +25,49 @@ pub(crate) fn fold_fmi_model_description_values_to_literals(
     dae: &mut Dae,
 ) -> Result<(), ToDaeError> {
     let dims = collect_variable_dims(dae)?;
-    let values = collect_best_effort_fmi_metadata_values(dae, &dims)?;
+    let runtime =
+        rumoca_eval_dae::build_partial_runtime_parameter_tail_env_with_declared_slots_and_runtime(
+            dae,
+            &[],
+            0.0,
+            Arc::new(rumoca_eval_dae::EvalRuntimeState::new()),
+        )
+        .map_err(|err| {
+            ToDaeError::runtime_metadata_violation(format!(
+                "could not prepare default parameter evaluation for FMI modelDescription: {err}"
+            ))
+        })?;
+    let values = collect_best_effort_fmi_metadata_values(dae, &dims, &runtime)?;
+    rewrite_fmi_model_description_values(dae, &dims, &runtime, &values)
+}
+
+pub(crate) fn fold_fmi_model_description_values_from_source(
+    target: &mut Dae,
+    source: &Dae,
+) -> Result<(), ToDaeError> {
+    let dims = collect_variable_dims(source)?;
+    let runtime =
+        rumoca_eval_dae::build_partial_runtime_parameter_tail_env_with_declared_slots_and_runtime(
+            source,
+            &[],
+            0.0,
+            Arc::new(rumoca_eval_dae::EvalRuntimeState::new()),
+        )
+        .map_err(|err| {
+            ToDaeError::runtime_metadata_violation(format!(
+                "could not prepare default parameter evaluation for FMI modelDescription: {err}"
+            ))
+        })?;
+    let values = collect_best_effort_fmi_metadata_values(source, &dims, &runtime)?;
+    rewrite_fmi_model_description_values(target, &dims, &runtime, &values)
+}
+
+fn rewrite_fmi_model_description_values(
+    target: &mut Dae,
+    dims: &HashMap<FmiValueKey, Vec<i64>>,
+    runtime: &rumoca_eval_dae::VarEnv<f64>,
+    values: &HashMap<FmiValueKey, FmiConstValue>,
+) -> Result<(), ToDaeError> {
     let mut rewrite_error = Ok(());
     let rewrite = |var: &mut Variable, _is_parameter: bool| {
         if rewrite_error.is_err() {
@@ -35,8 +78,9 @@ pub(crate) fn fold_fmi_model_description_values_to_literals(
                 var,
                 FmiNumericAttribute::Start,
                 expr,
-                &values,
-                &dims,
+                values,
+                dims,
+                runtime,
             ) {
                 Ok(expr) => var.start = Some(expr),
                 Err(err) => {
@@ -50,8 +94,9 @@ pub(crate) fn fold_fmi_model_description_values_to_literals(
                 var,
                 FmiNumericAttribute::Min,
                 expr,
-                &values,
-                &dims,
+                values,
+                dims,
+                runtime,
             ) {
                 Ok(expr) => var.min = Some(expr),
                 Err(err) => {
@@ -65,8 +110,9 @@ pub(crate) fn fold_fmi_model_description_values_to_literals(
                 var,
                 FmiNumericAttribute::Max,
                 expr,
-                &values,
-                &dims,
+                values,
+                dims,
+                runtime,
             ) {
                 Ok(expr) => var.max = Some(expr),
                 Err(err) => {
@@ -80,8 +126,9 @@ pub(crate) fn fold_fmi_model_description_values_to_literals(
                 var,
                 FmiNumericAttribute::Nominal,
                 expr,
-                &values,
-                &dims,
+                values,
+                dims,
+                runtime,
             ) {
                 Ok(expr) => var.nominal = Some(expr),
                 Err(err) => rewrite_error = Err(err),
@@ -89,7 +136,7 @@ pub(crate) fn fold_fmi_model_description_values_to_literals(
         }
     };
 
-    FmiMetadataRewriter { rewrite }.visit_variables_mut(&mut dae.variables);
+    FmiMetadataRewriter { rewrite }.visit_variables_mut(&mut target.variables);
     rewrite_error
 }
 
@@ -227,18 +274,22 @@ impl FmiConstValue {
                 Ok(())
             }
             Self::Real(_) => Err(FmiEvalError::NonFinite),
+            Self::Bool(value) => {
+                out.push(if *value { 1.0 } else { 0.0 });
+                Ok(())
+            }
             Self::Array(elements) => {
                 for element in elements {
                     element.flatten_numeric(out)?;
                 }
                 Ok(())
             }
-            Self::Bool(_) | Self::String(_) => Err(FmiEvalError::NonNumeric),
+            Self::String(_) => Err(FmiEvalError::NonNumeric),
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum FmiEvalError {
     PendingDependency,
     Unsupported(&'static str),
@@ -253,6 +304,7 @@ enum FmiEvalError {
     DivisionByZero,
     Overflow,
     MissingDefId,
+    FunctionEvaluation(String),
 }
 
 impl std::fmt::Display for FmiEvalError {
@@ -271,6 +323,9 @@ impl std::fmt::Display for FmiEvalError {
             Self::DivisionByZero => write!(f, "division by zero"),
             Self::Overflow => write!(f, "integer overflow while evaluating metadata"),
             Self::MissingDefId => write!(f, "structured reference is missing DefId metadata"),
+            Self::FunctionEvaluation(detail) => {
+                write!(f, "function evaluation failed: {detail}")
+            }
         }
     }
 }
@@ -278,6 +333,7 @@ impl std::fmt::Display for FmiEvalError {
 struct FmiMetadataEnv<'a> {
     values: &'a HashMap<FmiValueKey, FmiConstValue>,
     dims: &'a HashMap<FmiValueKey, Vec<i64>>,
+    runtime: &'a rumoca_eval_dae::VarEnv<f64>,
 }
 
 fn collect_variable_dims(dae: &Dae) -> Result<HashMap<FmiValueKey, Vec<i64>>, ToDaeError> {
@@ -320,6 +376,7 @@ impl DaeVisitor for VariableDimsCollector<'_> {
 fn collect_best_effort_fmi_metadata_values(
     dae: &Dae,
     dims: &HashMap<FmiValueKey, Vec<i64>>,
+    runtime: &rumoca_eval_dae::VarEnv<f64>,
 ) -> Result<HashMap<FmiValueKey, FmiConstValue>, ToDaeError> {
     let mut values: HashMap<FmiValueKey, FmiConstValue> = HashMap::new();
 
@@ -351,6 +408,7 @@ fn collect_best_effort_fmi_metadata_values(
                 let env = FmiMetadataEnv {
                     values: &values,
                     dims,
+                    runtime,
                 };
                 try_eval_fmi_const_expr(expr, &env)
             };
@@ -375,9 +433,14 @@ fn fmi_numeric_attribute_literal_expression(
     expr: &Expression,
     values: &HashMap<FmiValueKey, FmiConstValue>,
     dims: &HashMap<FmiValueKey, Vec<i64>>,
+    runtime: &rumoca_eval_dae::VarEnv<f64>,
 ) -> Result<Expression, ToDaeError> {
     let span = attr.span(var, expr)?;
-    let env = FmiMetadataEnv { values, dims };
+    let env = FmiMetadataEnv {
+        values,
+        dims,
+        runtime,
+    };
     let value = try_eval_fmi_const_expr(expr, &env)
         .map_err(|err| fmi_metadata_not_serializable_error(var, attr, expr, err))?;
     fmi_numeric_value_to_expression(var, value, span)
@@ -389,14 +452,23 @@ fn fmi_numeric_value_to_expression(
     value: FmiConstValue,
     span: Span,
 ) -> FmiEvalResult<Expression> {
-    if let FmiConstValue::Real(value) = value {
-        if !value.is_finite() {
-            return Err(FmiEvalError::NonFinite);
+    match &value {
+        FmiConstValue::Real(value) => {
+            if !value.is_finite() {
+                return Err(FmiEvalError::NonFinite);
+            }
+            return Ok(Expression::Literal {
+                value: Literal::Real(*value),
+                span,
+            });
         }
-        return Ok(Expression::Literal {
-            value: Literal::Real(value),
-            span,
-        });
+        FmiConstValue::Bool(value) => {
+            return Ok(Expression::Literal {
+                value: Literal::Real(if *value { 1.0 } else { 0.0 }),
+                span,
+            });
+        }
+        FmiConstValue::String(_) | FmiConstValue::Array(_) => {}
     }
 
     let mut values = Vec::new();
@@ -483,12 +555,18 @@ fn try_eval_fmi_const_expr(
         Expression::Binary { op, lhs, rhs, .. } => {
             let lhs = try_eval_fmi_const_expr(lhs, env)?;
             let rhs = try_eval_fmi_const_expr(rhs, env)?;
-            eval_fmi_binary(op, lhs, rhs)
+            let has_array =
+                matches!(&lhs, FmiConstValue::Array(_)) || matches!(&rhs, FmiConstValue::Array(_));
+            match eval_fmi_binary(op, lhs, rhs) {
+                Err(FmiEvalError::NonNumeric) if has_array => {
+                    eval_fmi_runtime_numeric_expr(expr, env)
+                }
+                result => result,
+            }
         }
         Expression::BuiltinCall { function, args, .. } => eval_fmi_builtin(*function, args, env),
-        Expression::FunctionCall { name, args, .. } => {
-            eval_fmi_named_function(name.last_segment(), args, env)
-        }
+        Expression::FunctionCall { name, args, .. } => eval_fmi_named_function(name, args, env),
+        Expression::FieldAccess { .. } => eval_fmi_runtime_numeric_expr(expr, env),
         Expression::If {
             branches,
             else_branch,
@@ -512,6 +590,20 @@ fn try_eval_fmi_const_expr(
             start, step, end, ..
         } => eval_fmi_range(start, step.as_deref(), end, env),
         _ => Err(FmiEvalError::Unsupported("expression kind")),
+    }
+}
+
+fn eval_fmi_runtime_numeric_expr(
+    expr: &Expression,
+    env: &FmiMetadataEnv<'_>,
+) -> FmiEvalResult<FmiConstValue> {
+    let values = rumoca_eval_dae::eval_array_values::<f64>(expr, env.runtime)
+        .map_err(|err| FmiEvalError::FunctionEvaluation(err.to_string()))?;
+    match values.as_slice() {
+        [value] => Ok(FmiConstValue::Real(*value)),
+        _ => Ok(FmiConstValue::Array(
+            values.into_iter().map(FmiConstValue::Real).collect(),
+        )),
     }
 }
 
@@ -733,6 +825,7 @@ fn eval_fmi_builtin(
             let count = fmi_array_count(args, 0, env)?;
             Ok(FmiConstValue::Array(vec![FmiConstValue::Real(1.0); count]))
         }
+        BuiltinFunction::Identity => eval_fmi_identity(args, env),
         BuiltinFunction::Fill => {
             let value = eval_arg(args, 0, env)?;
             let count = fmi_array_count(args, 1, env)?;
@@ -761,6 +854,26 @@ fn eval_fmi_builtin(
         }
         _ => eval_fmi_math_builtin(function, args, env),
     }
+}
+
+fn eval_fmi_identity(
+    args: &[Expression],
+    env: &FmiMetadataEnv<'_>,
+) -> FmiEvalResult<FmiConstValue> {
+    let dimension = usize::try_from(eval_arg(args, 0, env)?.as_index()?)
+        .map_err(|_| FmiEvalError::InvalidIndex)?;
+    let count = dimension
+        .checked_mul(dimension)
+        .ok_or(FmiEvalError::Overflow)?;
+    let mut values = vec![FmiConstValue::Real(0.0); count];
+    for index in 0..dimension {
+        let offset = index
+            .checked_mul(dimension)
+            .and_then(|offset| offset.checked_add(index))
+            .ok_or(FmiEvalError::Overflow)?;
+        values[offset] = FmiConstValue::Real(1.0);
+    }
+    Ok(FmiConstValue::Array(values))
 }
 
 fn eval_arg(
@@ -794,19 +907,36 @@ fn eval_fmi_math_builtin(
 }
 
 fn eval_fmi_named_function(
-    short_name: &str,
+    name: &Reference,
     args: &[Expression],
     env: &FmiMetadataEnv<'_>,
 ) -> FmiEvalResult<FmiConstValue> {
+    let short_name = name.last_segment();
+
+    if let Ok(values) =
+        rumoca_eval_dae::eval::eval_user_function_array_output_pub::<f64>(name, args, env.runtime)
+    {
+        return match values.as_slice() {
+            [value] => Ok(FmiConstValue::Real(*value)),
+            _ => Ok(FmiConstValue::Array(
+                values.into_iter().map(FmiConstValue::Real).collect(),
+            )),
+        };
+    }
+
     if short_name == "substring" {
         return eval_fmi_substring(args, env).map(FmiConstValue::String);
     }
     if short_name == "ln" {
         return eval_fmi_builtin(BuiltinFunction::Log, args, env);
     }
-    let function =
-        BuiltinFunction::from_name(short_name).ok_or(FmiEvalError::Unsupported("function"))?;
-    eval_fmi_builtin(function, args, env)
+    if let Some(function) = BuiltinFunction::from_name(short_name) {
+        return eval_fmi_builtin(function, args, env);
+    }
+
+    rumoca_eval_dae::eval_function_call_pub::<f64>(name.var_name(), args, env.runtime)
+        .map(FmiConstValue::Real)
+        .map_err(|err| FmiEvalError::FunctionEvaluation(err.to_string()))
 }
 
 fn eval_fmi_substring(args: &[Expression], env: &FmiMetadataEnv<'_>) -> FmiEvalResult<String> {

--- a/crates/rumoca-phase-dae/src/fmi_metadata_values_tests.rs
+++ b/crates/rumoca-phase-dae/src/fmi_metadata_values_tests.rs
@@ -1,8 +1,8 @@
 use crate::errors::ToDaeError;
 use crate::fmi_metadata_values::fold_fmi_model_description_values_to_literals;
 use rumoca_core::{
-    BuiltinFunction, ComponentRefPart, ComponentReference, DefId, Expression, Literal, OpBinary,
-    Reference, SourceId, Span, Subscript, VarName,
+    BuiltinFunction, ComponentRefPart, ComponentReference, DefId, Expression, Function,
+    FunctionParam, Literal, OpBinary, Reference, SourceId, Span, Statement, Subscript, VarName,
 };
 use rumoca_ir_dae::{Dae, Variable, VariableOrigin};
 
@@ -438,5 +438,99 @@ fn fmi_model_description_folds_array_constructors_and_ranges() {
             .as_ref()
             .expect("rangeVar start"),
         &[1.0, 2.0, 3.0],
+    );
+}
+
+#[test]
+fn fmi_model_description_folds_identity_matrix_start() {
+    let mut dae = Dae::new();
+    let mut rotation = state(
+        "rotation",
+        Expression::BuiltinCall {
+            function: BuiltinFunction::Identity,
+            args: vec![integer(3)],
+            span: test_span(39, 40),
+        },
+    );
+    rotation.dims = vec![3, 3];
+    dae.variables
+        .states
+        .insert(VarName::new("rotation"), rotation);
+
+    fold_fmi_model_description_values_to_literals(&mut dae)
+        .unwrap_or_else(|err| panic!("FMI identity folding should succeed: {err}"));
+
+    assert_real_array(
+        dae.variables.states[&VarName::new("rotation")]
+            .start
+            .as_ref()
+            .expect("rotation start"),
+        &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+    );
+}
+
+#[test]
+fn fmi_model_description_folds_array_returning_user_function_start() {
+    let mut dae = Dae::new();
+    let mut vector = Function::new("Pkg.vector", test_span(41, 42));
+    vector.add_output(
+        FunctionParam::new("v_out", "Real", test_span(41, 42))
+            .with_dims(vec![2])
+            .with_default(array(vec![real(2.0), real(3.0)])),
+    );
+    vector.body = vec![Statement::Empty {
+        span: test_span(41, 42),
+    }];
+    dae.symbols
+        .functions
+        .insert(VarName::new("Pkg.vector"), vector);
+
+    let mut output = state(
+        "output",
+        Expression::FunctionCall {
+            name: VarName::new("Pkg.vector").into(),
+            args: Vec::new(),
+            is_constructor: false,
+            span: test_span(43, 44),
+        },
+    );
+    output.dims = vec![2];
+    dae.variables.states.insert(VarName::new("output"), output);
+
+    fold_fmi_model_description_values_to_literals(&mut dae)
+        .unwrap_or_else(|err| panic!("FMI user-function array folding should succeed: {err}"));
+
+    assert_real_array(
+        dae.variables.states[&VarName::new("output")]
+            .start
+            .as_ref()
+            .expect("output start"),
+        &[2.0, 3.0],
+    );
+}
+
+#[test]
+fn fmi_model_description_encodes_boolean_start_for_numeric_runtime_slot() {
+    let mut dae = Dae::new();
+    dae.variables.discrete_valued.insert(
+        VarName::new("valid"),
+        state(
+            "valid",
+            Expression::Literal {
+                value: Literal::Boolean(false),
+                span: test_span(45, 46),
+            },
+        ),
+    );
+
+    fold_fmi_model_description_values_to_literals(&mut dae)
+        .unwrap_or_else(|err| panic!("FMI Boolean start folding should succeed: {err}"));
+
+    assert_real(
+        dae.variables.discrete_valued[&VarName::new("valid")]
+            .start
+            .as_ref()
+            .expect("valid start"),
+        0.0,
     );
 }

--- a/crates/rumoca-phase-dae/src/lib.rs
+++ b/crates/rumoca-phase-dae/src/lib.rs
@@ -94,7 +94,7 @@ use when_conversion::convert_when_clause;
 pub use balance::{BalanceError, balance, balance_detail, equations_unknowns, is_balanced};
 pub use dae_lowering::{
     CodegenDae, insert_array_size_args_dae, lower_record_function_params_dae,
-    prepare_dae_for_codegen, prepare_dae_for_fmi_model_description,
+    prepare_dae_for_codegen, prepare_dae_for_fmi_model_description, project_dae_for_fmi_metadata,
     scalarize_phantom_vector_equations,
 };
 pub use errors::{ToDaeError, ToDaeResult};
@@ -312,10 +312,6 @@ pub fn to_dae_with_options(
         }
         Ok::<(), ToDaeError>(())
     })?;
-    run_todae_phase(todae_subphase_timing, "assertion_actions", || {
-        assertion_actions::lower_assert_equations_to_event_actions(&mut dae, flat)
-    })?;
-
     // Process model/initial algorithms strictly through equation lowering.
     run_todae_phase(todae_subphase_timing, "algorithm_lowering", || {
         lower_algorithms_to_equations(&mut dae, flat)
@@ -342,6 +338,12 @@ pub fn to_dae_with_options(
     // immersed-boundary masks) out of the per-step / derivative hot path.
     run_todae_phase(todae_subphase_timing, "promote_parameter_variable", || {
         promote_parameter_variable::promote_parameter_variable_algebraics(&mut dae)
+    })?;
+    // Lower assertions after invariant algebraics have become derived parameters.
+    // This lets assertion constant folding and later Solve lowering see the same
+    // once-per-parameter-set classification as ordinary equation consumers.
+    run_todae_phase(todae_subphase_timing, "assertion_actions", || {
+        assertion_actions::lower_assert_equations_to_event_actions(&mut dae, flat)
     })?;
     run_todae_phase(todae_subphase_timing, "canonical_conditions", || {
         populate_canonical_conditions(&mut dae)

--- a/crates/rumoca-phase-dae/src/promote_parameter_variable.rs
+++ b/crates/rumoca-phase-dae/src/promote_parameter_variable.rs
@@ -18,10 +18,11 @@
 //! a parameter, so it stays directly evaluable instead of allocating an Appendix B
 //! event/condition variable.
 //!
-//! The DAE stores array equations scalarized (one residual per element) and groups
-//! them into [`dae::StructuredEquationFamily`] blocks. Promotion therefore: (1)
-//! only promotes variables whose every defining equation sits inside a structured
-//! family that is *entirely* promotable (never splitting a family); (2)
+//! The DAE may store array equations either as whole-array assignments or scalarized
+//! into [`dae::StructuredEquationFamily`] blocks. Promotion therefore: (1) promotes
+//! ordinary scalar and standalone whole-array assignments directly, and only
+//! promotes structured variables whose entire family is promotable (never
+//! splitting a family); (2)
 //! reconstructs each promoted array variable's per-element bindings, in equation
 //! order, into a flat array `start` expression; and (3) drops the emptied families
 //! and shifts the surviving families' `first_equation_index` to match the compacted
@@ -29,7 +30,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use rumoca_core::ExpressionVisitor;
+use rumoca_core::{ExpressionRewriter, ExpressionVisitor};
 use rumoca_ir_dae as dae;
 
 use crate::errors::ToDaeError;
@@ -69,22 +70,16 @@ fn promote(
                 base(target.as_str()).to_string(),
             ))
     };
-    // Only promote algebraics that a state derivative actually depends on
-    // (transitively). That is precisely where inlining a large parameter-variable
-    // definition into the per-step / derivative hot path causes codegen bloat;
-    // promoting a constant array no consumer reads buys nothing and would only
-    // perturb the equation structure of otherwise-trivial models. A *cheapened*
-    // family is the exception: its per-cell bodies were already dropped at flatten, so
-    // it MUST be promoted (reconstructed from the template) for correctness regardless
-    // of reachability — otherwise its `0.0` interiors would survive.
-    let worthwhile = derivative_reachable_algebraics(dae);
+    // Every parameter-variable algebraic is invariant for the whole simulation.
+    // Promote it even when no state derivative reaches it: visible observations and
+    // assertion conditions are runtime consumers too, and leaving a large static
+    // submodel in the algebraic partition makes them rebuild the same value at every
+    // output point. Derived parameters preserve the value while evaluating it once.
     let mut removable: HashMap<usize, (rumoca_core::VarName, rumoca_core::Expression)> =
         HashMap::new();
     for (index, equation) in dae.continuous.equations.iter().enumerate() {
         if let Some((target, binding)) = direct_assignment(equation)
             && promotable.contains(base(target.as_str()))
-            && (worthwhile.contains(base(target.as_str()))
-                || cheapened_algebraic_bases.contains(base(target.as_str())))
             && is_array_variable(&target)
         {
             removable.insert(index, (target, binding.clone()));
@@ -101,6 +96,7 @@ fn promote(
         &removable,
         &dae.continuous.structured_equations,
         dae.continuous.equations.len(),
+        dae,
     );
     if family_removed.is_empty() {
         return Ok(());
@@ -111,7 +107,8 @@ fn promote(
     // reference a value that does not exist at parameter-evaluation time (it is
     // still a solver algebraic). Iteratively drop candidates that reference a
     // non-promoted algebraic, then keep only the surviving variables' equations.
-    let promoted_vars = dependency_closed_promotions(&removable, &family_removed, dae);
+    let promotion_order = dependency_ordered_promotions(&removable, &family_removed, dae);
+    let promoted_vars: HashSet<&str> = promotion_order.iter().map(String::as_str).collect();
     let removed: HashSet<usize> = family_removed
         .into_iter()
         .filter(|index| {
@@ -159,7 +156,11 @@ fn promote(
 
     // Move each promoted variable into the parameter partition with a reconstructed
     // array binding (a scalar variable keeps its single binding).
-    for (key, bindings) in grouped {
+    for promoted_name in promotion_order {
+        let key = rumoca_core::VarName::new(promoted_name);
+        let Some(bindings) = grouped.shift_remove(&key) else {
+            continue;
+        };
         let Some((name, mut var)) = dae.variables.algebraics.shift_remove_entry(&key) else {
             continue;
         };
@@ -268,9 +269,9 @@ fn cheapened_algebraic_family_bases(dae: &dae::Dae) -> HashSet<String> {
 /// session reports the failing model instead of aborting the process) and points at the
 /// offending family. It should be unreachable in practice — flatten only cheapens
 /// parameter-variability ∩ derivative-reachable families (see
-/// `rumoca_phase_flatten`'s `param_variability::parameter_variability_family_bases`,
-/// which mirrors [`derivative_reachable_algebraics`]); the guard exists to catch drift
-/// between those two analyses before it becomes a silent miscompile.
+/// `rumoca_phase_flatten`'s `param_variability::parameter_variability_family_bases`);
+/// the guard exists to catch drift between those analyses before it becomes a silent
+/// miscompile.
 fn enforce_cheapened_algebraic_families_promoted(dae: &dae::Dae) -> Result<(), ToDaeError> {
     let survivors = cheapened_algebraic_families(dae);
     let Some(&(_, span)) = survivors.first() else {
@@ -362,10 +363,17 @@ fn comprehension_starts_from_families(
         if degenerate {
             continue;
         }
+        let binder_names = indices
+            .iter()
+            .map(|index| index.name.clone())
+            .collect::<HashSet<_>>();
         for body in &template.body {
             if let Some((target, rhs)) = residual_template_target_and_rhs(body) {
+                let mut rewriter = ComprehensionBinderRewriter {
+                    binder_names: &binder_names,
+                };
                 let comprehension = rumoca_core::Expression::ArrayComprehension {
-                    expr: Box::new(rhs.clone()),
+                    expr: Box::new(rewriter.rewrite_expression(rhs)),
                     indices: indices.clone(),
                     filter: None,
                     span: family.span,
@@ -375,6 +383,30 @@ fn comprehension_starts_from_families(
         }
     }
     result
+}
+
+struct ComprehensionBinderRewriter<'a> {
+    binder_names: &'a HashSet<String>,
+}
+
+impl ExpressionRewriter for ComprehensionBinderRewriter<'_> {
+    fn rewrite_var_ref_expression(
+        &mut self,
+        name: &rumoca_core::Reference,
+        subscripts: &[rumoca_core::Subscript],
+        span: rumoca_core::Span,
+    ) -> rumoca_core::Expression {
+        let binder_name = self
+            .binder_names
+            .iter()
+            .find(|binder| name.as_str() == binder.as_str());
+        let name = binder_name.map_or_else(|| name.clone(), rumoca_core::Reference::generated);
+        rumoca_core::Expression::VarRef {
+            name,
+            subscripts: self.rewrite_subscripts(subscripts),
+            span,
+        }
+    }
 }
 
 /// Extract `(target_base, rhs)` from a residual template body `lhs - rhs` whose target
@@ -447,80 +479,59 @@ fn binder_range_expr(
     }
 }
 
-/// Algebraic base names that a state-derivative equation depends on, transitively
-/// through other algebraics' defining equations. Promotion is only worthwhile here
-/// — these are the algebraics whose definitions would otherwise be inlined into the
-/// derivative hot path.
-fn derivative_reachable_algebraics(dae: &dae::Dae) -> HashSet<String> {
-    let algebraics: HashSet<String> = dae
-        .variables
-        .algebraics
-        .keys()
-        .map(|k| base(k.as_str()).to_string())
-        .collect();
-    // Each algebraic's defining-equation algebraic references (for transitive walk).
-    let mut algebraic_refs: HashMap<String, HashSet<String>> = HashMap::new();
-    let mut seed: Vec<String> = Vec::new();
-    for equation in &dae.continuous.equations {
-        let mut collector = ReferencedBases {
-            bases: HashSet::new(),
-        };
-        collector.visit_expression(&equation.rhs);
-        let referenced_algebraics: HashSet<String> = collector
-            .bases
-            .into_iter()
-            .filter(|r| algebraics.contains(r))
-            .collect();
-        if equation.rhs.contains_der() {
-            // A state-derivative equation: its algebraic reads are reachable roots.
-            seed.extend(referenced_algebraics.iter().cloned());
-        }
-        if let Some((target, _)) = direct_assignment(equation) {
-            algebraic_refs
-                .entry(base(target.as_str()).to_string())
-                .or_default()
-                .extend(referenced_algebraics);
-        }
-    }
-    let mut reachable = HashSet::new();
-    while let Some(name) = seed.pop() {
-        if !reachable.insert(name.clone()) {
-            continue;
-        }
-        if let Some(refs) = algebraic_refs.get(&name) {
-            seed.extend(refs.iter().cloned());
-        }
-    }
-    reachable
+/// Dependency order of variables that can be promoted without changing the scalar
+/// equation balance, splitting a structured family, or creating cyclic parameter
+/// bindings. Derived parameters are appended in this order because parameter start
+/// evaluation expects every dependency to precede its consumers.
+struct PromotionGraph {
+    candidate_order: Vec<String>,
+    algebraic_refs: HashMap<String, HashSet<String>>,
+    promoted: HashSet<String>,
 }
 
-/// The set of variable base names that can be promoted without dangling
-/// dependencies: starting from every family-eligible candidate, iteratively drop
-/// any variable whose binding references an algebraic that is not itself promoted.
-fn dependency_closed_promotions(
+fn build_promotion_graph(
     removable: &HashMap<usize, (rumoca_core::VarName, rumoca_core::Expression)>,
     family_removed: &HashSet<usize>,
     dae: &dae::Dae,
-) -> HashSet<String> {
+) -> PromotionGraph {
     let algebraics: HashSet<String> = dae
         .variables
         .algebraics
         .keys()
         .map(|k| base(k.as_str()).to_string())
         .collect();
-    // Per-candidate-variable: the algebraic base names its binding references.
+    let mut all_indices: HashMap<String, Vec<usize>> = HashMap::new();
+    for (index, (target, _)) in removable {
+        all_indices
+            .entry(base(target.as_str()).to_string())
+            .or_default()
+            .push(*index);
+    }
+
+    // Per-candidate-variable: its equation scalar count and the algebraic base
+    // names referenced by its reconstructed binding.
     let mut algebraic_refs: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut equation_scalar_counts: HashMap<String, usize> = HashMap::new();
     for index in family_removed {
         let Some((target, binding)) = removable.get(index) else {
             continue;
         };
-        let mut collector = ReferencedBases {
-            bases: HashSet::new(),
+        let Some(equation) = dae.continuous.equations.get(*index) else {
+            continue;
         };
+        let target_base = base(target.as_str()).to_string();
+        let Some(total) = equation_scalar_counts
+            .get(&target_base)
+            .copied()
+            .unwrap_or(0)
+            .checked_add(equation.scalar_count)
+        else {
+            continue;
+        };
+        equation_scalar_counts.insert(target_base.clone(), total);
+        let mut collector = ReferencedBases::default();
         collector.visit_expression(binding);
-        let entry = algebraic_refs
-            .entry(base(target.as_str()).to_string())
-            .or_default();
+        let entry = algebraic_refs.entry(target_base).or_default();
         entry.extend(
             collector
                 .bases
@@ -528,25 +539,174 @@ fn dependency_closed_promotions(
                 .filter(|r| algebraics.contains(r)),
         );
     }
-    let mut promoted: HashSet<String> = algebraic_refs.keys().cloned().collect();
+    let candidate_order = dae
+        .variables
+        .algebraics
+        .keys()
+        .map(|name| name.as_str().to_string())
+        .collect::<Vec<_>>();
+    let promoted = candidate_order
+        .iter()
+        .filter(|name| {
+            promotion_candidate_is_complete(
+                name,
+                &algebraic_refs,
+                &all_indices,
+                &equation_scalar_counts,
+                family_removed,
+                dae,
+            )
+        })
+        .cloned()
+        .collect();
+    PromotionGraph {
+        candidate_order,
+        algebraic_refs,
+        promoted,
+    }
+}
+
+fn promotion_candidate_is_complete(
+    name: &str,
+    algebraic_refs: &HashMap<String, HashSet<String>>,
+    all_indices: &HashMap<String, Vec<usize>>,
+    equation_scalar_counts: &HashMap<String, usize>,
+    family_removed: &HashSet<usize>,
+    dae: &dae::Dae,
+) -> bool {
+    let Some(variable) = dae
+        .variables
+        .algebraics
+        .get(&rumoca_core::VarName::new(name))
+    else {
+        return false;
+    };
+    let Some(variable_size) = variable.try_size().ok() else {
+        return false;
+    };
+    algebraic_refs.contains_key(name)
+        && all_indices
+            .get(name)
+            .is_some_and(|indices| indices.iter().all(|index| family_removed.contains(index)))
+        && equation_scalar_counts.get(name).copied() == Some(variable_size)
+}
+
+fn prune_dangling_promotions(
+    promoted: &mut HashSet<String>,
+    algebraic_refs: &HashMap<String, HashSet<String>>,
+) {
     loop {
-        let to_remove: Vec<String> = promoted
+        let to_remove = promoted
             .iter()
-            .filter(|var| {
-                algebraic_refs
-                    .get(var.as_str())
-                    .is_some_and(|refs| refs.iter().any(|r| r != *var && !promoted.contains(r)))
-            })
+            .filter(|var| promotion_has_dangling_reference(var, promoted, algebraic_refs))
             .cloned()
-            .collect();
+            .collect::<Vec<_>>();
         if to_remove.is_empty() {
-            break;
+            return;
         }
         for var in to_remove {
             promoted.remove(&var);
         }
     }
-    promoted
+}
+
+fn promotion_has_dangling_reference(
+    var: &str,
+    promoted: &HashSet<String>,
+    algebraic_refs: &HashMap<String, HashSet<String>>,
+) -> bool {
+    algebraic_refs.get(var).is_some_and(|refs| {
+        refs.iter()
+            .any(|reference| reference == var || !promoted.contains(reference))
+    })
+}
+
+fn dependency_ordered_promotions(
+    removable: &HashMap<usize, (rumoca_core::VarName, rumoca_core::Expression)>,
+    family_removed: &HashSet<usize>,
+    dae: &dae::Dae,
+) -> Vec<String> {
+    let PromotionGraph {
+        candidate_order,
+        algebraic_refs,
+        mut promoted,
+    } = build_promotion_graph(removable, family_removed, dae);
+
+    let family_targets = structured_family_targets(removable, family_removed, dae);
+    loop {
+        prune_dangling_promotions(&mut promoted, &algebraic_refs);
+
+        let split_family_targets = family_targets
+            .iter()
+            .filter(|targets| {
+                targets
+                    .iter()
+                    .any(|target| !promoted.contains(target.as_str()))
+            })
+            .flat_map(|targets| targets.iter().cloned())
+            .collect::<HashSet<_>>();
+        let before_family_prune = promoted.len();
+        promoted.retain(|name| !split_family_targets.contains(name));
+        if promoted.len() != before_family_prune {
+            continue;
+        }
+
+        let order = topological_promotion_order(&candidate_order, &algebraic_refs, &promoted);
+        if order.len() == promoted.len() {
+            return order;
+        }
+        let acyclic: HashSet<&str> = order.iter().map(String::as_str).collect();
+        promoted.retain(|name| acyclic.contains(name.as_str()));
+    }
+}
+
+fn structured_family_targets(
+    removable: &HashMap<usize, (rumoca_core::VarName, rumoca_core::Expression)>,
+    family_removed: &HashSet<usize>,
+    dae: &dae::Dae,
+) -> Vec<HashSet<String>> {
+    dae.continuous
+        .structured_equations
+        .iter()
+        .filter_map(|family| {
+            let total: usize = family.equation_counts.iter().sum();
+            let indices = family.first_equation_index..family.first_equation_index + total;
+            if !indices.clone().all(|index| family_removed.contains(&index)) {
+                return None;
+            }
+            Some(
+                indices
+                    .filter_map(|index| removable.get(&index))
+                    .map(|(target, _)| base(target.as_str()).to_string())
+                    .collect(),
+            )
+        })
+        .filter(|targets: &HashSet<String>| !targets.is_empty())
+        .collect()
+}
+
+fn topological_promotion_order(
+    candidate_order: &[String],
+    algebraic_refs: &HashMap<String, HashSet<String>>,
+    promoted: &HashSet<String>,
+) -> Vec<String> {
+    let mut remaining = promoted.clone();
+    let mut order = Vec::with_capacity(remaining.len());
+    loop {
+        let next = candidate_order.iter().find(|candidate| {
+            remaining.contains(candidate.as_str())
+                && algebraic_refs.get(candidate.as_str()).is_none_or(|refs| {
+                    refs.iter()
+                        .all(|reference| !remaining.contains(reference.as_str()))
+                })
+        });
+        let Some(next) = next else {
+            break;
+        };
+        remaining.remove(next.as_str());
+        order.push(next.clone());
+    }
+    order
 }
 
 /// Restrict the removable equation set so no structured family is split: an
@@ -556,6 +716,7 @@ fn removable_indices_respecting_families(
     removable: &HashMap<usize, (rumoca_core::VarName, rumoca_core::Expression)>,
     families: &[dae::StructuredEquationFamily],
     equation_count: usize,
+    dae: &dae::Dae,
 ) -> HashSet<usize> {
     // Map each equation index to its owning family (if any).
     let mut family_of: Vec<Option<usize>> = vec![None; equation_count];
@@ -582,14 +743,19 @@ fn removable_indices_respecting_families(
         .keys()
         .copied()
         .filter(|index| match family_of.get(*index).copied().flatten() {
-            // Promote only variables defined by a *structured* (array/grid)
-            // equation family — that is where inlining a parameter-variable
-            // definition into every consumer actually bloats codegen. Scalar
-            // standalone algebraics (e.g. connection aliases, algorithm outputs)
-            // keep their classification, which other passes may rely on, and the
-            // benefit of promoting a single scalar is negligible anyway.
             Some(family_index) => family_all_removable[family_index],
-            None => false,
+            None => removable.get(index).is_some_and(|(target, _)| {
+                let base_name = rumoca_core::VarName::new(base(target.as_str()).to_string());
+                let Some(equation) = dae.continuous.equations.get(*index) else {
+                    return false;
+                };
+                let Some(variable) = dae.variables.algebraics.get(&base_name) else {
+                    return false;
+                };
+                target.as_str() == base(target.as_str())
+                    && ((variable.dims.is_empty() && equation.origin.starts_with("equation from "))
+                        || (!variable.dims.is_empty() && equation.scalar_count > 1))
+            }),
         })
         .collect()
 }
@@ -637,6 +803,14 @@ fn parameter_variable_algebraics(dae: &dae::Dae) -> HashSet<String> {
             .map(|k| base(k.as_str()).to_string())
             .collect::<HashSet<String>>()
     };
+    let mut static_references = base_names(&dae.variables.parameters);
+    static_references.extend(base_names(&dae.variables.constants));
+    static_references.extend(
+        dae.symbols
+            .enum_literal_ordinals
+            .keys()
+            .map(|name| base(name).to_string()),
+    );
     let mut disqualifying = base_names(&dae.variables.states);
     disqualifying.extend(base_names(&dae.variables.inputs));
     disqualifying.extend(base_names(&dae.variables.outputs));
@@ -660,9 +834,7 @@ fn parameter_variable_algebraics(dae: &dae::Dae) -> HashSet<String> {
         if !algebraics.contains(&target) {
             continue;
         }
-        let mut collector = ReferencedBases {
-            bases: HashSet::new(),
-        };
+        let mut collector = ReferencedBases::default();
         collector.visit_expression(binding);
         definitions
             .entry(target)
@@ -684,6 +856,7 @@ fn parameter_variable_algebraics(dae: &dae::Dae) -> HashSet<String> {
                     &disqualifying,
                     &algebraics,
                     &parameter_variable,
+                    &static_references,
                 )
             });
             if provable {
@@ -701,13 +874,16 @@ fn parameter_variable_algebraics(dae: &dae::Dae) -> HashSet<String> {
 /// Whether a single reference `r` in `target`'s defining expression keeps `target`
 /// classifiable as parameter-variable: a state/input/output/discrete reference
 /// breaks it; another algebraic must already be proven parameter-variable (or be
-/// `target` itself); anything else (parameter, constant, loop index) is fine.
+/// `target` itself); every other reference must resolve to a known parameter,
+/// constant, or enumeration literal. Array-comprehension indices are removed by
+/// [`ReferencedBases`] as lexical locals.
 fn reference_is_parameter_variable(
     r: &str,
     target: &str,
     disqualifying: &HashSet<String>,
     algebraics: &HashSet<String>,
     parameter_variable: &HashSet<String>,
+    static_references: &HashSet<String>,
 ) -> bool {
     if r == "time" {
         return false;
@@ -718,7 +894,7 @@ fn reference_is_parameter_variable(
     if algebraics.contains(r) {
         return r == target || parameter_variable.contains(r);
     }
-    true
+    static_references.contains(r)
 }
 
 /// Interpret an equation as `target := binding`, handling both explicit
@@ -762,8 +938,10 @@ fn whole_var_ref(expr: &rumoca_core::Expression) -> Option<rumoca_core::VarName>
     }
 }
 
+#[derive(Default)]
 struct ReferencedBases {
     bases: HashSet<String>,
+    local_names: HashMap<String, usize>,
 }
 
 impl ExpressionVisitor for ReferencedBases {
@@ -772,10 +950,32 @@ impl ExpressionVisitor for ReferencedBases {
         name: &rumoca_core::Reference,
         subscripts: &[rumoca_core::Subscript],
     ) {
-        self.bases
-            .insert(base(name.var_name().as_str()).to_string());
+        let name = base(name.var_name().as_str());
+        if !self.local_names.contains_key(name) {
+            self.bases.insert(name.to_string());
+        }
         for subscript in subscripts {
             self.visit_subscript(subscript);
+        }
+    }
+
+    fn enter_scope(&mut self, scope: rumoca_core::ExpressionScope<'_>) {
+        let rumoca_core::ExpressionScope::ArrayComprehension(indices) = scope;
+        for index in indices {
+            *self.local_names.entry(index.name.clone()).or_default() += 1;
+        }
+    }
+
+    fn exit_scope(&mut self, scope: rumoca_core::ExpressionScope<'_>) {
+        let rumoca_core::ExpressionScope::ArrayComprehension(indices) = scope;
+        for index in indices {
+            let Some(depth) = self.local_names.get_mut(index.name.as_str()) else {
+                continue;
+            };
+            *depth -= 1;
+            if *depth == 0 {
+                self.local_names.remove(index.name.as_str());
+            }
         }
     }
 }
@@ -784,11 +984,56 @@ impl ExpressionVisitor for ReferencedBases {
 mod tests {
     use super::*;
 
+    fn test_span() -> rumoca_core::Span {
+        rumoca_core::Span::from_offsets(
+            rumoca_core::SourceId::from_source_name("promotion_test.mo"),
+            1,
+            2,
+        )
+    }
+
+    fn literal(value: f64) -> rumoca_core::Expression {
+        rumoca_core::Expression::Literal {
+            value: rumoca_core::Literal::Real(value),
+            span: test_span(),
+        }
+    }
+
+    fn var_ref(name: &str) -> rumoca_core::Expression {
+        rumoca_core::Expression::VarRef {
+            name: rumoca_core::Reference::generated(name),
+            subscripts: Vec::new(),
+            span: test_span(),
+        }
+    }
+
+    fn insert_scalar_algebraic(dae_model: &mut dae::Dae, name: &str) {
+        let name = rumoca_core::VarName::new(name);
+        dae_model
+            .variables
+            .algebraics
+            .insert(name.clone(), dae::Variable::new(name, test_span()));
+    }
+
+    fn push_scalar_equation(
+        dae_model: &mut dae::Dae,
+        target: &str,
+        binding: rumoca_core::Expression,
+    ) {
+        dae_model.continuous.equations.push(dae::Equation::explicit(
+            rumoca_core::VarName::new(target),
+            binding,
+            test_span(),
+            "equation from promotion fixture",
+        ));
+    }
+
     #[test]
     fn time_is_not_parameter_variable_reference() {
         let disqualifying = HashSet::new();
         let algebraics = HashSet::new();
         let parameter_variable = HashSet::from(["time".to_string()]);
+        let static_references = HashSet::new();
 
         assert!(!reference_is_parameter_variable(
             "time",
@@ -796,6 +1041,129 @@ mod tests {
             &disqualifying,
             &algebraics,
             &parameter_variable,
+            &static_references,
         ));
+    }
+
+    #[test]
+    fn promoted_parameters_are_ordered_before_their_consumers() {
+        let mut dae_model = dae::Dae::default();
+        insert_scalar_algebraic(&mut dae_model, "dependent");
+        insert_scalar_algebraic(&mut dae_model, "source");
+        push_scalar_equation(&mut dae_model, "dependent", var_ref("source"));
+        push_scalar_equation(&mut dae_model, "source", literal(2.0));
+
+        promote_parameter_variable_algebraics(&mut dae_model).unwrap();
+
+        assert_eq!(
+            dae_model
+                .variables
+                .parameters
+                .keys()
+                .map(rumoca_core::VarName::as_str)
+                .collect::<Vec<_>>(),
+            vec!["source", "dependent"]
+        );
+        assert!(dae_model.continuous.equations.is_empty());
+    }
+
+    #[test]
+    fn unresolved_aggregate_reference_prevents_promotion() {
+        let mut dae_model = dae::Dae::default();
+        insert_scalar_algebraic(&mut dae_model, "result");
+        push_scalar_equation(&mut dae_model, "result", var_ref("component.array.field"));
+
+        promote_parameter_variable_algebraics(&mut dae_model).unwrap();
+
+        assert!(
+            dae_model
+                .variables
+                .algebraics
+                .contains_key(&rumoca_core::VarName::new("result"))
+        );
+        assert_eq!(dae_model.continuous.equations.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_scalar_definitions_do_not_change_equation_balance() {
+        let mut dae_model = dae::Dae::default();
+        insert_scalar_algebraic(&mut dae_model, "result");
+        push_scalar_equation(&mut dae_model, "result", literal(1.0));
+        push_scalar_equation(&mut dae_model, "result", literal(2.0));
+
+        promote_parameter_variable_algebraics(&mut dae_model).unwrap();
+
+        assert!(
+            dae_model
+                .variables
+                .algebraics
+                .contains_key(&rumoca_core::VarName::new("result"))
+        );
+        assert_eq!(dae_model.continuous.equations.len(), 2);
+    }
+
+    #[test]
+    fn template_binder_is_rewritten_to_comprehension_local() {
+        let binder_names = HashSet::from(["i".to_string()]);
+        let mut rewriter = ComprehensionBinderRewriter {
+            binder_names: &binder_names,
+        };
+        let rewritten = rewriter.rewrite_expression(&rumoca_core::Expression::VarRef {
+            name: rumoca_core::Reference::new("i"),
+            subscripts: Vec::new(),
+            span: test_span(),
+        });
+
+        let rumoca_core::Expression::VarRef { name, .. } = rewritten else {
+            panic!("binder reference should remain a variable reference");
+        };
+        assert_eq!(name.as_str(), "i");
+        assert!(name.is_generated());
+    }
+
+    #[test]
+    fn qualified_component_with_binder_suffix_is_not_rewritten() {
+        let binder_names = HashSet::from(["i".to_string()]);
+        let mut rewriter = ComprehensionBinderRewriter {
+            binder_names: &binder_names,
+        };
+        let rewritten = rewriter.rewrite_expression(&rumoca_core::Expression::VarRef {
+            name: rumoca_core::Reference::new("pathPlanning.path.i"),
+            subscripts: Vec::new(),
+            span: test_span(),
+        });
+
+        let rumoca_core::Expression::VarRef { name, .. } = rewritten else {
+            panic!("component reference should remain a variable reference");
+        };
+        assert_eq!(name.as_str(), "pathPlanning.path.i");
+        assert!(!name.is_generated());
+    }
+
+    #[test]
+    fn promotes_ordinary_time_invariant_scalar_equation() {
+        let span = test_span();
+        let name = rumoca_core::VarName::new("staticResult");
+        let mut dae_model = dae::Dae::default();
+        dae_model
+            .variables
+            .algebraics
+            .insert(name.clone(), dae::Variable::new(name.clone(), span));
+        dae_model.continuous.equations.push(dae::Equation::explicit(
+            name.clone(),
+            rumoca_core::Expression::Literal {
+                value: rumoca_core::Literal::Real(3.0),
+                span,
+            },
+            span,
+            "equation from static fixture",
+        ));
+
+        promote_parameter_variable_algebraics(&mut dae_model)
+            .expect("ordinary invariant scalar should promote");
+
+        assert!(dae_model.variables.algebraics.is_empty());
+        assert!(dae_model.variables.parameters.contains_key(&name));
+        assert!(dae_model.continuous.equations.is_empty());
     }
 }

--- a/crates/rumoca-phase-dae/src/promote_parameter_variable.rs
+++ b/crates/rumoca-phase-dae/src/promote_parameter_variable.rs
@@ -4,19 +4,18 @@
 //! variability — every reference resolves (transitively) to a parameter,
 //! constant, structural loop index, or another parameter-variable algebraic, and
 //! never to a state, input, output, or discrete variable — is **constant for the
-//! entire simulation**. Keeping it as a solver algebraic forces every consumer
-//! (e.g. a state derivative) to either re-solve it each step or inline its full
-//! defining expression; the latter duplicates large expressions (coordinate
-//! transforms, immersed-boundary masks) across every kernel that uses them,
-//! bloating codegen and recomputing a constant every step.
+//! entire simulation**. When a state derivative depends on that algebraic, keeping
+//! it in the solver partition forces the derivative to inline or repeatedly solve
+//! the constant definition. Promotion is therefore restricted to algebraics on a
+//! derivative dependency path, plus structured families whose interiors were
+//! deliberately cheapened and must be reconstructed for correctness.
 //!
 //! Promoting it to a derived parameter — moving the variable into the parameter
 //! partition with its defining equation(s) reconstructed into a `Variable.start`
 //! binding, and dropping the now-redundant continuous equations — makes it a value
-//! evaluated once at parameter-set time. Running this BEFORE condition lowering
-//! also means a parameter-variable `if`-condition (e.g. `if sc < pc`) sees `sc` as
-//! a parameter, so it stays directly evaluable instead of allocating an Appendix B
-//! event/condition variable.
+//! evaluated once at parameter-set time. Restricting the transformation to those
+//! consumers preserves the declared DAE algebraic structure for unrelated static
+//! equations.
 //!
 //! The DAE may store array equations either as whole-array assignments or scalarized
 //! into [`dae::StructuredEquationFamily`] blocks. Promotion therefore: (1) promotes
@@ -70,16 +69,21 @@ fn promote(
                 base(target.as_str()).to_string(),
             ))
     };
-    // Every parameter-variable algebraic is invariant for the whole simulation.
-    // Promote it even when no state derivative reaches it: visible observations and
-    // assertion conditions are runtime consumers too, and leaving a large static
-    // submodel in the algebraic partition makes them rebuild the same value at every
-    // output point. Derived parameters preserve the value while evaluating it once.
+    // Only promote algebraics that a state derivative actually depends on
+    // (transitively). That is precisely where inlining a large parameter-variable
+    // definition into the per-step / derivative hot path causes codegen bloat.
+    // Promoting unrelated algebraics would perturb the public DAE structure without
+    // improving the hot path. A *cheapened* family is the exception: flatten already
+    // dropped its per-cell bodies, so it MUST be reconstructed as a parameter for
+    // correctness regardless of reachability.
+    let worthwhile = derivative_reachable_algebraics(dae);
     let mut removable: HashMap<usize, (rumoca_core::VarName, rumoca_core::Expression)> =
         HashMap::new();
     for (index, equation) in dae.continuous.equations.iter().enumerate() {
         if let Some((target, binding)) = direct_assignment(equation)
             && promotable.contains(base(target.as_str()))
+            && (worthwhile.contains(base(target.as_str()))
+                || cheapened_algebraic_bases.contains(base(target.as_str())))
             && is_array_variable(&target)
         {
             removable.insert(index, (target, binding.clone()));
@@ -477,6 +481,49 @@ fn binder_range_expr(
         end: int_lit(binder.upper),
         span,
     }
+}
+
+/// Algebraic base names that a state-derivative equation depends on, transitively
+/// through other algebraics' defining equations. Promotion is only worthwhile here:
+/// these are the algebraics whose definitions would otherwise be evaluated or
+/// inlined into the derivative hot path.
+fn derivative_reachable_algebraics(dae: &dae::Dae) -> HashSet<String> {
+    let algebraics: HashSet<String> = dae
+        .variables
+        .algebraics
+        .keys()
+        .map(|key| base(key.as_str()).to_string())
+        .collect();
+    let mut algebraic_refs: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut seed = Vec::new();
+    for equation in &dae.continuous.equations {
+        let mut collector = ReferencedBases::default();
+        collector.visit_expression(&equation.rhs);
+        let referenced_algebraics: HashSet<String> = collector
+            .bases
+            .into_iter()
+            .filter(|reference| algebraics.contains(reference))
+            .collect();
+        if equation.rhs.contains_der() {
+            seed.extend(referenced_algebraics.iter().cloned());
+        }
+        if let Some((target, _)) = direct_assignment(equation) {
+            algebraic_refs
+                .entry(base(target.as_str()).to_string())
+                .or_default()
+                .extend(referenced_algebraics);
+        }
+    }
+    let mut reachable = HashSet::new();
+    while let Some(name) = seed.pop() {
+        if !reachable.insert(name.clone()) {
+            continue;
+        }
+        if let Some(references) = algebraic_refs.get(&name) {
+            seed.extend(references.iter().cloned());
+        }
+    }
+    reachable
 }
 
 /// Dependency order of variables that can be promoted without changing the scalar
@@ -1007,6 +1054,14 @@ mod tests {
         }
     }
 
+    fn derivative(name: &str) -> rumoca_core::Expression {
+        rumoca_core::Expression::BuiltinCall {
+            function: rumoca_core::BuiltinFunction::Der,
+            args: vec![var_ref(name)],
+            span: test_span(),
+        }
+    }
+
     fn insert_scalar_algebraic(dae_model: &mut dae::Dae, name: &str) {
         let name = rumoca_core::VarName::new(name);
         dae_model
@@ -1052,6 +1107,16 @@ mod tests {
         insert_scalar_algebraic(&mut dae_model, "source");
         push_scalar_equation(&mut dae_model, "dependent", var_ref("source"));
         push_scalar_equation(&mut dae_model, "source", literal(2.0));
+        dae_model.continuous.equations.push(dae::Equation::residual(
+            rumoca_core::Expression::Binary {
+                op: rumoca_core::OpBinary::Sub,
+                lhs: Box::new(derivative("state")),
+                rhs: Box::new(var_ref("dependent")),
+                span: test_span(),
+            },
+            test_span(),
+            "state derivative from promotion fixture",
+        ));
 
         promote_parameter_variable_algebraics(&mut dae_model).unwrap();
 
@@ -1064,7 +1129,8 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["source", "dependent"]
         );
-        assert!(dae_model.continuous.equations.is_empty());
+        assert_eq!(dae_model.continuous.equations.len(), 1);
+        assert!(dae_model.continuous.equations[0].rhs.contains_der());
     }
 
     #[test]
@@ -1141,7 +1207,7 @@ mod tests {
     }
 
     #[test]
-    fn promotes_ordinary_time_invariant_scalar_equation() {
+    fn leaves_time_invariant_scalar_outside_derivative_path_as_algebraic() {
         let span = test_span();
         let name = rumoca_core::VarName::new("staticResult");
         let mut dae_model = dae::Dae::default();
@@ -1160,10 +1226,10 @@ mod tests {
         ));
 
         promote_parameter_variable_algebraics(&mut dae_model)
-            .expect("ordinary invariant scalar should promote");
+            .expect("ordinary invariant scalar should remain valid");
 
-        assert!(dae_model.variables.algebraics.is_empty());
-        assert!(dae_model.variables.parameters.contains_key(&name));
-        assert!(dae_model.continuous.equations.is_empty());
+        assert!(dae_model.variables.algebraics.contains_key(&name));
+        assert!(!dae_model.variables.parameters.contains_key(&name));
+        assert_eq!(dae_model.continuous.equations.len(), 1);
     }
 }

--- a/crates/rumoca-phase-dae/src/tests/conditions.rs
+++ b/crates/rumoca-phase-dae/src/tests/conditions.rs
@@ -265,20 +265,21 @@ fn test_todae_keeps_parameter_only_if_conditions_out_of_event_memory() {
         rhs: Box::new(int(2)),
         span: test_span(23, 24),
     };
+    let x = dae_model
+        .variables
+        .parameters
+        .get(&VarName::new("x"))
+        .expect("a parameter-only definition should become a derived parameter");
     assert!(
         matches!(
-            &dae_model.continuous.equations[0].rhs,
-            rumoca_core::Expression::Binary { rhs, .. }
-                if matches!(
-                    rhs.as_ref(),
-                    rumoca_core::Expression::If { branches, .. }
-                        if rumoca_core::expressions_semantically_equal(
-                            &branches[0].0,
-                            &lowered_condition,
-                        )
+            x.start.as_ref(),
+            Some(rumoca_core::Expression::If { branches, .. })
+                if rumoca_core::expressions_semantically_equal(
+                    &branches[0].0,
+                    &lowered_condition,
                 )
         ),
-        "the parameter condition should remain directly evaluable by initialization lowering"
+        "the parameter condition should remain directly evaluable during parameter initialization"
     );
 }
 

--- a/crates/rumoca-phase-dae/src/tests/conditions.rs
+++ b/crates/rumoca-phase-dae/src/tests/conditions.rs
@@ -265,21 +265,20 @@ fn test_todae_keeps_parameter_only_if_conditions_out_of_event_memory() {
         rhs: Box::new(int(2)),
         span: test_span(23, 24),
     };
-    let x = dae_model
-        .variables
-        .parameters
-        .get(&VarName::new("x"))
-        .expect("a parameter-only definition should become a derived parameter");
     assert!(
         matches!(
-            x.start.as_ref(),
-            Some(rumoca_core::Expression::If { branches, .. })
-                if rumoca_core::expressions_semantically_equal(
-                    &branches[0].0,
-                    &lowered_condition,
+            &dae_model.continuous.equations[0].rhs,
+            rumoca_core::Expression::Binary { rhs, .. }
+                if matches!(
+                    rhs.as_ref(),
+                    rumoca_core::Expression::If { branches, .. }
+                        if rumoca_core::expressions_semantically_equal(
+                            &branches[0].0,
+                            &lowered_condition,
+                        )
                 )
         ),
-        "the parameter condition should remain directly evaluable during parameter initialization"
+        "the parameter condition should remain directly evaluable by initialization lowering"
     );
 }
 

--- a/crates/rumoca-phase-dae/src/tests/root/tests_regressions/assertion_actions_tests.rs
+++ b/crates/rumoca-phase-dae/src/tests/root/tests_regressions/assertion_actions_tests.rs
@@ -117,3 +117,44 @@ fn test_todae_lowers_initial_assert_equation_to_initial_event_action() {
         "initial assertions must remain gated to initialization"
     );
 }
+
+#[test]
+fn test_todae_terminal_when_assert_does_not_create_continuous_roots() {
+    let mut flat = Model::new();
+    add_primitive_real(&mut flat, "x");
+    let span = crate::test_support::test_span();
+    let terminal = Expression::BuiltinCall {
+        function: BuiltinFunction::Terminal,
+        args: Vec::new(),
+        span,
+    };
+    let abs_x = Expression::BuiltinCall {
+        function: BuiltinFunction::Abs,
+        args: vec![make_var_ref("x")],
+        span,
+    };
+    let condition = Expression::Binary {
+        op: rumoca_core::OpBinary::Lt,
+        lhs: Box::new(abs_x),
+        rhs: Box::new(Expression::Literal {
+            value: Literal::Real(1.0e-6),
+            span,
+        }),
+        span,
+    };
+    let mut when_clause = flat::WhenClause::new(terminal, span);
+    when_clause.add_equation(flat::WhenEquation::assert(
+        condition,
+        string_lit("terminal assertion failed"),
+        span,
+        "assert in when terminal clause",
+    ));
+    flat.when_clauses.push(when_clause);
+
+    let dae = lower_assertion_model(&flat);
+
+    assert!(
+        dae.events.synthetic_root_conditions.is_empty(),
+        "terminal-only assertion expressions are evaluated at termination and must not be monitored as continuous roots"
+    );
+}

--- a/crates/rumoca-phase-flatten/src/equations/assert_equations.rs
+++ b/crates/rumoca-phase-flatten/src/equations/assert_equations.rs
@@ -51,6 +51,7 @@ pub(super) fn flatten_assert_equation(
             &lowering.ctx.current_imports,
             lowering.def_map,
             lowering.ctx,
+            None,
         )?,
         level
             .map(|expr| {
@@ -60,6 +61,7 @@ pub(super) fn flatten_assert_equation(
                     &lowering.ctx.current_imports,
                     lowering.def_map,
                     lowering.ctx,
+                    None,
                 )
             })
             .transpose()?,
@@ -106,6 +108,7 @@ pub(super) fn flatten_assert_function_call(
             &lowering.ctx.current_imports,
             lowering.def_map,
             lowering.ctx,
+            None,
         )?,
         level
             .map(|expr| {
@@ -115,6 +118,7 @@ pub(super) fn flatten_assert_function_call(
                     &lowering.ctx.current_imports,
                     lowering.def_map,
                     lowering.ctx,
+                    None,
                 )
             })
             .transpose()?,
@@ -166,6 +170,7 @@ fn qualify_assert_condition(
             &ctx.current_imports,
             def_map,
             ctx,
+            None,
         );
     }
     let rewritten = rewrite_structural_assert_condition(ctx, condition, prefix);
@@ -179,6 +184,7 @@ fn qualify_assert_condition(
         &ctx.current_imports,
         def_map,
         ctx,
+        None,
     )
 }
 

--- a/crates/rumoca-phase-flatten/src/equations/conditional_and_eval.rs
+++ b/crates/rumoca-phase-flatten/src/equations/conditional_and_eval.rs
@@ -138,6 +138,7 @@ pub(super) fn create_conditional_equation_from_simple(
         context.imports,
         context.def_map,
         context.ctx,
+        None,
     )?;
     Ok(flat::Equation::new(
         residual,
@@ -221,7 +222,7 @@ fn flatten_simple_in_list(
     let lhs = expand_array_comprehensions_in_expression(ctx, lhs, prefix, span)?;
     let rhs = expand_array_comprehensions_in_expression(ctx, rhs, prefix, span)?;
 
-    let residual = make_residual(ctx, &lhs, &rhs, prefix, def_map)?;
+    let residual = make_residual(ctx, &lhs, &rhs, prefix, def_map, None)?;
     let scalar_count = infer_simple_equation_scalar_count(&lhs, &rhs, prefix, ctx);
     if scalar_count == 0 {
         return Ok(vec![]);
@@ -279,16 +280,16 @@ pub(super) fn flatten_equations_list(
                 let imports = &ctx.current_imports;
                 let assert_eq = AssertEquation::new(
                     qualify_expression_imports_with_def_map_ctx(
-                        condition, prefix, imports, def_map, ctx,
+                        condition, prefix, imports, def_map, ctx, None,
                     )?,
                     qualify_expression_imports_with_def_map_ctx(
-                        message, prefix, imports, def_map, ctx,
+                        message, prefix, imports, def_map, ctx, None,
                     )?,
                     level
                         .as_ref()
                         .map(|expr| {
                             qualify_expression_imports_with_def_map_ctx(
-                                expr, prefix, imports, def_map, ctx,
+                                expr, prefix, imports, def_map, ctx, None,
                             )
                         })
                         .transpose()?,
@@ -1471,9 +1472,14 @@ fn try_eval_with_rumoca_eval_const(
 ) -> Option<i64> {
     let fallback_start = crate::maybe_start_timer();
     // Convert AST expression to qualified ast::Expression
-    let Ok(flat_expr) =
-        qualify_expression_imports_with_def_map_ctx(expr, prefix, &ctx.current_imports, None, ctx)
-    else {
+    let Ok(flat_expr) = qualify_expression_imports_with_def_map_ctx(
+        expr,
+        prefix,
+        &ctx.current_imports,
+        None,
+        ctx,
+        None,
+    ) else {
         return None;
     };
 

--- a/crates/rumoca-phase-flatten/src/equations/mod.rs
+++ b/crates/rumoca-phase-flatten/src/equations/mod.rs
@@ -3,7 +3,7 @@
 //! This module converts instance equations to flat equations in
 //! residual form (0 = residual).
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 mod shape_inference;
 pub(crate) use shape_inference::{
@@ -463,7 +463,7 @@ pub(crate) fn flatten_equation_with_def_map(
 
             // Preserve simple equations as a single residual equation.
             // Array scalarization and counting are handled downstream.
-            let residual = make_residual(ctx, &lhs, &rhs, prefix, def_map)?;
+            let residual = make_residual(ctx, &lhs, &rhs, prefix, def_map, None)?;
             let scalar_count = infer_simple_equation_scalar_count(&lhs, &rhs, prefix, ctx);
             if scalar_count == 0 {
                 return Ok(FlattenedEquations::default());
@@ -552,6 +552,7 @@ fn make_residual(
     rhs: &ast::Expression,
     prefix: &ast::QualifiedName,
     def_map: Option<&crate::ResolveDefMap>,
+    locals: Option<&HashSet<String>>,
 ) -> Result<rumoca_core::Expression, FlattenError> {
     // Create: lhs - rhs
     let residual = ast::Expression::Binary {
@@ -567,6 +568,7 @@ fn make_residual(
         &ctx.current_imports,
         def_map,
         ctx,
+        locals,
     )
 }
 
@@ -1032,7 +1034,7 @@ fn expand_for_equation(
     // every binder -- including the outer one when this is a nested `for i for j` --
     // stays symbolic. Needed BEFORE the cheapen decision: a parameter-variability
     // family is only cheapenable when its template can rebuild the promoted value.
-    let template = capture_comprehension_template(ctx, equations, prefix, def_map);
+    let template = capture_comprehension_template(ctx, indices, equations, prefix, def_map);
 
     // A regular family lowered with materialization off keeps only its corner cells
     // (base + one neighbor per binder) with full bodies; the interior cells get a
@@ -1124,12 +1126,17 @@ fn expand_for_equation(
 /// path in charge for those shapes.
 fn capture_comprehension_template(
     ctx: &Context,
+    indices: &[ast::ForIndex],
     equations: &[ast::Equation],
     prefix: &ast::QualifiedName,
     def_map: Option<&crate::ResolveDefMap>,
 ) -> Option<rumoca_core::ComprehensionTemplate> {
     let mut body = Vec::new();
-    collect_template_residuals(ctx, equations, prefix, def_map, &mut body)?;
+    let locals = indices
+        .iter()
+        .map(|index| index.ident.text.to_string())
+        .collect::<HashSet<_>>();
+    collect_template_residuals(ctx, equations, prefix, def_map, &locals, &mut body)?;
     (!body.is_empty()).then_some(rumoca_core::ComprehensionTemplate { body })
 }
 
@@ -1143,17 +1150,21 @@ fn collect_template_residuals(
     equations: &[ast::Equation],
     prefix: &ast::QualifiedName,
     def_map: Option<&crate::ResolveDefMap>,
+    locals: &HashSet<String>,
     body: &mut Vec<rumoca_core::Expression>,
 ) -> Option<()> {
     for equation in equations {
         match equation {
             ast::Equation::Simple { lhs, rhs } => {
-                body.push(make_residual(ctx, lhs, rhs, prefix, def_map).ok()?);
+                body.push(make_residual(ctx, lhs, rhs, prefix, def_map, Some(locals)).ok()?);
             }
             ast::Equation::For {
-                equations: inner, ..
+                indices,
+                equations: inner,
             } => {
-                collect_template_residuals(ctx, inner, prefix, def_map, body)?;
+                let mut nested_locals = locals.clone();
+                nested_locals.extend(indices.iter().map(|index| index.ident.text.to_string()));
+                collect_template_residuals(ctx, inner, prefix, def_map, &nested_locals, body)?;
             }
             _ => return None,
         }

--- a/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/context_and_tests.rs
@@ -1777,19 +1777,17 @@ pub(crate) fn qualify_expression_imports_with_def_map(
     } else {
         imports
     };
-    qualify_expression_with_effective_imports(expr, prefix, imports, def_map, opts, None)
+    qualify_expression_with_effective_imports(expr, prefix, imports, def_map, opts, None, None)
 }
 
-/// Like `qualify_expression_imports_with_def_map`, but receives flatten context
-/// semantic metadata. The context is currently used by class-reference
-/// canonicalization in qualification call sites; keeping this entry point
-/// prevents those call sites from falling back to context-free qualification.
+/// Qualify with flatten-context semantic metadata for class-reference canonicalization.
 pub(crate) fn qualify_expression_imports_with_def_map_ctx(
     expr: &ast::Expression,
     prefix: &QualifiedName,
     imports: &qualify::ImportMap,
     def_map: Option<&crate::ResolveDefMap>,
     ctx: &Context,
+    locals: Option<&std::collections::HashSet<String>>,
 ) -> Result<rumoca_core::Expression, FlattenError> {
     let opts = qualify::QualifyOptions {
         preserve_def_id: true,
@@ -1813,6 +1811,7 @@ pub(crate) fn qualify_expression_imports_with_def_map_ctx(
         def_map,
         opts,
         instance_name.as_deref(),
+        locals,
     )
 }
 
@@ -1823,8 +1822,14 @@ fn qualify_expression_with_effective_imports(
     def_map: Option<&crate::ResolveDefMap>,
     opts: qualify::QualifyOptions,
     instance_name: Option<&str>,
+    locals: Option<&std::collections::HashSet<String>>,
 ) -> Result<rumoca_core::Expression, FlattenError> {
-    let qualified = qualify::qualify_expression_with_imports(expr, prefix, opts, imports);
+    let qualified = locals.map_or_else(
+        || qualify::qualify_expression_with_imports(expr, prefix, opts, imports),
+        |locals| {
+            qualify::qualify_expression_with_imports_and_locals(expr, prefix, opts, locals, imports)
+        },
+    );
     crate::ast_lower::expression_from_ast_with_context(
         &qualified,
         crate::ast_lower::LoweringContext {

--- a/crates/rumoca-phase-flatten/src/pipeline/context_and_tests/import_shadow_tests.rs
+++ b/crates/rumoca-phase-flatten/src/pipeline/context_and_tests/import_shadow_tests.rs
@@ -131,7 +131,8 @@ fn instance_component_member_shadows_import_alias_during_equation_qualification(
     let prefix = QualifiedName::from_dotted("tank");
 
     let qualified =
-        qualify_expression_imports_with_def_map_ctx(&expr, &prefix, &imports, None, &ctx).unwrap();
+        qualify_expression_imports_with_def_map_ctx(&expr, &prefix, &imports, None, &ctx, None)
+            .unwrap();
 
     let rumoca_core::Expression::FunctionCall { name, args, .. } = qualified else {
         panic!("expected function call");

--- a/crates/rumoca-phase-flatten/src/when_equations.rs
+++ b/crates/rumoca-phase-flatten/src/when_equations.rs
@@ -76,6 +76,7 @@ pub(crate) fn flatten_when_block(
         &ctx.current_imports,
         def_map,
         ctx,
+        None,
     )?;
 
     let mut clause = flat::WhenClause::new(condition, span);
@@ -182,6 +183,7 @@ fn flatten_when_if_equation(
             &ctx.current_imports,
             def_map,
             ctx,
+            None,
         )?;
         let mut branch_eqs = Vec::new();
 
@@ -379,7 +381,7 @@ fn flatten_when_simple_equation(
 
         // Qualify the function call expression
         let function =
-            qualify_expression_imports_with_def_map_ctx(rhs, prefix, imports, def_map, ctx)?;
+            qualify_expression_imports_with_def_map_ctx(rhs, prefix, imports, def_map, ctx, None)?;
         let origin = format!(
             "when equation multi-output assignment to ({})",
             outputs
@@ -396,7 +398,8 @@ fn flatten_when_simple_equation(
 
     // Simple single-target assignment
     let target = extract_assignment_target(lhs, prefix)?;
-    let value = qualify_expression_imports_with_def_map_ctx(rhs, prefix, imports, def_map, ctx)?;
+    let value =
+        qualify_expression_imports_with_def_map_ctx(rhs, prefix, imports, def_map, ctx, None)?;
     let origin = format!("when equation assignment to {}", target);
     Ok(Some(flat::WhenEquation::assign(
         target, value, span, origin,
@@ -553,9 +556,9 @@ fn flatten_assert_call(
     }
 
     let condition =
-        qualify_expression_imports_with_def_map_ctx(&args[0], prefix, imports, def_map, ctx)?;
+        qualify_expression_imports_with_def_map_ctx(&args[0], prefix, imports, def_map, ctx, None)?;
     let message =
-        qualify_expression_imports_with_def_map_ctx(&args[1], prefix, imports, def_map, ctx)?;
+        qualify_expression_imports_with_def_map_ctx(&args[1], prefix, imports, def_map, ctx, None)?;
     let origin = "assert in when-clause".to_string();
 
     Ok(Some(flat::WhenEquation::assert(
@@ -580,7 +583,7 @@ fn flatten_terminate_call(
     }
 
     let message =
-        qualify_expression_imports_with_def_map_ctx(&args[0], prefix, imports, def_map, ctx)?;
+        qualify_expression_imports_with_def_map_ctx(&args[0], prefix, imports, def_map, ctx, None)?;
     let origin = "terminate in when-clause".to_string();
 
     Ok(Some(flat::WhenEquation::terminate(message, span, origin)))
@@ -604,7 +607,7 @@ fn flatten_reinit_call(
 
     let state = extract_assignment_target(&args[0], prefix)?;
     let value =
-        qualify_expression_imports_with_def_map_ctx(&args[1], prefix, imports, def_map, ctx)?;
+        qualify_expression_imports_with_def_map_ctx(&args[1], prefix, imports, def_map, ctx, None)?;
     let origin = format!("reinit({})", state);
 
     // Note: EQN-016 validation (reinit target must be state) is done in ToDae phase

--- a/crates/rumoca-phase-solve/src/lower/array_values/dynamic_selection.rs
+++ b/crates/rumoca-phase-solve/src/lower/array_values/dynamic_selection.rs
@@ -442,7 +442,7 @@ impl<'a> LowerBuilder<'a> {
                     step.as_deref(),
                     end,
                     range_span,
-                    &const_scope,
+                    const_scope,
                     "array slice range",
                 )?;
                 let mut indices =
@@ -457,7 +457,7 @@ impl<'a> LowerBuilder<'a> {
             _ => single_usize_vec(
                 self.eval_compile_time_positive_index_at(
                     expr,
-                    &const_scope,
+                    const_scope,
                     "array slice index",
                     span,
                 )?,
@@ -469,10 +469,8 @@ impl<'a> LowerBuilder<'a> {
         Ok(indices)
     }
 
-    fn compile_time_slice_bindings(&self, _scope: &Scope) -> IndexMap<String, f64> {
-        let mut bindings = (*self.structural_bindings).clone();
-        bindings.extend(self.local_const_bindings.clone());
-        bindings
+    fn compile_time_slice_bindings(&self, _scope: &Scope) -> &IndexMap<String, f64> {
+        &self.local_const_bindings
     }
 
     fn required_dynamic_selection_span(

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection.rs
@@ -35,7 +35,7 @@ mod tests;
 use dimension_helpers::{
     FunctionScopeSubstituter, append_projected_outputs, array_expression_dims,
     assignment_projection_dims, binary_mul_dims, constructor_input_projection_dims,
-    copy_projection_dims, declared_dims, elementwise_binary_dims,
+    copy_projection_dims, declared_dims, dimension_mismatch_error, elementwise_binary_dims,
     exact_declared_function_output_dims, flat_index_from_indices, flatten_array_elements,
     formal_actual_projection_dims, is_ignorable_projection_statement, is_same_plain_var_ref,
     named_actual_span, named_argument_spans, projected_declared_output_dims,
@@ -57,8 +57,9 @@ use inline_budget::{
 };
 use loop_projection::ForProjectionCtx;
 use projection_helpers::{
-    ArrayProjectionValueCtx, IfStatementProjection, IndexedAssignment, MatrixVectorProductDims,
-    ProjectionAssignmentTarget, ProjectionValueCtx, ScalarSelectionCtx, array_element_scalar_width,
+    ArrayProjectionValueCtx, IfStatementProjection, MatrixVectorProductDims,
+    ProjectionAssignmentSelector, ProjectionAssignmentTarget, ProjectionValueCtx,
+    ScalarSelectionCtx, SelectedAssignment, array_element_scalar_width,
     inherited_projection_source_span, inherited_projection_span, matrix_column_child_flat_index,
     matrix_column_operand_count, matrix_elements_are_row_literals,
     outputs_contain_unresolved_function_scope_refs, projection_actual_with_span,
@@ -664,9 +665,9 @@ impl<'a> FunctionProjectionAnalysis<'a> {
         let target = self.substitute_component_reference(target, scope)?;
         let target = projection_assignment_target(&target)?;
         if target
-            .indices
+            .selectors
             .as_ref()
-            .is_some_and(|indices| !indices.is_empty())
+            .is_some_and(|selectors| !selectors.is_empty())
         {
             return Err(unsupported_at(
                 "indexed procedure-call output targets cannot be projected",
@@ -747,13 +748,13 @@ impl<'a> FunctionProjectionAnalysis<'a> {
         if exceeds_projection_node_budget(&value) {
             return Err(projection_budget_exceeded(function));
         }
-        if let Some(indices) = target.indices.as_deref() {
+        if let Some(selectors) = target.selectors.as_deref() {
             let indexed_span = inherited_projection_span(target.span, assignment_span);
-            self.apply_indexed_assignment(
+            self.apply_selected_assignment(
                 function,
-                IndexedAssignment {
+                SelectedAssignment {
                     target: &target.base,
-                    indices,
+                    selectors,
                     value: &value,
                     span: indexed_span,
                     depth: depth + 1,
@@ -817,63 +818,92 @@ impl<'a> FunctionProjectionAnalysis<'a> {
         Ok(())
     }
 
-    fn apply_indexed_assignment(
+    fn apply_selected_assignment(
         &self,
         function: &rumoca_core::Function,
-        assignment: IndexedAssignment<'_>,
+        assignment: SelectedAssignment<'_>,
         scope: &mut FunctionProjectionScope,
     ) -> Result<(), LowerError> {
         let target = assignment.target;
         let span = assignment.span;
-        if self
-            .expr_dims_with_owner(assignment.value, scope, assignment.depth + 1, span)?
-            .is_some_and(|dims| !dims.is_empty())
-        {
-            return Err(unsupported_at(
-                format!("indexed assignment to scalar element `{target}` received an array value"),
-                span,
-            ));
-        }
         let dims = if let Some(dims) = scope.dims.get(target) {
             copy_projection_dims(dims, "indexed assignment scope dimension count", span)?
         } else {
             declared_dims(function, target)?
                 .ok_or_else(|| guarded_assignment_without_base(target, span))?
         };
-        let flat_index = flat_index_from_indices(
-            &dims,
-            assignment.indices,
-            span,
-            "indexed assignment flat index",
-        )?
-        .ok_or_else(|| {
-            let dims = format_i64_dims(&dims);
-            let indices = format_i64_dims(assignment.indices);
-            LowerError::contract_violation(
+        if dims.len() != assignment.selectors.len() || dims.is_empty() {
+            return Err(LowerError::contract_violation(
                 format!(
-                    "indexed assignment to `{target}` uses out-of-bounds index {indices} for dimensions {dims}"
+                    "selected assignment to `{target}` uses {} selectors for dimensions {}",
+                    assignment.selectors.len(),
+                    format_i64_dims(&dims)
                 ),
                 span,
-            )
-        })?;
+            ));
+        }
+        let selected = selected_assignment_indices(&dims, assignment.selectors, target, span)?;
+        let selected_dims = dims
+            .iter()
+            .zip(assignment.selectors)
+            .filter_map(|(dim, selector)| {
+                matches!(selector, ProjectionAssignmentSelector::All).then_some(*dim)
+            })
+            .collect::<Vec<_>>();
+        let value_dims =
+            self.expr_dims_with_owner(assignment.value, scope, assignment.depth + 1, span)?;
+        if value_dims.as_deref().unwrap_or_default() != selected_dims {
+            return Err(dimension_mismatch_error(
+                &format!("selected assignment to `{target}`"),
+                &selected_dims,
+                value_dims.as_deref().unwrap_or_default(),
+                span,
+            ));
+        }
+        let assigned_values = if selected_dims.is_empty() {
+            vec![self.substitute(assignment.value, scope)?]
+        } else {
+            self.project_value_scalars(
+                assignment.value,
+                &selected_dims,
+                scope,
+                assignment.depth + 1,
+                span,
+            )?
+            .ok_or_else(|| {
+                unsupported_at("selected assignment value could not be projected", span)
+            })?
+        };
+        if assigned_values.len() != selected.len() {
+            return Err(LowerError::contract_violation(
+                format!(
+                    "selected assignment to `{target}` projected {} values for {} target elements",
+                    assigned_values.len(),
+                    selected.len()
+                ),
+                span,
+            ));
+        }
         let mut values = scope
             .scalars
             .get(target)
             .cloned()
             .ok_or_else(|| guarded_assignment_without_base(target, span))?;
-        let Some(slot) = values.get_mut(flat_index) else {
-            return Err(LowerError::contract_violation(
-                format!(
-                    "indexed assignment to `{target}` flat index {flat_index} is missing from scalar projection"
-                ),
-                span,
-            ));
-        };
-        let slot_value = self.substitute(assignment.value, scope)?.with_span(span);
-        if exceeds_projection_node_budget(&slot_value) {
-            return Err(projection_budget_exceeded(function));
+        for (flat_index, value) in selected.into_iter().zip(assigned_values) {
+            let Some(slot) = values.get_mut(flat_index) else {
+                return Err(LowerError::contract_violation(
+                    format!(
+                        "selected assignment to `{target}` flat index {flat_index} is missing from scalar projection"
+                    ),
+                    span,
+                ));
+            };
+            let value = value.with_span(span);
+            if exceeds_projection_node_budget(&value) {
+                return Err(projection_budget_exceeded(function));
+            }
+            *slot = value;
         }
-        *slot = slot_value;
         scope.scalars.insert(target.to_string(), values);
         scope.dims.insert(target.to_string(), dims);
         Ok(())

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/dimension_helpers.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/dimension_helpers.rs
@@ -369,31 +369,34 @@ pub(super) fn projection_assignment_target(
     if last.subs.is_empty() {
         return Ok(ProjectionAssignmentTarget {
             base: component_ref.to_var_name().as_str().to_string(),
-            indices: None,
+            selectors: None,
             span,
         });
     }
-    let mut indices = projection_vec_with_capacity(
+    let mut selectors = projection_vec_with_capacity(
         last.subs.len(),
         "function assignment target subscript count",
         span,
     )?;
     for subscript in &last.subs {
-        let index = match subscript {
-            rumoca_core::Subscript::Index { value, span } if *value > 0 => Ok(*value),
+        let selector = match subscript {
+            rumoca_core::Subscript::Index { value, .. } if *value > 0 => {
+                Ok(ProjectionAssignmentSelector::Index(*value))
+            }
+            rumoca_core::Subscript::Colon { .. } => Ok(ProjectionAssignmentSelector::All),
             _ => Err(unsupported_at(
                 "dynamic function assignment target subscripts cannot be projected",
                 subscript.span(),
             )),
         }?;
-        indices.push(index);
+        selectors.push(selector);
     }
     last.subs.clear();
     Ok(ProjectionAssignmentTarget {
         base: rumoca_core::Reference::from_component_reference(base_ref)
             .as_str()
             .to_string(),
-        indices: Some(indices),
+        selectors: Some(selectors),
         span,
     })
 }
@@ -738,6 +741,7 @@ pub(super) fn binary_mul_dims(
     span: rumoca_core::Span,
 ) -> Result<Option<Vec<i64>>, LowerError> {
     Ok(match (lhs_dims, rhs_dims) {
+        ([], []) => Some(Vec::new()),
         ([], dims) if !dims.is_empty() => Some(copy_projection_dims(
             dims,
             "scalar lhs product dimension count",

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/dimension_inference.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/dimension_inference.rs
@@ -197,7 +197,7 @@ impl<'a> FunctionProjectionAnalysis<'a> {
                 let Some(size) = args.first() else {
                     return Ok(None);
                 };
-                let size = self.compile_time_int(&self.substitute(size, scope)?, scope, span)?;
+                let size = self.compile_time_int(size, scope, span)?;
                 copy_projection_dims(&[size, size], "identity matrix dimension count", span)
                     .map(Some)
             }
@@ -232,7 +232,7 @@ impl<'a> FunctionProjectionAnalysis<'a> {
         let mut dims =
             projection_vec_with_capacity(args.len(), "array constructor dimension count", span)?;
         for arg in args {
-            let dim = self.compile_time_int(&self.substitute(arg, scope)?, scope, span)?;
+            let dim = self.compile_time_int(arg, scope, span)?;
             if dim < 0 {
                 return Err(LowerError::contract_violation(
                     format!("array constructor dimension must be non-negative, got {dim}"),

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/loop_projection.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/loop_projection.rs
@@ -88,7 +88,7 @@ impl FunctionProjectionAnalysis<'_> {
     ) -> Result<rumoca_core::Subscript, LowerError> {
         match subscript {
             rumoca_core::Subscript::Expr { expr, span } => {
-                let value = self.compile_time_int(&self.substitute(expr, scope)?, scope, *span)?;
+                let value = self.compile_time_int(expr, scope, *span)?;
                 Ok(rumoca_core::Subscript::Index { value, span: *span })
             }
             rumoca_core::Subscript::Index { .. } | rumoca_core::Subscript::Colon { .. } => {
@@ -103,15 +103,14 @@ impl FunctionProjectionAnalysis<'_> {
         scope: &FunctionProjectionScope,
         span: rumoca_core::Span,
     ) -> Result<Vec<i64>, LowerError> {
-        let range = self.substitute(range, scope)?;
         match range {
             rumoca_core::Expression::Range {
                 start, step, end, ..
             } => {
-                let start = self.compile_time_int(&start, scope, span)?;
-                let end = self.compile_time_int(&end, scope, span)?;
+                let start = self.compile_time_int(start, scope, span)?;
+                let end = self.compile_time_int(end, scope, span)?;
                 let step = match step {
-                    Some(step) => self.compile_time_int(&step, scope, span)?,
+                    Some(step) => self.compile_time_int(step, scope, span)?,
                     None => 1,
                 };
                 if step == 0 {
@@ -139,7 +138,7 @@ impl FunctionProjectionAnalysis<'_> {
                     "function projection scalar range value count",
                     span,
                 )?;
-                values.push(self.compile_time_int(&range, scope, span)?);
+                values.push(self.compile_time_int(range, scope, span)?);
                 Ok(values)
             }
         }
@@ -169,6 +168,16 @@ impl FunctionProjectionAnalysis<'_> {
             return Ok(Some(value));
         }
         match expr {
+            rumoca_core::Expression::VarRef {
+                name, subscripts, ..
+            } if subscripts.is_empty() => {
+                if let Some(bound) = scope.full.get(name.as_str())
+                    && !is_same_plain_var_ref(bound, name.as_str())
+                {
+                    return self.compile_time_scalar_with_scope(bound, scope, span);
+                }
+                Ok(self.compile_time_scalar(expr))
+            }
             rumoca_core::Expression::Unary { op, rhs, .. } => {
                 let Some(value) = self.compile_time_scalar_with_scope(rhs, scope, span)? else {
                     return Ok(None);
@@ -223,7 +232,16 @@ impl FunctionProjectionAnalysis<'_> {
                 name, subscripts, ..
             } if subscripts.is_empty() => match scope.dims.get(name.as_str()) {
                 Some(dims) => Some(dims.clone()),
-                None => self.expr_dims_with_owner(array, scope, 0, span)?,
+                None => scope
+                    .full
+                    .iter()
+                    .find_map(|(formal, actual)| {
+                        is_same_plain_var_ref(actual, name.as_str())
+                            .then(|| scope.dims.get(formal))
+                            .flatten()
+                    })
+                    .cloned()
+                    .or(self.expr_dims_with_owner(array, scope, 0, span)?),
             },
             _ => self.expr_dims_with_owner(array, scope, 0, span)?,
         };

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/projection_helpers.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/projection_helpers.rs
@@ -40,13 +40,19 @@ pub(super) struct MatrixVectorProductDims<'a> {
 
 pub(super) struct ProjectionAssignmentTarget {
     pub(super) base: String,
-    pub(super) indices: Option<Vec<i64>>,
+    pub(super) selectors: Option<Vec<ProjectionAssignmentSelector>>,
     pub(super) span: rumoca_core::Span,
 }
 
-pub(super) struct IndexedAssignment<'a> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ProjectionAssignmentSelector {
+    Index(i64),
+    All,
+}
+
+pub(super) struct SelectedAssignment<'a> {
     pub(super) target: &'a str,
-    pub(super) indices: &'a [i64],
+    pub(super) selectors: &'a [ProjectionAssignmentSelector],
     pub(super) value: &'a rumoca_core::Expression,
     pub(super) span: rumoca_core::Span,
     pub(super) depth: usize,

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/tests.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs/function_projection/tests.rs
@@ -159,6 +159,86 @@ fn projected_scope_dimensions_override_full_binding_dimensions() {
 }
 
 #[test]
+fn size_uses_resolved_callee_dims_after_following_full_alias() -> Result<(), LowerError> {
+    let dae_model = dae::Dae::default();
+    let structural_bindings = IndexMap::new();
+    let analysis = FunctionProjectionAnalysis::new(&dae_model, &structural_bindings);
+    let mut scope = FunctionProjectionScope::default();
+    scope
+        .full
+        .insert("B".to_string(), local_var("callerRightHandSide"));
+    scope.dims.insert("B".to_string(), vec![3, 1]);
+    scope
+        .scalars
+        .insert("B".to_string(), vec![real(1.0), real(2.0), real(3.0)]);
+    let size = builtin(
+        rumoca_core::BuiltinFunction::Size,
+        vec![
+            local_var("B"),
+            rumoca_core::Expression::Literal {
+                value: Literal::Integer(1),
+                span: test_span(),
+            },
+        ],
+    );
+
+    let substituted = analysis.substitute(&size, &scope)?;
+    assert_eq!(
+        analysis.compile_time_int(&substituted, &scope, test_span())?,
+        3
+    );
+    Ok(())
+}
+
+#[test]
+fn static_colon_assignment_projects_array_into_matrix_column() -> Result<(), LowerError> {
+    let dae_model = dae::Dae::default();
+    let structural_bindings = IndexMap::new();
+    let analysis = FunctionProjectionAnalysis::new(&dae_model, &structural_bindings);
+    let mut function = rumoca_core::Function::new("My.columnAssign", test_span());
+    function
+        .locals
+        .push(function_param_with_dims("rightHandSide", &[3, 1]));
+    let mut scope = FunctionProjectionScope::default();
+    analysis.initialize_projected_declared_arrays(&function, &mut scope, 0, test_span())?;
+    let statement = rumoca_core::Statement::Assignment {
+        comp: rumoca_core::ComponentReference {
+            local: false,
+            span: test_span(),
+            parts: vec![rumoca_core::ComponentRefPart {
+                ident: "rightHandSide".to_string(),
+                span: test_span(),
+                subs: vec![
+                    rumoca_core::Subscript::Colon { span: test_span() },
+                    rumoca_core::Subscript::Index {
+                        value: 1,
+                        span: test_span(),
+                    },
+                ],
+            }],
+            def_id: None,
+        },
+        value: array(vec![real(1.0), real(2.0), real(3.0)], false),
+        span: test_span(),
+    };
+
+    analysis.apply_assignment(
+        &function,
+        &statement,
+        &mut scope,
+        &mut Vec::new(),
+        0,
+        test_span(),
+    )?;
+
+    assert_eq!(
+        scope.scalars.get("rightHandSide"),
+        Some(&vec![real(1.0), real(2.0), real(3.0)])
+    );
+    Ok(())
+}
+
+#[test]
 fn substitution_reads_current_projected_indexed_assignment() -> Result<(), LowerError> {
     let dae_model = dae::Dae::default();
     let structural_bindings = IndexMap::new();
@@ -402,6 +482,12 @@ fn array_binary_projection_rejects_unknown_operand_dimensions_with_span() {
         err.reason(),
         "binary lhs has unknown dimensions".to_string()
     );
+}
+
+#[test]
+fn scalar_scalar_product_dimensions_are_scalar() -> Result<(), LowerError> {
+    assert_eq!(binary_mul_dims(&[], &[], test_span())?, Some(Vec::new()));
+    Ok(())
 }
 
 #[test]

--- a/crates/rumoca-phase-solve/src/lower/derivative_rhs/projection_selection.rs
+++ b/crates/rumoca-phase-solve/src/lower/derivative_rhs/projection_selection.rs
@@ -11,6 +11,39 @@ pub(super) fn projection_vec_with_capacity<T>(
     Ok(values)
 }
 
+pub(super) fn selected_assignment_indices(
+    dims: &[i64],
+    selectors: &[ProjectionAssignmentSelector],
+    target: &str,
+    span: rumoca_core::Span,
+) -> Result<Vec<usize>, LowerError> {
+    let count = scalar_count_for_dims(dims, "selected assignment target", span)?;
+    let mut selected =
+        projection_vec_with_capacity(count, "selected assignment target scalar count", span)?;
+    for flat_index in 0..count {
+        let subscripts = required_flat_index_to_subscripts(dims, flat_index, span)?;
+        let is_selected = selectors
+            .iter()
+            .zip(&subscripts)
+            .all(|(selector, subscript)| match selector {
+                ProjectionAssignmentSelector::Index(index) => {
+                    usize::try_from(*index).ok() == Some(*subscript)
+                }
+                ProjectionAssignmentSelector::All => true,
+            });
+        if is_selected {
+            selected.push(flat_index);
+        }
+    }
+    if selected.is_empty() {
+        return Err(LowerError::contract_violation(
+            format!("selected assignment to `{target}` selects no target elements"),
+            span,
+        ));
+    }
+    Ok(selected)
+}
+
 fn reserve_projection_capacity<T>(
     values: &mut Vec<T>,
     additional: usize,

--- a/crates/rumoca-phase-solve/src/lower/function_calls.rs
+++ b/crates/rumoca-phase-solve/src/lower/function_calls.rs
@@ -1965,7 +1965,7 @@ impl<'a> LowerBuilder<'a> {
             } else {
                 0.0
             };
-            std::sync::Arc::make_mut(&mut self.structural_bindings)
+            self.local_const_bindings
                 .insert(super::size_binding_key(name, idx + 1), dim);
         }
         Ok(())
@@ -1981,7 +1981,8 @@ impl<'a> LowerBuilder<'a> {
         self.known_empty_local_arrays.shift_remove(name);
         for dimension in 1.. {
             let key = super::size_binding_key(name, dimension);
-            if std::sync::Arc::make_mut(&mut self.structural_bindings)
+            if self
+                .local_const_bindings
                 .shift_remove(key.as_str())
                 .is_none()
             {

--- a/crates/rumoca-phase-solve/src/lower/statements/compile_time.rs
+++ b/crates/rumoca-phase-solve/src/lower/statements/compile_time.rs
@@ -401,8 +401,9 @@ impl<'a> LowerBuilder<'a> {
             return Ok(1.0);
         }
         let key = size_binding_key(name.as_str(), dim);
-        self.structural_bindings
+        const_scope
             .get(key.as_str())
+            .or_else(|| self.structural_bindings.get(key.as_str()))
             .copied()
             .ok_or_else(|| LowerError::ForRangeUnknownDimension {
                 name: name.as_str().to_string(),

--- a/crates/rumoca-solver-diffsol/src/ode.rs
+++ b/crates/rumoca-solver-diffsol/src/ode.rs
@@ -496,7 +496,7 @@ pub(crate) fn build_state_ode_problem_with_runtime_params_and_initial(
         let start = root_counters.as_ref().map(|_| Instant::now());
         with_runtime_params(&root_params, p.as_slice(), |params| {
             if root_runtime
-                .eval_root_conditions_into(
+                .eval_root_search_conditions_into(
                     t,
                     y.as_slice(),
                     params,
@@ -576,7 +576,7 @@ fn build_ode_problem_with_initial(
     let root_fn = move |y: &Vector, p: &Vector, t: Scalar, out: &mut Vector| {
         with_runtime_params(&root_runtime_params, p.as_slice(), |params| {
             if root_runtime
-                .eval_root_conditions_into(
+                .eval_root_search_conditions_into(
                     t,
                     y.as_slice(),
                     params,

--- a/crates/rumoca-solver-diffsol/src/tests/root_events.rs
+++ b/crates/rumoca-solver-diffsol/src/tests/root_events.rs
@@ -2,6 +2,7 @@ use indexmap::IndexMap;
 use rumoca_ir_solve as solve;
 use rumoca_solver::SimOptions;
 
+use super::unit_integrator_model;
 use crate::simulate;
 
 macro_rules! fixture_span {
@@ -74,6 +75,65 @@ fn strict_post_crossing_reinit_evaluates_on_event_right_limit() {
         result.times,
         result.data[0],
         result.data[1]
+    );
+}
+
+#[test]
+fn state_only_bdf_uses_search_values_for_parameter_static_roots() {
+    let mut model = unit_integrator_model();
+    model.problem.solve_layout.parameter_count = 1;
+    model.problem.solve_layout.compiled_parameter_len = 1;
+    model.parameters = vec![0.0];
+    model.problem.events.root_conditions = solve::ScalarProgramBlock::with_source_span(
+        vec![vec![
+            solve::LinearOp::LoadP { dst: 0, index: 0 },
+            solve::LinearOp::StoreOutput { src: 0 },
+        ]],
+        fixture_span!(),
+    );
+    model.problem.discrete.update_targets = vec![solve::scalar_slot_y(0)];
+    model.problem.discrete.rhs = solve::ScalarProgramBlock::with_source_span(
+        vec![vec![
+            solve::LinearOp::LoadY { dst: 0, index: 0 },
+            solve::LinearOp::Const { dst: 1, value: 0.0 },
+            solve::LinearOp::Compare {
+                dst: 2,
+                op: solve::CompareOp::Gt,
+                lhs: 0,
+                rhs: 1,
+            },
+            solve::LinearOp::Const {
+                dst: 3,
+                value: 100.0,
+            },
+            solve::LinearOp::Select {
+                dst: 4,
+                cond: 2,
+                if_true: 3,
+                if_false: 0,
+            },
+            solve::LinearOp::StoreOutput { src: 4 },
+        ]],
+        fixture_span!(),
+    );
+
+    let result = simulate(
+        &model,
+        &SimOptions {
+            t_end: 0.001,
+            dt: Some(0.001),
+            ..Default::default()
+        },
+    )
+    .expect("a parameter-static root should not retrigger the BDF solver");
+
+    let final_x = result.data[0]
+        .last()
+        .copied()
+        .expect("x should be recorded");
+    assert!(
+        (final_x - 0.001).abs() <= 1.0e-8,
+        "a static zero root incorrectly fired a state reinit: x={final_x}"
     );
 }
 

--- a/crates/rumoca/Cargo.toml
+++ b/crates/rumoca/Cargo.toml
@@ -71,6 +71,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 miette = { workspace = true }
 minijinja = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["unbounded_depth"] }
 tempfile = { workspace = true }
@@ -157,7 +158,6 @@ walkdir = "2.5"
 ureq = "2.9"
 dirs = "5.0"
 serde = { version = "1.0", features = ["derive"] }
-rayon = { workspace = true }
 ntest = "0.9"  # Test timeouts
 # Direct phase access for debugging/analysis tests
 rumoca-ir-ast = { workspace = true }

--- a/crates/rumoca/src/compiler.rs
+++ b/crates/rumoca/src/compiler.rs
@@ -40,8 +40,9 @@ use std::path::Path;
 
 use rumoca_compile::analysis as dae_analysis;
 use rumoca_compile::codegen::{
-    CodegenError, SolveTemplateRenderer, dae_for_fmi_model_description_context,
-    dae_for_solve_template_context, dae_to_template_json, render_ast_template_with_name,
+    CodegenError, SolveTemplateRenderer, dae_for_fmi_implementation_context,
+    dae_for_fmi_native_implementation_context, dae_for_solve_template_context,
+    dae_to_template_json, fmi3_native_projection_available, render_ast_template_with_name,
     render_dae_template_with_json, render_dae_template_with_json_and_name,
     render_flat_template_with_name,
 };
@@ -79,9 +80,16 @@ pub struct CompilationResult {
     /// Cached solve-template renderer for targets that never read the `dae`
     /// template entry.
     solve_template_renderer_without_dae: std::sync::OnceLock<SolveTemplateRenderer>,
-    /// Cached solve renderer whose `dae` entry is prepared for FMI
-    /// modelDescription XML metadata.
-    fmi_model_description_renderer: std::sync::OnceLock<SolveTemplateRenderer>,
+    /// Separate XML and implementation renderers built together: FMI metadata
+    /// folding and numerical Solve IR lowering run concurrently, while each
+    /// renderer retains its own lazy symbol/materialization state.
+    fmi_template_renderers: std::sync::OnceLock<FmiTemplateRenderers>,
+}
+
+#[derive(Debug)]
+struct FmiTemplateRenderers {
+    model_description: SolveTemplateRenderer,
+    implementation: SolveTemplateRenderer,
 }
 
 /// Lean result of a successful DAE-only compilation.
@@ -101,7 +109,7 @@ fn build_solve_template_renderer(dae_model: &Dae) -> Result<SolveTemplateRendere
     let artifacts = lower_solve_artifacts(&problem)
         .map_err(|err| CompilerError::TemplateError(CodegenError::template(err.to_string())))?;
     let template_dae = dae_for_solve_template_context(dae_model)?;
-    SolveTemplateRenderer::new_with_dae(&problem, &artifacts, template_dae)
+    SolveTemplateRenderer::new_owned_with_dae(problem, artifacts, template_dae)
         .map_err(CompilerError::TemplateError)
 }
 
@@ -114,15 +122,47 @@ fn build_solve_template_renderer_without_dae(
     SolveTemplateRenderer::new(&problem, &artifacts, "").map_err(CompilerError::TemplateError)
 }
 
-fn build_fmi_model_description_renderer(
-    dae_model: &Dae,
-) -> Result<SolveTemplateRenderer, CompilerError> {
-    let problem = lower_solve_problem(dae_model)
-        .map_err(|err| CompilerError::TemplateError(CodegenError::template(err.to_string())))?;
-    let artifacts = rumoca_ir_solve::SolveArtifacts::default();
-    let template_dae = dae_for_fmi_model_description_context(dae_model)?;
-    SolveTemplateRenderer::new_with_dae(&problem, &artifacts, template_dae)
-        .map_err(CompilerError::TemplateError)
+fn build_fmi_template_renderers(dae_model: &Dae) -> Result<FmiTemplateRenderers, CompilerError> {
+    let (metadata, numerical) = rayon::join(
+        || {
+            dae_for_fmi_native_implementation_context(dae_model)
+                .map(std::sync::Arc::new)
+                .map_err(CompilerError::TemplateError)
+        },
+        || {
+            let problem = lower_solve_problem(dae_model).map_err(|err| {
+                CompilerError::TemplateError(CodegenError::template(err.to_string()))
+            })?;
+            let artifacts = lower_solve_artifacts(&problem).map_err(|err| {
+                CompilerError::TemplateError(CodegenError::template(err.to_string()))
+            })?;
+            let native_projection = (dae_model.variables.algebraics.is_empty()
+                && dae_model.variables.outputs.is_empty())
+                || fmi3_native_projection_available(&problem)
+                    .map_err(CompilerError::TemplateError)?;
+            Ok::<_, CompilerError>((problem, artifacts, native_projection))
+        },
+    );
+    let metadata = metadata?;
+    let (problem, artifacts, native_projection) = numerical?;
+    let model_description = SolveTemplateRenderer::new_owned_with_shared_dae(
+        rumoca_ir_solve::SolveProblem::default(),
+        rumoca_ir_solve::SolveArtifacts::default(),
+        metadata.clone(),
+    )
+    .map_err(CompilerError::TemplateError)?;
+    let implementation = if native_projection {
+        SolveTemplateRenderer::new_owned_with_shared_dae(problem, artifacts, metadata)
+            .map_err(CompilerError::TemplateError)?
+    } else {
+        let template_dae = dae_for_fmi_implementation_context(dae_model)?;
+        SolveTemplateRenderer::new_owned_with_dae(problem, artifacts, template_dae)
+            .map_err(CompilerError::TemplateError)?
+    };
+    Ok(FmiTemplateRenderers {
+        model_description,
+        implementation,
+    })
 }
 
 impl CompilationResult {
@@ -139,7 +179,7 @@ impl CompilationResult {
             resolved,
             solve_template_renderer: std::sync::OnceLock::new(),
             solve_template_renderer_without_dae: std::sync::OnceLock::new(),
-            fmi_model_description_renderer: std::sync::OnceLock::new(),
+            fmi_template_renderers: std::sync::OnceLock::new(),
         }
     }
 
@@ -409,16 +449,37 @@ impl CompilationResult {
         template: &str,
         model_name: &str,
     ) -> Result<String, CompilerError> {
-        if self.fmi_model_description_renderer.get().is_none() {
-            let renderer = build_fmi_model_description_renderer(&self.dae)?;
-            let _ = self.fmi_model_description_renderer.set(renderer);
+        if self.fmi_template_renderers.get().is_none() {
+            let renderers = build_fmi_template_renderers(&self.dae)?;
+            let _ = self.fmi_template_renderers.set(renderers);
         }
-        let renderer = self.fmi_model_description_renderer.get().ok_or_else(|| {
+        let renderers = self.fmi_template_renderers.get().ok_or_else(|| {
             CompilerError::TemplateError(CodegenError::template(
-                "FMI modelDescription renderer was not initialized after build",
+                "FMI template renderers were not initialized after build",
             ))
         })?;
-        renderer
+        renderers
+            .model_description
+            .render_with_name(template, model_name)
+            .map_err(CompilerError::TemplateError)
+    }
+
+    pub fn render_fmi_implementation_template_str_with_name(
+        &self,
+        template: &str,
+        model_name: &str,
+    ) -> Result<String, CompilerError> {
+        if self.fmi_template_renderers.get().is_none() {
+            let renderers = build_fmi_template_renderers(&self.dae)?;
+            let _ = self.fmi_template_renderers.set(renderers);
+        }
+        let renderers = self.fmi_template_renderers.get().ok_or_else(|| {
+            CompilerError::TemplateError(CodegenError::template(
+                "FMI template renderers were not initialized after build",
+            ))
+        })?;
+        renderers
+            .implementation
             .render_with_name(template, model_name)
             .map_err(CompilerError::TemplateError)
     }

--- a/crates/rumoca/src/fmu.rs
+++ b/crates/rumoca/src/fmu.rs
@@ -26,8 +26,12 @@ pub(crate) fn build_fmu(
     let lib_path = bin_dir.join(format!("{model_identifier}.{lib_ext}"));
 
     eprintln!("  compiling {}", c_path.display());
-    let status = Command::new("cc")
-        .args(["-shared", "-fPIC", "-O2", "-o"])
+    let compiler = std::env::var_os("CC").unwrap_or_else(|| "cc".into());
+    let cflags = std::env::var("CFLAGS").unwrap_or_else(|_| "-Og".to_string());
+    let status = Command::new(compiler)
+        .args(["-shared", "-fPIC"])
+        .args(cflags.split_whitespace())
+        .arg("-o")
         .arg(&lib_path)
         .arg(&c_path)
         .arg("-lm")

--- a/crates/rumoca/src/target_manifest.rs
+++ b/crates/rumoca/src/target_manifest.rs
@@ -322,6 +322,9 @@ fn render_raw_template(
         Some(TargetFileRenderContext::FmiModelDescription) => result
             .render_fmi_model_description_template_str_with_name(&template, &model_identifier)
             .with_context(|| format!("Render raw FMI modelDescription template: {target}")),
+        Some(TargetFileRenderContext::FmiImplementation) => result
+            .render_fmi_implementation_template_str_with_name(&template, &model_identifier)
+            .with_context(|| format!("Render raw FMI implementation template: {target}")),
         None => result
             .render_template_str_with_name_and_ir(&template, &model_identifier, ir)
             .with_context(|| format!("Render raw template: {target}")),
@@ -344,6 +347,7 @@ fn raw_template_render_context(template: &str) -> Result<Option<TargetFileRender
         };
         return match value.trim() {
             "fmi-model-description" => Ok(Some(TargetFileRenderContext::FmiModelDescription)),
+            "fmi-implementation" => Ok(Some(TargetFileRenderContext::FmiImplementation)),
             other => bail!("unknown raw template render context '{other}'"),
         };
     }
@@ -748,6 +752,9 @@ fn render_manifest_template(
     match context {
         Some(TargetFileRenderContext::FmiModelDescription) => result
             .render_fmi_model_description_template_str_with_name(template, model_identifier)
+            .map_err(Into::into),
+        Some(TargetFileRenderContext::FmiImplementation) => result
+            .render_fmi_implementation_template_str_with_name(template, model_identifier)
             .map_err(Into::into),
         None => renderer.render(result, template, model_identifier),
     }


### PR DESCRIPTION
## Summary

- generate the FMI numerical implementation from Solve IR using bounded C temporaries while preserving Solve IR evaluation order
- separate FMI metadata projection from numerical lowering, share immutable metadata, and prepare the two render contexts concurrently
- improve runtime evaluation, function and array projection, FMI metadata folding, and static/root-event handling exposed by the Modelica integration tests
- make the native FMI compiler honor `CC` and `CFLAGS`, with `-Og` as the default build/runtime balance

The DAE remains the canonical source for FMI variable layout, defaults, documentation, event and clock metadata, and symbol identity. Numerical FMI execution is generated from Solve IR.

## Root cause

The FMI C renderer recursively nested complete Solve IR programs into single expressions. On the integration model this produced lines as long as 136,232 characters and made native compilation dominate FMU generation. FMI rendering also repeated expensive DAE metadata work and numerical lowering. The interpreted Diffsol path additionally exposed static-root classification and runtime projection issues.

This change materializes non-leaf Solve IR operations as bounded C temporaries and uses lightweight, independent renderer contexts for metadata and numerical code.

## Results

Measured with `Tests.All` from `modelica_models`:

- Rumoca direct compile and simulation: 2.60 s
- OMC build and simulation: 3.73 s
- 20 native FMI simulations with the default `-Og`: 0.78 s
- 20 OMC generated-code simulations: 6.23 s
- warm full FMU generation improved from 26.62 s to 12.40 s
- generated C decreased from 2.48 MB to 1.93 MB
- maximum generated line length decreased from 136,232 to 169 characters

Full FMU generation remains slower than the 3.73 s OMC build-and-simulate measurement, while direct Rumoca execution and repeated native FMI simulation are faster.

Both implementations pass the Modelica assertions. Across 39,039 compared state samples, the maximum absolute Rumoca/OMC difference was 7.66e-7 and all samples were within 1e-6.

## Validation

- `cargo fmt --all -- --check`
- affected-crate Clippy with `-D warnings`
- 824 phase-Solve library tests
- 114 Solve evaluator tests
- 52 Diffsol tests
- 306 compiler tests
- 17 FMI 3 code-generation tests
- 13 FMI metadata tests
- Rumoca 0.9.20 and OMC integration simulation comparison
