### PR TITLE
fix(instantiate): resolve indexed array modifiers

### DIFF
--- a/crates/rumoca-phase-instantiate/src/mod_env.rs
+++ b/crates/rumoca-phase-instantiate/src/mod_env.rs
@@ -680,6 +680,11 @@ fn resolve_single_part_ref_expr(
     let name = comp_ref.parts[0].ident.text.as_ref();
     let qn = ast::QualifiedName::from_ident(name);
 
+    if let Some(subscripts) = comp_ref.parts[0].subs.as_ref() {
+        let mod_value = mod_env.get(&qn)?;
+        return select_array_value(&mod_value.value, subscripts);
+    }
+
     if let Some(mod_value) = mod_env.get(&qn)
         && mod_value.value != *expr
     {
@@ -687,6 +692,28 @@ fn resolve_single_part_ref_expr(
     }
 
     None
+}
+
+fn select_array_value(
+    mut expr: &ast::Expression,
+    subscripts: &[ast::Subscript],
+) -> Option<ast::Expression> {
+    subscripts.first()?;
+    for subscript in subscripts {
+        let ast::Subscript::Expression(ast::Expression::Terminal {
+            terminal_type: ast::TerminalType::UnsignedInteger,
+            token,
+            ..
+        }) = subscript
+        else {
+            return None;
+        };
+        let ast::Expression::Array { elements, .. } = expr else {
+            return None;
+        };
+        expr = elements.get(token.text.parse::<usize>().ok()?.checked_sub(1)?)?;
+    }
+    Some(expr.clone())
 }
 
 /// Resolve a multi-part component reference by following sibling modifications.
@@ -890,6 +917,27 @@ mod tests {
             .keys()
             .map(ToString::to_string)
             .collect()
+    }
+
+    #[test]
+    fn indexed_modifier_resolution_rejects_unsupported_selections() {
+        let array = ast::Expression::Array {
+            elements: vec![make_int_expr(1)],
+            is_matrix: false,
+            span: rumoca_core::Span::DUMMY,
+        };
+        let subscript = |expr| ast::Subscript::Expression(expr);
+        for invalid in [
+            make_int_expr(0),
+            make_int_expr(2),
+            make_comp_ref_expr(&["i"]),
+        ] {
+            assert_eq!(select_array_value(&array, &[subscript(invalid)]), None);
+        }
+        assert_eq!(
+            select_array_value(&make_int_expr(1), &[subscript(make_int_expr(1))]),
+            None
+        );
     }
 
     fn make_name(name: &str) -> ast::Name {

--- a/crates/rumoca/tests/mod_propagation_test.rs
+++ b/crates/rumoca/tests/mod_propagation_test.rs
@@ -86,6 +86,115 @@ fn assert_bool_binding(overlay: &ast::InstanceOverlay, comp_name: &str, expected
     }
 }
 
+#[test]
+fn test_array_component_modifier_reference_selects_scalar_element() {
+    let source = r#"
+        model Cell
+            parameter Real x;
+        end Cell;
+
+        model Group
+            parameter Real values[2];
+            Cell cells[2](x = values);
+        end Group;
+
+        model Top
+            Group group(values = {1.0, 2.0});
+        end Top;
+    "#;
+
+    let (_tree, overlay) = instantiate_test_model(source, "Top");
+
+    for (name, expected) in [("group.cells[1].x", "1.0"), ("group.cells[2].x", "2.0")] {
+        let component =
+            find_component(&overlay, name).unwrap_or_else(|| panic!("{name} should exist"));
+        let ast::Expression::Terminal {
+            terminal_type: ast::TerminalType::UnsignedReal,
+            token,
+            ..
+        } = component
+            .binding
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name} should have a binding"))
+        else {
+            panic!("{name} should bind to one scalar array element");
+        };
+        assert_eq!(token.text.as_ref(), expected);
+    }
+}
+
+#[test]
+fn test_array_component_modifier_reference_selects_element_row() {
+    let source = r#"
+        model Tower
+            parameter Real v_flow_rate[:];
+        end Tower;
+
+        model TowerGroup
+            parameter Integer n = 2;
+            parameter Real v_flow_rate[n, 3];
+            Tower ct[n](v_flow_rate = v_flow_rate);
+        end TowerGroup;
+
+        model Top
+            TowerGroup group(v_flow_rate = {{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}});
+        end Top;
+    "#;
+
+    let (_tree, overlay) = instantiate_test_model(source, "Top");
+
+    for (name, expected) in [
+        ("group.ct[1].v_flow_rate", ["1.0", "2.0", "3.0"]),
+        ("group.ct[2].v_flow_rate", ["4.0", "5.0", "6.0"]),
+    ] {
+        let component =
+            find_component(&overlay, name).unwrap_or_else(|| panic!("{name} should exist"));
+        assert!(
+            component.binding_from_modification,
+            "{name} binding should come from the array component modifier"
+        );
+        let ast::Expression::Array { elements, .. } = component
+            .binding
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name} should have a binding"))
+        else {
+            panic!("{name} should bind to one array row");
+        };
+        let actual = elements
+            .iter()
+            .map(|element| match element {
+                ast::Expression::Terminal {
+                    terminal_type: ast::TerminalType::UnsignedReal,
+                    token,
+                    ..
+                } => token.text.as_ref(),
+                other => panic!("{name} row should contain real literals, got {other:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
+
+    let first = find_component(&overlay, "group.ct[1].v_flow_rate")
+        .expect("first tower v_flow_rate should exist");
+    let ast::Expression::ComponentReference(source) = first
+        .binding_source
+        .as_ref()
+        .expect("first tower should retain its symbolic modifier source")
+    else {
+        panic!("first tower modifier source should remain a component reference");
+    };
+    let [part] = source.parts.as_slice() else {
+        panic!("first tower modifier source should be a single-part reference");
+    };
+    assert_eq!(part.ident.text.as_ref(), "v_flow_rate");
+    let Some([ast::Subscript::Expression(ast::Expression::Terminal { token, .. })]) =
+        part.subs.as_deref()
+    else {
+        panic!("first tower modifier source should retain its element index");
+    };
+    assert_eq!(token.text.as_ref(), "1");
+}
+
 /// Helper: Assert that a component has the expected dimensions.
 fn assert_dims(overlay: &ast::InstanceOverlay, comp_name: &str, expected_dims: &[i64]) {
     let data =


### PR DESCRIPTION
## Summary

- Fix non-`each` array component modifiers so an expanded component element resolves an indexed modifier reference to that element's scalar value or row instead of reusing the whole array.
- Add focused scalar, vector-row, nested-component, binding-source, and unsupported-selection regressions.
- Addresses [ClimaMind CLI-37](https://linear.app/climamind/issue/CLI-37/upstream-bug-%E4%BF%9D%E7%95%99-array-modifier-element-scope-%E4%B8%8E-indexed-modifier).

### Root cause

Array expansion already changed a modifier such as `v_flow_rate = v_flow_rate` on `ct[n]` into the element-specific reference `v_flow_rate[1]`. During instantiate, `resolve_single_part_ref_expr` then looked up only the reference name and returned the complete modifier value, ignoring its subscript. The first tower consequently received `{{1, 2, 3}}` instead of `{1, 2, 3}`; the scalar form had the same whole-array substitution.

The fix remains in the earliest owning phase: when a single-part modifier reference has positive integer literal subscripts, instantiate walks the materialized array value one dimension per subscript. Zero, out-of-bounds, symbolic, empty, or non-array selections return `None`, preserving the unresolved expression rather than substituting the whole array.

## Spec / MLS Alignment

- Relevant active specs checked: `SPEC_0007`, `SPEC_0021`, `SPEC_0022` (`INST-001`, `ARR-005`, `ARR-024`), `SPEC_0025`, `SPEC_0032`.
- Relevant MLS sections: §7.2 modifier semantics; §10.5 array field access/distribution.
- Crate/phase owner: `rumoca-phase-instantiate` / modifier resolution.

## Risk and Design Notes

- Main correctness risk: resolving an unsupported indexed reference to the whole array. The helper instead returns `None` for every unproven selection and uses checked one-based conversion plus bounds-checked access.
- Main maintenance risk: `mod_env.rs` is now exactly at the 2,000-line SPEC_0021 limit. This PR does not broaden scope into a file split; the hard-limit regression passes.
- The change belongs in instantiate because the incorrect value is already visible in `InstanceOverlay`, before flatten, ToDae, FMI, or codegen.
- No public API, new abstraction, compatibility path, migration, downstream compensation, or model-specific behavior was added.

## Testing

Passing locally:

- `cargo fmt --check`
- `cargo test -p rumoca --test mod_propagation_test` — 19 passed
- `cargo test -p rumoca-phase-instantiate` — 132 passed, 1 doc-test ignored
- `cargo test -p rumoca --test architecture_hardening_test size_and_validation::span_debt::test_rs_files_stay_under_spec_0021_hard_limit` — passed
- `cargo doc --no-deps` — passed
- Pinned `CogniPilot/modelica_models@973cc7f4`: `Tests.LieGroupTests.SO2` and `Tests.LieGroupTests.SE2` both compiled and simulated successfully at `stop-time 0.0`.

Passing on [upstream CI](https://github.com/CogniPilot/rumoca/actions/runs/29429012057) for this exact head:

- Format, lint, documentation, and complete workspace tests on Ubuntu, macOS, and Windows.
- Full MSL quality gate: all four shards plus the merged baseline/trace/speed gate.
- ModelicaTest semantic gate with all selected targets successful.
- Pinned `modelica_models@973cc7f4` aggregate `Tests.All` compile plus SO2/SE2 assertion smokes.
- DCO, architecture scan, coverage, Nix, Python, WASM, VS Code, playground, LSP/editor, and template-runtime checks.

No required verification gate was omitted.

## Code Size Budget (required)

- production_lines_added: 27
- production_lines_deleted: 0
- test_lines_added: 130
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 2
- net_added_lines: 157

The net growth is required to preserve the fixed instantiate behavior with two structured end-to-end regressions and a compact four-case rejection test. The first compression pass reduced the production implementation from 36 to 27 lines by merging index parsing and traversal into one private helper. No cleanup follow-up is proposed: the remaining growth is regression evidence, while a future unrelated addition to `mod_env.rs` should perform the file split required by its hard limit.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior and remaining environment gaps are disclosed.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] No public APIs added.
- [x] No old/new parallel paths added.
- [x] No `#[allow(clippy::...)]` added.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By`.
- [x] No external implementation material was added.
