### PR TITLE
Fix npm package directory resolution

### DIFF
--- a/packages/rumoca/build.mjs
+++ b/packages/rumoca/build.mjs
@@ -236,7 +236,7 @@ const utcTimestamp = () => {
 };
 
 const packTarball = async ({ cwd, packageDir, tarballDestDir, dev }) => {
-  const raw = runCapture("npm", ["pack", "--json", packageDir], { cwd });
+  const raw = runCapture("npm", ["pack", "--json", path.resolve(cwd, packageDir)], { cwd });
   const parsed = JSON.parse(raw);
   const filename = parsed?.[0]?.filename;
   if (!filename) {


### PR DESCRIPTION
## Summary

Pass an absolute local package directory to `npm pack`. npm 11 otherwise interprets `dist/release-core` as a GitHub shorthand and attempts an SSH fetch.

## Validation

- `node --check packages/rumoca/build.mjs`
- packed the existing `dist/dev-core` package to a temporary directory with npm 11.8.0
- `git diff --check`