### PR TITLE
fix(instantiate): preserve nested array modifier element scope

### DIFF
--- a/crates/rumoca-phase-instantiate/src/array_expansion.rs
+++ b/crates/rumoca-phase-instantiate/src/array_expansion.rs
@@ -280,12 +280,57 @@ fn distribute_component_ref_mods_for_element(
             continue;
         }
 
+        if let Some(indexed) =
+            index_nested_modification_for_element(tree, parent_components, expr, indices)?
+        {
+            scalar_comp.modifications.insert(name.clone(), indexed);
+            continue;
+        }
+
         let indexed = index_binding_for_element(tree, parent_components, expr, indices)?;
         if !matches!(indexed, ast::Expression::ArrayIndex { .. }) {
             scalar_comp.modifications.insert(name.clone(), indexed);
         }
     }
     Ok(())
+}
+
+fn index_nested_modification_for_element(
+    tree: &ast::ClassTree,
+    parent_components: &IndexMap<String, ast::Component>,
+    expr: &ast::Expression,
+    indices: &[i64],
+) -> InstantiateResult<Option<ast::Expression>> {
+    let mut indexed = expr.clone();
+    match &mut indexed {
+        ast::Expression::ClassModification {
+            modifications,
+            each_flags,
+            ..
+        } => {
+            for (position, nested) in modifications.iter_mut().enumerate() {
+                if !each_flags.get(position).copied().unwrap_or(false)
+                    && let Some(value) = index_nested_modification_for_element(
+                        tree,
+                        parent_components,
+                        nested,
+                        indices,
+                    )?
+                {
+                    *nested = value;
+                }
+            }
+        }
+        ast::Expression::Modification { value, .. } => {
+            if let Some(indexed_value) =
+                index_array_expression_for_element(tree, parent_components, value, indices)?
+            {
+                *value = Arc::new(indexed_value);
+            }
+        }
+        _ => return Ok(None),
+    }
+    Ok(Some(indexed))
 }
 
 /// Resolve a modification expression to its value, handling component references.

--- a/crates/rumoca/tests/mod_propagation_test.rs
+++ b/crates/rumoca/tests/mod_propagation_test.rs
@@ -1243,6 +1243,71 @@ fn test_nested_modifier_forwarding_keeps_outer_alias_scope() {
     );
 }
 
+#[test]
+fn test_nested_modifier_on_array_component_selects_element_row() {
+    let source = r#"
+        record Curve
+            parameter Real eta[:];
+        end Curve;
+
+        record Performance
+            parameter Curve motorEfficiency(eta={1.0});
+        end Performance;
+
+        model Pump
+            parameter Performance per;
+            Real y = per.motorEfficiency.eta[1];
+        end Pump;
+
+        model Top
+            parameter Real motorEta[2, 2] = {{0.87, 0.88}, {0.77, 0.78}};
+            Pump pumps[2](per(motorEfficiency(eta=motorEta)));
+            Pump shared[2](per(motorEfficiency(each eta={5, 6})));
+        end Top;
+    "#;
+
+    let compiled = rumoca::Compiler::new()
+        .model("Top")
+        .compile_str(source, "test.mo")
+        .expect("nested modifier should select one row for each array element");
+
+    for index in 1..=2 {
+        let name = format!("pumps[{index}].per.motorEfficiency.eta");
+        let eta = compiled
+            .flat
+            .variables
+            .get(&rumoca_core::VarName::new(&name))
+            .unwrap_or_else(|| panic!("{name} should be present"));
+        assert_eq!(eta.dims, vec![2]);
+        match eta.binding.as_ref().expect("binding should be preserved") {
+            rumoca_core::Expression::VarRef {
+                name, subscripts, ..
+            } => {
+                assert_eq!(name.as_str(), "motorEta");
+                assert!(
+                    matches!(
+                        subscripts.as_slice(),
+                        [rumoca_core::Subscript::Index { value, .. }] if *value == index
+                    ),
+                    "expected row {index}, got {subscripts:?}"
+                );
+            }
+            other => panic!("expected selected source row, got {other:?}"),
+        }
+
+        let shared = format!("shared[{index}].per.motorEfficiency.eta");
+        let binding = compiled.flat.variables[&rumoca_core::VarName::new(&shared)]
+            .binding
+            .as_ref()
+            .expect("each binding should be preserved");
+        let rumoca_core::Expression::Array { elements, .. } = binding else {
+            panic!("each modifier should keep the full array, got {binding:?}");
+        };
+        assert!(flat_expr_is_numeric_value(&elements[0], 5));
+        assert!(flat_expr_is_numeric_value(&elements[1], 6));
+    }
+}
+
 /// Helper: Parse source and instantiate a model.
 fn instantiate_test_model(
     source: &str,


### PR DESCRIPTION
## Summary

- Preserve the current array element's scope when distributing nested, non-`each` modifiers during component-array expansion.
- For `Pump pumps[2](per(curve(eta=motorEta)))`, the two scalar instances now retain `motorEta[1]` and `motorEta[2]` respectively instead of both retaining the unsliced matrix.
- This addresses only the array-modifier element-scope subproblem tracked in [ClimaMind CLI-37](https://linear.app/climamind/issue/CLI-37/upstream-bug-%E4%BF%9D%E7%95%99-array-modifier-element-scope-%E4%B8%8E-indexed-modifier). It does not include `end` lowering or downstream FMI compensation.

## Spec / MLS Alignment

- Relevant active spec(s) checked: SPEC_0007, SPEC_0021, SPEC_0022, SPEC_0025, SPEC_0029, SPEC_0032.
- Relevant MLS section(s), if semantics changed: MLS §7.2 (modifier value context) and §7.2.5 (`each` and array-modifier distribution).
- Crate/phase owner: `rumoca-phase-instantiate`, array expansion.

## Risk and Design Notes

- Main correctness risk: indexing scalar or shape-unproven nested expressions. The implementation reuses the existing conservative `index_array_expression_for_element` path and leaves values unchanged when array projection cannot be proven.
- Main maintenance risk: one additional private recursive helper in the existing array-expansion owner.
- Why the change belongs in these crate(s): the first divergence occurs while an array component is expanded into scalar instances; later Flat/DAE/FMI layers should receive already-correct modifier bindings.
- Any new abstraction, public API, or migration path: one private helper; no public API or migration.

## Testing

- Focused regression: `cargo test -p rumoca --test mod_propagation_test test_nested_modifier_on_array_component_selects_element_row -- --exact`
- The regression proves elements 1 and 2 select rows 1 and 2, while nested `each` preserves the complete shared array for both elements.
- [CI on exact head `0d9d172`](https://github.com/CogniPilot/rumoca/actions/runs/29646041834) passes formatting, lint, documentation, coverage, Linux/macOS/Windows tests, all four MSL quality shards and the final MSL merge gate.

## Code Size Budget (required)

- production_lines_added: 45
- production_lines_deleted: 0
- test_lines_added: 65
- test_lines_deleted: 0
- public_items_added: 0
- public_items_removed: 0
- files_touched: 2
- net_added_lines: 110

The net growth is the private recursive traversal needed to reach nested modification leaves plus one end-to-end regression. The first compression pass reduced the prior downstream candidate from 249 added lines across three files to 110 lines across two files by removing unrelated modifier-environment behavior and consolidating recursion around the existing conservative array-projection helper. No follow-up cleanup is planned because no parallel path or public abstraction remains.

## Reviewer Checklist

- [x] Relevant active specs were checked.
- [x] MLS-sensitive changes cite the right MLS section.
- [x] Crate boundaries and phase ownership preserved (SPEC_0029).
- [x] Tests prove behavior or explain the remaining gap.
- [x] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`, `cargo doc`).
- [x] MSL gate run for compiler/simulator changes; no regression vs baseline.
- [x] Size-budget section completed.
- [x] Positive net diff has explicit compression justification.
- [x] New APIs are required and minimal.
- [x] Old/new parallel paths removed unless explicitly migrating.
- [x] No `#[allow(clippy::...)]` added outside generated code.
- [x] Every commit signed off (`git commit -s`); no `Co-Authored-By` for AI.
- [x] External material (if any) attributed and Apache-2.0 compatible.
