### PR TITLE
fix(rk45): support zero-state batch simulations

### DIFF
--- a/crates/rumoca-solver-rk45/src/lib.rs
+++ b/crates/rumoca-solver-rk45/src/lib.rs
@@ -24,7 +24,7 @@ mod no_state;
 mod reset;
 mod trace;
 
-use no_state::NoStateSession;
+use no_state::{NoStateSession, simulate_no_state};
 use reset::Rk45ResetSnapshot;
 use trace::{
     record_derivative_eval_trace, record_root_eval_trace, reset_rk_eval_trace,
@@ -38,9 +38,6 @@ const ALGEBRAIC_REFRESH_TOL: f64 = 1.0e-10;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SimError {
-    #[error("empty system: no state equations to simulate")]
-    EmptySystem,
-
     #[error("rk45 backend does not support solver mode {requested:?}")]
     UnsupportedSolverMode { requested: SimSolverMode },
 
@@ -484,6 +481,10 @@ pub fn simulate(model: &solve::SolveModel, opts: &SimOptions) -> Result<SimResul
         requested => return Err(SimError::UnsupportedSolverMode { requested }),
     }
 
+    if model.state_scalar_count() == 0 {
+        return simulate_no_state(model, opts);
+    }
+
     validate_explicit_solve_model(model)?;
     let model = SolveRuntime::new(model)?;
     let sample_dt = default_output_dt(opts);
@@ -532,9 +533,6 @@ pub fn simulate(model: &solve::SolveModel, opts: &SimOptions) -> Result<SimResul
 
 fn validate_explicit_solve_model(model: &solve::SolveModel) -> Result<(), SimError> {
     let layout = &model.problem.solve_layout;
-    if layout.state_scalar_count == 0 {
-        return Err(SimError::EmptySystem);
-    }
     if model.initial_y.len() != model.solver_scalar_count() {
         return Err(SimError::SolveIr(format!(
             "initial vector length {} does not match solver layout {}",

--- a/crates/rumoca-solver-rk45/src/no_state.rs
+++ b/crates/rumoca-solver-rk45/src/no_state.rs
@@ -13,10 +13,52 @@ use rumoca_solver::{
     timeline::{event_left_limit_time, sample_time_match_with_tol},
 };
 
-use crate::{SessionState, SimError};
+use crate::{SessionState, SimError, checked_vec_with_capacity, default_output_dt};
 
 const NO_STATE_EVENT_UPDATE_MAX_ITERS: usize = 256;
 const ROOT_BISECTION_ITERS: usize = 64;
+
+pub(crate) fn simulate_no_state(
+    model: &solve::SolveModel,
+    opts: &SimOptions,
+) -> Result<rumoca_solver::SimResult, SimError> {
+    let sample_dt = default_output_dt(opts);
+    let sample_times =
+        rumoca_solver::timeline::build_output_times(opts.t_start, opts.t_end, sample_dt);
+    let mut session = NoStateSession::new(model, opts.clone())?;
+    let mut times = checked_vec_with_capacity(sample_times.len(), "RK45 no-state output times")?;
+    let mut data =
+        checked_vec_with_capacity(model.visible_names.len(), "RK45 no-state output series")?;
+    for _ in &model.visible_names {
+        data.push(checked_vec_with_capacity(
+            sample_times.len(),
+            "RK45 no-state output samples",
+        )?);
+    }
+
+    for sample_time in sample_times {
+        session.advance_to(sample_time)?;
+        let values = session.runtime.runtime.visible_values(
+            &session.runtime.current_y,
+            &session.runtime.params,
+            session.runtime.current_t,
+        )?;
+        for (series, value) in data.iter_mut().zip(values) {
+            series.push(value);
+        }
+        times.push(session.runtime.current_t);
+        if session.runtime.termination.is_some() {
+            break;
+        }
+    }
+
+    Ok(rumoca_solver::build_sim_result_from_solve_model(
+        model,
+        times,
+        data,
+        session.runtime.termination,
+    ))
+}
 
 pub(crate) struct NoStateSession {
     model: solve::SolveModel,

--- a/crates/rumoca-solver-rk45/src/tests.rs
+++ b/crates/rumoca-solver-rk45/src/tests.rs
@@ -883,6 +883,26 @@ fn rk45_session_runs_no_state_discrete_controller() {
 }
 
 #[test]
+fn rk45_batch_runs_no_state_discrete_controller() {
+    let model = no_state_input_accumulator_model();
+    let result = simulate(
+        &model,
+        &SimOptions {
+            t_end: 0.05,
+            dt: Some(0.01),
+            solver_mode: SimSolverMode::RkLike,
+            ..Default::default()
+        },
+    )
+    .expect("no-state batch simulation should succeed");
+
+    assert_eq!(result.times.len(), 6);
+    assert_eq!(result.names, ["y"]);
+    assert_eq!(result.data, [vec![0.0; 6]]);
+    assert_eq!(result.n_states, 0);
+}
+
+#[test]
 fn rk45_session_uses_adaptive_event_integration_for_stiff_contact() {
     let model = stiff_contact_model();
     let mut session = SimulationSession::new(


### PR DESCRIPTION
## Branch Naming

  - Descriptive branch name without an `agent/` prefix:
    `fix/rk45-zero-state-batch`

  ## Summary

  - Enable RK45 batch simulation for zero-state models.
  - Reuse the existing `NoStateSession` runtime instead of returning
    `EmptySystem`.

  ## Spec / MLS Alignment

  - Relevant active specs checked: SPEC_0029, SPEC_0032
  - Relevant MLS section(s), if semantics changed: N/A
  - Crate/phase owner: `rumoca-solver-rk45`

  ## Risk and Design Notes

  - Main correctness risk: Incorrect output sampling around events or termination.
  - Main maintenance risk: Batch and session behavior diverging.
  - Why the change belongs in these crate(s): RK45 owns this backend dispatch.
  - Any new abstraction, public API, or migration path: None.

  ## Testing

  - Key command(s) run: `cargo test -p rumoca-solver-rk45` — 24 passed.
  - Behavior or regression covered: Zero-state discrete batch simulation.
  - Commands NOT run and why: Full workspace, clippy, doc, and MSL gate were not
    run; verification was limited to the affected solver crate.
  - MSL gate: Not run.

  ## Code Size Budget (required)

  - production_lines_added: 48
  - production_lines_deleted: 8
  - test_lines_added: 20
  - test_lines_deleted: 0
  - public_items_added: 0
  - public_items_removed: 1
  - files_touched: 3
  - net_added_lines: 60
  - Net growth is required to collect batch samples through the existing
    zero-state session runtime.
  - Removed the obsolete `EmptySystem` variant and rejection path.
  - Follow-up cleanup: None identified; no parallel runtime was added.

  ## Reviewer Checklist

  - [x] Relevant active specs were checked.
  - [x] MLS-sensitive changes cite the right MLS section (N/A).
  - [x] Crate boundaries and phase ownership preserved (SPEC_0029).
  - [x] Tests prove behavior or explain the remaining gap.
  - [ ] Standard CI gates pass (`fmt`, `clippy -D warnings`, `cargo test`,
        `cargo doc`).
  - [ ] MSL gate run; no regression vs baseline.
  - [x] Size-budget section completed.
  - [x] Positive net diff has explicit compression justification.
  - [x] New APIs are required and minimal (none added).
  - [x] Old/new parallel paths removed unless explicitly migrating.
  - [x] No `#[allow(clippy::...)]` added outside generated code.
  - [x] Every commit signed off; no AI `Co-Authored-By`.
  - [x] External material attributed and Apache-2.0 compatible (none used).